### PR TITLE
Enforce HTTPS-only access

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,58 @@ pnpm dev
 ```
 
 Open <http://localhost:3000> to see the result.
+
+## HTTPS
+
+Production deployments must be served over HTTPS. The nginx reverse
+proxy handles TLS termination and redirects all HTTP traffic to HTTPS.
+
+### Production
+
+The production nginx config (`infra/nginx/nginx.prod.conf`) enables:
+
+- HTTP → HTTPS redirect (port 80 → 443)
+- HSTS with a 1-year `max-age` and `includeSubDomains`
+- Security headers: `X-Frame-Options`, `X-Content-Type-Options`,
+  `Referrer-Policy`
+
+The `__Host-csrf` cookie and `Secure` flag on the access token cookie
+are automatically enabled when `NODE_ENV=production` (set by the
+Dockerfile).
+
+### Development with Docker Compose
+
+```bash
+# Generate self-signed TLS certificates (one-time)
+mkdir -p infra/certs
+mkcert -install  # trust the local CA (optional, avoids browser warnings)
+mkcert -key-file infra/certs/dev.key -cert-file infra/certs/dev.crt localhost
+
+# Start nginx + PostgreSQL
+docker compose --profile dev up -d
+
+# Start the Next.js dev server (in a separate terminal)
+pnpm dev
+```
+
+Visit <https://localhost>. Nginx terminates TLS and proxies to
+`localhost:3000`.
+
+If you don't have `mkcert`, self-signed certificates also work but
+the browser will show a security warning:
+
+```bash
+openssl req -x509 -nodes -newkey rsa:2048 \
+  -keyout infra/certs/dev.key -out infra/certs/dev.crt \
+  -days 365 -subj '/CN=localhost'
+```
+
+### Development without Docker
+
+Running `pnpm dev` directly serves over HTTP on port 3000. This is
+acceptable for local development because `NODE_ENV` is not
+`production`, so:
+
+- The CSRF cookie uses `csrf` instead of `__Host-csrf`
+- The `Secure` flag is not set on cookies
+- No HSTS or security headers are applied (these come from nginx)

--- a/infra/nginx/nginx.dev.conf
+++ b/infra/nginx/nginx.dev.conf
@@ -9,6 +9,12 @@ server {
     ssl_certificate     /etc/nginx/certs/dev.crt;
     ssl_certificate_key /etc/nginx/certs/dev.key;
 
+    # Short max-age for dev to avoid browser caching issues.
+    add_header Strict-Transport-Security "max-age=300" always;
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+
     # Docker Desktop injects host.docker.internal; use a variable so
     # nginx -t does not fail in environments where it does not resolve.
     resolver 127.0.0.11 valid=10s;


### PR DESCRIPTION
## Summary

- Add HSTS and security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) to the development nginx config, mirroring production
- Expand README with HTTPS setup instructions covering Docker Compose with mkcert, self-signed certs, and plain HTTP development

## Context

The HTTPS infrastructure was already in place (HTTP→HTTPS redirect in both nginx configs, HSTS in production, `__Host-csrf` cookie and `Secure` flags conditional on `NODE_ENV`). This PR closes the gap by hardening the dev config and documenting the setup.

| Feature | Before | After |
|---------|--------|-------|
| Dev HSTS | Missing | `max-age=300` |
| Dev security headers | Missing | Matches production |
| HTTPS docs in README | Missing | Full setup guide |

Closes #79

## Test plan

- [x] `nginx -t` passes for both dev and prod configs (CI validates this)
- [x] `docker compose --profile dev up` redirects HTTP → HTTPS
- [x] Response headers at `https://localhost` include HSTS and security headers
- [x] `pnpm check && pnpm typecheck && pnpm test && pnpm build` pass