### PR TITLE
Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+.claude
 
 # TLS certificates (never commit private keys)
 /infra/certs/


### PR DESCRIPTION
## Summary
- Add `.claude` directory to `.gitignore` to prevent Claude Code's working files from being tracked.