### PR TITLE
Add branching and CI guidelines to agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,17 @@
 
 - Code, comments, commit messages, PR descriptions, and issues are written in
   English.
+
+## Branching and pushing
+
+- NEVER push directly to `main`. Always create a new branch before pushing.
+- Branch names must follow the format `<github-username>/issue-#` (e.g., `alice/issue-42`).
+  If there is no related issue, ask the user how to proceed before creating the
+  branch.
+
+## CI requirements
+
+- Before committing, ensure all CI lint/check steps (e.g., Biome, type checks)
+  would pass for the changed files.
+- Before pushing or opening a PR, ensure the full CI pipeline passes locally
+  (all checks, tests, and builds).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,17 @@
 
 - Code, comments, commit messages, PR descriptions, and issues are written in
   English.
+
+## Branching and pushing
+
+- NEVER push directly to `main`. Always create a new branch before pushing.
+- Branch names must follow the format `<github-username>/issue-#` (e.g., `alice/issue-42`).
+  If there is no related issue, ask the user how to proceed before creating the
+  branch.
+
+## CI requirements
+
+- Before committing, ensure all CI lint/check steps (e.g., Biome, type checks)
+  would pass for the changed files.
+- Before pushing or opening a PR, ensure the full CI pipeline passes locally
+  (all checks, tests, and builds).


### PR DESCRIPTION
## Summary

- Add `Branching and pushing` section: prohibit direct pushes to `main`, define `<github-username>/issue-#` branch naming convention
- Add `CI requirements` section: require CI lint/check steps to pass before committing, and full CI pipeline before pushing or opening a PR

Closes #23