### PR TITLE
Add Playwright E2E tests for authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,19 +102,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium --with-deps
       - name: Generate JWT signing key
-        run: node --input-type=module -e "
-          import { randomUUID } from 'node:crypto';
-          import { mkdirSync, writeFileSync } from 'node:fs';
-          import { exportJWK, generateKeyPair } from 'jose';
-          const { privateKey, publicKey } = await generateKeyPair('ES256', { extractable: true });
-          const kid = randomUUID();
-          const priv = await exportJWK(privateKey);
-          const pub = await exportJWK(publicKey);
-          priv.kid = kid; pub.kid = kid;
-          mkdirSync('data-e2e/keys', { recursive: true });
-          writeFileSync('data-e2e/keys/jwt-signing.json', JSON.stringify({ kid, algorithm: 'ES256', privateKey: priv, publicKey: pub }, null, 2));
-          console.log('JWT signing key generated at data-e2e/keys/jwt-signing.json');
-          "
+        run: node e2e/generate-key.mjs
+        env:
+          DATA_DIR: ./data-e2e
       - name: Run E2E tests
         run: pnpm e2e
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,20 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium --with-deps
+      - name: Generate JWT signing key
+        run: node --input-type=module -e "
+          import { randomUUID } from 'node:crypto';
+          import { mkdirSync, writeFileSync } from 'node:fs';
+          import { exportJWK, generateKeyPair } from 'jose';
+          const { privateKey, publicKey } = await generateKeyPair('ES256', { extractable: true });
+          const kid = randomUUID();
+          const priv = await exportJWK(privateKey);
+          const pub = await exportJWK(publicKey);
+          priv.kid = kid; pub.kid = kid;
+          mkdirSync('data-e2e/keys', { recursive: true });
+          writeFileSync('data-e2e/keys/jwt-signing.json', JSON.stringify({ kid, algorithm: 'ES256', privateKey: priv, publicKey: pub }, null, 2));
+          console.log('JWT signing key generated at data-e2e/keys/jwt-signing.json');
+          "
       - name: Run E2E tests
         run: pnpm e2e
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,53 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  e2e:
+    name: E2E
+    needs: check
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-bookworm
+        env:
+          POSTGRES_DB: auth_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create audit_db and audit_writer role
+        run: psql "postgres://postgres:postgres@localhost:5432/auth_db" -f infra/postgres/init-audit-db.sql
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install chromium --with-deps
+      - name: Run E2E tests
+        run: pnpm e2e
+        env:
+          CI: true
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/auth_db
+          AUDIT_DATABASE_URL: postgres://audit_writer:changeme@localhost:5432/audit_db
+          DATA_DIR: ./data-e2e
+          CSRF_SECRET: ci-e2e-csrf-secret-at-least-32-characters!!
+          INIT_ADMIN_USERNAME: admin
+          INIT_ADMIN_PASSWORD: Admin1234!
+          DEFAULT_LOCALE: en
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
   image-build:
     name: Image Build
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@
 # testing
 /coverage
 
+# Playwright
+/playwright-report/
+/test-results/
+/e2e/test-results/
+/e2e/playwright-report/
+/e2e/blob-report/
+
 # next.js
 /.next/
 /out/
@@ -27,6 +34,7 @@
 
 # Bootstrap data directory (consumed marker)
 /data
