### PR TITLE
Add JWT infrastructure for authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/auth_db
 AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5432/audit_db
 
 DATA_DIR=./data
+JWT_EXPIRATION_MINUTES=15
 INIT_ADMIN_USERNAME=
 INIT_ADMIN_PASSWORD=
 

--- a/src/__tests__/lib/auth/cookies.test.ts
+++ b/src/__tests__/lib/auth/cookies.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSet = vi.hoisted(() => vi.fn());
+const mockGet = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({
+    set: mockSet,
+    get: mockGet,
+    delete: mockDelete,
+  })),
+}));
+
+describe("cookies", () => {
+  let cookiesMod: typeof import("@/lib/auth/cookies");
+
+  beforeEach(async () => {
+    mockSet.mockReset();
+    mockGet.mockReset();
+    mockDelete.mockReset();
+
+    cookiesMod = await import("@/lib/auth/cookies");
+  });
+
+  describe("ACCESS_TOKEN_COOKIE", () => {
+    it("is 'at'", () => {
+      expect(cookiesMod.ACCESS_TOKEN_COOKIE).toBe("at");
+    });
+  });
+
+  describe("setAccessTokenCookie", () => {
+    it("sets the cookie with correct name, value, and options", async () => {
+      await cookiesMod.setAccessTokenCookie("my-token", 900);
+
+      expect(mockSet).toHaveBeenCalledWith("at", "my-token", {
+        httpOnly: true,
+        secure: false, // NODE_ENV !== "production" in test
+        sameSite: "strict",
+        path: "/",
+        maxAge: 900,
+      });
+    });
+
+    it("passes maxAge through", async () => {
+      await cookiesMod.setAccessTokenCookie("tok", 300);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        "at",
+        "tok",
+        expect.objectContaining({ maxAge: 300 }),
+      );
+    });
+  });
+
+  describe("getAccessTokenCookie", () => {
+    it("returns the token value when cookie exists", async () => {
+      mockGet.mockReturnValue({ value: "stored-token" });
+
+      const result = await cookiesMod.getAccessTokenCookie();
+      expect(result).toBe("stored-token");
+      expect(mockGet).toHaveBeenCalledWith("at");
+    });
+
+    it("returns undefined when cookie does not exist", async () => {
+      mockGet.mockReturnValue(undefined);
+
+      const result = await cookiesMod.getAccessTokenCookie();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("deleteAccessTokenCookie", () => {
+    it("calls delete with the correct cookie name", async () => {
+      await cookiesMod.deleteAccessTokenCookie();
+
+      expect(mockDelete).toHaveBeenCalledWith("at");
+    });
+  });
+});

--- a/src/__tests__/lib/auth/data-dir.test.ts
+++ b/src/__tests__/lib/auth/data-dir.test.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("getDataDir", () => {
+  const originalDataDir = process.env.DATA_DIR;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.DATA_DIR;
+  });
+
+  afterEach(() => {
+    if (originalDataDir !== undefined) {
+      process.env.DATA_DIR = originalDataDir;
+    } else {
+      delete process.env.DATA_DIR;
+    }
+  });
+
+  it("returns DATA_DIR env when set", async () => {
+    process.env.DATA_DIR = "/custom/data";
+    const { getDataDir } = await import("@/lib/auth/data-dir");
+
+    expect(getDataDir()).toBe("/custom/data");
+  });
+
+  it("defaults to cwd()/data when DATA_DIR is not set", async () => {
+    const { getDataDir } = await import("@/lib/auth/data-dir");
+
+    expect(getDataDir()).toBe(path.resolve(process.cwd(), "data"));
+  });
+
+  it("resolves relative paths", async () => {
+    process.env.DATA_DIR = "./relative/data";
+    const { getDataDir } = await import("@/lib/auth/data-dir");
+
+    expect(path.isAbsolute(getDataDir())).toBe(true);
+    expect(getDataDir()).toBe(path.resolve("./relative/data"));
+  });
+});

--- a/src/__tests__/lib/auth/guard.test.ts
+++ b/src/__tests__/lib/auth/guard.test.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const mockGetAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockVerifyJwtFull = vi.hoisted(() => vi.fn());
+const mockPoolQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/cookies", () => ({
+  getAccessTokenCookie: mockGetAccessTokenCookie,
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  verifyJwtFull: mockVerifyJwtFull,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+}));
+
+describe("withAuth", () => {
+  let guard: typeof import("@/lib/auth/guard");
+
+  const validSession: AuthSession = {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["admin"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+  };
+
+  function makeRequest(url = "http://localhost:3000/api/test") {
+    return new NextRequest(url);
+  }
+
+  function makeContext() {
+    return { params: Promise.resolve({}) };
+  }
+
+  beforeEach(async () => {
+    mockGetAccessTokenCookie.mockReset();
+    mockVerifyJwtFull.mockReset();
+    mockPoolQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+
+    guard = await import("@/lib/auth/guard");
+  });
+
+  it("returns 401 when no cookie is present", async () => {
+    mockGetAccessTokenCookie.mockResolvedValue(undefined);
+
+    const handler = vi.fn();
+    const wrapped = guard.withAuth(handler);
+    const response = await wrapped(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Authentication required");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token verification fails", async () => {
+    mockGetAccessTokenCookie.mockResolvedValue("bad-token");
+    mockVerifyJwtFull.mockRejectedValue(new Error("Invalid token"));
+
+    const handler = vi.fn();
+    const wrapped = guard.withAuth(handler);
+    const response = await wrapped(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Invalid or expired token");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when mustChangePassword is true", async () => {
+    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue({
+      ...validSession,
+      mustChangePassword: true,
+    });
+
+    const handler = vi.fn();
+    const wrapped = guard.withAuth(handler);
+    const response = await wrapped(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Password change required");
+    expect(body.redirect).toBe("/change-password");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("calls handler with session on valid token", async () => {
+    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(validSession);
+
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = guard.withAuth(handler);
+    const request = makeRequest();
+    const context = makeContext();
+
+    const response = await wrapped(request, context);
+    const body = await response.json();
+
+    expect(body.ok).toBe(true);
+    expect(handler).toHaveBeenCalledWith(request, context, validSession);
+  });
+
+  it("updates last_active_at in the database", async () => {
+    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(validSession);
+
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = guard.withAuth(handler);
+    await wrapped(makeRequest(), makeContext());
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE sessions SET last_active_at"),
+      ["session-1"],
+    );
+  });
+
+  it("updates last_active_at before calling the handler", async () => {
+    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+    mockVerifyJwtFull.mockResolvedValue(validSession);
+
+    const callOrder: string[] = [];
+
+    mockPoolQuery.mockImplementation(async () => {
+      callOrder.push("db-update");
+      return { rows: [], rowCount: 0 };
+    });
+
+    const handler = vi.fn().mockImplementation(async () => {
+      callOrder.push("handler");
+      return NextResponse.json({ ok: true });
+    });
+
+    const wrapped = guard.withAuth(handler);
+    await wrapped(makeRequest(), makeContext());
+
+    expect(callOrder).toEqual(["db-update", "handler"]);
+  });
+});

--- a/src/__tests__/lib/auth/jwt-keys.test.ts
+++ b/src/__tests__/lib/auth/jwt-keys.test.ts
@@ -1,0 +1,280 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const tmpDir = path.join(__dirname, ".tmp-jwt-keys");
+const dataDir = path.join(tmpDir, "data");
+
+describe("jwt-keys", () => {
+  let jwtKeys: typeof import("@/lib/auth/jwt-keys");
+
+  beforeEach(async () => {
+    mkdirSync(dataDir, { recursive: true });
+    process.env.DATA_DIR = dataDir;
+
+    // Fresh module per test
+    const mod = await import("@/lib/auth/jwt-keys");
+    jwtKeys = mod;
+    jwtKeys.resetKeyState();
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── generateJwtSigningKey ─────────────────────────────────────
+
+  describe("generateJwtSigningKey", () => {
+    it("writes a key file to disk", async () => {
+      await jwtKeys.generateJwtSigningKey();
+
+      const keyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      expect(existsSync(keyPath)).toBe(true);
+
+      const keyFile = JSON.parse(readFileSync(keyPath, "utf8"));
+      expect(keyFile.kid).toBeDefined();
+      expect(keyFile.algorithm).toBe("ES256");
+      expect(keyFile.privateKey).toBeDefined();
+      expect(keyFile.publicKey).toBeDefined();
+    });
+
+    it("creates the keys directory if it does not exist", async () => {
+      const keysDir = path.join(dataDir, "keys");
+      expect(existsSync(keysDir)).toBe(false);
+
+      await jwtKeys.generateJwtSigningKey();
+
+      expect(existsSync(keysDir)).toBe(true);
+    });
+  });
+
+  // ── loadSigningKeys ───────────────────────────────────────────
+
+  describe("loadSigningKeys", () => {
+    it("loads a generated key file", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+
+      await jwtKeys.loadSigningKeys();
+
+      const key = jwtKeys.getSigningKey();
+      expect(key.kid).toBeDefined();
+      expect(key.algorithm).toBe("ES256");
+      expect(key.privateKey).toBeDefined();
+      expect(key.publicKey).toBeDefined();
+    });
+
+    it("throws when key file is missing", async () => {
+      await expect(jwtKeys.loadSigningKeys()).rejects.toThrow(
+        /JWT signing key not found/,
+      );
+    });
+
+    it("loads previous key when present", async () => {
+      // Generate first key
+      await jwtKeys.generateJwtSigningKey();
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      // Copy current to prev and generate new current
+      const firstKey = readFileSync(currentKeyPath, "utf8");
+      writeFileSync(prevKeyPath, firstKey, "utf8");
+      await jwtKeys.generateJwtSigningKey();
+
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      const firstKid = JSON.parse(firstKey).kid;
+      const verificationKey = jwtKeys.getVerificationKey(firstKid);
+      expect(verificationKey).not.toBeNull();
+      expect(verificationKey?.algorithm).toBe("ES256");
+    });
+
+    it("works without a previous key file", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+
+      await jwtKeys.loadSigningKeys();
+
+      // Should not throw, previous key is optional
+      const key = jwtKeys.getSigningKey();
+      expect(key).toBeDefined();
+    });
+  });
+
+  // ── getSigningKey ─────────────────────────────────────────────
+
+  describe("getSigningKey", () => {
+    it("throws when keys are not loaded", () => {
+      expect(() => jwtKeys.getSigningKey()).toThrow(
+        /JWT signing keys not loaded/,
+      );
+    });
+
+    it("returns the current key after loading", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      const key = jwtKeys.getSigningKey();
+      expect(key.kid).toBeDefined();
+      expect(key.privateKey).toBeDefined();
+    });
+  });
+
+  // ── getVerificationKey ────────────────────────────────────────
+
+  describe("getVerificationKey", () => {
+    it("returns current key by kid", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      const key = jwtKeys.getSigningKey();
+      const verificationKey = jwtKeys.getVerificationKey(key.kid);
+      expect(verificationKey).not.toBeNull();
+      expect(verificationKey?.publicKey).toBeDefined();
+    });
+
+    it("returns previous key by kid", async () => {
+      // Setup: current → prev, then new current
+      await jwtKeys.generateJwtSigningKey();
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      const firstKeyData = readFileSync(currentKeyPath, "utf8");
+      const firstKid = JSON.parse(firstKeyData).kid;
+      writeFileSync(prevKeyPath, firstKeyData, "utf8");
+
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      const verificationKey = jwtKeys.getVerificationKey(firstKid);
+      expect(verificationKey).not.toBeNull();
+    });
+
+    it("returns null for unknown kid", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      const result = jwtKeys.getVerificationKey("unknown-kid");
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── getPublicKeyData ──────────────────────────────────────────
+
+  describe("getPublicKeyData", () => {
+    it("returns current key data", async () => {
+      await jwtKeys.generateJwtSigningKey();
+
+      const data = jwtKeys.getPublicKeyData();
+      expect(data).toHaveLength(1);
+      expect(data[0].kid).toBeDefined();
+      expect(data[0].algorithm).toBe("ES256");
+      expect(data[0].publicKey).toBeDefined();
+    });
+
+    it("returns both current and previous key data", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      const firstKey = readFileSync(currentKeyPath, "utf8");
+      writeFileSync(prevKeyPath, firstKey, "utf8");
+      await jwtKeys.generateJwtSigningKey();
+
+      const data = jwtKeys.getPublicKeyData();
+      expect(data).toHaveLength(2);
+      expect(data[0].kid).not.toBe(data[1].kid);
+    });
+
+    it("returns empty array when no keys exist", async () => {
+      const data = jwtKeys.getPublicKeyData();
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  // ── removePreviousKey ─────────────────────────────────────────
+
+  describe("removePreviousKey", () => {
+    it("deletes the previous key file from disk", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      writeFileSync(prevKeyPath, readFileSync(currentKeyPath, "utf8"), "utf8");
+      expect(existsSync(prevKeyPath)).toBe(true);
+
+      jwtKeys.removePreviousKey();
+
+      expect(existsSync(prevKeyPath)).toBe(false);
+    });
+
+    it("does not throw when previous key file does not exist", () => {
+      expect(() => jwtKeys.removePreviousKey()).not.toThrow();
+    });
+
+    it("clears previous key from memory after removal", async () => {
+      // Setup: generate key, copy to prev, generate new, load both
+      await jwtKeys.generateJwtSigningKey();
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      const firstKeyData = readFileSync(currentKeyPath, "utf8");
+      const firstKid = JSON.parse(firstKeyData).kid;
+      writeFileSync(prevKeyPath, firstKeyData, "utf8");
+      await jwtKeys.generateJwtSigningKey();
+
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      // Verify previous key is loaded
+      expect(jwtKeys.getVerificationKey(firstKid)).not.toBeNull();
+
+      // Remove and verify it's cleared
+      jwtKeys.removePreviousKey();
+      expect(jwtKeys.getVerificationKey(firstKid)).toBeNull();
+    });
+  });
+
+  // ── key rotation flow ─────────────────────────────────────────
+
+  describe("key rotation flow", () => {
+    it("supports current → prev rotation with both keys resolvable", async () => {
+      // Generate first key
+      await jwtKeys.generateJwtSigningKey();
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      const firstKeyData = JSON.parse(readFileSync(currentKeyPath, "utf8"));
+
+      // Rotate: move current to prev, generate new current
+      writeFileSync(prevKeyPath, JSON.stringify(firstKeyData, null, 2), "utf8");
+      await jwtKeys.generateJwtSigningKey();
+
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      const currentKey = jwtKeys.getSigningKey();
+      const newKid = currentKey.kid;
+      const oldKid = firstKeyData.kid;
+
+      // Both kids should be different
+      expect(newKid).not.toBe(oldKid);
+
+      // Both should resolve
+      expect(jwtKeys.getVerificationKey(newKid)).not.toBeNull();
+      expect(jwtKeys.getVerificationKey(oldKid)).not.toBeNull();
+    });
+  });
+});

--- a/src/__tests__/lib/auth/jwt-verify-stateless.test.ts
+++ b/src/__tests__/lib/auth/jwt-verify-stateless.test.ts
@@ -1,0 +1,178 @@
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tmpDir = path.join(__dirname, ".tmp-jwt-stateless");
+const dataDir = path.join(tmpDir, "data");
+
+describe("jwt-verify-stateless", () => {
+  let jwtKeys: typeof import("@/lib/auth/jwt-keys");
+  let jwt: typeof import("@/lib/auth/jwt");
+  let stateless: typeof import("@/lib/auth/jwt-verify-stateless");
+
+  // Mock DB for jwt.ts (issueAccessToken doesn't use DB, but module imports it)
+  const mockPoolQuery = vi.hoisted(() => vi.fn());
+
+  vi.mock("@/lib/db/client", () => ({
+    query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+  }));
+
+  beforeEach(async () => {
+    mkdirSync(dataDir, { recursive: true });
+    process.env.DATA_DIR = dataDir;
+
+    jwtKeys = await import("@/lib/auth/jwt-keys");
+    jwtKeys.resetKeyState();
+
+    await jwtKeys.generateJwtSigningKey();
+    await jwtKeys.loadSigningKeys();
+
+    jwt = await import("@/lib/auth/jwt");
+    stateless = await import("@/lib/auth/jwt-verify-stateless");
+
+    // Initialize stateless keys from the loaded key data
+    const publicKeyData = jwtKeys.getPublicKeyData();
+    await stateless.initStatelessKeys(publicKeyData);
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── verifyJwtStateless ────────────────────────────────────────
+
+  describe("verifyJwtStateless", () => {
+    it("verifies a valid token and returns payload", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      const payload = await stateless.verifyJwtStateless(token);
+
+      expect(payload.sub).toBe("account-1");
+      expect(payload.sid).toBe("session-1");
+      expect(payload.roles).toEqual(["admin"]);
+      expect(payload.token_version).toBe(0);
+      expect(payload.kid).toBeDefined();
+    });
+
+    it("throws on expired token", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 20 * 60 * 1000);
+
+      await expect(stateless.verifyJwtStateless(token)).rejects.toThrow();
+
+      vi.useRealTimers();
+    });
+
+    it("throws when kid does not match any initialized key", async () => {
+      const { SignJWT, generateKeyPair } = await import("jose");
+      const { privateKey } = await generateKeyPair("ES256");
+
+      const token = await new SignJWT({
+        sid: "s",
+        roles: [],
+        token_version: 0,
+        kid: "unknown-kid",
+      })
+        .setProtectedHeader({ alg: "ES256", kid: "unknown-kid" })
+        .setIssuer("aice-web-next")
+        .setSubject("acc")
+        .setAudience("aice-web-next")
+        .setIssuedAt()
+        .setExpirationTime("5m")
+        .sign(privateKey);
+
+      await expect(stateless.verifyJwtStateless(token)).rejects.toThrow(
+        "No verification key found",
+      );
+    });
+
+    it("throws when kid is missing from header", async () => {
+      const { SignJWT, generateKeyPair } = await import("jose");
+      const { privateKey } = await generateKeyPair("ES256");
+
+      const token = await new SignJWT({ sid: "s", roles: [] })
+        .setProtectedHeader({ alg: "ES256" })
+        .setSubject("acc")
+        .setIssuedAt()
+        .setExpirationTime("5m")
+        .sign(privateKey);
+
+      await expect(stateless.verifyJwtStateless(token)).rejects.toThrow(
+        "JWT header missing kid",
+      );
+    });
+
+    it("throws on tampered token (wrong signature)", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      // Tamper with the signature part
+      const parts = token.split(".");
+      parts[2] = `${parts[2]}tampered`;
+      const tamperedToken = parts.join(".");
+
+      await expect(
+        stateless.verifyJwtStateless(tamperedToken),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── multiple keys (rotation) ──────────────────────────────────
+
+  describe("key rotation support", () => {
+    it("verifies tokens signed with both current and previous keys", async () => {
+      // Issue a token with the first key
+      const tokenWithFirstKey = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      // Rotate: save current key file as prev, generate new
+      const { readFileSync, writeFileSync } = await import("node:fs");
+      const currentKeyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const prevKeyPath = path.join(dataDir, "keys", "jwt-signing.prev.json");
+
+      writeFileSync(prevKeyPath, readFileSync(currentKeyPath, "utf8"), "utf8");
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      // Issue a token with the new key
+      const tokenWithNewKey = await jwt.issueAccessToken({
+        accountId: "account-2",
+        sessionId: "session-2",
+        roles: ["viewer"],
+        tokenVersion: 1,
+      });
+
+      // Re-init stateless keys with both
+      await stateless.initStatelessKeys(jwtKeys.getPublicKeyData());
+
+      // Both tokens should verify
+      const payload1 = await stateless.verifyJwtStateless(tokenWithFirstKey);
+      expect(payload1.sub).toBe("account-1");
+
+      const payload2 = await stateless.verifyJwtStateless(tokenWithNewKey);
+      expect(payload2.sub).toBe("account-2");
+    });
+  });
+});

--- a/src/__tests__/lib/auth/jwt.test.ts
+++ b/src/__tests__/lib/auth/jwt.test.ts
@@ -1,0 +1,284 @@
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { decodeJwt, decodeProtectedHeader } from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPoolQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+}));
+
+const tmpDir = path.join(__dirname, ".tmp-jwt");
+const dataDir = path.join(tmpDir, "data");
+
+describe("jwt", () => {
+  let jwtKeys: typeof import("@/lib/auth/jwt-keys");
+  let jwt: typeof import("@/lib/auth/jwt");
+
+  beforeEach(async () => {
+    mkdirSync(dataDir, { recursive: true });
+    process.env.DATA_DIR = dataDir;
+    mockPoolQuery.mockReset();
+
+    jwtKeys = await import("@/lib/auth/jwt-keys");
+    jwtKeys.resetKeyState();
+
+    // Generate and load a key pair
+    await jwtKeys.generateJwtSigningKey();
+    await jwtKeys.loadSigningKeys();
+
+    jwt = await import("@/lib/auth/jwt");
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── issueAccessToken ──────────────────────────────────────────
+
+  describe("issueAccessToken", () => {
+    it("returns a valid JWT string", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      expect(typeof token).toBe("string");
+      expect(token.split(".")).toHaveLength(3);
+    });
+
+    it("includes correct claims in the payload", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin", "viewer"],
+        tokenVersion: 3,
+      });
+
+      const payload = decodeJwt(token);
+      expect(payload.iss).toBe("aice-web-next");
+      expect(payload.sub).toBe("account-1");
+      expect(payload.aud).toBe("aice-web-next");
+      expect(payload.sid).toBe("session-1");
+      expect(payload.roles).toEqual(["admin", "viewer"]);
+      expect(payload.token_version).toBe(3);
+      expect(payload.kid).toBeDefined();
+      expect(payload.iat).toBeDefined();
+      expect(payload.exp).toBeDefined();
+    });
+
+    it("sets kid in the protected header", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      const header = decodeProtectedHeader(token);
+      expect(header.kid).toBeDefined();
+      expect(header.alg).toBe("ES256");
+    });
+
+    it("clamps expiration to min 5 minutes", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+        expirationMinutes: 1,
+      });
+
+      const payload = decodeJwt(token);
+      const iat = payload.iat as number;
+      const exp = payload.exp as number;
+      const diffMinutes = (exp - iat) / 60;
+      expect(diffMinutes).toBeCloseTo(5, 0);
+    });
+
+    it("clamps expiration to max 15 minutes", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+        expirationMinutes: 60,
+      });
+
+      const payload = decodeJwt(token);
+      const iat = payload.iat as number;
+      const exp = payload.exp as number;
+      const diffMinutes = (exp - iat) / 60;
+      expect(diffMinutes).toBeCloseTo(15, 0);
+    });
+
+    it("uses default 15 minute expiration", async () => {
+      const token = await jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+
+      const payload = decodeJwt(token);
+      const iat = payload.iat as number;
+      const exp = payload.exp as number;
+      const diffMinutes = (exp - iat) / 60;
+      expect(diffMinutes).toBeCloseTo(15, 0);
+    });
+  });
+
+  // ── verifyJwtFull ─────────────────────────────────────────────
+
+  describe("verifyJwtFull", () => {
+    const validDbRow = {
+      sid: "session-1",
+      revoked: false,
+      token_version: 0,
+      status: "active",
+      must_change_password: false,
+    };
+
+    async function issueValidToken() {
+      return jwt.issueAccessToken({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+    }
+
+    it("returns AuthSession on valid token with valid DB state", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({ rows: [validDbRow] });
+
+      const session = await jwt.verifyJwtFull(token);
+
+      expect(session.accountId).toBe("account-1");
+      expect(session.sessionId).toBe("session-1");
+      expect(session.roles).toEqual(["admin"]);
+      expect(session.tokenVersion).toBe(0);
+      expect(session.mustChangePassword).toBe(false);
+    });
+
+    it("includes mustChangePassword from DB", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ ...validDbRow, must_change_password: true }],
+      });
+
+      const session = await jwt.verifyJwtFull(token);
+      expect(session.mustChangePassword).toBe(true);
+    });
+
+    it("throws when session is not found in DB", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow(
+        "Session not found",
+      );
+    });
+
+    it("throws when session is revoked", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ ...validDbRow, revoked: true }],
+      });
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow(
+        "Session has been revoked",
+      );
+    });
+
+    it("throws when account is not active", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ ...validDbRow, status: "disabled" }],
+      });
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow(
+        "Account is not active",
+      );
+    });
+
+    it("throws when token version mismatches", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ ...validDbRow, token_version: 99 }],
+      });
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow(
+        "Token version mismatch",
+      );
+    });
+
+    it("throws on expired token", async () => {
+      // Issue a token, then manipulate the clock
+      const token = await issueValidToken();
+
+      // Advance time beyond expiration
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 20 * 60 * 1000);
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow();
+
+      vi.useRealTimers();
+    });
+
+    it("throws on completely invalid token", async () => {
+      await expect(jwt.verifyJwtFull("not.a.jwt")).rejects.toThrow();
+    });
+
+    it("throws when kid is missing from header", async () => {
+      // Create a manually crafted token without kid using jose
+      const { SignJWT } = await import("jose");
+      const { generateKeyPair } = await import("jose");
+      const { privateKey } = await generateKeyPair("ES256");
+
+      const token = await new SignJWT({ sid: "s", roles: [] })
+        .setProtectedHeader({ alg: "ES256" }) // No kid
+        .setSubject("acc")
+        .setIssuedAt()
+        .setExpirationTime("5m")
+        .sign(privateKey);
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow(
+        "JWT header missing kid",
+      );
+    });
+
+    it("throws when kid does not match any known key", async () => {
+      // Create a token signed with a different key
+      const { SignJWT, generateKeyPair } = await import("jose");
+      const { privateKey } = await generateKeyPair("ES256");
+
+      const token = await new SignJWT({ sid: "s", roles: [] })
+        .setProtectedHeader({ alg: "ES256", kid: "unknown-kid" })
+        .setSubject("acc")
+        .setIssuedAt()
+        .setExpirationTime("5m")
+        .sign(privateKey);
+
+      await expect(jwt.verifyJwtFull(token)).rejects.toThrow(
+        "No verification key found",
+      );
+    });
+
+    it("executes correct JOIN query", async () => {
+      const token = await issueValidToken();
+      mockPoolQuery.mockResolvedValueOnce({ rows: [validDbRow] });
+
+      await jwt.verifyJwtFull(token);
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("JOIN accounts a ON"),
+        ["session-1", "account-1"],
+      );
+    });
+  });
+});

