### PR TITLE
Add sliding token rotation and /api/auth/me

### DIFF
--- a/src/__tests__/app/api/auth/me.test.ts
+++ b/src/__tests__/app/api/auth/me.test.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: unknown,
+  session: AuthSession,
+) => Promise<Response>;
+
+const mockPoolQuery = vi.hoisted(() => vi.fn());
+
+// Make withAuth a pass-through that directly calls the handler with a
+// controllable session object.
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn) => {
+    return async (request: NextRequest, context: unknown) => {
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+}));
+
+describe("GET /api/auth/me", () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  const validSession: AuthSession = {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["admin"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+    iat: now,
+    exp: now + 900,
+  };
+
+  function makeRequest() {
+    return new NextRequest("http://localhost:3000/api/auth/me");
+  }
+
+  function makeContext() {
+    return { params: Promise.resolve({}) };
+  }
+
+  it("returns user info with correct JSON structure", async () => {
+    currentSession = validSession;
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ username: "alice", display_name: "Alice Kim" }],
+    });
+
+    const { GET } = await import("@/app/api/auth/me/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      accountId: "account-1",
+      username: "alice",
+      displayName: "Alice Kim",
+      roles: ["admin"],
+      mustChangePassword: false,
+    });
+  });
+
+  it("queries accounts table with correct accountId", async () => {
+    currentSession = validSession;
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ username: "alice", display_name: null }],
+    });
+
+    const { GET } = await import("@/app/api/auth/me/route");
+    await GET(makeRequest(), makeContext());
+
+    expect(mockPoolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("SELECT username, display_name FROM accounts"),
+      ["account-1"],
+    );
+  });
+
+  it("returns 404 when account is not found", async () => {
+    currentSession = validSession;
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { GET } = await import("@/app/api/auth/me/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe("Account not found");
+  });
+
+  it("handles null display_name", async () => {
+    currentSession = validSession;
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ username: "bob", display_name: null }],
+    });
+
+    const { GET } = await import("@/app/api/auth/me/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.displayName).toBeNull();
+  });
+
+  it("reflects mustChangePassword from session", async () => {
+    currentSession = { ...validSession, mustChangePassword: true };
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ username: "alice", display_name: "Alice" }],
+    });
+
+    const { GET } = await import("@/app/api/auth/me/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(body.mustChangePassword).toBe(true);
+  });
+});

--- a/src/__tests__/lib/auth/guard.test.ts
+++ b/src/__tests__/lib/auth/guard.test.ts
@@ -9,6 +9,8 @@ const mockPoolQuery = vi.hoisted(() => vi.fn());
 const mockValidateCsrfToken = vi.hoisted(() => vi.fn());
 const mockValidateOrigin = vi.hoisted(() => vi.fn());
 const mockCheckApiRateLimit = vi.hoisted(() => vi.fn());
+const mockShouldRotate = vi.hoisted(() => vi.fn());
+const mockRotateTokens = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth/cookies", () => ({
   getAccessTokenCookie: mockGetAccessTokenCookie,
@@ -26,6 +28,11 @@ vi.mock("@/lib/rate-limit/limiter", () => ({
   checkApiRateLimit: mockCheckApiRateLimit,
 }));
 
