### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      next-runtime:
+        patterns:
+          - next
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      tooling:
+        patterns:
+          - "@biomejs/biome"
+          - vitest
+          - playwright
+          - markdownlint-cli2
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
+        versions:
+          - ">= 26"
+      - dependency-name: next
+        update-types:
+          - version-update:semver-major
+        versions:
+          - ">= 17"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
+        versions:
+          - ">= 26"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with grouped update strategy
- **npm**: weekly, groups `next-runtime` (next, react, react-dom, types) and `tooling` (biome, vitest, playwright, markdownlint-cli2)
- **github-actions**: weekly
- **docker**: weekly
- Ignore node >= 26 and next >= 17 major bumps
- All PRs labeled `dependencies`

## Test plan

- [ ] Verify Dependabot picks up config after merge

Closes #4