### PR TITLE
Add initial admin account bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,4 +6,8 @@ MTLS_CA_PATH=
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/auth_db
 AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5432/audit_db
 
+DATA_DIR=./data
+INIT_ADMIN_USERNAME=
+INIT_ADMIN_PASSWORD=
+
 DEFAULT_LOCALE=en

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 *.pem
 .claude
 
+# Bootstrap data directory (consumed marker)
+/data
+
 # TLS certificates (never commit private keys)
 /infra/certs/
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "argon2": "^0.44.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "graphql": "^16.13.0",
@@ -39,6 +40,11 @@
     "tw-animate-css": "^1.4.0",
     "undici": "^7.22.0",
     "zod": "^4.3.6"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "argon2"
+    ]
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
+      argon2:
+        specifier: ^0.44.0
+        version: 0.44.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -105,6 +108,9 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -625,6 +631,10 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@phc/format@1.0.0':
+    resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
+    engines: {node: '>=10'}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1709,6 +1719,10 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  argon2@0.44.0:
+    resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
+    engines: {node: '>=16.17.0'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1758,6 +1772,15 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1904,6 +1927,9 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2167,11 +2193,23 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-addon-api@8.6.0:
+    resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2339,6 +2377,14 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2540,6 +2586,11 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2560,6 +2611,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@epic-web/invariant@1.0.0': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2905,6 +2958,8 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@phc/format@1.0.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -3939,6 +3994,13 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  argon2@0.44.0:
+    dependencies:
+      '@phc/format': 1.0.0
+      cross-env: 10.1.0
+      node-addon-api: 8.6.0
+      node-gyp-build: 4.8.4
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -3972,6 +4034,17 @@ snapshots:
   clsx@2.1.1: {}
 
   commander@8.3.0: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csstype@3.2.3: {}
 
@@ -4121,6 +4194,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@4.0.0: {}
+
+  isexe@2.0.0: {}
 
   jiti@2.6.1: {}
 
@@ -4473,6 +4548,10 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-addon-api@8.6.0: {}
+
+  node-gyp-build@4.8.4: {}
+
   obug@2.1.1: {}
 
   parse-entities@4.0.2:
@@ -4484,6 +4563,8 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -4733,6 +4814,12 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   slash@5.1.0: {}
@@ -4871,6 +4958,10 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/__tests__/lib/auth/bootstrap.test.ts
+++ b/src/__tests__/lib/auth/bootstrap.test.ts
@@ -547,6 +547,42 @@ describe("bootstrap", () => {
       );
       expect(mockAuditPoolQuery).not.toHaveBeenCalled();
     });
+
+    it("warns but does not fail when audit DB query throws", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "audit-fail-uuid" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      // Simulate audit DB connection/query failure
+      mockAuditPoolQuery.mockRejectedValueOnce(
+        new Error("ECONNREFUSED: audit_db unreachable"),
+      );
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      // Should not throw — admin account is already created
+      await bootstrap.bootstrapAdminAccount();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Failed to write bootstrap audit log; admin account was created successfully",
+        expect.any(Error),
+      );
+      // Audit pool should still be cleaned up
+      expect(mockAuditPoolEnd).toHaveBeenCalled();
+    });
   });
 
   // ── constants ───────────────────────────────────────────────────

