### PR TITLE
Add route protection via proxy middleware

### DIFF
--- a/src/__tests__/lib/auth/proxy-auth.test.ts
+++ b/src/__tests__/lib/auth/proxy-auth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { AUTH_COOKIE_NAME, isPublicPath } from "@/lib/auth/proxy-auth";
+
+describe("AUTH_COOKIE_NAME", () => {
+  it('equals "at"', () => {
+    expect(AUTH_COOKIE_NAME).toBe("at");
+  });
+});
+
+describe("isPublicPath", () => {
+  describe("public paths", () => {
+    it("returns true for root /", () => {
+      expect(isPublicPath("/")).toBe(true);
+    });
+
+    it("returns true for /en (root with default locale)", () => {
+      expect(isPublicPath("/en")).toBe(true);
+    });
+
+    it("returns true for /ko (root with non-default locale)", () => {
+      expect(isPublicPath("/ko")).toBe(true);
+    });
+
+    it("returns true for /sign-in", () => {
+      expect(isPublicPath("/sign-in")).toBe(true);
+    });
+
+    it("returns true for /en/sign-in", () => {
+      expect(isPublicPath("/en/sign-in")).toBe(true);
+    });
+
+    it("returns true for /ko/sign-in", () => {
+      expect(isPublicPath("/ko/sign-in")).toBe(true);
+    });
+  });
+
+  describe("protected paths (fail-closed)", () => {
+    it("returns false for /audit-logs", () => {
+      expect(isPublicPath("/audit-logs")).toBe(false);
+    });
+
+    it("returns false for /en/audit-logs", () => {
+      expect(isPublicPath("/en/audit-logs")).toBe(false);
+    });
+
+    it("returns false for /ko/audit-logs", () => {
+      expect(isPublicPath("/ko/audit-logs")).toBe(false);
+    });
+
+    it("returns false for unknown path (fail-closed)", () => {
+      expect(isPublicPath("/some-future-page")).toBe(false);
+    });
+
+    it("returns false for nested unknown path", () => {
+      expect(isPublicPath("/en/some/nested/path")).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,0 +1,141 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Hoisted mocks ──────────────────────────────────────────────
+
+const mockVerifyJwtStateless = vi.hoisted(() => vi.fn());
+const mockIntlMiddleware = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/jwt-verify-stateless", () => ({
+  verifyJwtStateless: mockVerifyJwtStateless,
+}));
+
+vi.mock("next-intl/middleware", () => ({
+  default: () => mockIntlMiddleware,
+}));
+
+// ── Import under test (after mocks) ───────────────────────────
+
+import proxy, { config } from "@/proxy";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeRequest(path: string, cookie?: string): NextRequest {
+  const request = new NextRequest(`http://localhost:3000${path}`);
+  if (cookie) {
+    request.cookies.set("at", cookie);
+  }
+  return request;
+}
+
+function getRedirectPathname(response: Response): string {
+  const location = response.headers.get("location") ?? "";
+  return new URL(location).pathname;
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe("proxy", () => {
+  beforeEach(() => {
+    mockVerifyJwtStateless.mockReset();
+    mockIntlMiddleware.mockReset();
+    mockIntlMiddleware.mockReturnValue(new Response(null, { status: 200 }));
+  });
+
+  describe("public routes", () => {
+    it("passes / to intl middleware without auth check", async () => {
+      await proxy(makeRequest("/"));
+
+      expect(mockIntlMiddleware).toHaveBeenCalledTimes(1);
+      expect(mockVerifyJwtStateless).not.toHaveBeenCalled();
+    });
+
+    it("passes /sign-in to intl middleware without auth check", async () => {
+      await proxy(makeRequest("/sign-in"));
+
+      expect(mockIntlMiddleware).toHaveBeenCalledTimes(1);
+      expect(mockVerifyJwtStateless).not.toHaveBeenCalled();
+    });
+
+    it("passes /ko/sign-in to intl middleware without auth check", async () => {
+      await proxy(makeRequest("/ko/sign-in"));
+
+      expect(mockIntlMiddleware).toHaveBeenCalledTimes(1);
+      expect(mockVerifyJwtStateless).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("protected routes — no cookie", () => {
+    it("redirects /audit-logs to /sign-in", async () => {
+      const response = await proxy(makeRequest("/audit-logs"));
+
+      expect(response.status).toBe(307);
+      expect(getRedirectPathname(response)).toBe("/sign-in");
+      expect(mockIntlMiddleware).not.toHaveBeenCalled();
+    });
+
+    it("redirects /ko/audit-logs to /ko/sign-in", async () => {
+      const response = await proxy(makeRequest("/ko/audit-logs"));
+
+      expect(response.status).toBe(307);
+      expect(getRedirectPathname(response)).toBe("/ko/sign-in");
+    });
+
+    it("redirects /en/audit-logs to /sign-in (default locale, no prefix)", async () => {
+      const response = await proxy(makeRequest("/en/audit-logs"));
+
+      expect(response.status).toBe(307);
+      // "en" is the default locale — redirect has no locale prefix
+      expect(getRedirectPathname(response)).toBe("/sign-in");
+    });
+  });
+
+  describe("protected routes — invalid JWT", () => {
+    it("redirects when verifyJwtStateless throws", async () => {
+      mockVerifyJwtStateless.mockRejectedValue(new Error("JWT expired"));
+
+      const response = await proxy(makeRequest("/audit-logs", "bad-token"));
+
+      expect(response.status).toBe(307);
+      expect(getRedirectPathname(response)).toBe("/sign-in");
+      expect(mockVerifyJwtStateless).toHaveBeenCalledWith("bad-token");
+    });
+  });
+
+  describe("protected routes — valid JWT", () => {
+    it("calls intl middleware when JWT is valid", async () => {
+      mockVerifyJwtStateless.mockResolvedValue({
+        sub: "account-1",
+        sid: "session-1",
+        roles: ["admin"],
+        token_version: 0,
+        kid: "key-1",
+      });
+
+      await proxy(makeRequest("/audit-logs", "valid-token"));
+
+      expect(mockVerifyJwtStateless).toHaveBeenCalledWith("valid-token");
+      expect(mockIntlMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not redirect when JWT is valid", async () => {
+      mockVerifyJwtStateless.mockResolvedValue({
+        sub: "account-1",
+        sid: "session-1",
+        roles: ["admin"],
+        token_version: 0,
+        kid: "key-1",
+      });
+
+      const response = await proxy(makeRequest("/audit-logs", "valid-token"));
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("config", () => {
+    it("exports matcher that excludes api, _next, and static files", () => {
+      expect(config.matcher).toBe("/((?!api|trpc|_next|_vercel|.*\\..*).*)");
+    });
+  });
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,8 +2,16 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { runStartupMigrations } = await import("@/lib/db/migrate");
     const { bootstrapAdminAccount } = await import("@/lib/auth/bootstrap");
+    const { loadSigningKeys, getPublicKeyData } = await import(
+      "@/lib/auth/jwt-keys"
+    );
+    const { initStatelessKeys } = await import(
+      "@/lib/auth/jwt-verify-stateless"
+    );
 
     await runStartupMigrations();
     await bootstrapAdminAccount();
+    await loadSigningKeys();
+    await initStatelessKeys(getPublicKeyData());
   }
 }

--- a/src/lib/auth/proxy-auth.ts
+++ b/src/lib/auth/proxy-auth.ts
@@ -1,0 +1,31 @@
+// Edge Runtime compatible — no "server-only", no node:* imports, no DB
+
+import { routing } from "@/i18n/routing";
+
+// Canonical source: src/lib/auth/cookies.ts (ACCESS_TOKEN_COOKIE)
+// Duplicated here to avoid "server-only" import in proxy code.
+export const AUTH_COOKIE_NAME = "at";
+
+// Paths that do NOT require authentication. Everything else that
+// matches the proxy matcher is protected (fail-closed).
+const PUBLIC_PATHS = new Set(["/", "/sign-in"]);
+
+/**
+ * Strip the locale prefix from a pathname if present.
+ * "/ko/audit-logs" → "/audit-logs", "/audit-logs" → "/audit-logs"
+ */
+function stripLocalePrefix(pathname: string): string {
+  for (const locale of routing.locales) {
+    const prefix = `/${locale}`;
+    if (pathname === prefix) return "/";
+    if (pathname.startsWith(`${prefix}/`)) {
+      return pathname.slice(prefix.length);
+    }
+  }
+  return pathname;
+}
+
+/** True if the path does not require authentication. */
+export function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.has(stripLocalePrefix(pathname));
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,8 +1,52 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 
 import { routing } from "./i18n/routing";
+import { verifyJwtStateless } from "./lib/auth/jwt-verify-stateless";
+import { AUTH_COOKIE_NAME, isPublicPath } from "./lib/auth/proxy-auth";
 
-export default createMiddleware(routing);
+const intlMiddleware = createMiddleware(routing);
+
+export default async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Public paths: skip auth, run locale middleware
+  if (isPublicPath(pathname)) {
+    return intlMiddleware(request);
+  }
+
+  // Protected path: require valid JWT
+  const token = request.cookies.get(AUTH_COOKIE_NAME)?.value;
+  if (!token) {
+    return redirectToSignIn(request);
+  }
+
+  try {
+    await verifyJwtStateless(token);
+  } catch {
+    return redirectToSignIn(request);
+  }
+
+  return intlMiddleware(request);
+}
+
+function redirectToSignIn(request: NextRequest): NextResponse {
+  const { pathname } = request.nextUrl;
+
+  // Preserve locale prefix for non-default locales
+  let locale = routing.defaultLocale;
+  for (const l of routing.locales) {
+    if (pathname.startsWith(`/${l}/`) || pathname === `/${l}`) {
+      locale = l;
+      break;
+    }
+  }
+
+  const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;
+  const url = new URL(`${prefix}/sign-in`, request.url);
+  return NextResponse.redirect(url);
+}
 
 export const config = {
   matcher: "/((?!api|trpc|_next|_vercel|.*\\..*).*)",


### PR DESCRIPTION
## Summary

- Adds stateless JWT verification in the Next.js proxy (middleware) to gate dashboard routes
- Public paths (`/`, `/sign-in`) bypass auth; all other proxy-matched routes require a valid `at` cookie with a verifiable JWT
- Invalid or missing JWT redirects to `/sign-in` (preserving locale prefix for non-default locales)
- Initializes JWT signing keys in `instrumentation.ts` at startup so the stateless verifier has keys before the proxy runs

## New files

- `src/lib/auth/proxy-auth.ts` — Fail-closed route classification (`isPublicPath`) and `AUTH_COOKIE_NAME` constant
- `src/__tests__/lib/auth/proxy-auth.test.ts` — 12 tests for public/protected path classification
- `src/__tests__/proxy.test.ts` — 10 tests covering public routes, missing cookie, invalid JWT, valid JWT, and locale-aware redirects

## Modified files

- `src/proxy.ts` — Async proxy function with auth gate before next-intl delegation
- `src/instrumentation.ts` — Adds `loadSigningKeys()` + `initStatelessKeys()` in the nodejs startup branch

## Test plan

- [x] `pnpm check` — Biome lint/format passes
- [x] `pnpm typecheck` — TypeScript passes
- [x] `pnpm test` — All 376 tests pass (22 new)
- [x] `pnpm build` — Next.js build succeeds

Closes #61