### PR TITLE
Add PostgreSQL client and migration runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ REVIEW_GRAPHQL_ENDPOINT=
 MTLS_CERT_PATH=
 MTLS_KEY_PATH=
 MTLS_CA_PATH=
+
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/auth_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  postgres:
+    image: postgres:17-bookworm
+    profiles: [dev, prod]
+    environment:
+      POSTGRES_DB: auth_db
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   nginx-dev:
     image: nginx:alpine
     profiles: [dev]
@@ -20,6 +37,9 @@ services:
       - "3000"
     env_file:
       - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   nginx-prod:
     image: nginx:alpine
@@ -32,3 +52,6 @@ services:
       - ./infra/certs:/etc/nginx/certs:ro
     depends_on:
       - next-app
+
+volumes:
+  pgdata:

--- a/migrations/auth/0001_init_schema.sql
+++ b/migrations/auth/0001_init_schema.sql
@@ -1,0 +1,3 @@
+-- Initial empty migration to verify the migration runner.
+-- Actual auth_db schema will be added in Phase 1 (issue #39).
+SELECT 1;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "graphql-request": "^7.4.0",
     "jose": "^6.1.3",
     "next": "16.1.6",
+    "pg": "^8.19.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "server-only": "^0.0.1",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24",
+    "@types/pg": "^8.18.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "markdownlint-cli2": "^0.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      pg:
+        specifier: ^8.19.0
+        version: 8.19.0
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -39,6 +42,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.10.15
+      '@types/pg':
+        specifier: ^8.18.0
+        version: 8.18.0
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -725,6 +731,9 @@ packages:
   '@types/node@24.10.15':
     resolution: {integrity: sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==}
 
+  '@types/pg@8.18.0':
+    resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1178,6 +1187,40 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.11.0:
+    resolution: {integrity: sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.12.0:
+    resolution: {integrity: sha512-eIJ0DES8BLaziFHW7VgJEBPi5hg3Nyng5iKpYtj3wbcAUV9A1wLgWiY7ajf/f/oO1wfxt83phXPY8Emztg7ITg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.12.0:
+    resolution: {integrity: sha512-uOANXNRACNdElMXJ0tPz6RBM0XQ61nONGAwlt8da5zs/iUOOCLBQOHSXnrC6fMsvtjxbOJrZZl5IScGv+7mpbg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.19.0:
+    resolution: {integrity: sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1196,6 +1239,22 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -1251,6 +1310,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1277,9 +1340,6 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
-
-  tailwindcss@4.2.0:
-    resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
 
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
@@ -1407,6 +1467,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
 snapshots:
 
@@ -1825,6 +1889,12 @@ snapshots:
   '@types/node@24.10.15':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/pg@8.18.0':
+    dependencies:
+      '@types/node': 24.10.15
+      pg-protocol: 1.12.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2366,6 +2436,41 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.11.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.12.0(pg@8.19.0):
+    dependencies:
+      pg: 8.19.0
+
+  pg-protocol@1.12.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.19.0:
+    dependencies:
+      pg-connection-string: 2.11.0
+      pg-pool: 3.12.0(pg@8.19.0)
+      pg-protocol: 1.12.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -2383,6 +2488,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   punycode.js@2.3.1: {}
 
@@ -2477,6 +2592,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  split2@4.2.0: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
@@ -2494,8 +2611,6 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-
-  tailwindcss@4.2.0: {}
 
   tailwindcss@4.2.1: {}
 
@@ -2583,3 +2698,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xtend@4.0.2: {}

--- a/src/__tests__/lib/db/client.test.ts
+++ b/src/__tests__/lib/db/client.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockQuery, mockConnect, mockEnd, mockRelease, mockPoolClient } =
+  vi.hoisted(() => ({
+    mockQuery: vi.fn(),
+    mockConnect: vi.fn(),
+    mockEnd: vi.fn(),
+    mockRelease: vi.fn(),
+    mockPoolClient: { query: vi.fn(), release: vi.fn() },
+  }));
+
+vi.mock("pg", () => ({
+  default: {
+    Pool: class MockPool {
+      query = mockQuery;
+      connect = mockConnect;
+      end = mockEnd;
+    },
+  },
+}));
+
+describe("db client", () => {
+  let client: typeof import("@/lib/db/client");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.DATABASE_URL =
+      "postgres://postgres:postgres@localhost:5432/auth_db";
+
+    mockQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+    mockConnect.mockReset().mockResolvedValue(mockPoolClient);
+    mockEnd.mockReset().mockResolvedValue(undefined);
+    mockRelease.mockReset();
+    mockPoolClient.query
+      .mockReset()
+      .mockResolvedValue({ rows: [], rowCount: 0 });
+    mockPoolClient.release = mockRelease;
+
+    client = await import("@/lib/db/client");
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  // ── query ───────────────────────────────────────────────────────────
+
+  describe("query", () => {
+    it("executes SQL with parameters", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ id: 1 }], rowCount: 1 });
+
+      const result = await client.query(
+        "SELECT * FROM users WHERE id = $1",
+        [1],
+      );
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        "SELECT * FROM users WHERE id = $1",
+        [1],
+      );
+      expect(result.rows).toEqual([{ id: 1 }]);
+      expect(result.rowCount).toBe(1);
+    });
+
+    it("executes SQL without parameters", async () => {
+      mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await client.query("SELECT 1");
+
+      expect(mockQuery).toHaveBeenCalledWith("SELECT 1", undefined);
+    });
+
+    it("throws when DATABASE_URL is missing", async () => {
+      delete process.env.DATABASE_URL;
+      client.resetPool();
+
+      await expect(client.query("SELECT 1")).rejects.toThrow(
+        "Missing environment variable: DATABASE_URL",
+      );
+    });
+  });
+
+  // ── withTransaction ─────────────────────────────────────────────────
+
+  describe("withTransaction", () => {
+    it("wraps function in BEGIN/COMMIT", async () => {
+      await client.withTransaction(async (txClient) => {
+        await txClient.query("INSERT INTO users (name) VALUES ($1)", ["alice"]);
+      });
+
+      const calls = mockPoolClient.query.mock.calls.map((c: unknown[]) => c[0]);
+      expect(calls[0]).toBe("BEGIN");
+      expect(calls[1]).toBe("INSERT INTO users (name) VALUES ($1)");
+      expect(calls[2]).toBe("COMMIT");
+    });
+
+    it("rolls back on error", async () => {
+      mockPoolClient.query.mockImplementation((sql: string) => {
+        if (sql === "INSERT INTO users (name) VALUES ($1)") {
+          return Promise.reject(new Error("constraint violation"));
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      await expect(
+        client.withTransaction(async (txClient) => {
+          await txClient.query("INSERT INTO users (name) VALUES ($1)", [
+            "alice",
+          ]);
+        }),
+      ).rejects.toThrow("constraint violation");
+
+      const calls = mockPoolClient.query.mock.calls.map((c: unknown[]) => c[0]);
+      expect(calls[0]).toBe("BEGIN");
+      expect(calls[1]).toBe("INSERT INTO users (name) VALUES ($1)");
+      expect(calls[2]).toBe("ROLLBACK");
+    });
+
+    it("releases client after commit", async () => {
+      await client.withTransaction(async () => {});
+
+      expect(mockRelease).toHaveBeenCalledOnce();
+    });
+
+    it("releases client after rollback", async () => {
+      mockPoolClient.query.mockImplementation((sql: string) => {
+        if (sql !== "BEGIN" && sql !== "ROLLBACK") {
+          return Promise.reject(new Error("fail"));
+        }
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      });
+
+      await expect(
+        client.withTransaction(async (txClient) => {
+          await txClient.query("BAD SQL");
+        }),
+      ).rejects.toThrow("fail");
+
+      expect(mockRelease).toHaveBeenCalledOnce();
+    });
+
+    it("returns the value from the callback", async () => {
+      const result = await client.withTransaction(async () => 42);
+
+      expect(result).toBe(42);
+    });
+  });
+
+  // ── connectTo ───────────────────────────────────────────────────────
+
+  describe("connectTo", () => {
+    it("creates a pool for the given connection string", () => {
+      const pool = client.connectTo("postgres://localhost/test_db");
+
+      expect(pool).toBeDefined();
+      expect(pool.query).toBeDefined();
+    });
+  });
+
+  // ── end ─────────────────────────────────────────────────────────────
+
+  describe("end", () => {
+    it("ends the pool", async () => {
+      // Trigger pool creation
+      await client.query("SELECT 1");
+
+      await client.end();
+
+      expect(mockEnd).toHaveBeenCalledOnce();
+    });
+
+    it("is safe to call when no pool exists", async () => {
+      client.resetPool();
+      await client.end();
+      // No error thrown
+    });
+  });
+});

--- a/src/__tests__/lib/db/migrate.test.ts
+++ b/src/__tests__/lib/db/migrate.test.ts
@@ -1,0 +1,245 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockClientQuery,
+  mockRelease,
+  mockPoolEnd,
+  mockPoolConnect,
+  mockPoolQuery,
+} = vi.hoisted(() => {
+  const mockClientQuery = vi.fn();
+  const mockRelease = vi.fn();
+  const mockPoolEnd = vi.fn();
+  const mockPoolConnect = vi.fn();
+  const mockPoolQuery = vi.fn();
+  return {
+    mockClientQuery,
+    mockRelease,
+    mockPoolEnd,
+    mockPoolConnect,
+    mockPoolQuery,
+  };
+});
+
+vi.mock("pg", () => {
+  const Pool = vi.fn(() => ({
+    query: mockPoolQuery,
+    connect: mockPoolConnect,
+    end: mockPoolEnd,
+  }));
+  return { default: { Pool } };
+});
+
+vi.mock("@/lib/db/client", () => ({
+  connectTo: vi.fn(() => ({
+    query: mockPoolQuery,
+    connect: mockPoolConnect,
+    end: mockPoolEnd,
+  })),
+  query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+  withTransaction: vi.fn(),
+}));
+
+const tmpDir = path.join(__dirname, ".tmp-migrations");
+
+function writeMigration(subdir: string, filename: string, sql: string) {
+  const dir = path.join(tmpDir, "migrations", subdir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, filename), sql);
+}
+
+describe("migrate", () => {
+  let migrate: typeof import("@/lib/db/migrate");
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    mkdirSync(tmpDir, { recursive: true });
+
+    vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+    process.env.DATABASE_URL =
+      "postgres://postgres:postgres@localhost:5432/auth_db";
+
+    mockClientQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+    mockRelease.mockReset();
+    mockPoolEnd.mockReset().mockResolvedValue(undefined);
+    mockPoolConnect.mockReset().mockResolvedValue({
+      query: mockClientQuery,
+      release: mockRelease,
+    });
+    mockPoolQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+
+    migrate = await import("@/lib/db/migrate");
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── scanMigrations ──────────────────────────────────────────────────
+
+  describe("scanMigrations", () => {
+    it("returns sorted migration files", () => {
+      writeMigration("auth", "0002_add_sessions.sql", "SELECT 1");
+      writeMigration("auth", "0001_init_schema.sql", "SELECT 1");
+
+      const migrations = migrate._scanMigrations(
+        path.join(tmpDir, "migrations", "auth"),
+      );
+
+      expect(migrations).toHaveLength(2);
+      expect(migrations[0].version).toBe("0001");
+      expect(migrations[1].version).toBe("0002");
+    });
+
+    it("ignores non-sql files", () => {
+      writeMigration("auth", "0001_init_schema.sql", "SELECT 1");
+      writeMigration("auth", "README.md", "not a migration");
+
+      const migrations = migrate._scanMigrations(
+        path.join(tmpDir, "migrations", "auth"),
+      );
+
+      expect(migrations).toHaveLength(1);
+    });
+
+    it("ignores files with invalid naming", () => {
+      writeMigration("auth", "0001_init_schema.sql", "SELECT 1");
+      writeMigration("auth", "bad_name.sql", "SELECT 1");
+
+      const migrations = migrate._scanMigrations(
+        path.join(tmpDir, "migrations", "auth"),
+      );
+
+      expect(migrations).toHaveLength(1);
+      expect(migrations[0].version).toBe("0001");
+    });
+
+    it("returns empty array for missing directory", () => {
+      const migrations = migrate._scanMigrations("/nonexistent");
+
+      expect(migrations).toEqual([]);
+    });
+  });
+
+  // ── migrateAuthDb ───────────────────────────────────────────────────
+
+  describe("migrateAuthDb", () => {
+    it("applies pending migrations sequentially", async () => {
+      writeMigration("auth", "0001_init_schema.sql", "CREATE TABLE a (id INT)");
+      writeMigration("auth", "0002_add_col.sql", "ALTER TABLE a ADD name TEXT");
+
+      const count = await migrate.migrateAuthDb();
+
+      expect(count).toBe(2);
+
+      const queries = mockClientQuery.mock.calls.map((c: unknown[]) => c[0]);
+      expect(queries).toContain("CREATE TABLE a (id INT)");
+      expect(queries).toContain("ALTER TABLE a ADD name TEXT");
+    });
+
+    it("skips already-applied migrations", async () => {
+      writeMigration("auth", "0001_init_schema.sql", "CREATE TABLE a (id INT)");
+      writeMigration("auth", "0002_add_col.sql", "ALTER TABLE a ADD name TEXT");
+
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE TABLE _migrations
+        .mockResolvedValueOnce({
+          rows: [{ version: "0001" }],
+          rowCount: 1,
+        }); // SELECT versions
+
+      const count = await migrate.migrateAuthDb();
+
+      expect(count).toBe(1);
+      const queries = mockClientQuery.mock.calls.map((c: unknown[]) => c[0]);
+      expect(queries).not.toContain("CREATE TABLE a (id INT)");
+      expect(queries).toContain("ALTER TABLE a ADD name TEXT");
+    });
+
+    it("returns 0 when no migration files exist", async () => {
+      const count = await migrate.migrateAuthDb();
+
+      expect(count).toBe(0);
+    });
+
+    it("rolls back on migration failure", async () => {
+      writeMigration("auth", "0001_bad.sql", "INVALID SQL");
+
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE TABLE _migrations
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SELECT versions
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+        .mockRejectedValueOnce(new Error("syntax error")); // migration SQL
+
+      await expect(migrate.migrateAuthDb()).rejects.toThrow("syntax error");
+
+      const queries = mockClientQuery.mock.calls.map((c: unknown[]) => c[0]);
+      expect(queries).toContain("BEGIN");
+      expect(queries).toContain("ROLLBACK");
+      expect(queries).not.toContain("COMMIT");
+    });
+
+    it("ends the pool after migration", async () => {
+      writeMigration("auth", "0001_init_schema.sql", "SELECT 1");
+
+      await migrate.migrateAuthDb();
+
+      expect(mockPoolEnd).toHaveBeenCalled();
+    });
+  });
+
+  // ── provisionCustomerDb ─────────────────────────────────────────────
+
+  describe("provisionCustomerDb", () => {
+    it("drops database on migration failure", async () => {
+      writeMigration("customer", "0001_init.sql", "CREATE TABLE t (id INT)");
+
+      const { query: clientQuery } = await import("@/lib/db/client");
+
+      // CREATE DATABASE succeeds
+      vi.mocked(clientQuery).mockResolvedValueOnce({
+        rows: [],
+        rowCount: 0,
+      });
+
+      // Pool connect for customer migrations fails
+      mockPoolConnect.mockResolvedValueOnce({
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE TABLE _migrations
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SELECT versions
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+          .mockRejectedValueOnce(new Error("migration failed")),
+        release: vi.fn(),
+      });
+
+      await expect(migrate.provisionCustomerDb("customer_42")).rejects.toThrow(
+        "migration failed",
+      );
+
+      // Should attempt DROP DATABASE on failure
+      expect(vi.mocked(clientQuery)).toHaveBeenCalledWith(
+        'DROP DATABASE IF EXISTS "customer_42"',
+      );
+    });
+  });
+
+  // ── dropCustomerDb ──────────────────────────────────────────────────
+
+  describe("dropCustomerDb", () => {
+    it("executes DROP DATABASE with escaped name", async () => {
+      const { query: clientQuery } = await import("@/lib/db/client");
+
+      await migrate.dropCustomerDb("customer_42");
+
+      expect(vi.mocked(clientQuery)).toHaveBeenCalledWith(
+        'DROP DATABASE IF EXISTS "customer_42"',
+      );
+    });
+  });
+});

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,0 +1,62 @@
+import "server-only";
+
+import pg from "pg";
+
+let pool: pg.Pool | null = null;
+
+function getPool(): pg.Pool {
+  if (pool) return pool;
+
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("Missing environment variable: DATABASE_URL");
+  }
+
+  pool = new pg.Pool({ connectionString });
+  return pool;
+}
+
+export interface QueryResult<T> {
+  rows: T[];
+  rowCount: number | null;
+}
+
+export async function query<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<QueryResult<T>> {
+  const result = await getPool().query<T>(text, params);
+  return { rows: result.rows, rowCount: result.rowCount };
+}
+
+export async function withTransaction<T>(
+  fn: (client: pg.PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export function connectTo(connectionString: string): pg.Pool {
+  return new pg.Pool({ connectionString });
+}
+
+export async function end(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+export function resetPool(): void {
+  pool = null;
+}

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -1,0 +1,172 @@
+import "server-only";
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import type pg from "pg";
+
+import { connectTo, query } from "@/lib/db/client";
+
+const MIGRATIONS_TABLE = "_migrations";
+
+interface MigrationFile {
+  version: string;
+  name: string;
+  filePath: string;
+}
+
+function escapeIdentifier(str: string): string {
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+function requireDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error("Missing environment variable: DATABASE_URL");
+  }
+  return url;
+}
+
+function scanMigrations(directory: string): MigrationFile[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(directory);
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((f) => f.endsWith(".sql"))
+    .sort()
+    .map((f) => {
+      const match = f.match(/^(\d+)_(.+)\.sql$/);
+      if (!match) return null;
+      return {
+        version: match[1],
+        name: match[2],
+        filePath: path.join(directory, f),
+      };
+    })
+    .filter((m): m is MigrationFile => m !== null);
+}
+
+async function ensureMigrationsTable(client: pg.PoolClient): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      version    TEXT PRIMARY KEY,
+      name       TEXT NOT NULL,
+      applied_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+}
+
+async function getAppliedVersions(client: pg.PoolClient): Promise<Set<string>> {
+  const result = await client.query<{ version: string }>(
+    `SELECT version FROM ${MIGRATIONS_TABLE} ORDER BY version`,
+  );
+  return new Set(result.rows.map((r) => r.version));
+}
+
+async function applyMigrations(
+  pool: pg.Pool,
+  migrations: MigrationFile[],
+): Promise<number> {
+  const client = await pool.connect();
+  try {
+    await ensureMigrationsTable(client);
+    const applied = await getAppliedVersions(client);
+
+    const pending = migrations.filter((m) => !applied.has(m.version));
+    for (const migration of pending) {
+      const sql = readFileSync(migration.filePath, "utf8");
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
+        await client.query(
+          `INSERT INTO ${MIGRATIONS_TABLE} (version, name) VALUES ($1, $2)`,
+          [migration.version, migration.name],
+        );
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        throw err;
+      }
+    }
+
+    return pending.length;
+  } finally {
+    client.release();
+  }
+}
+
+function getMigrationsDir(subdir: string): string {
+  return path.resolve(process.cwd(), "migrations", subdir);
+}
+
+export async function migrateAuthDb(): Promise<number> {
+  const migrations = scanMigrations(getMigrationsDir("auth"));
+  if (migrations.length === 0) return 0;
+
+  const pool = connectTo(requireDatabaseUrl());
+  try {
+    return await applyMigrations(pool, migrations);
+  } finally {
+    await pool.end();
+  }
+}
+
+export async function migrateCustomerDb(
+  connectionString: string,
+): Promise<number> {
+  const migrations = scanMigrations(getMigrationsDir("customer"));
+  if (migrations.length === 0) return 0;
+
+  const pool = connectTo(connectionString);
+  try {
+    return await applyMigrations(pool, migrations);
+  } finally {
+    await pool.end();
+  }
+}
+
+export async function provisionCustomerDb(dbName: string): Promise<void> {
+  // CREATE DATABASE cannot run inside a transaction in PostgreSQL
+  await query(`CREATE DATABASE ${escapeIdentifier(dbName)}`);
+
+  const baseUrl = requireDatabaseUrl();
+  const url = new URL(baseUrl);
+  url.pathname = `/${dbName}`;
+  const customerPool = connectTo(url.toString());
+
+  try {
+    const migrations = scanMigrations(getMigrationsDir("customer"));
+    await applyMigrations(customerPool, migrations);
+  } catch (err) {
+    await customerPool.end();
+    await query(`DROP DATABASE IF EXISTS ${escapeIdentifier(dbName)}`);
+    throw err;
+  } finally {
+    await customerPool.end();
+  }
+}
+
+export async function dropCustomerDb(dbName: string): Promise<void> {
+  await query(`DROP DATABASE IF EXISTS ${escapeIdentifier(dbName)}`);
+}
+
+export async function runStartupMigrations(): Promise<void> {
+  await migrateAuthDb();
+
+  const result = await query<{ database_name: string }>(
+    "SELECT database_name FROM customers WHERE status = 'active'",
+  );
+
+  const baseUrl = requireDatabaseUrl();
+  for (const row of result.rows) {
+    const url = new URL(baseUrl);
+    url.pathname = `/${row.database_name}`;
+    await migrateCustomerDb(url.toString());
+  }
+}
+
+export { scanMigrations as _scanMigrations };


