### PR TITLE
[Phase 1-6] CSRF protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5432/audit_db
 
 DATA_DIR=./data
 JWT_EXPIRATION_MINUTES=15
+CSRF_SECRET=
 INIT_ADMIN_USERNAME=
 INIT_ADMIN_PASSWORD=
 

--- a/src/__tests__/lib/auth/csrf.test.ts
+++ b/src/__tests__/lib/auth/csrf.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CSRF_COOKIE_OPTIONS,
+  CSRF_HEADER_NAME,
+  generateCsrfToken,
+  isMutationMethod,
+  validateCsrfToken,
+  validateOrigin,
+} from "@/lib/auth/csrf";
+
+const TEST_SID = "550e8400-e29b-41d4-a716-446655440000";
+const TEST_SECRET = "test-csrf-secret-at-least-32-bytes-long";
+
+describe("CSRF", () => {
+  // ── generateCsrfToken() ─────────────────────────────────────
+
+  describe("generateCsrfToken()", () => {
+    it("returns token in nonce.issuedAt.signature format", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const parts = token.split(".");
+
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toMatch(/^[0-9a-f]+$/); // hex nonce
+      expect(Number(parts[1])).not.toBeNaN(); // numeric timestamp
+      expect(parts[2]).toMatch(/^[0-9a-f]+$/); // hex signature
+    });
+
+    it("nonce is 32 hex characters (16 bytes)", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const nonce = token.split(".")[0];
+
+      expect(nonce).toHaveLength(32);
+    });
+
+    it("issued_at is a valid Unix timestamp in seconds", () => {
+      const before = Math.floor(Date.now() / 1000);
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const after = Math.floor(Date.now() / 1000);
+
+      const issuedAt = Number(token.split(".")[1]);
+      expect(issuedAt).toBeGreaterThanOrEqual(before);
+      expect(issuedAt).toBeLessThanOrEqual(after);
+    });
+
+    it("produces different tokens on each call", () => {
+      const t1 = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const t2 = generateCsrfToken(TEST_SID, TEST_SECRET);
+
+      expect(t1.token).not.toBe(t2.token);
+      // Nonces should differ
+      expect(t1.token.split(".")[0]).not.toBe(t2.token.split(".")[0]);
+    });
+  });
+
+  // ── validateCsrfToken() — acceptance ────────────────────────
+
+  describe("validateCsrfToken() — acceptance", () => {
+    it("accepts a freshly generated token with same sid and secret", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      // jwtIat is before or at the token's issuedAt
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+
+      expect(validateCsrfToken(token, TEST_SID, TEST_SECRET, jwtIat)).toBe(
+        true,
+      );
+    });
+
+    it("accepts token when issued_at equals jwtIat", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const issuedAt = Number(token.split(".")[1]);
+
+      expect(validateCsrfToken(token, TEST_SID, TEST_SECRET, issuedAt)).toBe(
+        true,
+      );
+    });
+
+    it("accepts token when issued_at is after jwtIat (re-issued CSRF)", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const issuedAt = Number(token.split(".")[1]);
+
+      // JWT was issued 60 seconds before CSRF token
+      expect(
+        validateCsrfToken(token, TEST_SID, TEST_SECRET, issuedAt - 60),
+      ).toBe(true);
+    });
+  });
+
+  // ── validateCsrfToken() — rejection ─────────────────────────
+
+  describe("validateCsrfToken() — rejection", () => {
+    it("rejects token with wrong secret (HMAC mismatch)", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+
+      expect(validateCsrfToken(token, TEST_SID, "wrong-secret", jwtIat)).toBe(
+        false,
+      );
+    });
+
+    it("rejects token with wrong sid (HMAC mismatch)", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+
+      expect(
+        validateCsrfToken(token, "different-sid", TEST_SECRET, jwtIat),
+      ).toBe(false);
+    });
+
+    it("rejects stale token (issued_at < jwtIat)", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      // jwtIat is far in the future — token is stale
+      const jwtIat = Math.floor(Date.now() / 1000) + 3600;
+
+      expect(validateCsrfToken(token, TEST_SID, TEST_SECRET, jwtIat)).toBe(
+        false,
+      );
+    });
+
+    it("rejects malformed token (missing parts)", () => {
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+
+      expect(
+        validateCsrfToken("only-one-part", TEST_SID, TEST_SECRET, jwtIat),
+      ).toBe(false);
+      expect(
+        validateCsrfToken("two.parts", TEST_SID, TEST_SECRET, jwtIat),
+      ).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+
+      expect(validateCsrfToken("", TEST_SID, TEST_SECRET, jwtIat)).toBe(false);
+    });
+
+    it("rejects token with tampered signature", () => {
+      const { token } = generateCsrfToken(TEST_SID, TEST_SECRET);
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+      const parts = token.split(".");
+
+      // Flip last char of signature
+      const lastChar = parts[2].slice(-1);
+      const tampered = `${parts[0]}.${parts[1]}.${parts[2].slice(0, -1)}${lastChar === "0" ? "1" : "0"}`;
+
+      expect(validateCsrfToken(tampered, TEST_SID, TEST_SECRET, jwtIat)).toBe(
+        false,
+      );
+    });
+
+    it("rejects token with non-numeric issued_at", () => {
+      const jwtIat = Math.floor(Date.now() / 1000) - 10;
+
+      expect(
+        validateCsrfToken(
+          "aabbccdd.notanumber.eeff0011",
+          TEST_SID,
+          TEST_SECRET,
+          jwtIat,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  // ── validateOrigin() ────────────────────────────────────────
+
+  describe("validateOrigin()", () => {
+    const EXPECTED = "https://app.example.com";
+
+    it("accepts when Origin header matches", () => {
+      expect(validateOrigin(EXPECTED, null, EXPECTED)).toBe(true);
+    });
+
+    it("rejects when Origin header does not match", () => {
+      expect(validateOrigin("https://evil.com", null, EXPECTED)).toBe(false);
+    });
+
+    it("accepts Referer when Origin is absent", () => {
+      expect(
+        validateOrigin(null, "https://app.example.com/path", EXPECTED),
+      ).toBe(true);
+    });
+
+    it("rejects Referer when Origin is absent and Referer does not match", () => {
+      expect(validateOrigin(null, "https://evil.com/attack", EXPECTED)).toBe(
+        false,
+      );
+    });
+
+    it("rejects when neither Origin nor Referer is present", () => {
+      expect(validateOrigin(null, null, EXPECTED)).toBe(false);
+    });
+
+    it("rejects when Referer is malformed URL", () => {
+      expect(validateOrigin(null, "not-a-url", EXPECTED)).toBe(false);
+    });
+
+    it("prefers Origin over Referer", () => {
+      // Origin matches but Referer doesn't — should accept
+      expect(validateOrigin(EXPECTED, "https://evil.com/path", EXPECTED)).toBe(
+        true,
+      );
+    });
+  });
+
+  // ── isMutationMethod() ──────────────────────────────────────
+
+  describe("isMutationMethod()", () => {
+    it.each([
+      "POST",
+      "PUT",
+      "PATCH",
+      "DELETE",
+    ])("returns true for %s", (method) => {
+      expect(isMutationMethod(method)).toBe(true);
+    });
+
+    it.each(["GET", "HEAD", "OPTIONS"])("returns false for %s", (method) => {
+      expect(isMutationMethod(method)).toBe(false);
+    });
+
+    it("is case-insensitive", () => {
+      expect(isMutationMethod("post")).toBe(true);
+      expect(isMutationMethod("get")).toBe(false);
+    });
+  });
+
+  // ── Constants ───────────────────────────────────────────────
+
+  describe("constants", () => {
+    it("CSRF_HEADER_NAME is lowercase", () => {
+      expect(CSRF_HEADER_NAME).toBe("x-csrf-token");
+    });
+
+    it("CSRF_COOKIE_OPTIONS has httpOnly=false", () => {
+      expect(CSRF_COOKIE_OPTIONS.httpOnly).toBe(false);
+    });
+
+    it("CSRF_COOKIE_OPTIONS has sameSite=strict", () => {
+      expect(CSRF_COOKIE_OPTIONS.sameSite).toBe("strict");
+    });
+
+    it("CSRF_COOKIE_OPTIONS has path=/", () => {
+      expect(CSRF_COOKIE_OPTIONS.path).toBe("/");
+    });
+  });
+});

--- a/src/__tests__/lib/auth/guard.test.ts
+++ b/src/__tests__/lib/auth/guard.test.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthSession } from "@/lib/auth/jwt";
 
 const mockGetAccessTokenCookie = vi.hoisted(() => vi.fn());
 const mockVerifyJwtFull = vi.hoisted(() => vi.fn());
 const mockPoolQuery = vi.hoisted(() => vi.fn());
+const mockValidateCsrfToken = vi.hoisted(() => vi.fn());
+const mockValidateOrigin = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth/cookies", () => ({
   getAccessTokenCookie: mockGetAccessTokenCookie,
@@ -19,6 +21,15 @@ vi.mock("@/lib/db/client", () => ({
   query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
 }));
 
+vi.mock("@/lib/auth/csrf", () => ({
+  CSRF_HEADER_NAME: "x-csrf-token",
+  isMutationMethod: vi.fn((method: string) =>
+    new Set(["POST", "PUT", "PATCH", "DELETE"]).has(method.toUpperCase()),
+  ),
+  validateCsrfToken: mockValidateCsrfToken,
+  validateOrigin: mockValidateOrigin,
+}));
+
 describe("withAuth", () => {
   let guard: typeof import("@/lib/auth/guard");
 
@@ -28,10 +39,17 @@ describe("withAuth", () => {
     roles: ["admin"],
     tokenVersion: 0,
     mustChangePassword: false,
+    iat: Math.floor(Date.now() / 1000),
   };
 
-  function makeRequest(url = "http://localhost:3000/api/test") {
-    return new NextRequest(url);
+  function makeRequest(
+    url = "http://localhost:3000/api/test",
+    options?: { method?: string; headers?: Record<string, string> },
+  ) {
+    return new NextRequest(url, {
+      method: options?.method ?? "GET",
+      headers: options?.headers,
+    });
   }
 
   function makeContext() {
@@ -42,104 +60,312 @@ describe("withAuth", () => {
     mockGetAccessTokenCookie.mockReset();
     mockVerifyJwtFull.mockReset();
     mockPoolQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
+    mockValidateCsrfToken.mockReset();
+    mockValidateOrigin.mockReset();
+
+    process.env.CSRF_SECRET = "test-csrf-secret";
 
     guard = await import("@/lib/auth/guard");
   });
 
-  it("returns 401 when no cookie is present", async () => {
-    mockGetAccessTokenCookie.mockResolvedValue(undefined);
-
-    const handler = vi.fn();
-    const wrapped = guard.withAuth(handler);
-    const response = await wrapped(makeRequest(), makeContext());
-    const body = await response.json();
-
-    expect(response.status).toBe(401);
-    expect(body.error).toBe("Authentication required");
-    expect(handler).not.toHaveBeenCalled();
+  afterEach(() => {
+    delete process.env.CSRF_SECRET;
   });
 
-  it("returns 401 when token verification fails", async () => {
-    mockGetAccessTokenCookie.mockResolvedValue("bad-token");
-    mockVerifyJwtFull.mockRejectedValue(new Error("Invalid token"));
+  // ── Authentication ──────────────────────────────────────────
 
-    const handler = vi.fn();
-    const wrapped = guard.withAuth(handler);
-    const response = await wrapped(makeRequest(), makeContext());
-    const body = await response.json();
+  describe("authentication", () => {
+    it("returns 401 when no cookie is present", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue(undefined);
 
-    expect(response.status).toBe(401);
-    expect(body.error).toBe("Invalid or expired token");
-    expect(handler).not.toHaveBeenCalled();
-  });
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
 
-  it("returns 403 when mustChangePassword is true", async () => {
-    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
-    mockVerifyJwtFull.mockResolvedValue({
-      ...validSession,
-      mustChangePassword: true,
+      expect(response.status).toBe(401);
+      expect(body.error).toBe("Authentication required");
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    const handler = vi.fn();
-    const wrapped = guard.withAuth(handler);
-    const response = await wrapped(makeRequest(), makeContext());
-    const body = await response.json();
+    it("returns 401 when token verification fails", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("bad-token");
+      mockVerifyJwtFull.mockRejectedValue(new Error("Invalid token"));
 
-    expect(response.status).toBe(403);
-    expect(body.error).toBe("Password change required");
-    expect(body.redirect).toBe("/change-password");
-    expect(handler).not.toHaveBeenCalled();
-  });
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
 
-  it("calls handler with session on valid token", async () => {
-    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
-    mockVerifyJwtFull.mockResolvedValue(validSession);
-
-    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
-    const wrapped = guard.withAuth(handler);
-    const request = makeRequest();
-    const context = makeContext();
-
-    const response = await wrapped(request, context);
-    const body = await response.json();
-
-    expect(body.ok).toBe(true);
-    expect(handler).toHaveBeenCalledWith(request, context, validSession);
-  });
-
-  it("updates last_active_at in the database", async () => {
-    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
-    mockVerifyJwtFull.mockResolvedValue(validSession);
-
-    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
-    const wrapped = guard.withAuth(handler);
-    await wrapped(makeRequest(), makeContext());
-
-    expect(mockPoolQuery).toHaveBeenCalledWith(
-      expect.stringContaining("UPDATE sessions SET last_active_at"),
-      ["session-1"],
-    );
-  });
-
-  it("updates last_active_at before calling the handler", async () => {
-    mockGetAccessTokenCookie.mockResolvedValue("valid-token");
-    mockVerifyJwtFull.mockResolvedValue(validSession);
-
-    const callOrder: string[] = [];
-
-    mockPoolQuery.mockImplementation(async () => {
-      callOrder.push("db-update");
-      return { rows: [], rowCount: 0 };
+      expect(response.status).toBe(401);
+      expect(body.error).toBe("Invalid or expired token");
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    const handler = vi.fn().mockImplementation(async () => {
-      callOrder.push("handler");
-      return NextResponse.json({ ok: true });
+    it("returns 403 when mustChangePassword is true", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue({
+        ...validSession,
+        mustChangePassword: true,
+      });
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Password change required");
+      expect(body.redirect).toBe("/change-password");
+      expect(handler).not.toHaveBeenCalled();
     });
 
-    const wrapped = guard.withAuth(handler);
-    await wrapped(makeRequest(), makeContext());
+    it("calls handler with session on valid GET request", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
 
-    expect(callOrder).toEqual(["db-update", "handler"]);
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      const request = makeRequest();
+      const context = makeContext();
+
+      const response = await wrapped(request, context);
+      const body = await response.json();
+
+      expect(body.ok).toBe(true);
+      expect(handler).toHaveBeenCalledWith(request, context, validSession);
+    });
+
+    it("updates last_active_at in the database", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      await wrapped(makeRequest(), makeContext());
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE sessions SET last_active_at"),
+        ["session-1"],
+      );
+    });
+
+    it("updates last_active_at before calling the handler", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+
+      const callOrder: string[] = [];
+
+      mockPoolQuery.mockImplementation(async () => {
+        callOrder.push("db-update");
+        return { rows: [], rowCount: 0 };
+      });
+
+      const handler = vi.fn().mockImplementation(async () => {
+        callOrder.push("handler");
+        return NextResponse.json({ ok: true });
+      });
+
+      const wrapped = guard.withAuth(handler);
+      await wrapped(makeRequest(), makeContext());
+
+      expect(callOrder).toEqual(["db-update", "handler"]);
+    });
+  });
+
+  // ── CSRF protection ─────────────────────────────────────────
+
+  describe("CSRF protection", () => {
+    it("GET request passes without CSRF validation", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+
+      expect(response.status).toBe(200);
+      expect(handler).toHaveBeenCalled();
+      expect(mockValidateCsrfToken).not.toHaveBeenCalled();
+      expect(mockValidateOrigin).not.toHaveBeenCalled();
+    });
+
+    it("POST with valid CSRF token and valid Origin passes", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockValidateOrigin.mockReturnValue(true);
+      mockValidateCsrfToken.mockReturnValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: {
+          origin: "http://localhost:3000",
+          "x-csrf-token": "valid-csrf-token",
+        },
+      });
+
+      const response = await wrapped(request, makeContext());
+      expect(response.status).toBe(200);
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it("POST without CSRF token returns 403", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockValidateOrigin.mockReturnValue(true);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      });
+
+      const response = await wrapped(request, makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Invalid CSRF token");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("POST with invalid CSRF token returns 403", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockValidateOrigin.mockReturnValue(true);
+      mockValidateCsrfToken.mockReturnValue(false);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: {
+          origin: "http://localhost:3000",
+          "x-csrf-token": "invalid-token",
+        },
+      });
+
+      const response = await wrapped(request, makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Invalid CSRF token");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("POST with mismatched Origin returns 403", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockValidateOrigin.mockReturnValue(false);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: {
+          origin: "https://evil.com",
+          "x-csrf-token": "some-token",
+        },
+      });
+
+      const response = await wrapped(request, makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Origin mismatch");
+      expect(handler).not.toHaveBeenCalled();
+      // CSRF token should not be checked when origin fails
+      expect(mockValidateCsrfToken).not.toHaveBeenCalled();
+    });
+
+    it("missing CSRF_SECRET on POST returns 500", async () => {
+      delete process.env.CSRF_SECRET;
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      });
+
+      const response = await wrapped(request, makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe("Server configuration error");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("passes correct arguments to validateCsrfToken", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockValidateOrigin.mockReturnValue(true);
+      mockValidateCsrfToken.mockReturnValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: {
+          origin: "http://localhost:3000",
+          "x-csrf-token": "the-csrf-token",
+        },
+      });
+
+      await wrapped(request, makeContext());
+
+      expect(mockValidateCsrfToken).toHaveBeenCalledWith(
+        "the-csrf-token",
+        validSession.sessionId,
+        "test-csrf-secret",
+        validSession.iat,
+      );
+    });
+
+    it.each([
+      "PUT",
+      "PATCH",
+      "DELETE",
+    ])("%s request also requires CSRF validation", async (method) => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockValidateOrigin.mockReturnValue(true);
+      mockValidateCsrfToken.mockReturnValue(false);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+
+      const request = makeRequest("http://localhost:3000/api/test", {
+        method,
+        headers: {
+          origin: "http://localhost:3000",
+          "x-csrf-token": "bad",
+        },
+      });
+
+      const response = await wrapped(request, makeContext());
+      expect(response.status).toBe(403);
+      expect(handler).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/__tests__/lib/auth/jwt.test.ts
+++ b/src/__tests__/lib/auth/jwt.test.ts
@@ -163,6 +163,7 @@ describe("jwt", () => {
       expect(session.roles).toEqual(["admin"]);
       expect(session.tokenVersion).toBe(0);
       expect(session.mustChangePassword).toBe(false);
+      expect(session.iat).toEqual(expect.any(Number));
     });
 
     it("includes mustChangePassword from DB", async () => {

--- a/src/lib/auth/csrf.ts
+++ b/src/lib/auth/csrf.ts
@@ -1,0 +1,160 @@
+import "server-only";
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+// ── Constants ────────────────────────────────────────────────────
+
+const NONCE_BYTES = 16;
+const MUTATION_METHODS: ReadonlySet<string> = new Set([
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+]);
+
+/**
+ * CSRF cookie name.
+ *
+ * `__Host-` prefix requires `Secure` and `Path=/` without `Domain`,
+ * which only works over HTTPS.  In development (HTTP) we drop the
+ * prefix so the browser accepts the cookie.
+ */
+export const CSRF_COOKIE_NAME =
+  process.env.NODE_ENV === "production" ? "__Host-csrf" : "csrf";
+
+/** Header name the client sends the CSRF token in. */
+export const CSRF_HEADER_NAME = "x-csrf-token";
+
+/**
+ * Cookie options for the CSRF cookie.
+ *
+ * `httpOnly: false` — the client-side JS must be able to read the
+ * cookie value and attach it to the `X-CSRF-Token` header.
+ */
+export const CSRF_COOKIE_OPTIONS = {
+  httpOnly: false,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict" as const,
+  path: "/",
+};
+
+// ── Token generation ─────────────────────────────────────────────
+
+/**
+ * Generate an HMAC-based CSRF token bound to the given session ID.
+ *
+ * Token format: `<nonce>.<issued_at>.<signature>`
+ * where `signature = HMAC-SHA256(sid + nonce + issued_at, secret)`.
+ *
+ * The token is designed for the Double Submit Cookie pattern: set it
+ * as a non-httpOnly cookie, and the client reads it and sends it back
+ * in the `X-CSRF-Token` header on mutation requests.
+ */
+export function generateCsrfToken(
+  sid: string,
+  secret: string,
+): { token: string } {
+  const nonce = randomBytes(NONCE_BYTES).toString("hex");
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const signature = computeSignature(sid, nonce, issuedAt, secret);
+
+  return { token: `${nonce}.${issuedAt}.${signature}` };
+}
+
+// ── Token validation ─────────────────────────────────────────────
+
+/**
+ * Validate an HMAC-based CSRF token.
+ *
+ * Rejects if:
+ * - Token format is invalid (not 3 dot-separated parts)
+ * - HMAC signature mismatch (covers both tampering and `sid` mismatch,
+ *   because `sid` is part of the HMAC input)
+ * - `issued_at` < `jwtIat` (stale token — the CSRF token was issued
+ *   before the current JWT, meaning it belongs to a previous session
+ *   or a pre-rotation token)
+ *
+ * Uses constant-time comparison to prevent timing attacks.
+ */
+export function validateCsrfToken(
+  token: string,
+  sid: string,
+  secret: string,
+  jwtIat: number,
+): boolean {
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+
+  const [nonce, issuedAtStr, signature] = parts;
+
+  const issuedAt = Number(issuedAtStr);
+  if (Number.isNaN(issuedAt)) return false;
+
+  // Stale token check: CSRF must be issued at or after the JWT
+  if (issuedAt < jwtIat) return false;
+
+  // Recompute expected signature and compare in constant time
+  const expected = computeSignature(sid, nonce, issuedAt, secret);
+  return constantTimeEqual(signature, expected);
+}
+
+// ── Origin / Referer verification ────────────────────────────────
+
+/**
+ * Verify that the request originates from the expected app origin.
+ *
+ * Checks the `Origin` header first; falls back to extracting the
+ * origin from the `Referer` header.  Rejects if neither header is
+ * present or if neither matches.
+ *
+ * This is a defense-in-depth measure alongside the HMAC token.
+ */
+export function validateOrigin(
+  originHeader: string | null,
+  refererHeader: string | null,
+  expectedOrigin: string,
+): boolean {
+  if (originHeader) {
+    return originHeader === expectedOrigin;
+  }
+
+  if (refererHeader) {
+    try {
+      return new URL(refererHeader).origin === expectedOrigin;
+    } catch {
+      return false;
+    }
+  }
+
+  // Neither Origin nor Referer present — reject
+  return false;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Check whether the HTTP method requires CSRF validation. */
+export function isMutationMethod(method: string): boolean {
+  return MUTATION_METHODS.has(method.toUpperCase());
+}
+
+function computeSignature(
+  sid: string,
+  nonce: string,
+  issuedAt: number,
+  secret: string,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${sid}${nonce}${issuedAt}`)
+    .digest("hex");
+}
+
+/**
+ * Constant-time string comparison.
+ *
+ * Returns `false` early if lengths differ (length is not secret),
+ * then uses `crypto.timingSafeEqual` for the actual comparison.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -5,6 +5,12 @@ import { type NextRequest, NextResponse } from "next/server";
 import { query } from "@/lib/db/client";
 
 import { getAccessTokenCookie } from "./cookies";
+import {
+  CSRF_HEADER_NAME,
+  isMutationMethod,
+  validateCsrfToken,
+  validateOrigin,
+} from "./csrf";
 import type { AuthSession } from "./jwt";
 import { verifyJwtFull } from "./jwt";
 
@@ -24,13 +30,20 @@ type AuthenticatedHandler = (
 // ── Public API ──────────────────────────────────────────────────
 
 /**
- * Higher-order function that wraps Route Handlers with authentication.
+ * Higher-order function that wraps Route Handlers with authentication
+ * and CSRF protection.
  *
  * 1. Reads the access token from the cookie
  * 2. Verifies the token (stateless + DB checks)
- * 3. Checks must_change_password → 403 with redirect indicator
- * 4. Updates session last_active_at
- * 5. Calls the wrapped handler with the authenticated session
+ * 3. For mutation methods (POST/PUT/PATCH/DELETE):
+ *    a. Validates Origin/Referer header
+ *    b. Validates CSRF token from X-CSRF-Token header
+ * 4. Checks must_change_password → 403 with redirect indicator
+ * 5. Updates session last_active_at
+ * 6. Calls the wrapped handler with the authenticated session
+ *
+ * Server Actions are naturally exempt — they do not go through Route
+ * Handlers and have Next.js built-in CSRF protection.
  */
 export function withAuth(handler: AuthenticatedHandler): RouteHandler {
   return async (request, context) => {
@@ -54,7 +67,46 @@ export function withAuth(handler: AuthenticatedHandler): RouteHandler {
       );
     }
 
-    // Step 3: Check must_change_password
+    // Step 3: CSRF validation for mutation methods
+    if (isMutationMethod(request.method)) {
+      const csrfSecret = process.env.CSRF_SECRET;
+      if (!csrfSecret) {
+        return NextResponse.json(
+          { error: "Server configuration error" },
+          { status: 500 },
+        );
+      }
+
+      // Step 3a: Origin / Referer verification
+      if (
+        !validateOrigin(
+          request.headers.get("origin"),
+          request.headers.get("referer"),
+          request.nextUrl.origin,
+        )
+      ) {
+        return NextResponse.json({ error: "Origin mismatch" }, { status: 403 });
+      }
+
+      // Step 3b: CSRF token verification
+      const csrfToken = request.headers.get(CSRF_HEADER_NAME);
+      if (
+        !csrfToken ||
+        !validateCsrfToken(
+          csrfToken,
+          session.sessionId,
+          csrfSecret,
+          session.iat,
+        )
+      ) {
+        return NextResponse.json(
+          { error: "Invalid CSRF token" },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Step 4: Check must_change_password
     if (session.mustChangePassword) {
       return NextResponse.json(
         { error: "Password change required", redirect: "/change-password" },
@@ -62,12 +114,12 @@ export function withAuth(handler: AuthenticatedHandler): RouteHandler {
       );
     }
 
-    // Step 4: Update last_active_at on the session
+    // Step 5: Update last_active_at on the session
     await query("UPDATE sessions SET last_active_at = NOW() WHERE sid = $1", [
       session.sessionId,
     ]);
 
-    // Step 5: Invoke the authenticated handler
+    // Step 6: Invoke the authenticated handler
     return handler(request, context, session);
   };
 }

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -36,6 +36,8 @@ export interface AuthSession {
   roles: string[];
   tokenVersion: number;
   mustChangePassword: boolean;
+  /** JWT issued-at timestamp (seconds since epoch). */
+  iat: number;
 }
 
 // ── Issuance ────────────────────────────────────────────────────
@@ -145,5 +147,6 @@ export async function verifyJwtFull(token: string): Promise<AuthSession> {
     roles: payload.roles,
     tokenVersion: payload.token_version,
     mustChangePassword: row.must_change_password,
+    iat: payload.iat,
   };
 }


### PR DESCRIPTION
## Context

Phase 1 task 1-6 from #39. Implements HMAC-based Double Submit Cookie pattern for CSRF protection on all state-changing Route Handler requests. Server Actions are exempt (Next.js built-in CSRF).

References: Discussion #32 §9

## Changes

### New: `src/lib/auth/csrf.ts` — CSRF module (standalone, no JWT dependency)

- **Token formula**: `HMAC-SHA256(sid + nonce + issued_at, secret)`, transmitted as `nonce.issued_at.signature`
- **`generateCsrfToken(sid, secret)`**: Produces an HMAC token with a random 16-byte nonce, bound to the given session ID
- **`validateCsrfToken(token, sid, secret, jwtIat)`**: Rejects HMAC mismatch (covers sid mismatch), stale tokens (`issued_at < jwtIat`), and malformed inputs. Uses `crypto.timingSafeEqual` for constant-time comparison.
- **`validateOrigin(origin, referer, expectedOrigin)`**: Defense-in-depth Origin/Referer verification. Checks `Origin` header first, falls back to `Referer`.
- **`isMutationMethod(method)`**: Returns true for POST, PUT, PATCH, DELETE
- **Cookie**: `__Host-csrf` (production) / `csrf` (development), `httpOnly=false` (client must read), `sameSite=strict`, `path=/`
- **No JWT import** — receives `sid` and `jwtIat` as plain parameters

### Modified: `src/lib/auth/guard.ts` — CSRF validation in withAuth()

Added CSRF + origin validation between JWT verification and business logic:

```
1. Read access token cookie → 401
2. Verify JWT → 401
3. If mutation method (POST/PUT/PATCH/DELETE):    ← NEW
   a. Check CSRF_SECRET env var → 500 if missing
   b. Validate Origin/Referer → 403 if mismatch
   c. Validate CSRF token → 403 if invalid
4. Check must_change_password → 403
5. Update last_active_at
6. Call handler
```

### Modified: `src/lib/auth/jwt.ts` — `iat` added to AuthSession

Added `iat: number` to `AuthSession` interface so the guard can pass it to `validateCsrfToken()` for the staleness check.

### New: `src/__tests__/lib/auth/csrf.test.ts` — 33 unit tests

- Token generation (format, nonce length, timestamp, uniqueness)
- Token acceptance (fresh, equal iat, re-issued)
- Token rejection (wrong secret, wrong sid, stale, malformed, empty, tampered, non-numeric)
- Origin validation (match, mismatch, Referer fallback, neither present, malformed, priority)
- Mutation method detection (POST/PUT/PATCH/DELETE → true, GET/HEAD/OPTIONS → false)
- Cookie/header constants

### Modified: `src/__tests__/lib/auth/guard.test.ts` — 16 tests (6 existing + 10 new)

New CSRF tests: GET passes without CSRF, POST with valid CSRF, POST without/invalid CSRF, Origin mismatch, missing CSRF_SECRET, argument passing, PUT/PATCH/DELETE coverage.

### Modified: `.env.example` — Added `CSRF_SECRET`

## Verification

- `pnpm check` — Biome lint/format ✅
- `pnpm typecheck` — TypeScript ✅
- `pnpm test` — 275 tests pass (232 existing + 43 new) ✅
- `pnpm build` — Next.js build succeeds ✅

Closes #54