### PR TITLE
[Phase 1-10a] Audit log service (logger)

### DIFF
--- a/src/__tests__/lib/audit/logger.test.ts
+++ b/src/__tests__/lib/audit/logger.test.ts
@@ -1,0 +1,484 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock setup ────────────────────────────────────────────────────
+
+const { mockPoolQuery, mockPoolEnd } = vi.hoisted(() => {
+  const mockPoolQuery = vi.fn();
+  const mockPoolEnd = vi.fn();
+  return { mockPoolQuery, mockPoolEnd };
+});
+
+vi.mock("@/lib/db/client", () => ({
+  connectTo: vi.fn(() => ({
+    query: mockPoolQuery,
+    end: mockPoolEnd,
+  })),
+}));
+
+const { mockGetCorrelationId } = vi.hoisted(() => {
+  const mockGetCorrelationId = vi.fn();
+  return { mockGetCorrelationId };
+});
+
+vi.mock("@/lib/audit/correlation", () => ({
+  getCorrelationId: mockGetCorrelationId,
+}));
+
+// ── Import after mocks ───────────────────────────────────────────
+
+import type { AuditAction } from "@/lib/audit/logger";
+
+describe("auditLog", () => {
+  let auditLog: typeof import("@/lib/audit/logger")["auditLog"];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockPoolQuery.mockReset();
+    mockPoolEnd.mockReset();
+    mockGetCorrelationId.mockReset();
+
+    process.env.AUDIT_DATABASE_URL =
+      "postgres://audit_writer:pass@localhost:5432/audit_db";
+
+    const mod = await import("@/lib/audit/logger");
+    auditLog = mod.auditLog;
+  });
+
+  afterEach(async () => {
+    auditLog.resetPool();
+    delete process.env.AUDIT_DATABASE_URL;
+  });
+
+  // ── record() — basic insertion ────────────────────────────────
+
+  describe("record() — basic insertion", () => {
+    it("inserts event with all fields populated", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "user-123",
+        action: "auth.sign_in.success",
+        target: "session",
+        targetId: "session-456",
+        details: { username: "admin", ip: "10.0.0.1" },
+        ip: "10.0.0.1",
+        sid: "sid-789",
+        customerId: 42,
+        correlationId: "corr-abc",
+      });
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO audit_logs"),
+        [
+          "user-123",
+          "auth.sign_in.success",
+          "session",
+          "session-456",
+          JSON.stringify({ username: "admin", ip: "10.0.0.1" }),
+          "10.0.0.1",
+          "sid-789",
+          42,
+          "corr-abc",
+        ],
+      );
+    });
+
+    it("inserts event with minimal fields", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+      });
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO audit_logs"),
+        [
+          "system",
+          "account.create",
+          "account",
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ],
+      );
+    });
+
+    it("serializes details as JSON string", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "account.lock",
+        target: "account",
+        targetId: "user-2",
+        details: { reason: "too many failures", count: 5 },
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[4]).toBe(
+        JSON.stringify({ reason: "too many failures", count: 5 }),
+      );
+    });
+
+    it("passes null when details is undefined", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.unlock",
+        target: "account",
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[4]).toBeNull();
+    });
+  });
+
+  // ── record() — correlation ID ─────────────────────────────────
+
+  describe("record() — correlation ID", () => {
+    it("uses explicitly provided correlationId", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      mockGetCorrelationId.mockReturnValue("als-id");
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "auth.sign_out",
+        target: "session",
+        correlationId: "explicit-id",
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[8]).toBe("explicit-id");
+    });
+
+    it("auto-reads from AsyncLocalStorage when correlationId is omitted", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      mockGetCorrelationId.mockReturnValue("als-correlation-id");
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "auth.sign_in.success",
+        target: "session",
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[8]).toBe("als-correlation-id");
+    });
+
+    it("passes null when neither explicit nor ALS correlation ID is available", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      mockGetCorrelationId.mockReturnValue(undefined);
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "auth.sign_in.failure",
+        target: "account",
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[8]).toBeNull();
+    });
+
+    it("prefers explicit correlationId over ALS value", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      mockGetCorrelationId.mockReturnValue("als-value");
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "auth.session_extend",
+        target: "session",
+        correlationId: "explicit-value",
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[8]).toBe("explicit-value");
+    });
+  });
+
+  // ── record() — sensitive field redaction ───────────────────────
+
+  describe("record() — sensitive field redaction", () => {
+    it("redacts top-level password field", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+        details: { username: "admin", password: "secret123" },
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      const details = JSON.parse(params[4] as string);
+      expect(details.password).toBe("[REDACTED]");
+      expect(details.username).toBe("admin");
+    });
+
+    it("redacts password_hash in nested before/after objects", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "account.create",
+        target: "account",
+        details: {
+          before: { password_hash: "old-hash", status: "active" },
+          after: { password_hash: "new-hash", status: "locked" },
+        },
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      const details = JSON.parse(params[4] as string);
+      expect(details.before.password_hash).toBe("[REDACTED]");
+      expect(details.before.status).toBe("active");
+      expect(details.after.password_hash).toBe("[REDACTED]");
+      expect(details.after.status).toBe("locked");
+    });
+
+    it("preserves non-sensitive fields intact", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "account.lock",
+        target: "account",
+        details: { reason: "brute force", count: 5, ip: "10.0.0.1" },
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      const details = JSON.parse(params[4] as string);
+      expect(details).toEqual({
+        reason: "brute force",
+        count: 5,
+        ip: "10.0.0.1",
+      });
+    });
+
+    it("redacts all known sensitive keys", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+        details: {
+          password: "p",
+          passwordHash: "ph",
+          secret: "s",
+          token: "t",
+          accessToken: "at",
+          refreshToken: "rt",
+          apiKey: "ak",
+          privateKey: "pk",
+          credential: "c",
+          username: "admin",
+        },
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      const details = JSON.parse(params[4] as string);
+      expect(details.password).toBe("[REDACTED]");
+      expect(details.passwordHash).toBe("[REDACTED]");
+      expect(details.secret).toBe("[REDACTED]");
+      expect(details.token).toBe("[REDACTED]");
+      expect(details.accessToken).toBe("[REDACTED]");
+      expect(details.refreshToken).toBe("[REDACTED]");
+      expect(details.apiKey).toBe("[REDACTED]");
+      expect(details.privateKey).toBe("[REDACTED]");
+      expect(details.credential).toBe("[REDACTED]");
+      expect(details.username).toBe("admin");
+    });
+
+    it("handles details with no sensitive fields unchanged", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const originalDetails = { action: "login", user: "alice" };
+
+      await auditLog.record({
+        actor: "user-1",
+        action: "auth.sign_in.success",
+        target: "session",
+        details: originalDetails,
+      });
+
+      const params = mockPoolQuery.mock.calls[0][1] as unknown[];
+      expect(params[4]).toBe(JSON.stringify(originalDetails));
+    });
+  });
+
+  // ── record() — error handling ─────────────────────────────────
+
+  describe("record() — error handling", () => {
+    it("propagates database errors", async () => {
+      mockPoolQuery.mockRejectedValueOnce(new Error("connection refused"));
+
+      await expect(
+        auditLog.record({
+          actor: "user-1",
+          action: "auth.sign_in.success",
+          target: "session",
+        }),
+      ).rejects.toThrow("connection refused");
+    });
+
+    it("throws when AUDIT_DATABASE_URL is missing", async () => {
+      delete process.env.AUDIT_DATABASE_URL;
+      auditLog.resetPool();
+
+      // Re-import to get a fresh module without the cached pool
+      vi.resetModules();
+      const mod = await import("@/lib/audit/logger");
+
+      await expect(
+        mod.auditLog.record({
+          actor: "user-1",
+          action: "auth.sign_in.success",
+          target: "session",
+        }),
+      ).rejects.toThrow("AUDIT_DATABASE_URL");
+    });
+  });
+
+  // ── Pool management ───────────────────────────────────────────
+
+  describe("pool management", () => {
+    it("creates pool lazily on first record() call", async () => {
+      const { connectTo } = await import("@/lib/db/client");
+      (connectTo as ReturnType<typeof vi.fn>).mockClear();
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      // Pool should not exist before first call
+      auditLog.resetPool();
+      expect(connectTo).not.toHaveBeenCalled();
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+      });
+
+      expect(connectTo).toHaveBeenCalledWith(
+        "postgres://audit_writer:pass@localhost:5432/audit_db",
+      );
+    });
+
+    it("reuses pool across multiple record() calls", async () => {
+      const { connectTo } = await import("@/lib/db/client");
+      (connectTo as ReturnType<typeof vi.fn>).mockClear();
+      auditLog.resetPool();
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+      });
+      await auditLog.record({
+        actor: "system",
+        action: "account.lock",
+        target: "account",
+      });
+      await auditLog.record({
+        actor: "system",
+        action: "account.unlock",
+        target: "account",
+      });
+
+      // connectTo called only once despite 3 record() calls
+      expect(connectTo).toHaveBeenCalledTimes(1);
+    });
+
+    it("endPool() ends the pool and resets reference", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      mockPoolEnd.mockResolvedValueOnce(undefined);
+
+      // Trigger pool creation
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+      });
+
+      await auditLog.endPool();
+
+      expect(mockPoolEnd).toHaveBeenCalledOnce();
+    });
+
+    it("endPool() is safe when no pool exists", async () => {
+      // Should not throw
+      await auditLog.endPool();
+      expect(mockPoolEnd).not.toHaveBeenCalled();
+    });
+
+    it("resetPool() clears reference without ending", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      // Trigger pool creation
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+      });
+
+      auditLog.resetPool();
+      expect(mockPoolEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── SQL safety ────────────────────────────────────────────────
+
+  describe("SQL safety", () => {
+    it("only uses INSERT SQL (never UPDATE or DELETE)", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      await auditLog.record({
+        actor: "system",
+        action: "account.create",
+        target: "account",
+      });
+
+      const sql = mockPoolQuery.mock.calls[0][0] as string;
+      expect(sql).toContain("INSERT INTO audit_logs");
+      expect(sql.toUpperCase()).not.toContain("UPDATE");
+      expect(sql.toUpperCase()).not.toContain("DELETE");
+    });
+  });
+
+  // ── Event type coverage ───────────────────────────────────────
+
+  describe("event type coverage", () => {
+    const PHASE_1_ACTIONS: AuditAction[] = [
+      "auth.sign_in.success",
+      "auth.sign_in.failure",
+      "auth.sign_out",
+      "auth.session_extend",
+      "session.ip_mismatch",
+      "session.ua_mismatch",
+      "session.revoke",
+      "account.create",
+      "account.lock",
+      "account.unlock",
+    ];
+
+    for (const action of PHASE_1_ACTIONS) {
+      it(`accepts action: ${action}`, async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+        await auditLog.record({
+          actor: "system",
+          action,
+          target: "account",
+        });
+
+        const params = mockPoolQuery.mock.calls.at(-1)?.[1] as unknown[];
+        expect(params[1]).toBe(action);
+      });
+    }
+  });
+});

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -1,0 +1,182 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { getCorrelationId } from "@/lib/audit/correlation";
+import { connectTo } from "@/lib/db/client";
+
+// ── Sensitive Field Redaction ─────────────────────────────────────
+
+const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+  "password",
+  "password_hash",
+  "passwordHash",
+  "secret",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "apiKey",
+  "privateKey",
+  "credential",
+]);
+
+/**
+ * Recursively redact sensitive keys from an object.
+ *
+ * Replaces values of known sensitive keys with `"[REDACTED]"`.
+ * Traverses nested plain objects up to the given depth limit.
+ */
+function sanitizeDetails(
+  obj: Record<string, unknown>,
+  depth = 0,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (SENSITIVE_KEYS.has(key)) {
+      result[key] = "[REDACTED]";
+    } else if (
+      depth < 3 &&
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      result[key] = sanitizeDetails(
+        value as Record<string, unknown>,
+        depth + 1,
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+// ── Types ─────────────────────────────────────────────────────────
+
+/** Phase 1 authentication event actions. */
+type AuthAction =
+  | "auth.sign_in.success"
+  | "auth.sign_in.failure"
+  | "auth.sign_out"
+  | "auth.session_extend";
+
+/** Phase 1 session event actions. */
+type SessionAction =
+  | "session.ip_mismatch"
+  | "session.ua_mismatch"
+  | "session.revoke";
+
+/** Phase 1 account event actions. */
+type AccountAction = "account.create" | "account.lock" | "account.unlock";
+
+/** All Phase 1 audit event actions (Discussion #46 §4). */
+export type AuditAction = AuthAction | SessionAction | AccountAction;
+
+/** Target entity types for Phase 1 events. */
+export type AuditTargetType = "account" | "session";
+
+/**
+ * Parameters for recording a single audit log entry.
+ *
+ * `correlationId` is optional — if omitted, it is auto-read from the
+ * `AsyncLocalStorage` context set by `withCorrelationId()`.  Pass it
+ * explicitly in contexts where ALS is unavailable (background jobs,
+ * Edge Middleware, React Server Components).
+ */
+export interface AuditEvent {
+  /** Account ID of the actor, or `"system"` for automated actions. */
+  actor: string;
+  /** The action being recorded. */
+  action: AuditAction;
+  /** The type of entity being acted upon. */
+  target: AuditTargetType;
+  /** Identifier of the target entity (nullable for some events). */
+  targetId?: string;
+  /** Arbitrary event details. Sensitive fields are auto-redacted. */
+  details?: Record<string, unknown>;
+  /** Client IP address. */
+  ip?: string;
+  /** Session ID. */
+  sid?: string;
+  /** Related customer ID. */
+  customerId?: number;
+  /** Explicit correlation ID (overrides ALS auto-read). */
+  correlationId?: string;
+}
+
+// ── Pool Management ───────────────────────────────────────────────
+
+let auditPool: pg.Pool | null = null;
+
+function getAuditPool(): pg.Pool {
+  if (auditPool) return auditPool;
+
+  const connectionString = process.env.AUDIT_DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("Missing environment variable: AUDIT_DATABASE_URL");
+  }
+
+  auditPool = connectTo(connectionString);
+  return auditPool;
+}
+
+// ── SQL ───────────────────────────────────────────────────────────
+
+const INSERT_SQL = `INSERT INTO audit_logs
+  (actor_id, action, target_type, target_id, details,
+   ip_address, sid, customer_id, correlation_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`;
+
+// ── Public API ────────────────────────────────────────────────────
+
+/**
+ * Insert a structured audit log entry into `audit_db`.
+ *
+ * Correlation ID is resolved in order:
+ * 1. Explicit `event.correlationId` (if provided)
+ * 2. `AsyncLocalStorage` context via `getCorrelationId()`
+ * 3. `NULL` (no correlation — standalone event)
+ *
+ * Sensitive fields in `details` are automatically redacted before
+ * serialization.  Database errors propagate to the caller.
+ */
+async function record(event: AuditEvent): Promise<void> {
+  const correlationId = event.correlationId ?? getCorrelationId() ?? null;
+
+  const sanitizedDetails = event.details
+    ? JSON.stringify(sanitizeDetails(event.details))
+    : null;
+
+  await getAuditPool().query(INSERT_SQL, [
+    event.actor,
+    event.action,
+    event.target,
+    event.targetId ?? null,
+    sanitizedDetails,
+    event.ip ?? null,
+    event.sid ?? null,
+    event.customerId ?? null,
+    correlationId,
+  ]);
+}
+
+/** Close the audit database pool. Call during graceful shutdown. */
+async function endPool(): Promise<void> {
+  if (auditPool) {
+    await auditPool.end();
+    auditPool = null;
+  }
+}
+
+/** Reset pool reference without closing connections (testing only). */
+function resetPool(): void {
+  auditPool = null;
+}
+
+export const auditLog = {
+  record,
+  endPool,
+  resetPool,
+} as const;


### PR DESCRIPTION
## Context

Phase 1 task 1-10a from #39. Implements the centralized audit log recording service that all other Phase 1+ features will import to record events. Depends on #50 (schema) and #65 (correlation ID utility).

References: Discussion #46 §2–5

## Changes

### `src/lib/audit/logger.ts` — Core audit logger module

- **Public API**: `auditLog.record(event)` — inserts structured record into `audit_db`
- **Lazy singleton pool**: Created on first call via `connectTo(AUDIT_DATABASE_URL)`, reused for all subsequent calls
- **Correlation ID**: Auto-read from `AsyncLocalStorage` context (set by `withCorrelationId()`); explicit `correlationId` parameter overrides ALS; `NULL` when neither is available
- **Sensitive field redaction**: Recursive sanitization (max depth 3) replaces known sensitive keys (`password`, `password_hash`, `token`, `apiKey`, etc.) with `[REDACTED]` before JSON serialization
- **Typed event actions**: `AuditAction` union covers all Phase 1 events:
  - Auth: `auth.sign_in.success`, `auth.sign_in.failure`, `auth.sign_out`, `auth.session_extend`
  - Session: `session.ip_mismatch`, `session.ua_mismatch`, `session.revoke`
  - Account: `account.create`, `account.lock`, `account.unlock`
- **INSERT-only SQL**: Single constant — never UPDATE or DELETE (matches `audit_writer` role grants)

### `src/__tests__/lib/audit/logger.test.ts` — 31 unit tests

- Basic insertion (all fields, minimal fields, JSON serialization, null details)
- Correlation ID resolution (explicit, ALS auto-read, null fallback, explicit-wins-over-ALS)
- Sensitive field redaction (top-level, nested before/after, all known keys, non-sensitive passthrough)
- Error handling (DB error propagation, missing AUDIT_DATABASE_URL)
- Pool management (lazy creation, reuse, endPool, resetPool)
- SQL safety (no UPDATE/DELETE)
- All 10 Phase 1 action strings accepted

## Verification

- `pnpm check` — Biome lint/format ✅
- `pnpm typecheck` — TypeScript ✅
- `pnpm test` — 232 tests pass (201 existing + 31 new) ✅
- `pnpm build` — Next.js build succeeds ✅

Closes #51