--- a/src/lib/auth/bootstrap.ts
+++ b/src/lib/auth/bootstrap.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 
 import { connectTo, query } from "@/lib/db/client";
 
+import { getDataDir } from "./data-dir";
 import { hashPassword } from "./password";
 
 const SYSTEM_ADMIN_ROLE_NAME = "System Administrator";
@@ -22,11 +23,6 @@ export const MAX_SYSTEM_ADMINISTRATORS = 5;
 const SECRET_USERNAME_PATH = "/run/secrets/init_admin_username";
 const SECRET_PASSWORD_PATH = "/run/secrets/init_admin_password";
 const CONSUMED_MARKER_FILENAME = ".init_admin_consumed";
-
-function getDataDir(): string {
-  const dir = process.env.DATA_DIR || path.join(process.cwd(), "data");
-  return path.resolve(dir);
-}
 
 function isConsumedMarkerPresent(): boolean {
   try {

--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+export const ACCESS_TOKEN_COOKIE = "at";
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict" as const,
+  path: "/",
+};
+
+/** Set the access token cookie with the given max age (in seconds). */
+export async function setAccessTokenCookie(
+  token: string,
+  maxAgeSeconds: number,
+): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(ACCESS_TOKEN_COOKIE, token, {
+    ...COOKIE_OPTIONS,
+    maxAge: maxAgeSeconds,
+  });
+}
+
+/** Read the access token from the cookie. Returns undefined if absent. */
+export async function getAccessTokenCookie(): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  return cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
+}
+
+/** Delete the access token cookie. */
+export async function deleteAccessTokenCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(ACCESS_TOKEN_COOKIE);
+}

