### PR TITLE
Strengthen biome CI check

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",
-    "check": "biome check src",
+    "check": "biome ci --error-on-warnings .",
     "fix": "biome check --write src",
     "markdownlint": "markdownlint-cli2 '**/*.md'",
     "test": "vitest run",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,13 +2,13 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "src"),
-			"server-only": path.resolve(
-				__dirname,
-				"src/__tests__/mocks/server-only.ts",
-			),
-		},
-	},
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+      "server-only": path.resolve(
+        __dirname,
+        "src/__tests__/mocks/server-only.ts",
+      ),
+    },
+  },
 });


### PR DESCRIPTION
## Summary

- `pnpm check` now runs `biome ci --error-on-warnings .` instead of `biome check src`
- Full project is checked (not just `src`), and warnings are treated as errors
- Bumps `biome.json` schema version to 2.4.4 to match installed CLI
- Fixes tab indentation in `vitest.config.ts` caught by the stricter check

Closes #21