### PR TITLE
Add auth and dashboard layouts

### DIFF
--- a/src/__tests__/components/layout/breadcrumbs.test.ts
+++ b/src/__tests__/components/layout/breadcrumbs.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NAV_SEGMENTS,
+  parseBreadcrumbs,
+  SETTINGS_SEGMENTS,
+} from "@/lib/breadcrumbs";
+
+// ── Helpers ────────────────────────────
+
+/** A translate function that returns the key prefixed with its namespace. */
+function mockTranslate(ns: "nav" | "settings", key: string): string {
+  return `${ns}.${key}`;
+}
+
+// ── parseBreadcrumbs ────────────────────────────
+
+describe("parseBreadcrumbs", () => {
+  it("returns empty array for root path", () => {
+    const result = parseBreadcrumbs("/", mockTranslate);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    const result = parseBreadcrumbs("", mockTranslate);
+    expect(result).toEqual([]);
+  });
+
+  it("parses a single nav segment", () => {
+    const result = parseBreadcrumbs("/dashboard", mockTranslate);
+    expect(result).toEqual([{ label: "nav.dashboard", href: "/dashboard" }]);
+  });
+
+  it("parses nested settings path", () => {
+    const result = parseBreadcrumbs("/settings/accounts", mockTranslate);
+    expect(result).toEqual([
+      { label: "nav.settings", href: "/settings" },
+      { label: "settings.accounts", href: "/settings/accounts" },
+    ]);
+  });
+
+  it("capitalises unknown segments", () => {
+    const result = parseBreadcrumbs("/settings/unknown-page", mockTranslate);
+    expect(result).toEqual([
+      { label: "nav.settings", href: "/settings" },
+      { label: "Unknown-page", href: "/settings/unknown-page" },
+    ]);
+  });
+
+  it("uses translate fallback when translate returns null", () => {
+    const nullTranslate = () => null;
+    const result = parseBreadcrumbs("/dashboard", nullTranslate);
+    expect(result).toEqual([{ label: "Dashboard", href: "/dashboard" }]);
+  });
+
+  it("builds cumulative href paths", () => {
+    const result = parseBreadcrumbs("/settings/roles/detail", mockTranslate);
+    expect(result).toHaveLength(3);
+    expect(result[0].href).toBe("/settings");
+    expect(result[1].href).toBe("/settings/roles");
+    expect(result[2].href).toBe("/settings/roles/detail");
+  });
+
+  it("handles all three settings sub-segments", () => {
+    for (const segment of ["accounts", "roles", "profile"]) {
+      const result = parseBreadcrumbs(`/settings/${segment}`, mockTranslate);
+      expect(result[1].label).toBe(`settings.${segment}`);
+    }
+  });
+});
+
+// ── Segment sets ────────────────────────────
+
+describe("NAV_SEGMENTS", () => {
+  it("contains all expected navigation keys", () => {
+    const expected = [
+      "home",
+      "dashboard",
+      "event",
+      "detection",
+      "triage",
+      "report",
+      "settings",
+    ];
+    for (const key of expected) {
+      expect(NAV_SEGMENTS.has(key)).toBe(true);
+    }
+    expect(NAV_SEGMENTS.size).toBe(expected.length);
+  });
+});
+
+describe("SETTINGS_SEGMENTS", () => {
+  it("contains all expected settings keys", () => {
+    const expected = ["accounts", "roles", "profile"];
+    for (const key of expected) {
+      expect(SETTINGS_SEGMENTS.has(key)).toBe(true);
+    }
+    expect(SETTINGS_SEGMENTS.size).toBe(expected.length);
+  });
+});