--- a/src/lib/auth/data-dir.ts
+++ b/src/lib/auth/data-dir.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+import path from "node:path";
+
+/**
+ * Return the resolved data directory path.
+ * Defaults to `./data` relative to the project root.
+ */
+export function getDataDir(): string {
+  const dir = process.env.DATA_DIR || path.join(process.cwd(), "data");
+  return path.resolve(dir);
+}

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { query } from "@/lib/db/client";
+
+import { getAccessTokenCookie } from "./cookies";
+import type { AuthSession } from "./jwt";
+import { verifyJwtFull } from "./jwt";
+
+// ── Types ───────────────────────────────────────────────────────
+
+type RouteHandler = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+) => Promise<NextResponse | Response>;
+
+type AuthenticatedHandler = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<NextResponse | Response>;
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Higher-order function that wraps Route Handlers with authentication.
+ *
+ * 1. Reads the access token from the cookie
+ * 2. Verifies the token (stateless + DB checks)
+ * 3. Checks must_change_password → 403 with redirect indicator
+ * 4. Updates session last_active_at
+ * 5. Calls the wrapped handler with the authenticated session
+ */
+export function withAuth(handler: AuthenticatedHandler): RouteHandler {
+  return async (request, context) => {
+    // Step 1: Read token from cookie
+    const token = await getAccessTokenCookie();
+    if (!token) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    // Step 2: Full JWT verification (stateless + DB checks)
+    let session: AuthSession;
+    try {
+      session = await verifyJwtFull(token);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid or expired token" },
+        { status: 401 },
+      );
+    }
+
+    // Step 3: Check must_change_password
+    if (session.mustChangePassword) {
+      return NextResponse.json(
+        { error: "Password change required", redirect: "/change-password" },
+        { status: 403 },
+      );
+    }
+
+    // Step 4: Update last_active_at on the session
+    await query("UPDATE sessions SET last_active_at = NOW() WHERE sid = $1", [
+      session.sessionId,
+    ]);
+
+    // Step 5: Invoke the authenticated handler
+    return handler(request, context, session);
+  };
+}

