### PR TITLE
Fix next-intl INVALID_KEY in audit log i18n

### DIFF
--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -62,6 +62,11 @@ const ACTION_KEYS = [
 
 const TARGET_TYPE_KEYS = ["account", "session"] as const;
 
+/** Convert a dotted DB action key to an i18n-safe underscore key. */
+function actionToI18nKey(action: string): string {
+  return action.replaceAll(".", "_");
+}
+
 // ── Component ────────────────────────────────────────────────────
 
 export function AuditLogTable() {
@@ -234,7 +239,7 @@ export function AuditLogTable() {
               <SelectContent>
                 {ACTION_KEYS.map((key) => (
                   <SelectItem key={key} value={key}>
-                    {t(`actions.${key}`)}
+                    {t(`actions.${actionToI18nKey(key)}`)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -317,7 +322,11 @@ export function AuditLogTable() {
                   <TableCell className="text-xs">{entry.actor_id}</TableCell>
                   <TableCell>
                     <Badge variant="secondary" className="text-xs">
-                      {t(`actions.${entry.action}` as Parameters<typeof t>[0])}
+                      {t(
+                        `actions.${actionToI18nKey(entry.action)}` as Parameters<
+                          typeof t
+                        >[0],
+                      )}
                     </Badge>
                   </TableCell>
                   <TableCell className="text-xs">{entry.target_type}</TableCell>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -63,16 +63,16 @@
     "allActions": "All actions",
     "allTargetTypes": "All target types",
     "actions": {
-      "auth.sign_in.success": "Sign in success",
-      "auth.sign_in.failure": "Sign in failure",
-      "auth.sign_out": "Sign out",
-      "auth.session_extend": "Session extend",
-      "session.ip_mismatch": "IP mismatch",
-      "session.ua_mismatch": "UA mismatch",
-      "session.revoke": "Session revoke",
-      "account.create": "Account create",
-      "account.lock": "Account lock",
-      "account.unlock": "Account unlock"
+      "auth_sign_in_success": "Sign in success",
+      "auth_sign_in_failure": "Sign in failure",
+      "auth_sign_out": "Sign out",
+      "auth_session_extend": "Session extend",
+      "session_ip_mismatch": "IP mismatch",
+      "session_ua_mismatch": "UA mismatch",
+      "session_revoke": "Session revoke",
+      "account_create": "Account create",
+      "account_lock": "Account lock",
+      "account_unlock": "Account unlock"
     },
     "targetTypes": {
       "account": "Account",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -63,16 +63,16 @@
     "allActions": "모든 작업",
     "allTargetTypes": "모든 대상 유형",
     "actions": {
-      "auth.sign_in.success": "로그인 성공",
-      "auth.sign_in.failure": "로그인 실패",
-      "auth.sign_out": "로그아웃",
-      "auth.session_extend": "세션 연장",
-      "session.ip_mismatch": "IP 불일치",
-      "session.ua_mismatch": "UA 불일치",
-      "session.revoke": "세션 해지",
-      "account.create": "계정 생성",
-      "account.lock": "계정 잠금",
-      "account.unlock": "계정 잠금 해제"
+      "auth_sign_in_success": "로그인 성공",
+      "auth_sign_in_failure": "로그인 실패",
+      "auth_sign_out": "로그아웃",
+      "auth_session_extend": "세션 연장",
+      "session_ip_mismatch": "IP 불일치",
+      "session_ua_mismatch": "UA 불일치",
+      "session_revoke": "세션 해지",
+      "account_create": "계정 생성",
+      "account_lock": "계정 잠금",
+      "account_unlock": "계정 잠금 해제"
     },
     "targetTypes": {
       "account": "계정",


### PR DESCRIPTION
## Summary
- Rename dotted i18n keys in `auditLogs.actions` to underscored keys (e.g., `auth.sign_in.success` → `auth_sign_in_success`) because next-intl treats dots as nesting separators
- Add `actionToI18nKey()` helper in `audit-log-table.tsx` to convert DB action values (dotted) to i18n keys (underscored)

## Test plan
- [x] All 354 tests pass
- [x] Biome lint, TypeScript type check pass

Closes #72