--- a/src/__tests__/lib/auth/bootstrap.test.ts
+++ b/src/__tests__/lib/auth/bootstrap.test.ts
@@ -1,0 +1,559 @@
+import type { PathLike } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPoolQuery, mockAuditPoolQuery, mockAuditPoolEnd } = vi.hoisted(
+  () => {
+    const mockPoolQuery = vi.fn();
+    const mockAuditPoolQuery = vi.fn();
+    const mockAuditPoolEnd = vi.fn();
+    return { mockPoolQuery, mockAuditPoolQuery, mockAuditPoolEnd };
+  },
+);
+
+vi.mock("@/lib/db/client", () => ({
+  connectTo: vi.fn(() => ({
+    query: mockAuditPoolQuery,
+    end: mockAuditPoolEnd,
+  })),
+  query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+}));
+
+vi.mock("argon2", () => ({
+  default: {
+    hash: vi.fn().mockResolvedValue("$argon2id$v=19$mocked-hash"),
+    verify: vi.fn().mockResolvedValue(true),
+    argon2id: 2,
+  },
+}));
+
+const tmpDir = path.join(__dirname, ".tmp-bootstrap");
+const dataDir = path.join(tmpDir, "data");
+const secretsDir = path.join(tmpDir, "secrets");
+
+function writeSecret(filename: string, content: string) {
+  mkdirSync(secretsDir, { recursive: true });
+  writeFileSync(path.join(secretsDir, filename), content);
+}
+
+describe("bootstrap", () => {
+  let bootstrap: typeof import("@/lib/auth/bootstrap");
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    mkdirSync(tmpDir, { recursive: true });
+
+    process.env.DATABASE_URL =
+      "postgres://postgres:postgres@localhost:5432/auth_db";
+    process.env.AUDIT_DATABASE_URL =
+      "postgres://audit_writer:changeme@localhost:5432/audit_db";
+    process.env.DATA_DIR = dataDir;
+
+    delete process.env.INIT_ADMIN_USERNAME;
+    delete process.env.INIT_ADMIN_PASSWORD;
+
+    mockPoolQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+    mockAuditPoolQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+    mockAuditPoolEnd.mockReset().mockResolvedValue(undefined);
+
+    // Patch secret file paths for testing
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+
+      const originalReadFileSync = actual.readFileSync;
+      const originalUnlinkSync = actual.unlinkSync;
+      const originalAccessSync = actual.accessSync;
+
+      return {
+        ...actual,
+        readFileSync: vi.fn(
+          (filePath: PathLike | number, encoding?: BufferEncoding) => {
+            // Redirect secret file reads to tmp directory
+            if (filePath === "/run/secrets/init_admin_username") {
+              return originalReadFileSync(
+                path.join(secretsDir, "init_admin_username"),
+                encoding as BufferEncoding,
+              );
+            }
+            if (filePath === "/run/secrets/init_admin_password") {
+              return originalReadFileSync(
+                path.join(secretsDir, "init_admin_password"),
+                encoding as BufferEncoding,
+              );
+            }
+            return originalReadFileSync(filePath, encoding as BufferEncoding);
+          },
+        ),
+        unlinkSync: vi.fn((filePath: PathLike) => {
+          const fp = String(filePath);
+          if (
+            fp === "/run/secrets/init_admin_username" ||
+            fp === "/run/secrets/init_admin_password"
+          ) {
+            return originalUnlinkSync(path.join(secretsDir, path.basename(fp)));
+          }
+          return originalUnlinkSync(filePath);
+        }),
+        accessSync: vi.fn((filePath: string, mode?: number) => {
+          // DATA_DIR marker check uses actual path, no redirect needed
+          return originalAccessSync(filePath, mode);
+        }),
+      };
+    });
+
+    bootstrap = await import("@/lib/auth/bootstrap");
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+    delete process.env.AUDIT_DATABASE_URL;
+    delete process.env.DATA_DIR;
+    delete process.env.INIT_ADMIN_USERNAME;
+    delete process.env.INIT_ADMIN_PASSWORD;
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── credential resolution ───────────────────────────────────────
+
+  describe("credential resolution", () => {
+    it("reads from secret files when they exist", async () => {
+      writeSecret("init_admin_username", "file-admin\n");
+      writeSecret("init_admin_password", "file-pass123\n");
+
+      // COUNT(*) returns 0
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      // Role lookup
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      // INSERT RETURNING
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "uuid-123" }],
+        rowCount: 1,
+      });
+      // password_history INSERT
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      // Verify INSERT was called with trimmed username from file
+      const insertCall = mockPoolQuery.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("INSERT INTO accounts"),
+      );
+      expect(insertCall).toBeDefined();
+      expect(insertCall?.[1]).toEqual([
+        "file-admin",
+        "file-admin",
+        "$argon2id$v=19$mocked-hash",
+        1,
+      ]);
+    });
+
+    it("falls back to env vars when secret files don't exist", async () => {
+      process.env.INIT_ADMIN_USERNAME = "env-admin";
+      process.env.INIT_ADMIN_PASSWORD = "env-pass123";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "uuid-456" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      const insertCall = mockPoolQuery.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("INSERT INTO accounts"),
+      );
+      expect(insertCall?.[1]).toEqual([
+        "env-admin",
+        "env-admin",
+        "$argon2id$v=19$mocked-hash",
+        1,
+      ]);
+    });
+
+    it("prefers secret files over env vars when both exist", async () => {
+      writeSecret("init_admin_username", "file-admin");
+      writeSecret("init_admin_password", "file-pass123");
+      process.env.INIT_ADMIN_USERNAME = "env-admin";
+      process.env.INIT_ADMIN_PASSWORD = "env-pass123";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "uuid-789" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      const insertCall = mockPoolQuery.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("INSERT INTO accounts"),
+      );
+      expect(insertCall?.[1]?.[0]).toBe("file-admin");
+    });
+
+    it("skips when consumed marker exists", async () => {
+      writeSecret("init_admin_username", "file-admin");
+      writeSecret("init_admin_password", "file-pass123");
+
+      // Write consumed marker
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(path.join(dataDir, ".init_admin_consumed"), "consumed");
+
+      // No env vars set → no credentials available
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      // No INSERT should have been attempted
+      const insertCalls = mockPoolQuery.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("INSERT INTO accounts"),
+      );
+      expect(insertCalls).toHaveLength(0);
+    });
+
+    it("returns early when no credentials are available", async () => {
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      // Only the COUNT query should have been made
+      expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── account creation ────────────────────────────────────────────
+
+  describe("account creation", () => {
+    it("creates admin when accounts table is empty", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "new-uuid" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      const insertCall = mockPoolQuery.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("INSERT INTO accounts"),
+      );
+      expect(insertCall).toBeDefined();
+      // must_change_password=true is in the SQL literal
+      expect(insertCall?.[0]).toContain("true");
+    });
+
+    it("skips when accounts already exist", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "3" }],
+        rowCount: 1,
+      });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("inserts password_history entry", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "new-uuid" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      const historyCall = mockPoolQuery.mock.calls.find(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("INSERT INTO password_history"),
+      );
+      expect(historyCall).toBeDefined();
+      expect(historyCall?.[1]).toEqual([
+        "new-uuid",
+        "$argon2id$v=19$mocked-hash",
+      ]);
+    });
+
+    it("throws when System Administrator role is missing", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      // Role lookup returns empty
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await expect(bootstrap.bootstrapAdminAccount()).rejects.toThrow(
+        'Role "System Administrator" not found',
+      );
+    });
+  });
+
+  // ── race condition handling ─────────────────────────────────────
+
+  describe("race condition handling", () => {
+    it("handles concurrent insert gracefully (INSERT returns 0 rows)", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      // COUNT returns 0 (stale read)
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      // INSERT returns 0 rows (another instance won)
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      // Should not throw
+      await bootstrap.bootstrapAdminAccount();
+
+      // No audit log should be written
+      expect(mockAuditPoolQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── secret file consumption ─────────────────────────────────────
+
+  describe("secret file consumption", () => {
+    it("deletes secret files after successful bootstrap", async () => {
+      writeSecret("init_admin_username", "file-admin");
+      writeSecret("init_admin_password", "file-pass123");
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "uuid-del" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      // Verify unlinkSync was called for both secret paths
+      const fs = await import("node:fs");
+      const unlinkCalls = vi.mocked(fs.unlinkSync).mock.calls.map((c) => c[0]);
+      expect(unlinkCalls).toContain("/run/secrets/init_admin_username");
+      expect(unlinkCalls).toContain("/run/secrets/init_admin_password");
+    });
+
+    it("writes consumed marker when deletion fails", async () => {
+      writeSecret("init_admin_username", "file-admin");
+      writeSecret("init_admin_password", "file-pass123");
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "uuid-marker" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      // Make unlinkSync throw for secret paths
+      const fs = await import("node:fs");
+      vi.mocked(fs.unlinkSync).mockImplementation((filePath: PathLike) => {
+        const fp = String(filePath);
+        if (
+          fp === "/run/secrets/init_admin_username" ||
+          fp === "/run/secrets/init_admin_password"
+        ) {
+          throw new Error("EROFS: read-only file system");
+        }
+      });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      // Verify marker was written to disk (writeFileSync uses real impl via ...actual)
+      const markerPath = path.join(dataDir, ".init_admin_consumed");
+      const { existsSync, readFileSync } = await import("node:fs");
+      expect(existsSync(markerPath)).toBe(true);
+      const content = readFileSync(markerPath, "utf8");
+      // Marker contains an ISO timestamp
+      expect(content).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("does not consume files when source is env_var", async () => {
+      process.env.INIT_ADMIN_USERNAME = "env-admin";
+      process.env.INIT_ADMIN_PASSWORD = "env-pass123";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "uuid-env" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      const fs = await import("node:fs");
+      expect(vi.mocked(fs.unlinkSync)).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── audit logging ───────────────────────────────────────────────
+
+  describe("audit logging", () => {
+    it("writes audit log entry on successful creation", async () => {
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "audit-uuid" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await bootstrap.bootstrapAdminAccount();
+
+      expect(mockAuditPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO audit_logs"),
+        [
+          "system",
+          "account.create",
+          "account",
+          "audit-uuid",
+          JSON.stringify({
+            username: "admin",
+            role: "System Administrator",
+            source: "bootstrap",
+          }),
+        ],
+      );
+      expect(mockAuditPoolEnd).toHaveBeenCalled();
+    });
+
+    it("warns but does not fail when AUDIT_DATABASE_URL is missing", async () => {
+      delete process.env.AUDIT_DATABASE_URL;
+
+      process.env.INIT_ADMIN_USERNAME = "admin";
+      process.env.INIT_ADMIN_PASSWORD = "secure-password";
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ count: "0" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1 }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: "no-audit-uuid" }],
+        rowCount: 1,
+      });
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await bootstrap.bootstrapAdminAccount();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "AUDIT_DATABASE_URL not set; skipping bootstrap audit log entry",
+      );
+      expect(mockAuditPoolQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── constants ───────────────────────────────────────────────────
+
+  describe("constants", () => {
+    it("exports MAX_SYSTEM_ADMINISTRATORS as 5", () => {
+      expect(bootstrap.MAX_SYSTEM_ADMINISTRATORS).toBe(5);
+    });
+  });
+});

--- a/src/__tests__/lib/auth/password.test.ts
+++ b/src/__tests__/lib/auth/password.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { hashPassword, verifyPassword } from "@/lib/auth/password";
+
+describe("password", () => {
+  describe("hashPassword", () => {
+    it("returns an Argon2id PHC string", async () => {
+      const hash = await hashPassword("test-password");
+
+      expect(hash).toMatch(/^\$argon2id\$/);
+    });
+
+    it("produces different hashes for the same input (random salt)", async () => {
+      const hash1 = await hashPassword("same-password");
+      const hash2 = await hashPassword("same-password");
+
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe("verifyPassword", () => {
+    it("returns true for a matching password", async () => {
+      const hash = await hashPassword("correct-password");
+
+      const result = await verifyPassword(hash, "correct-password");
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false for a non-matching password", async () => {
+      const hash = await hashPassword("correct-password");
+
+      const result = await verifyPassword(hash, "wrong-password");
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { runStartupMigrations } = await import("@/lib/db/migrate");
+    const { bootstrapAdminAccount } = await import("@/lib/auth/bootstrap");
+
+    await runStartupMigrations();
+    await bootstrapAdminAccount();
+  }
+}

--- a/src/lib/auth/bootstrap.ts
+++ b/src/lib/auth/bootstrap.ts
@@ -211,8 +211,15 @@ export async function bootstrapAdminAccount(): Promise<void> {
     [accountId, passwordHash],
   );
 
-  // Step 7: Write audit log
-  await writeBootstrapAuditLog(accountId, username);
+  // Step 7: Write audit log (non-fatal — account is already created)
+  try {
+    await writeBootstrapAuditLog(accountId, username);
+  } catch (error) {
+    console.warn(
+      "Failed to write bootstrap audit log; admin account was created successfully",
+      error,
+    );
+  }
 
   // Step 8: Consume secret files if source was secret_file
   if (source === "secret_file") {

--- a/src/lib/auth/bootstrap.ts
+++ b/src/lib/auth/bootstrap.ts
@@ -1,0 +1,221 @@
+import "server-only";
+
+import {
+  accessSync,
+  constants,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { connectTo, query } from "@/lib/db/client";
+
+import { hashPassword } from "./password";
+
+const SYSTEM_ADMIN_ROLE_NAME = "System Administrator";
+
+/** Hardcoded upper bound for System Administrator accounts (Discussion #32 §4.5). */
+export const MAX_SYSTEM_ADMINISTRATORS = 5;
+
+const SECRET_USERNAME_PATH = "/run/secrets/init_admin_username";
+const SECRET_PASSWORD_PATH = "/run/secrets/init_admin_password";
+const CONSUMED_MARKER_FILENAME = ".init_admin_consumed";
+
+function getDataDir(): string {
+  const dir = process.env.DATA_DIR || path.join(process.cwd(), "data");
+  return path.resolve(dir);
+}
+
+function isConsumedMarkerPresent(): boolean {
+  try {
+    accessSync(
+      path.join(getDataDir(), CONSUMED_MARKER_FILENAME),
+      constants.F_OK,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readSecretFiles(): { username: string; password: string } | null {
+  if (isConsumedMarkerPresent()) {
+    return null;
+  }
+
+  try {
+    const username = readFileSync(SECRET_USERNAME_PATH, "utf8").trim();
+    const password = readFileSync(SECRET_PASSWORD_PATH, "utf8").trim();
+
+    if (!username || !password) {
+      return null;
+    }
+
+    return { username, password };
+  } catch {
+    return null;
+  }
+}
+
+function readEnvCredentials(): { username: string; password: string } | null {
+  const username = process.env.INIT_ADMIN_USERNAME?.trim();
+  const password = process.env.INIT_ADMIN_PASSWORD?.trim();
+
+  if (!username || !password) {
+    return null;
+  }
+
+  return { username, password };
+}
+
+function resolveCredentials(): {
+  username: string;
+  password: string;
+  source: "secret_file" | "env_var";
+} | null {
+  const fromFile = readSecretFiles();
+  if (fromFile) {
+    return { ...fromFile, source: "secret_file" };
+  }
+
+  const fromEnv = readEnvCredentials();
+  if (fromEnv) {
+    return { ...fromEnv, source: "env_var" };
+  }
+
+  return null;
+}
+
+function consumeSecretFiles(): void {
+  let deletionFailed = false;
+
+  for (const filePath of [SECRET_USERNAME_PATH, SECRET_PASSWORD_PATH]) {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      deletionFailed = true;
+    }
+  }
+
+  if (deletionFailed) {
+    const dataDir = getDataDir();
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      path.join(dataDir, CONSUMED_MARKER_FILENAME),
+      new Date().toISOString(),
+      "utf8",
+    );
+  }
+}
+
+async function writeBootstrapAuditLog(
+  accountId: string,
+  username: string,
+): Promise<void> {
+  const auditUrl = process.env.AUDIT_DATABASE_URL;
+  if (!auditUrl) {
+    console.warn(
+      "AUDIT_DATABASE_URL not set; skipping bootstrap audit log entry",
+    );
+    return;
+  }
+
+  const auditPool = connectTo(auditUrl);
+  try {
+    await auditPool.query(
+      `INSERT INTO audit_logs
+        (actor_id, action, target_type, target_id, details)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [
+        "system",
+        "account.create",
+        "account",
+        accountId,
+        JSON.stringify({
+          username,
+          role: SYSTEM_ADMIN_ROLE_NAME,
+          source: "bootstrap",
+        }),
+      ],
+    );
+  } finally {
+    await auditPool.end();
+  }
+}
+
+/**
+ * Bootstrap the initial System Administrator account on first startup.
+ *
+ * Reads credentials from Docker secret files or environment variables,
+ * hashes the password with Argon2id, and inserts a single admin account
+ * only if the accounts table is empty. Concurrent instances are handled
+ * atomically via INSERT ... WHERE NOT EXISTS.
+ */
+export async function bootstrapAdminAccount(): Promise<void> {
+  // Step 1: Check if accounts already exist
+  const { rows: countRows } = await query<{ count: string }>(
+    "SELECT COUNT(*)::text AS count FROM accounts",
+  );
+  const accountCount = Number.parseInt(countRows[0].count, 10);
+
+  if (accountCount > 0) {
+    return;
+  }
+
+  // Step 2: Resolve credentials
+  const credentials = resolveCredentials();
+  if (!credentials) {
+    return;
+  }
+
+  const { username, password, source } = credentials;
+
+  // Step 3: Look up System Administrator role ID
+  const { rows: roleRows } = await query<{ id: number }>(
+    "SELECT id FROM roles WHERE name = $1",
+    [SYSTEM_ADMIN_ROLE_NAME],
+  );
+
+  if (roleRows.length === 0) {
+    throw new Error(
+      `Role "${SYSTEM_ADMIN_ROLE_NAME}" not found. Ensure migrations have run.`,
+    );
+  }
+
+  const roleId = roleRows[0].id;
+
+  // Step 4: Hash password
+  const passwordHash = await hashPassword(password);
+
+  // Step 5: Insert account with atomic race-condition guard
+  const { rows: insertedRows } = await query<{ id: string }>(
+    `INSERT INTO accounts
+       (username, display_name, password_hash, role_id, must_change_password)
+     SELECT $1, $2, $3, $4, true
+     WHERE NOT EXISTS (SELECT 1 FROM accounts)
+     RETURNING id`,
+    [username, username, passwordHash, roleId],
+  );
+
+  if (insertedRows.length === 0) {
+    return;
+  }
+
+  const accountId = insertedRows[0].id;
+
+  // Step 6: Insert initial password history entry
+  await query(
+    "INSERT INTO password_history (account_id, password_hash) VALUES ($1, $2)",
+    [accountId, passwordHash],
+  );
+
+  // Step 7: Write audit log
+  await writeBootstrapAuditLog(accountId, username);
+
+  // Step 8: Consume secret files if source was secret_file
+  if (source === "secret_file") {
+    consumeSecretFiles();
+  }
+}

--- a/src/lib/auth/password.ts
+++ b/src/lib/auth/password.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import argon2 from "argon2";
+
+/**
+ * Hash a plaintext password using Argon2id.
+ * Returns a PHC-format string: $argon2id$v=19$m=65536,t=3,p=4$<salt>$<hash>
+ */
+export async function hashPassword(password: string): Promise<string> {
+  return argon2.hash(password, {
+    type: argon2.argon2id,
+  });
+}
+
+/**
+ * Verify a plaintext password against an Argon2id PHC string.
+ */
+export async function verifyPassword(
+  hash: string,
+  password: string,
+): Promise<boolean> {
+  return argon2.verify(hash, password);
+}


### PR DESCRIPTION
## Summary

- Add Argon2id password hashing module (`src/lib/auth/password.ts`) with `hashPassword` and `verifyPassword` functions
- Implement admin bootstrap logic (`src/lib/auth/bootstrap.ts`) that creates the first System Administrator account on startup from Docker secret files or environment variables
- Add Next.js instrumentation hook (`src/instrumentation.ts`) to run migrations then bootstrap on Node.js startup
- Atomic INSERT with `WHERE NOT EXISTS` guard prevents race conditions across concurrent instances
- Secret files are consumed (deleted or marked) after use to prevent re-processing

## Verification

- [x] `pnpm check` — Biome lint/format passes
- [x] `pnpm typecheck` — TypeScript compilation passes
- [x] `pnpm test` — 135 tests pass (17 new bootstrap + 4 new password tests)
- [x] `pnpm build` — Next.js build succeeds

## Test plan

- Credential resolution: secret files, env var fallback, file priority, consumed marker blocks, no credentials → early return
- Account creation: creates when empty, skips when accounts exist, sets `must_change_password=true`, inserts password_history, throws when role missing
- Race condition: INSERT returns 0 rows → returns gracefully
- Secret consumption: deletes files, writes marker on deletion failure, no consumption for env var source
- Audit logging: writes to audit_db, warns but succeeds when AUDIT_DATABASE_URL missing, warns but succeeds when audit DB query throws
- Password hashing: PHC format, random salt, verify true/false

Closes #56