--- a/src/__tests__/hooks/use-sidebar.test.ts
+++ b/src/__tests__/hooks/use-sidebar.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── localStorage mock ────────────────────────────
+
+const storage = new Map<string, string>();
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => storage.set(key, value)),
+  removeItem: vi.fn((key: string) => storage.delete(key)),
+  clear: vi.fn(() => storage.clear()),
+};
+
+vi.stubGlobal("localStorage", localStorageMock);
+
+// ── React hooks mock ────────────────────────────
+
+let stateValue = false;
+const setStateFn = vi.fn((updater: boolean | ((prev: boolean) => boolean)) => {
+  if (typeof updater === "function") {
+    stateValue = updater(stateValue);
+  } else {
+    stateValue = updater;
+  }
+});
+
+const useEffectCallbacks: Array<() => void> = [];
+
+vi.mock("react", () => ({
+  useState: (initial: boolean) => {
+    stateValue = initial;
+    return [stateValue, setStateFn] as const;
+  },
+  useCallback: (fn: () => void) => fn,
+  useEffect: (cb: () => void) => {
+    useEffectCallbacks.push(cb);
+  },
+}));
+
+// ── Tests ────────────────────────────
+
+describe("useSidebar", () => {
+  beforeEach(() => {
+    storage.clear();
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    setStateFn.mockClear();
+    stateValue = false;
+    useEffectCallbacks.length = 0;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns collapsed=false by default", async () => {
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    const result = useSidebar();
+
+    expect(result.collapsed).toBe(false);
+  });
+
+  it("reads localStorage on mount via useEffect", async () => {
+    storage.set("sidebar-collapsed", "true");
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    useSidebar();
+
+    // Simulate useEffect running
+    for (const cb of useEffectCallbacks) {
+      cb();
+    }
+
+    expect(localStorageMock.getItem).toHaveBeenCalledWith("sidebar-collapsed");
+    expect(setStateFn).toHaveBeenCalledWith(true);
+  });
+
+  it("does not set collapsed when localStorage has no value", async () => {
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    useSidebar();
+
+    for (const cb of useEffectCallbacks) {
+      cb();
+    }
+
+    expect(localStorageMock.getItem).toHaveBeenCalledWith("sidebar-collapsed");
+    // setStateFn should NOT have been called (only initial useState call)
+    expect(setStateFn).not.toHaveBeenCalled();
+  });
+
+  it("toggle() flips collapsed and persists to localStorage", async () => {
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    const { toggle } = useSidebar();
+
+    // stateValue starts as false, so toggle should set it to true
+    toggle();
+
+    expect(setStateFn).toHaveBeenCalledOnce();
+    // The updater function was called: !false => true
+    expect(stateValue).toBe(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "sidebar-collapsed",
+      "true",
+    );
+  });
+
+  it("collapse() sets collapsed=true and persists", async () => {
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    const { collapse } = useSidebar();
+
+    collapse();
+
+    expect(setStateFn).toHaveBeenCalledWith(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "sidebar-collapsed",
+      "true",
+    );
+  });
+
+  it("expand() sets collapsed=false and persists", async () => {
+    stateValue = true;
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    const { expand } = useSidebar();
+
+    expand();
+
+    expect(setStateFn).toHaveBeenCalledWith(false);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "sidebar-collapsed",
+      "false",
+    );
+  });
+
+  it("toggle() twice returns to original state", async () => {
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    const { toggle } = useSidebar();
+
+    toggle(); // false -> true
+    expect(stateValue).toBe(true);
+
+    toggle(); // true -> false
+    expect(stateValue).toBe(false);
+
+    expect(localStorageMock.setItem).toHaveBeenLastCalledWith(
+      "sidebar-collapsed",
+      "false",
+    );
+  });
+
+  it("uses 'sidebar-collapsed' as the storage key", async () => {
+    storage.set("sidebar-collapsed", "true");
+    const { useSidebar } = await import("@/hooks/use-sidebar");
+    const { toggle } = useSidebar();
+
+    for (const cb of useEffectCallbacks) {
+      cb();
+    }
+
+    toggle();
+
+    expect(localStorageMock.getItem).toHaveBeenCalledWith("sidebar-collapsed");
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "sidebar-collapsed",
+      expect.any(String),
+    );
+  });
+});

