### PR TITLE
Add audit log search API and UI

### DIFF
--- a/src/__tests__/app/api/audit-logs/route.test.ts
+++ b/src/__tests__/app/api/audit-logs/route.test.ts
@@ -1,0 +1,318 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: unknown,
+  session: AuthSession,
+) => Promise<Response>;
+
+const mockQueryAudit = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn) => {
+    return async (request: NextRequest, context: unknown) => {
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/audit/client", () => ({
+  queryAudit: vi.fn((...args: unknown[]) => mockQueryAudit(...args)),
+}));
+
+describe("GET /api/audit-logs", () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  const adminSession: AuthSession = {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["System Administrator"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+    iat: now,
+    exp: now + 900,
+  };
+
+  const viewerSession: AuthSession = {
+    ...adminSession,
+    roles: ["viewer"],
+  };
+
+  function makeRequest(params = "") {
+    return new NextRequest(
+      `http://localhost:3000/api/audit-logs${params ? `?${params}` : ""}`,
+    );
+  }
+
+  function makeContext() {
+    return { params: Promise.resolve({}) };
+  }
+
+  beforeEach(() => {
+    mockQueryAudit.mockReset();
+    currentSession = adminSession;
+
+    // Default: COUNT returns 0, data returns empty
+    mockQueryAudit.mockResolvedValue({ rows: [{ count: "0" }], rowCount: 1 });
+  });
+
+  // ── Permission ──────────────────────────────────────────────────
+
+  describe("permission", () => {
+    it("returns 403 when user lacks System Administrator role", async () => {
+      currentSession = viewerSession;
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Forbidden");
+    });
+
+    it("allows access for System Administrator", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "0" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest(), makeContext());
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  // ── Pagination ──────────────────────────────────────────────────
+
+  describe("pagination", () => {
+    it("defaults to page=1, pageSize=20", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "0" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(body.page).toBe(1);
+      expect(body.pageSize).toBe(20);
+    });
+
+    it("respects custom page and pageSize", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "50" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(
+        makeRequest("page=3&pageSize=10"),
+        makeContext(),
+      );
+      const body = await response.json();
+
+      expect(body.page).toBe(3);
+      expect(body.pageSize).toBe(10);
+    });
+
+    it("clamps pageSize to 100", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "0" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest("pageSize=500"), makeContext());
+      const body = await response.json();
+
+      expect(body.pageSize).toBe(100);
+    });
+
+    it("clamps page to minimum of 1", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "0" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest("page=-5"), makeContext());
+      const body = await response.json();
+
+      expect(body.page).toBe(1);
+    });
+  });
+
+  // ── Validation ──────────────────────────────────────────────────
+
+  describe("validation", () => {
+    it("returns 400 for invalid from date", async () => {
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest("from=not-a-date"), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe("Invalid 'from' date");
+    });
+
+    it("returns 400 for invalid to date", async () => {
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest("to=not-a-date"), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe("Invalid 'to' date");
+    });
+
+    it("returns 400 for invalid action type", async () => {
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(
+        makeRequest("action=invalid.action"),
+        makeContext(),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe("Invalid action type");
+    });
+
+    it("returns 400 for invalid target type", async () => {
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(
+        makeRequest("targetType=unknown"),
+        makeContext(),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe("Invalid target type");
+    });
+
+    it("returns 400 for non-UUID correlationId", async () => {
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(
+        makeRequest("correlationId=not-a-uuid"),
+        makeContext(),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe("Invalid correlation ID format");
+    });
+  });
+
+  // ── Query building ──────────────────────────────────────────────
+
+  describe("query building", () => {
+    it("passes no WHERE conditions when no filters", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "0" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      await GET(makeRequest(), makeContext());
+
+      // COUNT query — no WHERE
+      expect(mockQueryAudit).toHaveBeenCalledWith(
+        expect.stringContaining("SELECT COUNT(*)"),
+        [],
+      );
+    });
+
+    it("applies actor filter", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      await GET(makeRequest("actor=alice"), makeContext());
+
+      expect(mockQueryAudit).toHaveBeenCalledWith(
+        expect.stringContaining("actor_id = $1"),
+        ["alice"],
+      );
+    });
+
+    it("applies action filter", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      await GET(makeRequest("action=auth.sign_in.success"), makeContext());
+
+      expect(mockQueryAudit).toHaveBeenCalledWith(
+        expect.stringContaining("action = $1"),
+        ["auth.sign_in.success"],
+      );
+    });
+
+    it("applies correlation ID filter", async () => {
+      const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      await GET(makeRequest(`correlationId=${uuid}`), makeContext());
+
+      expect(mockQueryAudit).toHaveBeenCalledWith(
+        expect.stringContaining("correlation_id = $1"),
+        [uuid],
+      );
+    });
+
+    it("combines multiple filters with AND", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      await GET(
+        makeRequest("actor=alice&action=auth.sign_out&targetType=session"),
+        makeContext(),
+      );
+
+      // COUNT query should have all three conditions
+      const countCall = mockQueryAudit.mock.calls[0];
+      expect(countCall[0]).toContain("actor_id = $1");
+      expect(countCall[0]).toContain("action = $2");
+      expect(countCall[0]).toContain("target_type = $3");
+      expect(countCall[1]).toEqual(["alice", "auth.sign_out", "session"]);
+    });
+  });
+
+  // ── Response ────────────────────────────────────────────────────
+
+  describe("response", () => {
+    it("returns { data, total, page, pageSize } structure", async () => {
+      const sampleRow = {
+        id: "1",
+        timestamp: "2026-03-01T00:00:00Z",
+        actor_id: "account-1",
+        action: "auth.sign_in.success",
+        target_type: "account",
+        target_id: "account-1",
+        details: null,
+        ip_address: "1.2.3.4",
+        sid: "session-1",
+        customer_id: null,
+        correlation_id: null,
+      };
+
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [sampleRow], rowCount: 1 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.data).toHaveLength(1);
+      expect(body.total).toBe(1);
+      expect(body.page).toBe(1);
+      expect(body.pageSize).toBe(20);
+      expect(body.data[0].action).toBe("auth.sign_in.success");
+    });
+  });
+});