### PR DESCRIPTION
Parent: #39 (Phase 0-1)

## Summary

Implement the PostgreSQL client layer and migration runner as defined in Discussion #34.

## Changes

- **docker-compose.yml**: Add `postgres` service (postgres:17-bookworm) for both `dev` and `prod` profiles with named volume (`pgdata`), health check (`pg_isready`), and `depends_on` with `condition: service_healthy` for `next-app`
- **.env.example**: Add `DATABASE_URL`
- **package.json**: Add `pg` and `@types/pg`
- **src/lib/db/client.ts**: Connection pool with lazy initialization, `query<T>()`, `withTransaction()`, `connectTo()`, `end()`, `resetPool()`
- **src/lib/db/migrate.ts**: Migration runner with:
  - `scanMigrations()` — reads versioned `.sql` files
  - `migrateAuthDb()` — applies pending auth migrations
  - `migrateCustomerDb()` — applies pending customer migrations
  - `provisionCustomerDb()` — CREATE DATABASE + run all customer migrations (drops DB on failure)
  - `dropCustomerDb()` — DROP DATABASE
  - `runStartupMigrations()` — auth + all active customer databases
- **migrations/auth/0001_init_schema.sql**: Empty initial migration to verify the runner
- **Unit tests** (22 tests): sequential application, no duplicate application, rollback on failure, transaction handling, pool lifecycle

## Test plan

- [x] `pnpm check` passes (Biome lint + format)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (83 tests, including 22 new)

Closes #40
Refs #39