+/data-e2e
 
 # TLS certificates (never commit private keys)
 /infra/certs/

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+import { clearMustChangePassword, revokeAllSessions } from "./helpers/setup-db";
+
+const ADMIN_USERNAME = "admin";
+const ADMIN_PASSWORD = "Admin1234!";
+
+test.describe("Authentication E2E", () => {
+  test.beforeAll(async () => {
+    await clearMustChangePassword(ADMIN_USERNAME);
+    await revokeAllSessions(ADMIN_USERNAME);
+  });
+
+  test("unauthenticated access to protected route redirects to sign-in", async ({
+    page,
+  }) => {
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/sign-in");
+    await expect(page).toHaveURL(/\/sign-in$/);
+  });
+
+  test("/ko/sign-in renders Korean labels", async ({ page }) => {
+    await page.goto("/ko/sign-in");
+
+    await expect(
+      page.getByRole("heading", { name: "계정에 로그인" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("계정 ID")).toBeVisible();
+    // Password label check via locator — FormControl wraps input in a
+    // <div> so getByLabel cannot resolve the <input> directly.
+    await expect(page.locator("label", { hasText: "비밀번호" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "로그인" })).toBeVisible();
+  });
+
+  test("sign-in with invalid credentials shows error message", async ({
+    page,
+  }) => {
+    await page.goto("/sign-in");
+    await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
+    await page.locator("input[name='password']").fill("WrongPassword123!");
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    // Use p[role='alert'] to exclude Next.js route announcer <div>
+    const alert = page.locator("p[role='alert']");
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText("Invalid account ID or password");
+  });
+
+  test("sign-in with valid credentials redirects to dashboard", async ({
+    page,
+  }) => {
+    await page.goto("/sign-in");
+    await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
+    await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+  });
+
+  test("sign-out clears session and redirects to sign-in", async ({ page }) => {
+    // Sign in first
+    await page.goto("/sign-in");
+    await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
+    await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+    await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+
+    // Sign out via API (NavUser button not wired yet).
+    // The endpoint requires CSRF token + Origin header.
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+    const response = await page.request.post("/api/auth/sign-out", {
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Protected route should redirect to sign-in
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/sign-in");
+    await expect(page).toHaveURL(/\/sign-in$/);
+  });
+});

--- a/e2e/generate-key.mjs
+++ b/e2e/generate-key.mjs
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { exportJWK, generateKeyPair } from "jose";
+
+const dataDir = process.env.DATA_DIR || "data";
+const keysDir = resolve(dataDir, "keys");
+const keyPath = resolve(keysDir, "jwt-signing.json");
+
+if (existsSync(keyPath)) {
+  console.log(`JWT signing key already exists at ${keyPath}`);
+  process.exit(0);
+}
+
+const { privateKey, publicKey } = await generateKeyPair("ES256", {
+  extractable: true,
+});
+
+const kid = randomUUID();
+const priv = await exportJWK(privateKey);
+const pub = await exportJWK(publicKey);
+priv.kid = kid;
+pub.kid = kid;
+
+mkdirSync(keysDir, { recursive: true });
+writeFileSync(
+  keyPath,
+  JSON.stringify(
+    { kid, algorithm: "ES256", privateKey: priv, publicKey: pub },
+    null,
+    2,
+  ),
+);
+console.log(`JWT signing key generated at ${keyPath}`);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -65,5 +65,12 @@ async function ensureJwtSigningKey(): Promise<void> {
 }
 
 export default async function globalSetup(): Promise<void> {
-  await ensureJwtSigningKey();
+  console.log("[e2e] Running global setup…");
+  try {
+    await ensureJwtSigningKey();
+    console.log("[e2e] Global setup complete.");
+  } catch (error) {
+    console.error("[e2e] Global setup failed:", error);
+    throw error;
+  }
 }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { exportJWK, generateKeyPair } from "jose";
+
+/**
+ * Resolve DATA_DIR the same way the app does:
+ * process.env → .env.local → default "./data".
+ */
+function getDataDir(): string {
+  if (process.env.DATA_DIR) return resolve(process.env.DATA_DIR);
+
+  try {
+    const envFile = readFileSync(resolve(__dirname, "../.env.local"), "utf8");
+    const match = envFile.match(/^DATA_DIR=(.+)$/m);
+    if (match) return resolve(match[1].trim());
+  } catch {
+    // .env.local not found — use default
+  }
+
+  return resolve("data");
+}
+
+/**
+ * Generate an ES256 JWT signing key if one doesn't already exist.
+ * The dev server's `instrumentation.ts` calls `loadSigningKeys()` and
+ * throws if the key file is absent, so we must create it before the
+ * webServer starts.
+ */
+async function ensureJwtSigningKey(): Promise<void> {
+  const dataDir = getDataDir();
+  const keysDir = resolve(dataDir, "keys");
+  const keyPath = resolve(keysDir, "jwt-signing.json");
+
+  if (existsSync(keyPath)) return;
+
+  console.log(`[e2e] Generating JWT signing key at ${keyPath}`);
+
+  const { privateKey, publicKey } = await generateKeyPair("ES256", {
+    extractable: true,
+  });
+
+  const kid = randomUUID();
+  const privateJwk = await exportJWK(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+  privateJwk.kid = kid;
+  publicJwk.kid = kid;
+
+  mkdirSync(keysDir, { recursive: true });
+  writeFileSync(
+    keyPath,
+    JSON.stringify(
+      {
+        kid,
+        algorithm: "ES256",
+        privateKey: privateJwk,
+        publicKey: publicJwk,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+export default async function globalSetup(): Promise<void> {
+  await ensureJwtSigningKey();
+}

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import pg from "pg";
+
+/**
+ * Load DATABASE_URL: prefer process.env, then parse .env.local.
+ */
+function getDatabaseUrl(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+
+  try {
+    const envFile = readFileSync(
+      resolve(__dirname, "../../.env.local"),
+      "utf8",
+    );
+    const match = envFile.match(/^DATABASE_URL=(.+)$/m);
+    if (match) return match[1].trim();
+  } catch {
+    // .env.local not found — use default
+  }
+
+  return "postgres://postgres:postgres@localhost:5432/auth_db";
+}
+
+const DATABASE_URL = getDatabaseUrl();
+
+/**
+ * Clear `must_change_password` so the E2E admin account redirects to
+ * "/" instead of the non-existent "/change-password".
+ */
+export async function clearMustChangePassword(username: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET must_change_password = false WHERE username = $1",
+      [username],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Revoke all sessions so subsequent sign-in tests start clean.
+ */
+export async function revokeAllSessions(username: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `UPDATE sessions SET revoked = true
+       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+      [username],
+    );
+  } finally {
+    await client.end();
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Build webServer.env: only set values that are explicitly provided
+// via environment variables (e.g., from CI). Omitted keys let Next.js
+// fall back to .env.local for local development.
+function buildEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  const keys = [
+    "DATABASE_URL",
+    "AUDIT_DATABASE_URL",
+    "DATA_DIR",
+    "CSRF_SECRET",
+    "INIT_ADMIN_USERNAME",
+    "INIT_ADMIN_PASSWORD",
+    "DEFAULT_LOCALE",
+  ] as const;
+
+  for (const key of keys) {
+    if (process.env[key]) {
+      env[key] = process.env[key];
+    }
+  }
+
+  return env;
+}
+
+export default defineConfig({
+  globalSetup: "./global-setup.ts",
+  testDir: ".",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"]]
+    : [["html", { open: "on-failure" }]],
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: buildEnv(),
+  },
+});

--- a/infra/postgres/init-audit-db.sql
+++ b/infra/postgres/init-audit-db.sql
@@ -9,3 +9,9 @@ CREATE DATABASE audit_db;
 -- Password should be overridden via POSTGRES_INITDB_ARGS or changed
 -- after provisioning for production deployments.
 CREATE ROLE audit_writer WITH LOGIN PASSWORD 'changeme';
+
+-- PostgreSQL 15+ revokes CREATE on the public schema from PUBLIC by
+-- default.  The application runs migrations (CREATE TABLE) as
+-- audit_writer, so it needs CREATE + USAGE on the public schema.
+\c audit_db
+GRANT CREATE, USAGE ON SCHEMA public TO audit_writer;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fix": "biome check --write src",
     "markdownlint": "markdownlint-cli2 '**/*.md'",
     "test": "vitest run",
+    "e2e": "playwright test --config e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -47,6 +48,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24",
     "@types/pg": "^8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,10 @@ importers:
         version: 0.575.0(react@19.2.4)
       next:
         specifier: 16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
         specifier: ^4.8.3
-        version: 4.8.3(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.8.3(next@16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -72,6 +72,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.0
+        version: 1.58.2
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
@@ -635,6 +638,11 @@ packages:
   '@phc/format@1.0.0':
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
     engines: {node: '>=10'}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1857,6 +1865,11 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2258,6 +2271,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -2960,6 +2983,10 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
 
   '@phc/format@1.0.0': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4132,6 +4159,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4500,14 +4530,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.8.3: {}
 
-  next-intl@4.8.3(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.8.3(next@16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.18
       icu-minify: 4.8.3
       negotiator: 1.0.0
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl-swc-plugin-extractor: 4.8.3
       po-parser: 2.1.1
       react: 19.2.4
@@ -4522,7 +4552,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -4541,6 +4571,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.58.2
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -4608,6 +4639,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/src/__tests__/app/api/auth/sign-in/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-in/route.test.ts
@@ -240,6 +240,7 @@ describe("POST /api/auth/sign-in", () => {
       expect(response.status).toBe(403);
       const body = await response.json();
       expect(body.error).toBe("Account is locked");
+      expect(body.code).toBe("ACCOUNT_LOCKED");
     });
 
     it("returns 403 when temporary lock has not expired", async () => {
@@ -322,6 +323,7 @@ describe("POST /api/auth/sign-in", () => {
       expect(response.status).toBe(403);
       const body = await response.json();
       expect(body.error).toBe("Account is not active");
+      expect(body.code).toBe("ACCOUNT_INACTIVE");
     });
   });
 
@@ -337,6 +339,7 @@ describe("POST /api/auth/sign-in", () => {
       expect(response.status).toBe(403);
       const body = await response.json();
       expect(body.error).toBe("Access denied from this network");
+      expect(body.code).toBe("IP_RESTRICTED");
     });
   });
 

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -165,7 +165,10 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
       target: "account",
       details: { reason: "invalid_credentials", ip },
     });
-    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    return NextResponse.json(
+      { error: "Invalid credentials", code: "INVALID_CREDENTIALS" },
+      { status: 401 },
+    );
   }
 
   const account = accountRows[0];
@@ -181,7 +184,10 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
         targetId: account.id,
         details: { reason: "account_locked", ip },
       });
-      return NextResponse.json({ error: "Account is locked" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Account is locked", code: "ACCOUNT_LOCKED" },
+        { status: 403 },
+      );
     }
 
     const lockExpiry = new Date(account.locked_until);
@@ -194,7 +200,10 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
         targetId: account.id,
         details: { reason: "account_locked", ip },
       });
-      return NextResponse.json({ error: "Account is locked" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Account is locked", code: "ACCOUNT_LOCKED" },
+        { status: 403 },
+      );
     }
 
     // Temporary lock expired — auto-unlock
@@ -218,7 +227,7 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
       details: { reason: "account_inactive", status: account.status, ip },
     });
     return NextResponse.json(
-      { error: "Account is not active" },
+      { error: "Account is not active", code: "ACCOUNT_INACTIVE" },
       { status: 403 },
     );
   }
@@ -233,7 +242,7 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
       details: { reason: "ip_restricted", ip },
     });
     return NextResponse.json(
-      { error: "Access denied from this network" },
+      { error: "Access denied from this network", code: "IP_RESTRICTED" },
       { status: 403 },
     );
   }
@@ -295,7 +304,10 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
       targetId: account.id,
       details: { reason: "invalid_credentials", ip },
     });
-    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    return NextResponse.json(
+      { error: "Invalid credentials", code: "INVALID_CREDENTIALS" },
+      { status: 401 },
+    );
   }
 
   // Step 8: Max sessions check
@@ -322,7 +334,10 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
         },
       });
       return NextResponse.json(
-        { error: "Maximum number of active sessions reached" },
+        {
+          error: "Maximum number of active sessions reached",
+          code: "MAX_SESSIONS",
+        },
         { status: 403 },
       );
     }

--- a/src/lib/auth/jwt-keys.ts
+++ b/src/lib/auth/jwt-keys.ts
@@ -30,10 +30,15 @@ interface LoadedPublicKey {
   publicKey: CryptoKey;
 }
 
-// ── Module state ────────────────────────────────────────────────
+// ── Global state ────────────────────────────────────────────────
+// Keys are stored on globalThis so they survive module
+// re-instantiation across Next.js server chunks (turbopack HMR
+// and standalone output both create separate module instances).
 
-let currentKey: LoadedKeyPair | null = null;
-let previousKey: LoadedPublicKey | null = null;
+const g = globalThis as unknown as {
+  __jwtCurrentKey?: LoadedKeyPair | null;
+  __jwtPreviousKey?: LoadedPublicKey | null;
+};
 
 // ── File paths ──────────────────────────────────────────────────
 
@@ -74,7 +79,7 @@ export async function loadSigningKeys(): Promise<void> {
     );
   }
 
-  currentKey = {
+  g.__jwtCurrentKey = {
     kid: currentFile.kid,
     algorithm: currentFile.algorithm,
     privateKey: (await importJWK(
@@ -89,7 +94,7 @@ export async function loadSigningKeys(): Promise<void> {
 
   const prevFile = readKeyFile(previousKeyPath());
   if (prevFile) {
-    previousKey = {
+    g.__jwtPreviousKey = {
       kid: prevFile.kid,
       algorithm: prevFile.algorithm,
       publicKey: (await importJWK(
@@ -98,31 +103,34 @@ export async function loadSigningKeys(): Promise<void> {
       )) as CryptoKey,
     };
   } else {
-    previousKey = null;
+    g.__jwtPreviousKey = null;
   }
 }
 
 /** Return the current signing key pair. Throws if not loaded. */
 export function getSigningKey(): LoadedKeyPair {
-  if (!currentKey) {
+  if (!g.__jwtCurrentKey) {
     throw new Error(
       "JWT signing keys not loaded. Call loadSigningKeys() first.",
     );
   }
-  return currentKey;
+  return g.__jwtCurrentKey;
 }
 
 /** Look up a verification key by `kid`. Returns null if unknown. */
 export function getVerificationKey(
   kid: string,
 ): { publicKey: CryptoKey; algorithm: string } | null {
-  if (currentKey?.kid === kid) {
-    return { publicKey: currentKey.publicKey, algorithm: currentKey.algorithm };
-  }
-  if (previousKey?.kid === kid) {
+  if (g.__jwtCurrentKey?.kid === kid) {
     return {
-      publicKey: previousKey.publicKey,
-      algorithm: previousKey.algorithm,
+      publicKey: g.__jwtCurrentKey.publicKey,
+      algorithm: g.__jwtCurrentKey.algorithm,
+    };
+  }
+  if (g.__jwtPreviousKey?.kid === kid) {
+    return {
+      publicKey: g.__jwtPreviousKey.publicKey,
+      algorithm: g.__jwtPreviousKey.algorithm,
     };
   }
   return null;
@@ -197,11 +205,11 @@ export function removePreviousKey(): void {
   } catch {
     // Already absent — no-op
   }
-  previousKey = null;
+  g.__jwtPreviousKey = null;
 }
 
 /** Reset in-memory state. For testing only. */
 export function resetKeyState(): void {
-  currentKey = null;
-  previousKey = null;
+  g.__jwtCurrentKey = null;
+  g.__jwtPreviousKey = null;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,4 +11,7 @@ export default defineConfig({
       ),
     },
   },
+  test: {
+    exclude: ["node_modules", "e2e", ".next"],
+  },
 });


### PR DESCRIPTION
## Summary

- Set up Playwright 1.58 E2E test infrastructure with Chromium, globalSetup for JWT key provisioning, and DB helpers for test isolation
- Write 5 E2E tests covering all 7 acceptance criteria: unauthenticated redirect, Korean locale rendering, invalid credentials error, successful sign-in, and sign-out with session invalidation
- Fix sign-in API to return error `code` field so the form maps errors to i18n keys instead of showing a generic message
- Fix JWT signing key storage to use `globalThis` so keys survive module re-instantiation across Next.js server chunks
- Add CI `e2e` job with Postgres service container, Playwright install, and artifact upload

## Bug fixes included

**Sign-in error codes**: The sign-in API returned `{ error: "..." }` without a `code` field, but the sign-in form reads `body.code` to map errors to i18n keys. All non-200 responses now include a `code` field (`INVALID_CREDENTIALS`, `ACCOUNT_LOCKED`, `ACCOUNT_INACTIVE`, `IP_RESTRICTED`, `MAX_SESSIONS`).

**JWT key persistence**: `jwt-keys.ts` stored loaded keys in module-level variables that were lost when turbopack HMR or standalone output re-instantiated the module. Keys are now stored on `globalThis` to persist across module reloads.

## Test plan

- [x] All 5 E2E tests pass locally against Postgres (`pnpm e2e`)
- [x] 427 unit tests pass (`pnpm test`)
- [x] Lint, typecheck, build pass (`pnpm check && pnpm typecheck && pnpm build`)
- [ ] CI e2e job passes with Postgres service container

Closes #76