--- a/src/__tests__/components/layout/breadcrumbs.test.ts
+++ b/src/__tests__/components/layout/breadcrumbs.test.ts
@@ -80,6 +80,7 @@ describe("NAV_SEGMENTS", () => {
       "detection",
       "triage",
       "report",
+      "audit-logs",
       "settings",
     ];
     for (const key of expected) {

--- a/src/__tests__/i18n/messages.test.ts
+++ b/src/__tests__/i18n/messages.test.ts
@@ -13,6 +13,15 @@ function getKeys(obj: Record<string, unknown>, prefix = ""): string[] {
   });
 }
 
+function getLeafValues(obj: Record<string, unknown>): string[] {
+  return Object.values(obj).flatMap((value) => {
+    if (typeof value === "object" && value !== null) {
+      return getLeafValues(value as Record<string, unknown>);
+    }
+    return [value as string];
+  });
+}
+
 describe("translation messages", () => {
   it("en.json and ko.json have the same key structure", () => {
     const enKeys = getKeys(en);
@@ -32,15 +41,7 @@ describe("translation messages", () => {
   });
 
   it("has no empty string values in en.json", () => {
-    const values = getKeys(en).map(
-      (key) =>
-        key
-          .split(".")
-          .reduce(
-            (obj, k) => (obj as Record<string, unknown>)[k],
-            en as unknown,
-          ) as string,
-    );
+    const values = getLeafValues(en);
 
     for (const value of values) {
       expect(value).not.toBe("");
@@ -48,15 +49,7 @@ describe("translation messages", () => {
   });
 
   it("has no empty string values in ko.json", () => {
-    const values = getKeys(ko).map(
-      (key) =>
-        key
-          .split(".")
-          .reduce(
-            (obj, k) => (obj as Record<string, unknown>)[k],
-            ko as unknown,
-          ) as string,
-    );
+    const values = getLeafValues(ko);
 
     for (const value of values) {
       expect(value).not.toBe("");

--- a/src/__tests__/lib/audit/client.test.ts
+++ b/src/__tests__/lib/audit/client.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock setup ────────────────────────────────────────────────────
+
+const { mockPoolQuery, mockPoolEnd, connectTo } = vi.hoisted(() => {
+  const mockPoolQuery = vi.fn();
+  const mockPoolEnd = vi.fn();
+  const connectTo = vi.fn(() => ({
+    query: mockPoolQuery,
+    end: mockPoolEnd,
+  }));
+  return { mockPoolQuery, mockPoolEnd, connectTo };
+});
+
+vi.mock("@/lib/db/client", () => ({
+  connectTo,
+}));
+
+describe("audit client", () => {
+  let client: typeof import("@/lib/audit/client");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockPoolQuery.mockReset();
+    mockPoolEnd.mockReset();
+    connectTo.mockClear();
+
+    process.env.AUDIT_DATABASE_URL =
+      "postgres://audit_reader:pass@localhost:5432/audit_db";
+
+    client = await import("@/lib/audit/client");
+  });
+
+  afterEach(() => {
+    client.resetAuditReadPool();
+    delete process.env.AUDIT_DATABASE_URL;
+  });
+
+  // ── queryAudit ──────────────────────────────────────────────────
+
+  describe("queryAudit()", () => {
+    it("returns rows and rowCount from audit_db", async () => {
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 1, action: "auth.sign_in.success" }],
+        rowCount: 1,
+      });
+
+      const result = await client.queryAudit("SELECT * FROM audit_logs");
+
+      expect(result.rows).toEqual([{ id: 1, action: "auth.sign_in.success" }]);
+      expect(result.rowCount).toBe(1);
+    });
+
+    it("creates pool lazily on first call", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      await client.queryAudit("SELECT 1");
+
+      expect(connectTo).toHaveBeenCalledWith(
+        "postgres://audit_reader:pass@localhost:5432/audit_db",
+      );
+    });
+
+    it("reuses pool across multiple calls", async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+      await client.queryAudit("SELECT 1");
+      await client.queryAudit("SELECT 2");
+
+      expect(connectTo).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when AUDIT_DATABASE_URL is missing", async () => {
+      delete process.env.AUDIT_DATABASE_URL;
+      client.resetAuditReadPool();
+
+      await expect(client.queryAudit("SELECT 1")).rejects.toThrow(
+        "Missing environment variable: AUDIT_DATABASE_URL",
+      );
+    });
+
+    it("propagates database errors", async () => {
+      mockPoolQuery.mockRejectedValueOnce(new Error("connection refused"));
+
+      await expect(client.queryAudit("SELECT 1")).rejects.toThrow(
+        "connection refused",
+      );
+    });
+
+    it("passes params to the pool query", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await client.queryAudit("SELECT * FROM audit_logs WHERE id = $1", [42]);
+
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        "SELECT * FROM audit_logs WHERE id = $1",
+        [42],
+      );
+    });
+  });
+
+  // ── endAuditReadPool ────────────────────────────────────────────
+
+  describe("endAuditReadPool()", () => {
+    it("ends the pool and resets reference", async () => {
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      await client.queryAudit("SELECT 1"); // initialize pool
+      mockPoolEnd.mockResolvedValueOnce(undefined);
+
+      await client.endAuditReadPool();
+
+      expect(mockPoolEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it("is safe when no pool exists", async () => {
+      client.resetAuditReadPool();
+      await client.endAuditReadPool();
+
+      expect(mockPoolEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── resetAuditReadPool ──────────────────────────────────────────
+
+  describe("resetAuditReadPool()", () => {
+    it("clears reference so next call creates new pool", async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+      await client.queryAudit("SELECT 1");
+      expect(connectTo).toHaveBeenCalledTimes(1);
+
+      client.resetAuditReadPool();
+      await client.queryAudit("SELECT 2");
+      expect(connectTo).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/app/[locale]/(dashboard)/audit-logs/page.tsx
+++ b/src/app/[locale]/(dashboard)/audit-logs/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { AuditLogTable } from "@/components/audit/audit-log-table";
+
+export default function AuditLogsPage() {
+  return (
+    <Suspense>
+      <AuditLogTable />
+    </Suspense>
+  );
+}

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -1,0 +1,198 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { queryAudit } from "@/lib/audit/client";
+import { withAuth } from "@/lib/auth/guard";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface AuditLogRow {
+  id: string;
+  timestamp: string;
+  actor_id: string;
+  action: string;
+  target_type: string;
+  target_id: string | null;
+  details: Record<string, unknown> | null;
+  ip_address: string | null;
+  sid: string | null;
+  customer_id: number | null;
+  correlation_id: string | null;
+}
+
+interface CountRow {
+  count: string;
+}
+
+// ── Constants ────────────────────────────────────────────────────
+
+const ALLOWED_ACTIONS = new Set([
+  "auth.sign_in.success",
+  "auth.sign_in.failure",
+  "auth.sign_out",
+  "auth.session_extend",
+  "session.ip_mismatch",
+  "session.ua_mismatch",
+  "session.revoke",
+  "account.create",
+  "account.lock",
+  "account.unlock",
+]);
+
+const ALLOWED_TARGET_TYPES = new Set(["account", "session"]);
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function isValidISODate(value: string): boolean {
+  const d = new Date(value);
+  return !Number.isNaN(d.getTime());
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ── Route Handler ────────────────────────────────────────────────
+
+/**
+ * GET /api/audit-logs
+ *
+ * Search and filter audit log entries.  System Administrator only.
+ *
+ * Query parameters:
+ *   page, pageSize, from, to, actor, action, targetType, targetId,
+ *   correlationId
+ */
+export const GET = withAuth(async (request, _context, session) => {
+  // Permission check
+  if (!session.roles.includes("System Administrator")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = request.nextUrl;
+
+  // ── Parse pagination ────────────────────────────────────────────
+
+  const page = Math.max(
+    DEFAULT_PAGE,
+    Number.parseInt(url.searchParams.get("page") ?? "", 10) || DEFAULT_PAGE,
+  );
+  const pageSize = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(
+      1,
+      Number.parseInt(url.searchParams.get("pageSize") ?? "", 10) ||
+        DEFAULT_PAGE_SIZE,
+    ),
+  );
+
+  // ── Build dynamic WHERE clause ──────────────────────────────────
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  // Date range
+  const from = url.searchParams.get("from");
+  if (from) {
+    if (!isValidISODate(from)) {
+      return NextResponse.json(
+        { error: "Invalid 'from' date" },
+        { status: 400 },
+      );
+    }
+    conditions.push(`timestamp >= $${idx++}`);
+    params.push(from);
+  }
+
+  const to = url.searchParams.get("to");
+  if (to) {
+    if (!isValidISODate(to)) {
+      return NextResponse.json({ error: "Invalid 'to' date" }, { status: 400 });
+    }
+    conditions.push(`timestamp <= $${idx++}`);
+    params.push(to);
+  }
+
+  // Actor
+  const actor = url.searchParams.get("actor");
+  if (actor) {
+    conditions.push(`actor_id = $${idx++}`);
+    params.push(actor);
+  }
+
+  // Action (validated)
+  const action = url.searchParams.get("action");
+  if (action) {
+    if (!ALLOWED_ACTIONS.has(action)) {
+      return NextResponse.json(
+        { error: "Invalid action type" },
+        { status: 400 },
+      );
+    }
+    conditions.push(`action = $${idx++}`);
+    params.push(action);
+  }
+
+  // Target type (validated)
+  const targetType = url.searchParams.get("targetType");
+  if (targetType) {
+    if (!ALLOWED_TARGET_TYPES.has(targetType)) {
+      return NextResponse.json(
+        { error: "Invalid target type" },
+        { status: 400 },
+      );
+    }
+    conditions.push(`target_type = $${idx++}`);
+    params.push(targetType);
+  }
+
+  // Target ID
+  const targetId = url.searchParams.get("targetId");
+  if (targetId) {
+    conditions.push(`target_id = $${idx++}`);
+    params.push(targetId);
+  }
+
+  // Correlation ID (validated as UUID)
+  const correlationId = url.searchParams.get("correlationId");
+  if (correlationId) {
+    if (!UUID_RE.test(correlationId)) {
+      return NextResponse.json(
+        { error: "Invalid correlation ID format" },
+        { status: 400 },
+      );
+    }
+    conditions.push(`correlation_id = $${idx++}`);
+    params.push(correlationId);
+  }
+
+  // ── Execute queries ─────────────────────────────────────────────
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  // Total count (shares the same WHERE + params)
+  const { rows: countRows } = await queryAudit<CountRow>(
+    `SELECT COUNT(*) AS count FROM audit_logs ${where}`,
+    params,
+  );
+  const total = Number.parseInt(countRows[0].count, 10);
+
+  // Data page
+  const offset = (page - 1) * pageSize;
+  const { rows } = await queryAudit<AuditLogRow>(
+    `SELECT id, timestamp, actor_id, action, target_type, target_id,
+            details, ip_address, sid, customer_id, correlation_id
+       FROM audit_logs ${where}
+      ORDER BY timestamp DESC
+      LIMIT $${idx++} OFFSET $${idx++}`,
+    [...params, pageSize, offset],
+  );
+
+  return NextResponse.json({ data: rows, total, page, pageSize });
+});

--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface AuditLogEntry {
+  id: string;
+  timestamp: string;
+  actor_id: string;
+  action: string;
+  target_type: string;
+  target_id: string | null;
+  details: Record<string, unknown> | null;
+  ip_address: string | null;
+  correlation_id: string | null;
+}
+
+interface SearchResult {
+  data: AuditLogEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+// ── Constants ────────────────────────────────────────────────────
+
+const ACTION_KEYS = [
+  "auth.sign_in.success",
+  "auth.sign_in.failure",
+  "auth.sign_out",
+  "auth.session_extend",
+  "session.ip_mismatch",
+  "session.ua_mismatch",
+  "session.revoke",
+  "account.create",
+  "account.lock",
+  "account.unlock",
+] as const;
+
+const TARGET_TYPE_KEYS = ["account", "session"] as const;
+
+// ── Component ────────────────────────────────────────────────────
+
+export function AuditLogTable() {
+  const t = useTranslations("auditLogs");
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [result, setResult] = useState<SearchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // ── Local filter state (synced from URL on mount) ───────────
+
+  const [from, setFrom] = useState(searchParams.get("from") ?? "");
+  const [to, setTo] = useState(searchParams.get("to") ?? "");
+  const [actor, setActor] = useState(searchParams.get("actor") ?? "");
+  const [action, setAction] = useState(searchParams.get("action") ?? "");
+  const [targetType, setTargetType] = useState(
+    searchParams.get("targetType") ?? "",
+  );
+  const [targetId, setTargetId] = useState(searchParams.get("targetId") ?? "");
+  const [correlationId, setCorrelationId] = useState(
+    searchParams.get("correlationId") ?? "",
+  );
+
+  // ── URL helpers ─────────────────────────────────────────────
+
+  const buildParams = useCallback(
+    (overrides: Record<string, string | null> = {}) => {
+      const base: Record<string, string> = {};
+      if (from) base.from = from;
+      if (to) base.to = to;
+      if (actor) base.actor = actor;
+      if (action) base.action = action;
+      if (targetType) base.targetType = targetType;
+      if (targetId) base.targetId = targetId;
+      if (correlationId) base.correlationId = correlationId;
+
+      const merged = { ...base, ...overrides };
+      const params = new URLSearchParams();
+      for (const [k, v] of Object.entries(merged)) {
+        if (v) params.set(k, v);
+      }
+      return params;
+    },
+    [from, to, actor, action, targetType, targetId, correlationId],
+  );
+
+  // ── Fetch ───────────────────────────────────────────────────
+
+  const fetchLogs = useCallback(
+    async (params: URLSearchParams) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/audit-logs?${params.toString()}`);
+        if (!res.ok) {
+          const body = await res.json();
+          throw new Error(body.error ?? "Failed to fetch");
+        }
+        const data: SearchResult = await res.json();
+        setResult(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("error"));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [t],
+  );
+
+  // Fetch on URL change
+  useEffect(() => {
+    fetchLogs(searchParams);
+  }, [searchParams, fetchLogs]);
+
+  // ── Handlers ────────────────────────────────────────────────
+
+  const handleSearch = useCallback(() => {
+    const params = buildParams();
+    router.push(`${pathname}?${params.toString()}`);
+  }, [buildParams, router, pathname]);
+
+  const handleClear = useCallback(() => {
+    setFrom("");
+    setTo("");
+    setActor("");
+    setAction("");
+    setTargetType("");
+    setTargetId("");
+    setCorrelationId("");
+    router.push(pathname);
+  }, [router, pathname]);
+
+  const handleCorrelationClick = useCallback(
+    (cid: string) => {
+      setCorrelationId(cid);
+      setFrom("");
+      setTo("");
+      setActor("");
+      setAction("");
+      setTargetType("");
+      setTargetId("");
+      const params = new URLSearchParams({ correlationId: cid });
+      router.push(`${pathname}?${params.toString()}`);
+    },
+    [router, pathname],
+  );
+
+  const goToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("page", String(page));
+      router.push(`${pathname}?${params.toString()}`);
+    },
+    [searchParams, router, pathname],
+  );
+
+  // ── Derived ─────────────────────────────────────────────────
+
+  const totalPages = result
+    ? Math.max(1, Math.ceil(result.total / result.pageSize))
+    : 1;
+  const currentPage = result?.page ?? 1;
+
+  // ── Render ──────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      {/* Title */}
+      <h1 className="text-foreground text-2xl font-bold">{t("title")}</h1>
+
+      {/* Filters */}
+      <div className="bg-card space-y-4 rounded-lg border p-4">
+        <h2 className="text-foreground text-sm font-medium">{t("filters")}</h2>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="space-y-1">
+            <Label>{t("from")}</Label>
+            <Input
+              type="datetime-local"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>{t("to")}</Label>
+            <Input
+              type="datetime-local"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>{t("actor")}</Label>
+            <Input
+              type="text"
+              value={actor}
+              placeholder={t("actor")}
+              onChange={(e) => setActor(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>{t("action")}</Label>
+            <Select value={action} onValueChange={setAction}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("allActions")} />
+              </SelectTrigger>
+              <SelectContent>
+                {ACTION_KEYS.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {t(`actions.${key}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label>{t("targetType")}</Label>
+            <Select value={targetType} onValueChange={setTargetType}>
+              <SelectTrigger>
+                <SelectValue placeholder={t("allTargetTypes")} />
+              </SelectTrigger>
+              <SelectContent>
+                {TARGET_TYPE_KEYS.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {t(`targetTypes.${key}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label>{t("targetId")}</Label>
+            <Input
+              type="text"
+              value={targetId}
+              placeholder={t("targetId")}
+              onChange={(e) => setTargetId(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>{t("correlationId")}</Label>
+            <Input
+              type="text"
+              value={correlationId}
+              placeholder={t("correlationId")}
+              onChange={(e) => setCorrelationId(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <Button onClick={handleSearch}>{t("search")}</Button>
+          <Button variant="outline" onClick={handleClear}>
+            {t("clear")}
+          </Button>
+        </div>
+      </div>
+
+      {/* Loading / Error / Empty */}
+      {loading && (
+        <p className="text-muted-foreground text-sm">{t("loading")}</p>
+      )}
+      {error && <p className="text-destructive text-sm">{error}</p>}
+      {!loading && !error && result && result.data.length === 0 && (
+        <p className="text-muted-foreground text-sm">{t("noResults")}</p>
+      )}
+
+      {/* Table */}
+      {!loading && result && result.data.length > 0 && (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("timestamp")}</TableHead>
+                <TableHead>{t("actor")}</TableHead>
+                <TableHead>{t("action")}</TableHead>
+                <TableHead>{t("targetType")}</TableHead>
+                <TableHead>{t("targetId")}</TableHead>
+                <TableHead>{t("correlationId")}</TableHead>
+                <TableHead>{t("ipAddress")}</TableHead>
+                <TableHead>{t("details")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result.data.map((entry) => (
+                <TableRow key={entry.id}>
+                  <TableCell className="whitespace-nowrap text-xs">
+                    {new Date(entry.timestamp).toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-xs">{entry.actor_id}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary" className="text-xs">
+                      {t(`actions.${entry.action}` as Parameters<typeof t>[0])}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-xs">{entry.target_type}</TableCell>
+                  <TableCell className="text-xs">
+                    {entry.target_id ?? "-"}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {entry.correlation_id ? (
+                      <button
+                        type="button"
+                        className="text-primary hover:underline"
+                        onClick={() =>
+                          handleCorrelationClick(entry.correlation_id as string)
+                        }
+                      >
+                        {entry.correlation_id.slice(0, 8)}...
+                      </button>
+                    ) : (
+                      "-"
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {entry.ip_address ?? "-"}
+                  </TableCell>
+                  <TableCell className="max-w-[200px] truncate text-xs">
+                    {entry.details ? JSON.stringify(entry.details) : "-"}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground text-sm">
+              {t("page", { current: currentPage, total: totalPages })}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage <= 1}
+                onClick={() => goToPage(currentPage - 1)}
+              >
+                {t("previous")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={currentPage >= totalPages}
+                onClick={() => goToPage(currentPage + 1)}
+              >
+                {t("next")}
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -6,6 +6,7 @@ import {
   LayoutDashboard,
   Menu,
   Radio,
+  ScrollText,
   Search,
   Settings,
   Shield,
@@ -33,6 +34,7 @@ const NAV_ITEMS = [
   { key: "detection", href: "/detection", icon: Search },
   { key: "triage", href: "/triage", icon: Shield },
   { key: "report", href: "/report", icon: FileText },
+  { key: "audit-logs", href: "/audit-logs", icon: ScrollText },
   { key: "settings", href: "/settings", icon: Settings },
 ] as const;
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Home,
   LayoutDashboard,
   Radio,
+  ScrollText,
   Search,
   Settings,
   Shield,
@@ -34,6 +35,7 @@ const NAV_ITEMS = [
   { key: "detection", href: "/detection", icon: Search },
   { key: "triage", href: "/triage", icon: Shield },
   { key: "report", href: "/report", icon: FileText },
+  { key: "audit-logs", href: "/audit-logs", icon: ScrollText },
   { key: "settings", href: "/settings", icon: Settings },
 ] as const;
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex h-9 w-full items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-sm font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,111 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-wrapper" className="relative w-full overflow-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-muted-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -26,7 +26,8 @@
     "detection": "Detection",
     "triage": "Triage",
     "report": "Report",
-    "settings": "Settings"
+    "settings": "Settings",
+    "audit-logs": "Audit Logs"
   },
   "settings": {
     "accounts": "Accounts",
@@ -37,5 +38,45 @@
     "required": "{field} is required",
     "passwordMinLength": "Password must be at least {min} characters",
     "passwordMismatch": "Passwords do not match"
+  },
+  "auditLogs": {
+    "title": "Audit Logs",
+    "filters": "Filters",
+    "from": "From",
+    "to": "To",
+    "actor": "Actor",
+    "action": "Action",
+    "targetType": "Target Type",
+    "targetId": "Target ID",
+    "correlationId": "Correlation ID",
+    "search": "Search",
+    "clear": "Clear",
+    "noResults": "No audit log entries found",
+    "loading": "Loading...",
+    "error": "Failed to load audit logs",
+    "timestamp": "Timestamp",
+    "ipAddress": "IP Address",
+    "details": "Details",
+    "page": "Page {current} of {total}",
+    "previous": "Previous",
+    "next": "Next",
+    "allActions": "All actions",
+    "allTargetTypes": "All target types",
+    "actions": {
+      "auth.sign_in.success": "Sign in success",
+      "auth.sign_in.failure": "Sign in failure",
+      "auth.sign_out": "Sign out",
+      "auth.session_extend": "Session extend",
+      "session.ip_mismatch": "IP mismatch",
+      "session.ua_mismatch": "UA mismatch",
+      "session.revoke": "Session revoke",
+      "account.create": "Account create",
+      "account.lock": "Account lock",
+      "account.unlock": "Account unlock"
+    },
+    "targetTypes": {
+      "account": "Account",
+      "session": "Session"
+    }
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -26,7 +26,8 @@
     "detection": "탐지",
     "triage": "분류",
     "report": "보고서",
-    "settings": "설정"
+    "settings": "설정",
+    "audit-logs": "감사 로그"
   },
   "settings": {
     "accounts": "계정",
@@ -37,5 +38,45 @@
     "required": "{field}은(는) 필수입니다",
     "passwordMinLength": "비밀번호는 최소 {min}자 이상이어야 합니다",
     "passwordMismatch": "비밀번호가 일치하지 않습니다"
+  },
+  "auditLogs": {
+    "title": "감사 로그",
+    "filters": "필터",
+    "from": "시작일",
+    "to": "종료일",
+    "actor": "행위자",
+    "action": "작업",
+    "targetType": "대상 유형",
+    "targetId": "대상 ID",
+    "correlationId": "상관 ID",
+    "search": "검색",
+    "clear": "초기화",
+    "noResults": "감사 로그 항목이 없습니다",
+    "loading": "로딩 중...",
+    "error": "감사 로그를 불러오지 못했습니다",
+    "timestamp": "타임스탬프",
+    "ipAddress": "IP 주소",
+    "details": "상세 정보",
+    "page": "페이지 {current} / {total}",
+    "previous": "이전",
+    "next": "다음",
+    "allActions": "모든 작업",
+    "allTargetTypes": "모든 대상 유형",
+    "actions": {
+      "auth.sign_in.success": "로그인 성공",
+      "auth.sign_in.failure": "로그인 실패",
+      "auth.sign_out": "로그아웃",
+      "auth.session_extend": "세션 연장",
+      "session.ip_mismatch": "IP 불일치",
+      "session.ua_mismatch": "UA 불일치",
+      "session.revoke": "세션 해지",
+      "account.create": "계정 생성",
+      "account.lock": "계정 잠금",
+      "account.unlock": "계정 잠금 해제"
+    },
+    "targetTypes": {
+      "account": "계정",
+      "session": "세션"
+    }
   }
 }

--- a/src/lib/audit/client.ts
+++ b/src/lib/audit/client.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { connectTo, type QueryResult } from "@/lib/db/client";
+
+// ── Pool management ─────────────────────────────────────────────
+
+let pool: pg.Pool | null = null;
+
+function getPool(): pg.Pool {
+  if (pool) return pool;
+
+  const connectionString = process.env.AUDIT_DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("Missing environment variable: AUDIT_DATABASE_URL");
+  }
+
+  pool = connectTo(connectionString);
+  return pool;
+}
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Execute a read query against the audit database.
+ *
+ * Uses a separate connection pool from the write pool in `logger.ts`
+ * so that read and write concerns remain isolated.
+ */
+export async function queryAudit<
+  T extends pg.QueryResultRow = pg.QueryResultRow,
+>(text: string, params?: unknown[]): Promise<QueryResult<T>> {
+  const result = await getPool().query<T>(text, params);
+  return { rows: result.rows, rowCount: result.rowCount };
+}
+
+/** Gracefully close the audit read pool. */
+export async function endAuditReadPool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}
+
+/** Reset pool reference without ending connections. For tests only. */
+export function resetAuditReadPool(): void {
+  pool = null;
+}

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -6,6 +6,7 @@ export const NAV_SEGMENTS = new Set([
   "detection",
   "triage",
   "report",
+  "audit-logs",
   "settings",
 ]);
 


### PR DESCRIPTION
## Summary
- Add `GET /api/audit-logs` endpoint with parameterized filtering (date range, actor, action, target type/ID, correlation ID) and offset pagination, protected by System Administrator role check
- Add `src/lib/audit/client.ts` read-only audit DB pool (separate from the write pool in `logger.ts`)
- Add `audit-logs` page with filterable table, clickable correlation IDs, and Previous/Next pagination
- Add shadcn/ui `table.tsx` and `select.tsx` primitives
- Add i18n translations for both English and Korean
- Update sidebar, mobile header, and breadcrumbs with audit-logs nav item

## Test plan
- [x] 9 tests for audit DB client (pool lifecycle, query delegation, error propagation)
- [x] 17 tests for audit-logs API route (permission, pagination, validation, query building)
- [x] Existing breadcrumbs and i18n message tests updated for new segment/keys
- [x] All 354 tests pass
- [x] Biome lint, TypeScript type check, Next.js build all pass

Closes #52