--- a/src/app/[locale]/(auth)/layout.tsx
+++ b/src/app/[locale]/(auth)/layout.tsx
@@ -1,0 +1,13 @@
+export default function AuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--bg-canvas)] p-4">
+      <div className="bg-card w-full max-w-[432px] rounded-md p-8 shadow-[0_10px_10px_rgba(0,0,0,0.04),0_20px_25px_rgba(0,0,0,0.01)]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+
+import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { MobileHeader } from "@/components/layout/mobile-header";
+import { Sidebar } from "@/components/layout/sidebar";
+import { useSidebar } from "@/hooks/use-sidebar";
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const { collapsed, toggle } = useSidebar();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen flex-col">
+      {/* Mobile header — visible only below desktop breakpoint */}
+      <MobileHeader open={mobileOpen} onOpenChange={setMobileOpen} />
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Desktop sidebar — hidden below desktop breakpoint */}
+        <div className="hidden desktop:flex">
+          <Sidebar collapsed={collapsed} onToggle={toggle} />
+        </div>
+
+        {/* Main content */}
+        <main className="flex flex-1 flex-col overflow-hidden">
+          {/* Breadcrumb bar */}
+          <div className="flex h-16 shrink-0 items-center border-b px-6">
+            <Breadcrumbs />
+          </div>
+
+          {/* Page content */}
+          <div className="flex-1 overflow-y-auto p-6">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/breadcrumbs.tsx
+++ b/src/components/layout/breadcrumbs.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Fragment } from "react";
+import { Link, usePathname } from "@/i18n/navigation";
+import { parseBreadcrumbs } from "@/lib/breadcrumbs";
+import { cn } from "@/lib/utils";
+
+export function Breadcrumbs() {
+  const pathname = usePathname();
+  const tNav = useTranslations("nav");
+  const tSettings = useTranslations("settings");
+
+  const crumbs = parseBreadcrumbs(pathname, (ns, key) => {
+    if (ns === "nav") return tNav(key);
+    if (ns === "settings") return tSettings(key);
+    return null;
+  });
+
+  if (crumbs.length === 0) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm">
+      {crumbs.map((crumb, index) => {
+        const isLast = index === crumbs.length - 1;
+        return (
+          <Fragment key={crumb.href}>
+            {index > 0 && (
+              <ChevronRight className="text-muted-foreground h-3.5 w-3.5" />
+            )}
+            {isLast ? (
+              <span className="text-foreground font-medium">{crumb.label}</span>
+            ) : (
+              <Link
+                href={crumb.href}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground transition-colors",
+                )}
+              >
+                {crumb.label}
+              </Link>
+            )}
+          </Fragment>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  FileText,
+  Home,
+  LayoutDashboard,
+  Menu,
+  Radio,
+  Search,
+  Settings,
+  Shield,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { usePathname } from "@/i18n/navigation";
+import { ThemeToggle } from "../theme-toggle";
+import { NavUser } from "./nav-user";
+import { SidebarItem } from "./sidebar-item";
+
+const NAV_ITEMS = [
+  { key: "home", href: "/home", icon: Home },
+  { key: "dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { key: "event", href: "/event", icon: Radio },
+  { key: "detection", href: "/detection", icon: Search },
+  { key: "triage", href: "/triage", icon: Shield },
+  { key: "report", href: "/report", icon: FileText },
+  { key: "settings", href: "/settings", icon: Settings },
+] as const;
+
+interface MobileHeaderProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function MobileHeader({ open, onOpenChange }: MobileHeaderProps) {
+  const t = useTranslations("nav");
+  const pathname = usePathname();
+
+  return (
+    <>
+      <header className="bg-card flex h-14 items-center border-b px-4 desktop:hidden">
+        <Button variant="ghost" size="icon" onClick={() => onOpenChange(true)}>
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Open menu</span>
+        </Button>
+        <span className="text-foreground ml-3 text-lg font-bold">AICE</span>
+      </header>
+
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent side="left" className="w-64 p-0">
+          <SheetHeader className="border-b px-4">
+            <SheetTitle className="text-lg font-bold">AICE</SheetTitle>
+          </SheetHeader>
+          <TooltipProvider>
+            <nav className="flex-1 space-y-1 overflow-y-auto p-2">
+              {NAV_ITEMS.map((item) => (
+                <SidebarItem
+                  key={item.key}
+                  href={item.href}
+                  icon={item.icon}
+                  label={t(item.key)}
+                  active={pathname.startsWith(item.href)}
+                />
+              ))}
+            </nav>
+            <div className="space-y-1 p-2">
+              <Separator className="mb-2" />
+              <div className="px-1">
+                <ThemeToggle />
+              </div>
+              <NavUser />
+            </div>
+          </TooltipProvider>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/layout/nav-user.tsx
+++ b/src/components/layout/nav-user.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { LogOut, User } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface NavUserProps {
+  collapsed?: boolean;
+}
+
+export function NavUser({ collapsed = false }: NavUserProps) {
+  const t = useTranslations();
+
+  const initials = "U";
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger
+            className={cn(
+              "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              "hover:bg-accent hover:text-accent-foreground text-muted-foreground",
+              collapsed && "justify-center px-2",
+            )}
+          >
+            <Avatar className="h-7 w-7 shrink-0">
+              <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+            </Avatar>
+            {!collapsed && (
+              <span className="truncate">{t("settings.profile")}</span>
+            )}
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        {collapsed && (
+          <TooltipContent side="right">{t("settings.profile")}</TooltipContent>
+        )}
+      </Tooltip>
+      <DropdownMenuContent side="right" align="end" className="w-48">
+        <DropdownMenuItem>
+          <User className="mr-2 h-4 w-4" />
+          {t("settings.profile")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <LogOut className="mr-2 h-4 w-4" />
+          {t("common.signOut")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/layout/sidebar-item.tsx
+++ b/src/components/layout/sidebar-item.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+
+interface SidebarItemProps {
+  href: string;
+  icon: LucideIcon;
+  label: string;
+  active?: boolean;
+  collapsed?: boolean;
+}
+
+export function SidebarItem({
+  href,
+  icon: Icon,
+  label,
+  active = false,
+  collapsed = false,
+}: SidebarItemProps) {
+  const linkContent = (
+    <Link
+      href={href}
+      className={cn(
+        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        active ? "bg-accent text-accent-foreground" : "text-muted-foreground",
+        collapsed && "justify-center px-2",
+      )}
+    >
+      <Icon className="h-5 w-5 shrink-0" />
+      {!collapsed && <span>{label}</span>}
+    </Link>
+  );
+
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+        <TooltipContent side="right">{label}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return linkContent;
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import {
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Home,
+  LayoutDashboard,
+  Radio,
+  Search,
+  Settings,
+  Shield,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { usePathname } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+import { ThemeToggle } from "../theme-toggle";
+import { NavUser } from "./nav-user";
+import { SidebarItem } from "./sidebar-item";
+
+interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+const NAV_ITEMS = [
+  { key: "home", href: "/home", icon: Home },
+  { key: "dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { key: "event", href: "/event", icon: Radio },
+  { key: "detection", href: "/detection", icon: Search },
+  { key: "triage", href: "/triage", icon: Shield },
+  { key: "report", href: "/report", icon: FileText },
+  { key: "settings", href: "/settings", icon: Settings },
+] as const;
+
+export function Sidebar({ collapsed, onToggle }: SidebarProps) {
+  const t = useTranslations("nav");
+  const pathname = usePathname();
+
+  return (
+    <TooltipProvider>
+      <aside
+        className={cn(
+          "bg-card flex h-full flex-col border-r transition-[width] duration-200",
+          collapsed ? "w-16" : "w-64",
+        )}
+      >
+        {/* Logo / Header */}
+        <div
+          className={cn(
+            "flex h-16 items-center border-b px-4",
+            collapsed ? "justify-center" : "justify-between",
+          )}
+        >
+          {!collapsed && (
+            <span className="text-foreground text-lg font-bold">AICE</span>
+          )}
+          <Button variant="ghost" size="icon" onClick={onToggle}>
+            {collapsed ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronLeft className="h-4 w-4" />
+            )}
+            <span className="sr-only">Toggle sidebar</span>
+          </Button>
+        </div>
+
+        {/* Navigation */}
+        <nav className="flex-1 space-y-1 overflow-y-auto p-2">
+          {NAV_ITEMS.map((item) => (
+            <SidebarItem
+              key={item.key}
+              href={item.href}
+              icon={item.icon}
+              label={t(item.key)}
+              active={pathname.startsWith(item.href)}
+              collapsed={collapsed}
+            />
+          ))}
+        </nav>
+
+        {/* Bottom section */}
+        <div className="space-y-1 p-2">
+          <Separator className="mb-2" />
+          <div className={cn("flex", collapsed ? "justify-center" : "px-1")}>
+            <ThemeToggle />
+          </div>
+          <NavUser collapsed={collapsed} />
+        </div>
+      </aside>
+    </TooltipProvider>
+  );
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Avatar as AvatarPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg";
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full ring-2 select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+};

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { XIcon } from "lucide-react";
+import { Dialog as SheetPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left";
+  showCloseButton?: boolean;
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+          side === "top" &&
+            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+          side === "bottom" &&
+            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/hooks/use-sidebar.ts
+++ b/src/hooks/use-sidebar.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "sidebar-collapsed";
+
+export function useSidebar() {
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "true") {
+      setCollapsed(true);
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  const collapse = useCallback(() => {
+    setCollapsed(true);
+    localStorage.setItem(STORAGE_KEY, "true");
+  }, []);
+
+  const expand = useCallback(() => {
+    setCollapsed(false);
+    localStorage.setItem(STORAGE_KEY, "false");
+  }, []);
+
+  return { collapsed, toggle, collapse, expand } as const;
+}

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -1,0 +1,52 @@
+/** Segments that map to translation keys in "nav" namespace. */
+export const NAV_SEGMENTS = new Set([
+  "home",
+  "dashboard",
+  "event",
+  "detection",
+  "triage",
+  "report",
+  "settings",
+]);
+
+/** Segments that map to translation keys in "settings" namespace. */
+export const SETTINGS_SEGMENTS = new Set(["accounts", "roles", "profile"]);
+
+export interface BreadcrumbSegment {
+  label: string;
+  href: string;
+}
+
+/**
+ * Parse a pathname into breadcrumb segments with translated labels.
+ *
+ * @param pathname - URL pathname without locale prefix (e.g. "/settings/accounts")
+ * @param translate - Resolves a segment to a translated label, or returns `null`
+ *   to fall back to the capitalised segment name.
+ */
+export function parseBreadcrumbs(
+  pathname: string,
+  translate: (ns: "nav" | "settings", key: string) => string | null,
+): BreadcrumbSegment[] {
+  const segments = pathname.split("/").filter(Boolean);
+  const crumbs: BreadcrumbSegment[] = [];
+
+  let currentPath = "";
+  for (const segment of segments) {
+    currentPath += `/${segment}`;
+
+    let label: string | null = null;
+    if (NAV_SEGMENTS.has(segment)) {
+      label = translate("nav", segment);
+    } else if (SETTINGS_SEGMENTS.has(segment)) {
+      label = translate("settings", segment);
+    }
+
+    crumbs.push({
+      label: label ?? segment.charAt(0).toUpperCase() + segment.slice(1),
+      href: currentPath,
+    });
+  }
+
+  return crumbs;
+}


### PR DESCRIPTION
## Summary

- Install shadcn/ui Phase 2 components: `sheet`, `dropdown-menu`, `avatar`, `tooltip`, `badge`, `separator`
- Add auth layout `(auth)/layout.tsx` with full-screen centered card (432px max-width, 6px radius, shadow)
- Add dashboard layout `(dashboard)/layout.tsx` with collapsible sidebar + main content area
- Add `sidebar.tsx` (256px expanded / 64px collapsed), `sidebar-item.tsx` (icon + text or icon + tooltip), `breadcrumbs.tsx`, `nav-user.tsx`, `mobile-header.tsx`
- Add `use-sidebar` hook with `localStorage` persistence
- Extract `parseBreadcrumbs` into `lib/breadcrumbs.ts` for testability
- Mobile responsive: sidebar collapses into Sheet slide-over overlay below 1280px breakpoint
- Add 18 unit tests for breadcrumbs path parsing and sidebar hook

## Test plan

- [x] `pnpm check` (Biome lint/format) passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 109 tests pass (18 new)
- [x] `pnpm build` succeeds

Closes #43
Refs #39