### PR TITLE
Add correlation ID for cross-log traceability

### DIFF
--- a/migrations/audit/0002_add_correlation_id.sql
+++ b/migrations/audit/0002_add_correlation_id.sql
@@ -1,0 +1,7 @@
+ALTER TABLE audit_logs ADD COLUMN correlation_id UUID;
+
+-- Partial index: excludes NULL rows (pre-correlation entries, standalone
+-- system events) to reduce index size on a table that grows indefinitely.
+CREATE INDEX idx_audit_logs_correlation_id
+  ON audit_logs (correlation_id)
+  WHERE correlation_id IS NOT NULL;

--- a/src/__tests__/lib/audit/correlation.test.ts
+++ b/src/__tests__/lib/audit/correlation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe("correlation", () => {
+  let correlation: typeof import("@/lib/audit/correlation");
+
+  // Use a fresh import so module-level AsyncLocalStorage is available
+  it("module loads", async () => {
+    correlation = await import("@/lib/audit/correlation");
+    expect(correlation).toBeDefined();
+  });
+
+  // ── generateCorrelationId ─────────────────────────────────────
+
+  describe("generateCorrelationId", () => {
+    it("returns a valid UUID v4", async () => {
+      correlation = await import("@/lib/audit/correlation");
+      const id = correlation.generateCorrelationId();
+      expect(id).toMatch(UUID_REGEX);
+    });
+
+    it("returns unique values on each call", async () => {
+      correlation = await import("@/lib/audit/correlation");
+      const ids = new Set(
+        Array.from({ length: 100 }, () => correlation.generateCorrelationId()),
+      );
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  // ── getCorrelationId ──────────────────────────────────────────
+
+  describe("getCorrelationId", () => {
+    it("returns undefined outside context", async () => {
+      correlation = await import("@/lib/audit/correlation");
+      expect(correlation.getCorrelationId()).toBeUndefined();
+    });
+  });
+
+  // ── withCorrelationId ─────────────────────────────────────────
+
+  describe("withCorrelationId", () => {
+    it("makes ID available via getCorrelationId", async () => {
+      correlation = await import("@/lib/audit/correlation");
+      const id = "test-id-1234";
+
+      correlation.withCorrelationId(id, () => {
+        expect(correlation.getCorrelationId()).toBe(id);
+      });
+    });
+
+    it("restores context after completion", async () => {
+      correlation = await import("@/lib/audit/correlation");
+
+      correlation.withCorrelationId("inner-id", () => {
+        // ID is available inside
+        expect(correlation.getCorrelationId()).toBe("inner-id");
+      });
+
+      // ID is gone outside
+      expect(correlation.getCorrelationId()).toBeUndefined();
+    });
+
+    it("supports nested contexts (innermost wins)", async () => {
+      correlation = await import("@/lib/audit/correlation");
+
+      correlation.withCorrelationId("outer", () => {
+        expect(correlation.getCorrelationId()).toBe("outer");
+
+        correlation.withCorrelationId("inner", () => {
+          expect(correlation.getCorrelationId()).toBe("inner");
+        });
+
+        // Outer is restored after inner completes
+        expect(correlation.getCorrelationId()).toBe("outer");
+      });
+    });
+
+    it("preserves ID across async operations", async () => {
+      correlation = await import("@/lib/audit/correlation");
+      const id = "async-test-id";
+
+      await correlation.withCorrelationId(id, async () => {
+        // Simulate async work
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(correlation.getCorrelationId()).toBe(id);
+
+        // Another async hop
+        await Promise.resolve();
+        expect(correlation.getCorrelationId()).toBe(id);
+      });
+    });
+
+    it("returns the value from the wrapped function", async () => {
+      correlation = await import("@/lib/audit/correlation");
+
+      const result = correlation.withCorrelationId("id", () => 42);
+      expect(result).toBe(42);
+    });
+
+    it("returns the promise from an async wrapped function", async () => {
+      correlation = await import("@/lib/audit/correlation");
+
+      const result = await correlation.withCorrelationId(
+        "id",
+        async () => "async-result",
+      );
+      expect(result).toBe("async-result");
+    });
+  });
+});

--- a/src/__tests__/lib/auth/bootstrap.test.ts
+++ b/src/__tests__/lib/auth/bootstrap.test.ts
@@ -513,6 +513,7 @@ describe("bootstrap", () => {
             role: "System Administrator",
             source: "bootstrap",
           }),
+          expect.any(String),
         ],
       );
       expect(mockAuditPoolEnd).toHaveBeenCalled();

--- a/src/lib/audit/correlation.ts
+++ b/src/lib/audit/correlation.ts
@@ -1,0 +1,63 @@
+import "server-only";
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+
+/**
+ * AsyncLocalStorage instance for propagating correlation IDs through
+ * the async call stack within a single request.
+ *
+ * ## Boundary rules
+ *
+ * ALS propagation is reliable only within the same Node.js async context:
+ *
+ * | Scope                         | Works? | Approach                            |
+ * |-------------------------------|--------|-------------------------------------|
+ * | Route Handlers                | Yes    | Auto-read via `getCorrelationId()`  |
+ * | Server Actions                | Yes    | Auto-read via `getCorrelationId()`  |
+ * | `instrumentation.ts` hooks    | Yes    | Auto-read via `getCorrelationId()`  |
+ * | Next.js Middleware (Edge)     | No     | Separate execution context          |
+ * | React Server Components       | No     | React concurrent scheduling         |
+ * | Background jobs / detached    | No     | Pass `correlationId` explicitly     |
+ *
+ * When ALS context is unavailable, callers **must** pass `correlationId`
+ * explicitly to `auditLog.record()`.
+ *
+ * ## Trust policy
+ *
+ * `correlation_id` is always generated server-side via `crypto.randomUUID()`.
+ * External headers (`X-Request-ID`, `X-Correlation-ID`, W3C `traceparent`)
+ * are **not** accepted as `correlation_id` to preserve audit integrity.
+ * If external request tracing is needed, store the external ID in a separate
+ * field (e.g., `details.external_request_id`).
+ */
+const storage = new AsyncLocalStorage<string>();
+
+/**
+ * Generate a new correlation ID (UUID v4).
+ *
+ * Always server-generated — never derived from external input.
+ */
+export function generateCorrelationId(): string {
+  return randomUUID();
+}
+
+/**
+ * Execute `fn` within a correlation ID context.
+ *
+ * All calls to `getCorrelationId()` within `fn` (including nested async
+ * calls) will return the given `id`. Supports both sync and async `fn`.
+ */
+export function withCorrelationId<T>(id: string, fn: () => T): T {
+  return storage.run(id, fn);
+}
+
+/**
+ * Read the current correlation ID from the async context.
+ *
+ * Returns `undefined` if called outside a `withCorrelationId()` context
+ * (e.g., background jobs, detached promises, Middleware, RSC).
+ */
+export function getCorrelationId(): string | undefined {
+  return storage.getStore();
+}

--- a/src/lib/auth/bootstrap.ts
+++ b/src/lib/auth/bootstrap.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+import { generateCorrelationId } from "@/lib/audit/correlation";
 import { connectTo, query } from "@/lib/db/client";
 
 import { getDataDir } from "./data-dir";
@@ -109,6 +110,7 @@ function consumeSecretFiles(): void {
 async function writeBootstrapAuditLog(
   accountId: string,
   username: string,
+  correlationId: string,
 ): Promise<void> {
   const auditUrl = process.env.AUDIT_DATABASE_URL;
   if (!auditUrl) {
@@ -122,8 +124,8 @@ async function writeBootstrapAuditLog(
   try {
     await auditPool.query(
       `INSERT INTO audit_logs
-        (actor_id, action, target_type, target_id, details)
-       VALUES ($1, $2, $3, $4, $5)`,
+        (actor_id, action, target_type, target_id, details, correlation_id)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
       [
         "system",
         "account.create",
@@ -134,6 +136,7 @@ async function writeBootstrapAuditLog(
           role: SYSTEM_ADMIN_ROLE_NAME,
           source: "bootstrap",
         }),
+        correlationId,
       ],
     );
   } finally {
@@ -208,8 +211,9 @@ export async function bootstrapAdminAccount(): Promise<void> {
   );
 
   // Step 7: Write audit log (non-fatal — account is already created)
+  const correlationId = generateCorrelationId();
   try {
-    await writeBootstrapAuditLog(accountId, username);
+    await writeBootstrapAuditLog(accountId, username, correlationId);
   } catch (error) {
     console.warn(
       "Failed to write bootstrap audit log; admin account was created successfully",


### PR DESCRIPTION
## Summary

Adds a `correlation_id` (UUID) column to `audit_logs` and an `AsyncLocalStorage`-based propagation utility, so that multiple log entries from a single operation can be traced as a group.

- **Schema migration** (`0002_add_correlation_id.sql`) — `correlation_id UUID` column with partial index (`WHERE IS NOT NULL`) for storage efficiency on a table that grows indefinitely
- **`src/lib/audit/correlation.ts`** — three functions: `generateCorrelationId()` (UUID v4), `withCorrelationId(id, fn)` (ALS propagation), `getCorrelationId()` (ALS read)
- **`bootstrap.ts` updated** — generates a correlation ID per bootstrap operation and includes it in the audit INSERT

### Design decisions

| Decision | Rationale |
|---|---|
| PostgreSQL `UUID` type (not TEXT) | 16 bytes vs 36+, binary comparison, DB-level format validation |
| Partial index (`WHERE IS NOT NULL`) | Excludes pre-correlation entries to reduce index size/write cost |
| Server-generated only (no external headers) | Preserves audit integrity — external `X-Request-ID` could be spoofed |
| ALS with explicit fallback | Auto-propagation in Route Handlers; explicit pass for background jobs |
| Boundary rules documented in JSDoc | ALS does not work in Edge Middleware, RSC, or detached async |

## Test plan

- [x] `correlation.test.ts` — UUID v4 generation, uniqueness, ALS propagation, nesting, async preservation, context restoration (10 tests)
- [x] `bootstrap.test.ts` — existing audit log test updated to expect 6th `correlation_id` parameter
- [x] All 201 tests pass (`pnpm test`)
- [x] Biome lint/format pass (`pnpm check`)
- [x] TypeScript passes (`pnpm typecheck`)
- [x] Next.js build succeeds (`pnpm build`)

Closes #65