### PR TITLE
Add Docker and Nginx setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.git
+.env*
+!.env.example
+infra/
+docker-compose.yml
+.claude
+.agent*
+.github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,35 @@ jobs:
       - run: pnpm check
       - run: pnpm typecheck
       - uses: DavidAnson/markdownlint-cli2-action@v22
+      - uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
+  nginx-config:
+    name: Nginx Config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate dummy TLS certs
+        run: |
+          mkdir -p infra/certs
+          openssl req -x509 -nodes -newkey rsa:2048 \
+            -keyout infra/certs/dev.key -out infra/certs/dev.crt \
+            -days 1 -subj '/CN=localhost'
+          cp infra/certs/dev.key infra/certs/prod.key
+          cp infra/certs/dev.crt infra/certs/prod.crt
+      - name: Validate dev config
+        run: |
+          docker run --rm \
+            -v "$PWD/infra/nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro" \
+            -v "$PWD/infra/certs:/etc/nginx/certs:ro" \
+            nginx:alpine nginx -t
+      - name: Validate prod config
+        run: |
+          docker run --rm \
+            -v "$PWD/infra/nginx/nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro" \
+            -v "$PWD/infra/certs:/etc/nginx/certs:ro" \
+            nginx:alpine nginx -t
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 .DS_Store
 *.pem
 
+# TLS certificates (never commit private keys)
+/infra/certs/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM node:24-bookworm-slim AS builder
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+# Run stage
+FROM node:24-bookworm-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000 HOSTNAME=0.0.0.0
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  nginx-dev:
+    image: nginx:alpine
+    profiles: [dev]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/certs:/etc/nginx/certs:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  next-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    profiles: [prod]
+    expose:
+      - "3000"
+    env_file:
+      - .env
+
+  nginx-prod:
+    image: nginx:alpine
+    profiles: [prod]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./infra/nginx/nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/certs:/etc/nginx/certs:ro
+    depends_on:
+      - next-app

--- a/infra/nginx/nginx.dev.conf
+++ b/infra/nginx/nginx.dev.conf
@@ -9,8 +9,13 @@ server {
     ssl_certificate     /etc/nginx/certs/dev.crt;
     ssl_certificate_key /etc/nginx/certs/dev.key;
 
+    # Docker Desktop injects host.docker.internal; use a variable so
+    # nginx -t does not fail in environments where it does not resolve.
+    resolver 127.0.0.11 valid=10s;
+
     location / {
-        proxy_pass http://host.docker.internal:3000;
+        set $upstream http://host.docker.internal:3000;
+        proxy_pass $upstream;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/infra/nginx/nginx.dev.conf
+++ b/infra/nginx/nginx.dev.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+
+    ssl_certificate     /etc/nginx/certs/dev.crt;
+    ssl_certificate_key /etc/nginx/certs/dev.key;
+
+    location / {
+        proxy_pass http://host.docker.internal:3000;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/infra/nginx/nginx.prod.conf
+++ b/infra/nginx/nginx.prod.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+
+    ssl_certificate     /etc/nginx/certs/prod.crt;
+    ssl_certificate_key /etc/nginx/certs/prod.key;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
+    location / {
+        proxy_pass http://next-app:3000;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/infra/nginx/nginx.prod.conf
+++ b/infra/nginx/nginx.prod.conf
@@ -14,8 +14,14 @@ server {
     add_header X-Content-Type-Options nosniff always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
 
+    # Docker Compose internal DNS resolver.
+    # Variable assignment defers DNS lookup to request time,
+    # allowing nginx to start before next-app is ready.
+    resolver 127.0.0.11 valid=10s;
+
     location / {
-        proxy_pass http://next-app:3000;
+        set $upstream http://next-app:3000;
+        proxy_pass $upstream;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` with non-root user for production builds
- Add `infra/nginx/nginx.dev.conf` (proxy to host) and `nginx.prod.conf` (proxy to container, security headers)
- Add `docker-compose.yml` with `dev` and `prod` profiles
- Add `.dockerignore`
- Set `output: 'standalone'` in `next.config.ts`
- Add Dockerfile linting (hadolint) and nginx config validation (`nginx -t`) to CI

## Test plan

- [x] `pnpm typecheck` passes
- [x] `docker build -t aice-web-next .` succeeds
- [x] `docker compose --profile dev up` starts nginx only
- [x] `docker compose --profile prod up` starts next-app + nginx
- [x] CI: hadolint passes
- [x] CI: `nginx -t` passes for both dev and prod configs

Closes #5