+vi.mock("@/lib/auth/rotation", () => ({
+  shouldRotate: mockShouldRotate,
+  rotateTokens: mockRotateTokens,
+}));
+
 vi.mock("@/lib/auth/csrf", () => ({
   CSRF_HEADER_NAME: "x-csrf-token",
   isMutationMethod: vi.fn((method: string) =>
@@ -38,13 +45,16 @@ vi.mock("@/lib/auth/csrf", () => ({
 describe("withAuth", () => {
   let guard: typeof import("@/lib/auth/guard");
 
+  const now = Math.floor(Date.now() / 1000);
+
   const validSession: AuthSession = {
     accountId: "account-1",
     sessionId: "session-1",
     roles: ["admin"],
     tokenVersion: 0,
     mustChangePassword: false,
-    iat: Math.floor(Date.now() / 1000),
+    iat: now,
+    exp: now + 900, // 15 minutes
   };
 
   function makeRequest(
@@ -68,6 +78,8 @@ describe("withAuth", () => {
     mockValidateCsrfToken.mockReset();
     mockValidateOrigin.mockReset();
     mockCheckApiRateLimit.mockReset().mockResolvedValue({ limited: false });
+    mockShouldRotate.mockReset().mockReturnValue(false);
+    mockRotateTokens.mockReset().mockResolvedValue(undefined);
 
     process.env.CSRF_SECRET = "test-csrf-secret";
 
@@ -450,6 +462,124 @@ describe("withAuth", () => {
       await wrapped(makeRequest(), makeContext());
 
       expect(mockCheckApiRateLimit).toHaveBeenCalledWith("account-1");
+    });
+  });
+
+  // ── Sliding rotation ──────────────────────────────────────────
+
+  describe("sliding rotation", () => {
+    it("rotates tokens when shouldRotate returns true", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockShouldRotate.mockReturnValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      await wrapped(makeRequest(), makeContext());
+
+      expect(mockShouldRotate).toHaveBeenCalledWith(
+        validSession.iat,
+        validSession.exp,
+      );
+      expect(mockRotateTokens).toHaveBeenCalledWith(validSession);
+    });
+
+    it("does not rotate when shouldRotate returns false", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockShouldRotate.mockReturnValue(false);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      await wrapped(makeRequest(), makeContext());
+
+      expect(mockShouldRotate).toHaveBeenCalledWith(
+        validSession.iat,
+        validSession.exp,
+      );
+      expect(mockRotateTokens).not.toHaveBeenCalled();
+    });
+
+    it("returns the handler's response after rotation", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockShouldRotate.mockReturnValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ data: "hello" }));
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(body.data).toBe("hello");
+      expect(mockRotateTokens).toHaveBeenCalled();
+    });
+
+    it("rotation happens after the handler is called", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockShouldRotate.mockReturnValue(true);
+
+      const callOrder: string[] = [];
+
+      mockRotateTokens.mockImplementation(async () => {
+        callOrder.push("rotate");
+      });
+
+      const handler = vi.fn().mockImplementation(async () => {
+        callOrder.push("handler");
+        return NextResponse.json({ ok: true });
+      });
+
+      const wrapped = guard.withAuth(handler);
+      await wrapped(makeRequest(), makeContext());
+
+      expect(callOrder).toEqual(["handler", "rotate"]);
+    });
+  });
+
+  // ── skipPasswordCheck option ──────────────────────────────────
+
+  describe("skipPasswordCheck option", () => {
+    it("allows handler when mustChangePassword is true and skipPasswordCheck is true", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue({
+        ...validSession,
+        mustChangePassword: true,
+      });
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler, { skipPasswordCheck: true });
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(handler).toHaveBeenCalled();
+    });
+
+    it("still blocks when mustChangePassword is true and no options are given", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue({
+        ...validSession,
+        mustChangePassword: true,
+      });
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Password change required");
+      expect(handler).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/lib/auth/jwt.test.ts
+++ b/src/__tests__/lib/auth/jwt.test.ts
@@ -164,6 +164,8 @@ describe("jwt", () => {
       expect(session.tokenVersion).toBe(0);
       expect(session.mustChangePassword).toBe(false);
       expect(session.iat).toEqual(expect.any(Number));
+      expect(session.exp).toEqual(expect.any(Number));
+      expect(session.exp).toBeGreaterThan(session.iat);
     });
 
     it("includes mustChangePassword from DB", async () => {

--- a/src/__tests__/lib/auth/rotation.test.ts
+++ b/src/__tests__/lib/auth/rotation.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const mockIssueAccessToken = vi.hoisted(() => vi.fn());
+const mockGenerateCsrfToken = vi.hoisted(() => vi.fn());
+const mockSetAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockCookiesSet = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/jwt", () => ({
+  issueAccessToken: mockIssueAccessToken,
+}));
+
+vi.mock("@/lib/auth/csrf", () => ({
+  CSRF_COOKIE_NAME: "csrf",
+  CSRF_COOKIE_OPTIONS: {
+    httpOnly: false,
+    secure: false,
+    sameSite: "strict",
+    path: "/",
+  },
+  generateCsrfToken: mockGenerateCsrfToken,
+}));
+
+vi.mock("@/lib/auth/cookies", () => ({
+  setAccessTokenCookie: mockSetAccessTokenCookie,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ set: mockCookiesSet })),
+}));
+
+describe("rotation", () => {
+  let rotation: typeof import("@/lib/auth/rotation");
+
+  const now = Math.floor(Date.now() / 1000);
+
+  const validSession: AuthSession = {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["admin"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+    iat: now - 600, // 10 min ago
+    exp: now + 300, // 5 min from now (total 15 min)
+  };
+
+  beforeEach(async () => {
+    mockIssueAccessToken.mockReset().mockResolvedValue("new-jwt-token");
+    mockGenerateCsrfToken.mockReset().mockReturnValue({ token: "new-csrf" });
+    mockSetAccessTokenCookie.mockReset().mockResolvedValue(undefined);
+    mockCookiesSet.mockReset();
+
+    process.env.CSRF_SECRET = "test-csrf-secret";
+
+    rotation = await import("@/lib/auth/rotation");
+  });
+
+  afterEach(() => {
+    delete process.env.CSRF_SECRET;
+  });
+
+  // ── shouldRotate() ────────────────────────────────────────────
+
+  describe("shouldRotate()", () => {
+    it("returns false when plenty of time remaining", () => {
+      // 10 min left of 15 min total — well outside rotation window
+      const iat = now - 300; // 5 min ago
+      const exp = now + 600; // 10 min from now
+
+      expect(rotation.shouldRotate(iat, exp)).toBe(false);
+    });
+
+    it("returns true when ≤ 1/3 remaining", () => {
+      // 4 min left of 15 min total — inside rotation window
+      const iat = now - 660; // 11 min ago
+      const exp = now + 240; // 4 min from now
+
+      expect(rotation.shouldRotate(iat, exp)).toBe(true);
+    });
+
+    it("returns true at exactly 1/3 boundary", () => {
+      // 5 min left of 15 min total — exactly at boundary
+      const iat = now - 600; // 10 min ago
+      const exp = now + 300; // 5 min from now (300 = 900/3)
+
+      expect(rotation.shouldRotate(iat, exp)).toBe(true);
+    });
+
+    it("returns true when about to expire", () => {
+      // 30 sec left
+      const iat = now - 870; // 14.5 min ago
+      const exp = now + 30;
+
+      expect(rotation.shouldRotate(iat, exp)).toBe(true);
+    });
+
+    it("returns false when token is already expired", () => {
+      const iat = now - 900;
+      const exp = now - 10; // expired 10 sec ago
+
+      expect(rotation.shouldRotate(iat, exp)).toBe(false);
+    });
+  });
+
+  // ── rotateTokens() ───────────────────────────────────────────
+
+  describe("rotateTokens()", () => {
+    it("issues new JWT with correct session params", async () => {
+      await rotation.rotateTokens(validSession);
+
+      expect(mockIssueAccessToken).toHaveBeenCalledWith({
+        accountId: "account-1",
+        sessionId: "session-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+      });
+    });
+
+    it("generates new CSRF token with sid and secret", async () => {
+      await rotation.rotateTokens(validSession);
+
+      expect(mockGenerateCsrfToken).toHaveBeenCalledWith(
+        "session-1",
+        "test-csrf-secret",
+      );
+    });
+
+    it("sets JWT cookie via setAccessTokenCookie", async () => {
+      await rotation.rotateTokens(validSession);
+
+      expect(mockSetAccessTokenCookie).toHaveBeenCalledWith(
+        "new-jwt-token",
+        900, // 15 * 60
+      );
+    });
+
+    it("sets CSRF cookie with correct options", async () => {
+      await rotation.rotateTokens(validSession);
+
+      expect(mockCookiesSet).toHaveBeenCalledWith("csrf", "new-csrf", {
+        httpOnly: false,
+        secure: false,
+        sameSite: "strict",
+        path: "/",
+        maxAge: 900,
+      });
+    });
+
+    it("skips silently when CSRF_SECRET is missing", async () => {
+      delete process.env.CSRF_SECRET;
+
+      await rotation.rotateTokens(validSession);
+
+      expect(mockIssueAccessToken).not.toHaveBeenCalled();
+      expect(mockGenerateCsrfToken).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { query } from "@/lib/db/client";
+
+/**
+ * GET /api/auth/me
+ *
+ * Returns current user info.  Rotation is triggered automatically
+ * through `withAuth()` when the JWT is within the rotation window.
+ */
+export const GET = withAuth(async (_request, _context, session) => {
+  const { rows } = await query<{
+    username: string;
+    display_name: string | null;
+  }>("SELECT username, display_name FROM accounts WHERE id = $1", [
+    session.accountId,
+  ]);
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    accountId: session.accountId,
+    username: rows[0].username,
+    displayName: rows[0].display_name,
+    roles: session.roles,
+    mustChangePassword: session.mustChangePassword,
+  });
+});

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -14,6 +14,7 @@ import {
 } from "./csrf";
 import type { AuthSession } from "./jwt";
 import { verifyJwtFull } from "./jwt";
+import { rotateTokens, shouldRotate } from "./rotation";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -28,11 +29,22 @@ type AuthenticatedHandler = (
   session: AuthSession,
 ) => Promise<NextResponse | Response>;
 
+// ── Options ─────────────────────────────────────────────────────
+
+interface WithAuthOptions {
+  /**
+   * When `true`, skip the must-change-password check (step 5).
+   * Needed for endpoints like sign-out that must remain accessible
+   * even when a password change is pending.
+   */
+  skipPasswordCheck?: boolean;
+}
+
 // ── Public API ──────────────────────────────────────────────────
 
 /**
  * Higher-order function that wraps Route Handlers with authentication,
- * rate limiting, and CSRF protection.
+ * rate limiting, CSRF protection, and sliding token rotation.
  *
  * 1. Reads the access token from the cookie
  * 2. Verifies the token (stateless + DB checks)
@@ -41,13 +53,19 @@ type AuthenticatedHandler = (
  *    a. Validates Origin/Referer header
  *    b. Validates CSRF token from X-CSRF-Token header
  * 5. Checks must_change_password → 403 with redirect indicator
+ *    (skippable via `options.skipPasswordCheck`)
  * 6. Updates session last_active_at
  * 7. Calls the wrapped handler with the authenticated session
+ * 8. Sliding rotation — re-issues JWT + CSRF when ≤ 1/3 lifetime
+ *    remains
  *
  * Server Actions are naturally exempt — they do not go through Route
  * Handlers and have Next.js built-in CSRF protection.
  */
-export function withAuth(handler: AuthenticatedHandler): RouteHandler {
+export function withAuth(
+  handler: AuthenticatedHandler,
+  options?: WithAuthOptions,
+): RouteHandler {
   return async (request, context) => {
     // Step 1: Read token from cookie
     const token = await getAccessTokenCookie();
@@ -122,8 +140,8 @@ export function withAuth(handler: AuthenticatedHandler): RouteHandler {
       }
     }
 
-    // Step 5: Check must_change_password
-    if (session.mustChangePassword) {
+    // Step 5: Check must_change_password (skippable)
+    if (!options?.skipPasswordCheck && session.mustChangePassword) {
       return NextResponse.json(
         { error: "Password change required", redirect: "/change-password" },
         { status: 403 },
@@ -136,6 +154,13 @@ export function withAuth(handler: AuthenticatedHandler): RouteHandler {
     ]);
 
     // Step 7: Invoke the authenticated handler
-    return handler(request, context, session);
+    const response = await handler(request, context, session);
+
+    // Step 8: Sliding rotation — re-issue tokens when nearing expiry
+    if (shouldRotate(session.iat, session.exp)) {
+      await rotateTokens(session);
+    }
+
+    return response;
   };
 }

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -38,6 +38,8 @@ export interface AuthSession {
   mustChangePassword: boolean;
   /** JWT issued-at timestamp (seconds since epoch). */
   iat: number;
+  /** JWT expiration timestamp (seconds since epoch). */
+  exp: number;
 }
 
 // ── Issuance ────────────────────────────────────────────────────
@@ -148,5 +150,6 @@ export async function verifyJwtFull(token: string): Promise<AuthSession> {
     tokenVersion: payload.token_version,
     mustChangePassword: row.must_change_password,
     iat: payload.iat,
+    exp: payload.exp,
   };
 }

--- a/src/lib/auth/rotation.ts
+++ b/src/lib/auth/rotation.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+import { setAccessTokenCookie } from "./cookies";
+import {
+  CSRF_COOKIE_NAME,
+  CSRF_COOKIE_OPTIONS,
+  generateCsrfToken,
+} from "./csrf";
+import type { AuthSession } from "./jwt";
+import { issueAccessToken } from "./jwt";
+
+// ── Constants ────────────────────────────────────────────────────
+
+/**
+ * Rotate when the remaining lifetime is ≤ 1/ROTATION_FRACTION of
+ * the total lifetime.  For a 15-minute token this triggers at ≤ 5
+ * minutes remaining.
+ */
+const ROTATION_FRACTION = 3;
+
+/** Default token lifetime in seconds (must match JWT issuance). */
+const DEFAULT_MAX_AGE_SECONDS = 15 * 60;
+
+// ── Public API ───────────────────────────────────────────────────
+
+/**
+ * Determine whether a JWT should be rotated based on its remaining
+ * lifetime.
+ *
+ * @param iat  JWT issued-at (seconds since epoch)
+ * @param exp  JWT expiration (seconds since epoch)
+ * @returns `true` when remaining ≤ 1/3 of total and token is not
+ *          already expired
+ */
+export function shouldRotate(iat: number, exp: number): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  const total = exp - iat;
+  const remaining = exp - now;
+
+  return remaining > 0 && remaining <= total / ROTATION_FRACTION;
+}
+
+/**
+ * Issue a new JWT + CSRF token pair and set them as cookies.
+ *
+ * Called by the `withAuth()` guard after the handler completes when
+ * the current token is within the rotation window.  The previous
+ * token is **not** revoked — it remains valid until its natural
+ * expiration (automatic grace period).
+ */
+export async function rotateTokens(session: AuthSession): Promise<void> {
+  const csrfSecret = process.env.CSRF_SECRET;
+  if (!csrfSecret) return; // Cannot rotate without CSRF secret
+
+  // Issue new JWT
+  const newToken = await issueAccessToken({
+    accountId: session.accountId,
+    sessionId: session.sessionId,
+    roles: session.roles,
+    tokenVersion: session.tokenVersion,
+  });
+
+  // Issue new CSRF token
+  const { token: newCsrfToken } = generateCsrfToken(
+    session.sessionId,
+    csrfSecret,
+  );
+
+  // Set JWT cookie
+  await setAccessTokenCookie(newToken, DEFAULT_MAX_AGE_SECONDS);
+
+  // Set CSRF cookie
+  const cookieStore = await cookies();
+  cookieStore.set(CSRF_COOKIE_NAME, newCsrfToken, {
+    ...CSRF_COOKIE_OPTIONS,
+    maxAge: DEFAULT_MAX_AGE_SECONDS,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds **sliding JWT rotation** to the `withAuth()` guard: when a token's remaining lifetime drops to ≤ 1/3 of its total (e.g. ≤ 5 min for a 15-min token), a new JWT + CSRF pair is issued automatically after the handler completes. The old token remains valid until natural expiration — no revocation needed.
- Adds `GET /api/auth/me` endpoint returning current user info (accountId, username, displayName, roles, mustChangePassword). Rotation triggers automatically through `withAuth()`.
- Adds `skipPasswordCheck` option to `withAuth()` for endpoints like sign-out that must remain accessible during password-change state.
- Adds `exp` field to `AuthSession` interface (needed for rotation window calculation).

## Changes

| File | Change |
|------|--------|
| `src/lib/auth/rotation.ts` | New — `shouldRotate()` + `rotateTokens()` |
| `src/lib/auth/guard.ts` | Step 8 sliding rotation + `skipPasswordCheck` option |
| `src/lib/auth/jwt.ts` | `exp` added to `AuthSession` + `verifyJwtFull()` |
| `src/app/api/auth/me/route.ts` | New — `GET /api/auth/me` endpoint |
| `src/__tests__/lib/auth/rotation.test.ts` | 10 tests |
| `src/__tests__/lib/auth/guard.test.ts` | 6 new tests (26 total) |
| `src/__tests__/lib/auth/jwt.test.ts` | 2 new assertions |
| `src/__tests__/app/api/auth/me.test.ts` | 5 tests |

## Test plan

- [x] All 328 tests pass (`pnpm test`)
- [x] Biome lint/format clean (`pnpm check`)
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Next.js build succeeds (`pnpm build`)

Closes #58