### PR TITLE
Add auth_db and audit_db schema migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ MTLS_KEY_PATH=
 MTLS_CA_PATH=
 
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/auth_db
+AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5432/audit_db
 
 DEFAULT_LOCALE=en

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./infra/postgres/init-audit-db.sql:/docker-entrypoint-initdb.d/init-audit-db.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 5s

--- a/infra/postgres/init-audit-db.sql
+++ b/infra/postgres/init-audit-db.sql
@@ -1,0 +1,11 @@
+-- This script runs once when the PostgreSQL volume is first initialized
+-- (via docker-entrypoint-initdb.d). It creates the audit_db database
+-- and the restricted audit_writer role used by the application at runtime.
+
+CREATE DATABASE audit_db;
+
+-- The audit_writer role has INSERT/SELECT only on audit_logs (granted by
+-- migration 0001_init_audit_logs.sql after the table is created).
+-- Password should be overridden via POSTGRES_INITDB_ARGS or changed
+-- after provisioning for production deployments.
+CREATE ROLE audit_writer WITH LOGIN PASSWORD 'changeme';

--- a/migrations/audit/0001_init_audit_logs.sql
+++ b/migrations/audit/0001_init_audit_logs.sql
@@ -1,0 +1,28 @@
+CREATE TABLE audit_logs (
+  id          BIGSERIAL PRIMARY KEY,
+  timestamp   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  actor_id    TEXT NOT NULL,
+  action      TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id   TEXT,
+  details     JSONB,
+  ip_address  TEXT,
+  sid         TEXT,
+  customer_id INTEGER
+);
+
+CREATE INDEX idx_audit_logs_timestamp ON audit_logs (timestamp);
+CREATE INDEX idx_audit_logs_actor_id ON audit_logs (actor_id);
+CREATE INDEX idx_audit_logs_action ON audit_logs (action);
+
+-- Grant INSERT/SELECT only to audit_writer role for tamper resistance
+-- (Discussion #46 §2). The role is created during database provisioning
+-- (see infra/postgres/init-audit-db.sql). If the role does not exist
+-- (e.g., non-Docker environment), grants are skipped.
+DO $$ BEGIN
+  EXECUTE 'GRANT USAGE ON SCHEMA public TO audit_writer';
+  EXECUTE 'GRANT SELECT, INSERT ON TABLE audit_logs TO audit_writer';
+  EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE audit_logs_id_seq TO audit_writer';
+EXCEPTION WHEN undefined_object THEN
+  RAISE NOTICE 'Role audit_writer does not exist. Skipping grants.';
+END $$;

--- a/migrations/auth/0002_roles.sql
+++ b/migrations/auth/0002_roles.sql
@@ -1,0 +1,47 @@
+CREATE TABLE roles (
+  id           SERIAL PRIMARY KEY,
+  name         TEXT NOT NULL UNIQUE,
+  description  TEXT,
+  is_builtin   BOOLEAN NOT NULL DEFAULT false,
+  mfa_required BOOLEAN NOT NULL DEFAULT false,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE role_permissions (
+  role_id    INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  permission TEXT NOT NULL,
+  PRIMARY KEY (role_id, permission)
+);
+
+-- Seed built-in roles
+INSERT INTO roles (name, description, is_builtin) VALUES
+  ('System Administrator', 'Full system, account, role, customer management', true),
+  ('Tenant Administrator', 'Tenant-scoped operations and Security Monitor account management', true),
+  ('Security Monitor', 'Event and dashboard read-only within assigned customer', true);
+
+-- System Administrator: all permissions (Discussion #32 §1.4)
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, p.permission
+FROM roles r,
+LATERAL (VALUES
+  ('accounts:read'), ('accounts:write'), ('accounts:delete'),
+  ('roles:read'), ('roles:write'), ('roles:delete'),
+  ('customers:read'), ('customers:write'), ('customers:access-all'),
+  ('audit-logs:read'),
+  ('system-settings:read'), ('system-settings:write')
+) AS p(permission)
+WHERE r.name = 'System Administrator';
+
+-- Tenant Administrator: scoped account and customer permissions (Discussion #32 §1.4)
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, p.permission
+FROM roles r,
+LATERAL (VALUES
+  ('accounts:read'), ('accounts:write'), ('accounts:delete'),
+  ('customers:read'), ('customers:write')
+) AS p(permission)
+WHERE r.name = 'Tenant Administrator';
+
+-- Security Monitor: no account management permissions (Discussion #32 §1.4).
+-- Data access permissions (events, dashboards) are defined separately.

--- a/migrations/auth/0003_accounts.sql
+++ b/migrations/auth/0003_accounts.sql
@@ -1,0 +1,24 @@
+CREATE TABLE accounts (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  username              TEXT NOT NULL UNIQUE,
+  display_name          TEXT NOT NULL,
+  password_hash         TEXT NOT NULL,
+  email                 TEXT,
+  phone                 TEXT,
+  role_id               INTEGER NOT NULL REFERENCES roles(id),
+  status                TEXT NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active', 'locked', 'suspended', 'disabled')),
+  token_version         INTEGER NOT NULL DEFAULT 0,
+  must_change_password  BOOLEAN NOT NULL DEFAULT false,
+  mfa_required          BOOLEAN,
+  failed_sign_in_count  INTEGER NOT NULL DEFAULT 0,
+  locked_until          TIMESTAMPTZ,
+  max_sessions          INTEGER,
+  allowed_ips           TEXT[],
+  locale                TEXT,
+  timezone              TEXT,
+  last_sign_in_at       TIMESTAMPTZ,
+  password_changed_at   TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/auth/0004_sessions.sql
+++ b/migrations/auth/0004_sessions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE sessions (
+  sid            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id     UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  ip_address     TEXT NOT NULL,
+  user_agent     TEXT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_active_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked        BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX idx_sessions_account_id ON sessions (account_id);

--- a/migrations/auth/0005_customers.sql
+++ b/migrations/auth/0005_customers.sql
@@ -1,0 +1,15 @@
+CREATE TABLE customers (
+  id            SERIAL PRIMARY KEY,
+  name          TEXT NOT NULL,
+  description   TEXT,
+  database_name TEXT NOT NULL UNIQUE,
+  status        TEXT NOT NULL DEFAULT 'active',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE account_customer (
+  account_id  UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  customer_id INTEGER NOT NULL REFERENCES customers(id) ON DELETE RESTRICT,
+  PRIMARY KEY (account_id, customer_id)
+);

--- a/migrations/auth/0006_password_history.sql
+++ b/migrations/auth/0006_password_history.sql
@@ -1,0 +1,9 @@
+CREATE TABLE password_history (
+  id            BIGSERIAL PRIMARY KEY,
+  account_id    UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  password_hash TEXT NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_password_history_account_created
+  ON password_history (account_id, created_at DESC);

--- a/migrations/auth/0007_system_settings.sql
+++ b/migrations/auth/0007_system_settings.sql
@@ -1,0 +1,43 @@
+CREATE TABLE system_settings (
+  key        TEXT PRIMARY KEY,
+  value      JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO system_settings (key, value) VALUES
+  ('password_policy', '{
+    "min_length": 12,
+    "max_length": 128,
+    "complexity_enabled": false,
+    "reuse_ban_count": 5,
+    "periodic_change_enabled": false,
+    "periodic_change_days": null
+  }'::jsonb),
+  ('session_policy', '{
+    "idle_timeout_minutes": 30,
+    "absolute_timeout_hours": 8,
+    "max_sessions": null
+  }'::jsonb),
+  ('lockout_policy', '{
+    "stage1_threshold": 5,
+    "stage1_duration_minutes": 30,
+    "stage2_threshold": 3
+  }'::jsonb),
+  ('signin_rate_limit', '{
+    "per_ip_count": 20,
+    "per_ip_window_minutes": 5,
+    "per_account_ip_count": 5,
+    "per_account_ip_window_minutes": 5,
+    "global_count": 100,
+    "global_window_minutes": 1
+  }'::jsonb),
+  ('api_rate_limit', '{
+    "per_user_count": 100,
+    "per_user_window_minutes": 1
+  }'::jsonb),
+  ('jwt_policy', '{
+    "access_token_expiration_minutes": 15
+  }'::jsonb),
+  ('mfa_policy', '{
+    "allowed_methods": ["webauthn", "totp"]
+  }'::jsonb);

--- a/src/__tests__/lib/db/migrate.test.ts
+++ b/src/__tests__/lib/db/migrate.test.ts
@@ -76,6 +76,7 @@ describe("migrate", () => {
 
   afterEach(() => {
     delete process.env.DATABASE_URL;
+    delete process.env.AUDIT_DATABASE_URL;
     vi.restoreAllMocks();
     rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -240,6 +241,112 @@ describe("migrate", () => {
       expect(vi.mocked(clientQuery)).toHaveBeenCalledWith(
         'DROP DATABASE IF EXISTS "customer_42"',
       );
+    });
+  });
+
+  // ── migrateAuditDb ────────────────────────────────────────────────
+
+  describe("migrateAuditDb", () => {
+    it("applies pending audit migrations using AUDIT_DATABASE_URL", async () => {
+      process.env.AUDIT_DATABASE_URL =
+        "postgres://postgres:postgres@localhost:5432/audit_db";
+
+      writeMigration(
+        "audit",
+        "0001_init_audit_logs.sql",
+        "CREATE TABLE audit_logs (id BIGSERIAL)",
+      );
+
+      const count = await migrate.migrateAuditDb();
+
+      expect(count).toBe(1);
+
+      const queries = mockClientQuery.mock.calls.map((c: unknown[]) => c[0]);
+      expect(queries).toContain("CREATE TABLE audit_logs (id BIGSERIAL)");
+    });
+
+    it("throws when AUDIT_DATABASE_URL is missing", async () => {
+      delete process.env.AUDIT_DATABASE_URL;
+
+      writeMigration(
+        "audit",
+        "0001_init_audit_logs.sql",
+        "CREATE TABLE audit_logs (id BIGSERIAL)",
+      );
+
+      await expect(migrate.migrateAuditDb()).rejects.toThrow(
+        "Missing environment variable: AUDIT_DATABASE_URL",
+      );
+    });
+
+    it("returns 0 when no audit migration files exist", async () => {
+      process.env.AUDIT_DATABASE_URL =
+        "postgres://postgres:postgres@localhost:5432/audit_db";
+
+      const count = await migrate.migrateAuditDb();
+
+      expect(count).toBe(0);
+    });
+
+    it("skips already-applied audit migrations (idempotency)", async () => {
+      process.env.AUDIT_DATABASE_URL =
+        "postgres://postgres:postgres@localhost:5432/audit_db";
+
+      writeMigration(
+        "audit",
+        "0001_init_audit_logs.sql",
+        "CREATE TABLE audit_logs (id BIGSERIAL)",
+      );
+
+      mockClientQuery
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // CREATE TABLE _migrations
+        .mockResolvedValueOnce({
+          rows: [{ version: "0001" }],
+          rowCount: 1,
+        }); // SELECT versions — already applied
+
+      const count = await migrate.migrateAuditDb();
+
+      expect(count).toBe(0);
+      const queries = mockClientQuery.mock.calls.map((c: unknown[]) => c[0]);
+      expect(queries).not.toContain("CREATE TABLE audit_logs (id BIGSERIAL)");
+    });
+  });
+
+  // ── runStartupMigrations ──────────────────────────────────────────
+
+  describe("runStartupMigrations", () => {
+    it("runs auth → audit → customer migrations in order", async () => {
+      process.env.AUDIT_DATABASE_URL =
+        "postgres://postgres:postgres@localhost:5432/audit_db";
+
+      writeMigration("auth", "0001_init.sql", "SELECT 1");
+      writeMigration("audit", "0001_init.sql", "SELECT 1");
+      writeMigration("customer", "0001_init.sql", "SELECT 1");
+
+      const { connectTo, query: clientQuery } = await import("@/lib/db/client");
+      const callOrder: string[] = [];
+
+      vi.mocked(connectTo).mockImplementation((url: string) => {
+        if (url.includes("auth_db")) callOrder.push("auth");
+        else if (url.includes("audit_db")) callOrder.push("audit");
+        else callOrder.push("customer");
+        return {
+          query: mockPoolQuery,
+          connect: mockPoolConnect,
+          end: mockPoolEnd,
+        } as never;
+      });
+
+      // customers query (called after auth + audit migrations)
+      vi.mocked(clientQuery).mockResolvedValueOnce({
+        rows: [{ database_name: "customer_1" }],
+        rowCount: 1,
+      });
+
+      await migrate.runStartupMigrations();
+
+      expect(callOrder).toEqual(["auth", "audit", "customer"]);
     });
   });
 });

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -27,6 +27,14 @@ function requireDatabaseUrl(): string {
   return url;
 }
 
+function requireAuditDatabaseUrl(): string {
+  const url = process.env.AUDIT_DATABASE_URL;
+  if (!url) {
+    throw new Error("Missing environment variable: AUDIT_DATABASE_URL");
+  }
+  return url;
+}
+
 function scanMigrations(directory: string): MigrationFile[] {
   let entries: string[];
   try {
@@ -115,6 +123,18 @@ export async function migrateAuthDb(): Promise<number> {
   }
 }
 
+export async function migrateAuditDb(): Promise<number> {
+  const migrations = scanMigrations(getMigrationsDir("audit"));
+  if (migrations.length === 0) return 0;
+
+  const pool = connectTo(requireAuditDatabaseUrl());
+  try {
+    return await applyMigrations(pool, migrations);
+  } finally {
+    await pool.end();
+  }
+}
+
 export async function migrateCustomerDb(
   connectionString: string,
 ): Promise<number> {
@@ -156,6 +176,7 @@ export async function dropCustomerDb(dbName: string): Promise<void> {
 
 export async function runStartupMigrations(): Promise<void> {
   await migrateAuthDb();
+  await migrateAuditDb();
 
   const result = await query<{ database_name: string }>(
     "SELECT database_name FROM customers WHERE status = 'active'",


### PR DESCRIPTION
## Summary
- Add 6 auth_db migrations (roles, accounts, sessions, customers, password_history, system_settings) with built-in role seeds and default policy settings
- Add audit_db migration (audit_logs) with tamper-resistant INSERT/SELECT-only GRANT for `audit_writer` role
- Extend migration runner with `migrateAuditDb()` and update startup ordering to auth → audit → customer
- Add Docker init script (`infra/postgres/init-audit-db.sql`) to provision `audit_db` and `audit_writer` role on first container start

## Test plan
- [x] `pnpm check` — Biome lint/format passes
- [x] `pnpm typecheck` — TypeScript passes
- [x] `pnpm test` — 114 tests pass (5 new: audit migration apply, env var missing, no files, idempotency, startup ordering)
- [x] `pnpm build` — Next.js production build succeeds
- [x] Manual: `docker compose --profile dev up` with fresh volume → verify `audit_db` and `audit_writer` role created
- [x] Manual: connect as `audit_writer` → verify `INSERT`/`SELECT` allowed, `UPDATE`/`DELETE` denied on `audit_logs`

Closes #50