### PR TITLE
Update ARCHITECTURE.md for account management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,14 +8,18 @@ communication between the browser and `review-web` (the GraphQL backend).
 
 ```text
 Browser ──► Next.js (aice-web-next) ──► review-web (GraphQL)
-              │                            │
-              ├─ Route Handlers            ├─ mTLS handshake
-              ├─ Server Actions            ├─ Context JWT verification
-              └─ React Server Components   └─ RoleGuard + CustomerIds
+              │         │                    │
+              │         └─► auth_db (PG)     ├─ mTLS handshake
+              │                              ├─ Context JWT verification
+              ├─ Route Handlers              └─ RoleGuard + CustomerIds
+              ├─ Server Actions
+              └─ React Server Components
 ```
 
 The browser never accesses `review-web` directly. Every GraphQL request
-originates from the server side of Next.js.
+originates from the server side of Next.js. `aice-web-next` connects to
+`auth_db` (PostgreSQL) for account management; it does not connect to
+`customer_db` (see Discussion #32 §3).
 
 ## Authentication flow
 
@@ -26,6 +30,13 @@ originates from the server side of Next.js.
    in an `HttpOnly Secure` cookie.
 3. Subsequent requests include the cookie automatically. The BFF validates it
    on each request.
+
+The BFF uses **Access Token only** — no Refresh Token. Token lifetime is
+extended via **Sliding Rotation**: each server request within the validity
+window issues a replacement token with a reset expiry. A single BFF instance
+handles all requests, so the "stateless JWT to avoid DB lookups" benefit of
+Refresh Tokens does not apply; `sid` validation already requires a DB lookup
+on every request (see Discussion #32 §7).
 
 Authentication endpoints (`/api/auth/*`) are the **only** place where auth
 logic lives. Server Actions handle business logic only.
@@ -65,28 +76,61 @@ All mTLS and JWT signing logic is encapsulated in `lib/mtls.ts`:
 - `reload()` atomically replaces both the Agent and the signing key for
   certificate rotation.
 
+## Role system
+
+aice-web-next defines three built-in roles and supports custom roles
+(see Discussion #32 §1):
+
+| Role | Scope | Deletable |
+|------|-------|-----------|
+| System Administrator | Full system, account, role, customer management | No |
+| Tenant Administrator | Tenant-scoped ops + Security Monitor account management | No |
+| Security Monitor | Event/dashboard read-only within assigned customer | No |
+| Custom Role | System Administrator-defined permission combinations | Yes |
+
+- Built-in roles are auto-created on first startup.
+- Custom Role accounts are managed by System Administrator only.
+  Tenant Administrator can only manage Security Monitor accounts.
+- Next.js Middleware enforces role-based route protection. Server
+  Actions and Route Handlers check permissions before executing.
+
 ## Data communication
 
-### Two-layer architecture
+### Three-layer architecture
 
 | Layer | Direction | Technology | Transport |
 |-------|-----------|------------|-----------|
 | Client | Browser → BFF | TanStack Query | HTTP (fetch) |
 | Server | BFF → review-web | graphql-request | HTTPS (mTLS) |
+| DB | BFF → auth_db | pg | PostgreSQL protocol |
 
 - **Client layer**: React components use TanStack Query to call Route Handlers
   or Server Actions. The browser has no knowledge of GraphQL.
 - **Server layer**: Route Handlers and Server Actions use `graphql-request`
   with the mTLS `https.Agent` to query `review-web`.
+- **DB layer**: Account management operations (auth, sessions, roles) query
+  `auth_db` directly via `pg`.
 
 ### Auth boundary
 
 | Concern | Mechanism | Location |
 |---------|-----------|----------|
 | Sign-in / sign-out | Route Handler | `app/api/auth/` |
-| Token rotation / CSRF | Route Handler | `app/api/auth/` |
-| Business data queries | Server Action or Route Handler | `app/`, `lib/` |
+| Token rotation / CSRF (HMAC Double Submit Cookie) | Route Handler | `app/api/auth/` |
+| Business mutations | Server Action (Next.js built-in CSRF) | `app/`, `lib/` |
 | mTLS + Context JWT | Server-only module | `lib/mtls.ts` |
+
+## Database migrations
+
+Raw SQL with `pg` — no ORM. SQL is explicit and fully visible, which aids
+both human and AI-driven debugging. SQL injection is prevented by
+parameterized queries. See Discussion #34 for the full strategy.
+
+- Versioned `.sql` (DDL) and `.ts` (DML) files, applied in order by a
+  custom runner.
+- Forward-only: rollbacks are new migration files, not reverse operations.
+- Migration files are separated by database (`auth/` for `auth_db`,
+  `customer/` for per-customer databases).
 
 ## Directory structure
 
@@ -101,6 +145,7 @@ src/
   lib/
     mtls.ts                # mTLS + Context JWT encapsulation
     graphql/               # graphql-request client setup
+    db/                    # pg client, migration runner
   components/
     ui/                    # shadcn/ui components
   i18n/
@@ -140,6 +185,7 @@ src/
 |------------|---------|---------|
 | TanStack Query | v5.x | Client-side server state |
 | graphql-request | 7.x | Server-side GraphQL client |
+| pg | 8.x | PostgreSQL client (auth_db) |
 | jose | — | Context JWT signing |
 
 ### i18n
@@ -170,3 +216,9 @@ src/
   Authentication and data flow architecture
 - [aicers/review-web#768](https://github.com/aicers/review-web/issues/768) —
   mTLS + Context JWT on review-web side
+- [Discussion #32](https://github.com/aicers/aice-web-next/discussions/32) —
+  Account management feature specification
+- [Discussion #33](https://github.com/aicers/aice-web-next/discussions/33) —
+  UI architecture
+- [Discussion #34](https://github.com/aicers/aice-web-next/discussions/34) —
+  Database migration strategy


### PR DESCRIPTION
## Summary
- Add `auth_db` connection to system overview diagram; clarify aice-web-next connects to `auth_db` only
- Document JWT strategy (Access Token only, Sliding Rotation, no Refresh Token)
- Add Role system section (3 built-in roles + Custom Role, management scope)
- Expand data communication to three layers (add DB layer via `pg`)
- Clarify CSRF scope: HMAC Double Submit Cookie for Route Handlers, Next.js built-in CSRF for Server Actions
- Add Database migrations section (no ORM, raw SQL, forward-only rollback, per-database separation)
- Add `pg` to tech stack, `lib/db/` to directory structure, Discussion links to References

## Context
These changes reflect architectural decisions established in:
- Discussion #32 (Account Management Feature Specification)
- Discussion #33 (UI Architecture)
- Discussion #34 (Database Migration Strategy)

Closes #35