--- a/src/lib/auth/jwt-keys.ts
+++ b/src/lib/auth/jwt-keys.ts
@@ -1,0 +1,207 @@
+import "server-only";
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import type { CryptoKey, JWK } from "jose";
+import { exportJWK, generateKeyPair, importJWK } from "jose";
+
+import { getDataDir } from "./data-dir";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface JwtKeyFile {
+  kid: string;
+  algorithm: string;
+  privateKey: JWK;
+  publicKey: JWK;
+}
+
+interface LoadedKeyPair {
+  kid: string;
+  algorithm: string;
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+}
+
+interface LoadedPublicKey {
+  kid: string;
+  algorithm: string;
+  publicKey: CryptoKey;
+}
+
+// ── Module state ────────────────────────────────────────────────
+
+let currentKey: LoadedKeyPair | null = null;
+let previousKey: LoadedPublicKey | null = null;
+
+// ── File paths ──────────────────────────────────────────────────
+
+function keysDir(): string {
+  return path.join(getDataDir(), "keys");
+}
+
+function currentKeyPath(): string {
+  return path.join(keysDir(), "jwt-signing.json");
+}
+
+function previousKeyPath(): string {
+  return path.join(keysDir(), "jwt-signing.prev.json");
+}
+
+// ── Key file I/O ────────────────────────────────────────────────
+
+function readKeyFile(filePath: string): JwtKeyFile | null {
+  try {
+    const content = readFileSync(filePath, "utf8");
+    return JSON.parse(content) as JwtKeyFile;
+  } catch {
+    return null;
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Load JWT signing keys from disk.
+ * Current key is required (throws if missing); previous key is optional.
+ */
+export async function loadSigningKeys(): Promise<void> {
+  const currentFile = readKeyFile(currentKeyPath());
+  if (!currentFile) {
+    throw new Error(
+      `JWT signing key not found at ${currentKeyPath()}. Generate one before starting.`,
+    );
+  }
+
+  currentKey = {
+    kid: currentFile.kid,
+    algorithm: currentFile.algorithm,
+    privateKey: (await importJWK(
+      currentFile.privateKey,
+      currentFile.algorithm,
+    )) as CryptoKey,
+    publicKey: (await importJWK(
+      currentFile.publicKey,
+      currentFile.algorithm,
+    )) as CryptoKey,
+  };
+
+  const prevFile = readKeyFile(previousKeyPath());
+  if (prevFile) {
+    previousKey = {
+      kid: prevFile.kid,
+      algorithm: prevFile.algorithm,
+      publicKey: (await importJWK(
+        prevFile.publicKey,
+        prevFile.algorithm,
+      )) as CryptoKey,
+    };
+  } else {
+    previousKey = null;
+  }
+}
+
+/** Return the current signing key pair. Throws if not loaded. */
+export function getSigningKey(): LoadedKeyPair {
+  if (!currentKey) {
+    throw new Error(
+      "JWT signing keys not loaded. Call loadSigningKeys() first.",
+    );
+  }
+  return currentKey;
+}
+
+/** Look up a verification key by `kid`. Returns null if unknown. */
+export function getVerificationKey(
+  kid: string,
+): { publicKey: CryptoKey; algorithm: string } | null {
+  if (currentKey?.kid === kid) {
+    return { publicKey: currentKey.publicKey, algorithm: currentKey.algorithm };
+  }
+  if (previousKey?.kid === kid) {
+    return {
+      publicKey: previousKey.publicKey,
+      algorithm: previousKey.algorithm,
+    };
+  }
+  return null;
+}
+
+/**
+ * Return raw JWK public key data for all loaded keys.
+ * Used to initialize the Edge-compatible stateless verifier.
+ */
+export function getPublicKeyData(): Array<{
+  kid: string;
+  algorithm: string;
+  publicKey: JWK;
+}> {
+  const keys: Array<{ kid: string; algorithm: string; publicKey: JWK }> = [];
+
+  const currentFile = readKeyFile(currentKeyPath());
+  if (currentFile) {
+    keys.push({
+      kid: currentFile.kid,
+      algorithm: currentFile.algorithm,
+      publicKey: currentFile.publicKey,
+    });
+  }
+
+  const prevFile = readKeyFile(previousKeyPath());
+  if (prevFile) {
+    keys.push({
+      kid: prevFile.kid,
+      algorithm: prevFile.algorithm,
+      publicKey: prevFile.publicKey,
+    });
+  }
+
+  return keys;
+}
+
+/**
+ * Generate a new JWT signing key pair and write it to disk.
+ * Defaults to ES256 (ECDSA P-256).
+ */
+export async function generateJwtSigningKey(
+  algorithm = "ES256",
+): Promise<void> {
+  const { privateKey, publicKey } = await generateKeyPair(algorithm, {
+    extractable: true,
+  });
+
+  const kid = randomUUID();
+  const privateJwk = await exportJWK(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+
+  privateJwk.kid = kid;
+  publicJwk.kid = kid;
+
+  const keyFile: JwtKeyFile = {
+    kid,
+    algorithm,
+    privateKey: privateJwk,
+    publicKey: publicJwk,
+  };
+
+  const dir = keysDir();
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(currentKeyPath(), JSON.stringify(keyFile, null, 2), "utf8");
+}
+
+/** Delete the previous key file and clear it from memory. */
+export function removePreviousKey(): void {
+  try {
+    unlinkSync(previousKeyPath());
+  } catch {
+    // Already absent — no-op
+  }
+  previousKey = null;
+}
+
+/** Reset in-memory state. For testing only. */
+export function resetKeyState(): void {
+  currentKey = null;
+  previousKey = null;
+}

--- a/src/lib/auth/jwt-verify-stateless.ts
+++ b/src/lib/auth/jwt-verify-stateless.ts
@@ -1,0 +1,78 @@
+// Edge Runtime compatible — no "server-only", no node:* imports, no DB
+
+import type { CryptoKey, JWK, JWTPayload } from "jose";
+import { decodeProtectedHeader, importJWK, jwtVerify } from "jose";
+
+const JWT_ISSUER = "aice-web-next";
+const JWT_AUDIENCE = "aice-web-next";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface StatelessPayload extends JWTPayload {
+  sub: string;
+  sid: string;
+  roles: string[];
+  token_version: number;
+  kid: string;
+}
+
+interface VerificationKeyEntry {
+  kid: string;
+  algorithm: string;
+  publicKey: CryptoKey;
+}
+
+// ── Module state ────────────────────────────────────────────────
+
+let verificationKeys: VerificationKeyEntry[] = [];
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Initialize stateless verification keys from JWK public keys.
+ * Called once at startup (from middleware or server initialization).
+ * Accepts raw JWK objects so no file I/O is needed.
+ */
+export async function initStatelessKeys(
+  keys: Array<{ kid: string; algorithm: string; publicKey: JWK }>,
+): Promise<void> {
+  verificationKeys = await Promise.all(
+    keys.map(async (k) => ({
+      kid: k.kid,
+      algorithm: k.algorithm,
+      publicKey: (await importJWK(k.publicKey, k.algorithm)) as CryptoKey,
+    })),
+  );
+}
+
+/**
+ * Verify a JWT using only cryptographic checks (signature, exp, kid).
+ * No database access — safe for Edge Runtime / Next.js middleware.
+ */
+export async function verifyJwtStateless(
+  token: string,
+): Promise<StatelessPayload> {
+  const header = decodeProtectedHeader(token);
+  const kid = header.kid;
+
+  if (!kid) {
+    throw new Error("JWT header missing kid");
+  }
+
+  const keyEntry = verificationKeys.find((k) => k.kid === kid);
+  if (!keyEntry) {
+    throw new Error(`No verification key found for kid: ${kid}`);
+  }
+
+  const { payload } = await jwtVerify<StatelessPayload>(
+    token,
+    keyEntry.publicKey,
+    {
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
+      algorithms: [keyEntry.algorithm],
+    },
+  );
+
+  return payload;
+}

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -1,0 +1,149 @@
+import "server-only";
+
+import type { JWTPayload } from "jose";
+import { decodeProtectedHeader, jwtVerify, SignJWT } from "jose";
+
+import { query } from "@/lib/db/client";
+
+import { getSigningKey, getVerificationKey } from "./jwt-keys";
+
+// ── Constants ───────────────────────────────────────────────────
+
+const JWT_ISSUER = "aice-web-next";
+const JWT_AUDIENCE = "aice-web-next";
+
+const DEFAULT_EXPIRATION_MINUTES = 15;
+const MIN_EXPIRATION_MINUTES = 5;
+const MAX_EXPIRATION_MINUTES = 15;
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface AccessTokenPayload extends JWTPayload {
+  iss: string;
+  sub: string;
+  aud: string;
+  iat: number;
+  exp: number;
+  sid: string;
+  roles: string[];
+  token_version: number;
+  kid: string;
+}
+
+export interface AuthSession {
+  accountId: string;
+  sessionId: string;
+  roles: string[];
+  tokenVersion: number;
+  mustChangePassword: boolean;
+}
+
+// ── Issuance ────────────────────────────────────────────────────
+
+export async function issueAccessToken(params: {
+  accountId: string;
+  sessionId: string;
+  roles: string[];
+  tokenVersion: number;
+  expirationMinutes?: number;
+}): Promise<string> {
+  const { accountId, sessionId, roles, tokenVersion } = params;
+
+  const expMinutes = Math.max(
+    MIN_EXPIRATION_MINUTES,
+    Math.min(
+      MAX_EXPIRATION_MINUTES,
+      params.expirationMinutes ?? DEFAULT_EXPIRATION_MINUTES,
+    ),
+  );
+
+  const key = getSigningKey();
+
+  return new SignJWT({
+    sid: sessionId,
+    roles,
+    token_version: tokenVersion,
+    kid: key.kid,
+  })
+    .setProtectedHeader({ alg: key.algorithm, kid: key.kid })
+    .setIssuer(JWT_ISSUER)
+    .setSubject(accountId)
+    .setAudience(JWT_AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime(`${expMinutes}m`)
+    .sign(key.privateKey);
+}
+
+// ── Stateful verification ───────────────────────────────────────
+
+/**
+ * Fully verify a JWT: stateless checks (signature, exp, kid) plus
+ * database checks (session exists + not revoked, account active,
+ * token_version matches).
+ */
+export async function verifyJwtFull(token: string): Promise<AuthSession> {
+  // Step 1: Decode header to get kid
+  const header = decodeProtectedHeader(token);
+  const kid = header.kid;
+
+  if (!kid) {
+    throw new Error("JWT header missing kid");
+  }
+
+  const keyInfo = getVerificationKey(kid);
+  if (!keyInfo) {
+    throw new Error(`No verification key found for kid: ${kid}`);
+  }
+
+  // Step 2: Verify signature, exp, iss, aud
+  const { payload } = await jwtVerify<AccessTokenPayload>(
+    token,
+    keyInfo.publicKey,
+    {
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
+      algorithms: [keyInfo.algorithm],
+    },
+  );
+
+  // Step 3: Database checks — single JOIN query
+  const { rows } = await query<{
+    sid: string;
+    revoked: boolean;
+    token_version: number;
+    status: string;
+    must_change_password: boolean;
+  }>(
+    `SELECT s.sid, s.revoked, a.token_version, a.status, a.must_change_password
+     FROM sessions s
+     JOIN accounts a ON s.account_id = a.id
+     WHERE s.sid = $1 AND s.account_id = $2`,
+    [payload.sid, payload.sub],
+  );
+
+  if (rows.length === 0) {
+    throw new Error("Session not found");
+  }
+
+  const row = rows[0];
+
+  if (row.revoked) {
+    throw new Error("Session has been revoked");
+  }
+
+  if (row.status !== "active") {
+    throw new Error("Account is not active");
+  }
+
+  if (row.token_version !== payload.token_version) {
+    throw new Error("Token version mismatch (token has been invalidated)");
+  }
+
+  return {
+    accountId: payload.sub,
+    sessionId: payload.sid,
+    roles: payload.roles,
+    tokenVersion: payload.token_version,
+    mustChangePassword: row.must_change_password,
+  };
+}


### PR DESCRIPTION
## Summary

Implements the JWT infrastructure layer needed by the authentication system (Phase 1-4).

- **`data-dir.ts`** — Extracted shared `getDataDir()` utility from `bootstrap.ts`; used by both bootstrap and key management
- **`jwt-keys.ts`** — ES256 key pair management with `kid`-based rotation; supports current + previous key for graceful rollover
- **`jwt.ts`** — Token issuance via `SignJWT` and stateful verification with a single JOIN query across `sessions` + `accounts` tables
- **`jwt-verify-stateless.ts`** — Edge Runtime-compatible verifier (no `server-only`, no `node:*`, no DB imports) for use in Next.js middleware
- **`cookies.ts`** — `httpOnly` / `secure` / `sameSite: strict` cookie transport for access tokens
- **`guard.ts`** — `withAuth()` higher-order function that wraps Route Handlers with authentication, password-change enforcement, and session activity tracking

### Design decisions

| Decision | Rationale |
|---|---|
| JWK format (not PEM) | `importJWK()` works in both Node.js and Edge Runtime |
| Separate stateless verifier file | No `server-only` or `node:*` → safe for Edge middleware |
| ES256 (ECDSA P-256) default | Compact signatures, native Web Crypto support |
| Single JOIN in stateful verification | Avoids 3 DB queries per request |
| `kid` in header + payload | Header for jose key resolution (RFC 7515), payload for app access |

## Test plan

- [x] `data-dir.test.ts` — `DATA_DIR` env resolution (3 tests)
- [x] `jwt-keys.test.ts` — Generate, load, rotate, verify keys; real crypto (18 tests)
- [x] `jwt.test.ts` — Issue tokens, verify claims, DB state checks, error cases; real crypto + mock DB (17 tests)
- [x] `jwt-verify-stateless.test.ts` — Stateless verification, key rotation, tampering; real crypto (6 tests)
- [x] `cookies.test.ts` — Set/get/delete with correct attributes; mock `next/headers` (6 tests)
- [x] `guard.test.ts` — 401/403 scenarios, handler invocation, `last_active_at` update; mock cookies + jwt + DB (6 tests)
- [x] All 191 tests pass (`pnpm test`)
- [x] Biome lint/format pass (`pnpm check`)
- [x] TypeScript passes (`pnpm typecheck`)
- [x] Next.js build succeeds (`pnpm build`)

Closes #53