### PR TITLE
Add comprehensive E2E test coverage

### DIFF
--- a/e2e/audit-logs.spec.ts
+++ b/e2e/audit-logs.spec.ts
@@ -65,7 +65,16 @@ test.describe("Audit log page", () => {
     // the trigger by its visible placeholder text.
     await page.getByText("All actions").click();
     await page.getByRole("option", { name: "Sign in success" }).click();
+
+    // Wait for the select trigger to reflect the chosen value before
+    // clicking Search (React state must update first).
+    await expect(page.getByText("All actions")).not.toBeVisible();
+
     await page.getByRole("button", { name: "Search" }).click();
+
+    // Wait for the URL to include the action filter, confirming the
+    // request was sent with the correct parameter.
+    await page.waitForURL(/action=/, { timeout: 10_000 });
 
     // All visible rows should have "Sign in success" badge.
     await expect(page.locator("table tbody tr").first()).toBeVisible({

--- a/e2e/audit-logs.spec.ts
+++ b/e2e/audit-logs.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import { resetAccountDefaults } from "./helpers/setup-db";
+
+test.describe("Audit log page", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("audit log page loads and displays entries", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/audit-logs");
+
+    // The heading is rendered by AuditLogTable component.
+    await expect(page.getByRole("heading", { name: "Audit Logs" })).toBeVisible(
+      { timeout: 10_000 },
+    );
+
+    // Table should have at least one row (from the sign-in we just did).
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("sign-in event appears in audit log", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/audit-logs");
+
+    // Wait for table to load.
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+
+    // Look for the "Sign in success" action badge.
+    const signInBadge = page
+      .locator("table tbody")
+      .getByText("Sign in success");
+    await expect(signInBadge.first()).toBeVisible();
+  });
+
+  test("filter by action returns filtered results", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/audit-logs");
+
+    // Wait for initial load.
+    await expect(page.locator("table tbody tr").first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Select the "Sign in success" action filter.
+    // Label is not associated with the Select via htmlFor/id, so locate
+    // the trigger by its visible placeholder text.
+    await page.getByText("All actions").click();
+    await page.getByRole("option", { name: "Sign in success" }).click();
+    await page.getByRole("button", { name: "Search" }).click();
+
+    // All visible rows should have "Sign in success" badge.
+    await expect(page.locator("table tbody tr").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    const badges = page.locator("table tbody .inline-flex");
+    const count = await badges.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(badges.nth(i)).toContainText("Sign in success");
+    }
+  });
+
+  test("filter by date range returns results", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/audit-logs");
+
+    // Set "from" to 1 hour ago, "to" to now.
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+    const formatDatetime = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}T${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+
+    const dateInputs = page.locator('input[type="datetime-local"]');
+    await dateInputs.first().fill(formatDatetime(oneHourAgo));
+    await dateInputs.nth(1).fill(formatDatetime(now));
+    await page.getByRole("button", { name: "Search" }).click();
+
+    // Should show results (we just signed in).
+    await expect(page.locator("table tbody tr").first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { resetRateLimits } from "./helpers/auth";
 import { clearMustChangePassword, revokeAllSessions } from "./helpers/setup-db";
 
 const ADMIN_USERNAME = "admin";
@@ -7,6 +8,7 @@ const ADMIN_PASSWORD = "Admin1234!";
 
 test.describe("Authentication E2E", () => {
   test.beforeAll(async () => {
+    await resetRateLimits();
     await clearMustChangePassword(ADMIN_USERNAME);
     await revokeAllSessions(ADMIN_USERNAME);
   });

--- a/e2e/csrf.spec.ts
+++ b/e2e/csrf.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import { resetAccountDefaults } from "./helpers/setup-db";
+
+test.describe("CSRF protection", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("POST without x-csrf-token header returns 403", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const response = await page.request.post("/api/auth/sign-out", {
+      headers: {
+        Origin: "http://localhost:3000",
+        // Deliberately omit x-csrf-token
+      },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+
+  test("POST with wrong CSRF token returns 403", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const response = await page.request.post("/api/auth/sign-out", {
+      headers: {
+        "x-csrf-token": "invalid-token-value",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+
+  test("POST without Origin header returns 403", async ({
+    page,
+    playwright,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Extract cookies from the authenticated context.
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+    const atCookie = cookies.find((c) => c.name === "at");
+
+    // Create a standalone API context without automatic Origin.
+    const apiContext = await playwright.request.newContext({
+      baseURL: "http://localhost:3000",
+      extraHTTPHeaders: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Cookie: `at=${atCookie?.value ?? ""}; csrf=${csrfCookie?.value ?? ""}`,
+        // Deliberately omit Origin
+      },
+    });
+
+    try {
+      const response = await apiContext.post("/api/auth/sign-out");
+      expect(response.status()).toBe(403);
+    } finally {
+      await apiContext.dispose();
+    }
+  });
+});

--- a/e2e/error-messages.spec.ts
+++ b/e2e/error-messages.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signIn,
+} from "./helpers/auth";
+import {
+  createFakeSessions,
+  resetAccountDefaults,
+  setAccountStatus,
+  setMaxSessions,
+} from "./helpers/setup-db";
+
+const alert = (page: import("@playwright/test").Page) =>
+  page.locator("p[role='alert']");
+
+test.describe("Sign-in error messages", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+  });
+
+  test.afterEach(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("inactive account shows 'Account is not active'", async ({ page }) => {
+    await setAccountStatus(ADMIN_USERNAME, "disabled");
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText("Account is not active");
+  });
+
+  test("max sessions exceeded shows error", async ({ page }) => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await setMaxSessions(ADMIN_USERNAME, 1);
+    await createFakeSessions(ADMIN_USERNAME, 1);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText(
+      "Maximum number of active sessions reached",
+    );
+  });
+});

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,75 @@
+import type { Page } from "@playwright/test";
+
+export const ADMIN_USERNAME = "admin";
+export const ADMIN_PASSWORD = "Admin1234!";
+
+const BASE_URL = "http://localhost:3000";
+
+/**
+ * Reset the in-memory rate limiter via the test-only API endpoint.
+ * Uses `fetch()` directly so it works in `test.beforeAll` (where the
+ * Playwright `request` fixture has no baseURL).
+ */
+export async function resetRateLimits(): Promise<void> {
+  const res = await fetch(`${BASE_URL}/api/e2e/reset-rate-limits`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error(`reset-rate-limits failed: ${res.status}`);
+}
+
+/**
+ * Fill the sign-in form and submit. Does NOT wait for a specific
+ * outcome — callers should assert the expected result.
+ */
+export async function signIn(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.getByLabel("Account ID").fill(username);
+  await page.locator("input[name='password']").fill(password);
+  await page.getByRole("button", { name: "Sign In" }).click();
+}
+
+/**
+ * Korean variant of signIn — navigates to /ko/sign-in first.
+ */
+export async function signInKo(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.goto("/ko/sign-in");
+  await page.getByLabel("계정 ID").fill(username);
+  await page.locator("input[name='password']").fill(password);
+  await page.getByRole("button", { name: "로그인" }).click();
+}
+
+/**
+ * Sign out via API using the CSRF cookie from the current page context.
+ */
+export async function signOut(page: Page): Promise<void> {
+  const cookies = await page.context().cookies();
+  const csrfCookie = cookies.find((c) => c.name === "csrf");
+  await page.request.post("/api/auth/sign-out", {
+    headers: {
+      "x-csrf-token": csrfCookie?.value ?? "",
+      Origin: "http://localhost:3000",
+    },
+  });
+}
+
+/**
+ * Full sign-in flow: navigate to /sign-in, fill form, wait for redirect.
+ */
+export async function signInAndWait(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.goto("/sign-in");
+  await signIn(page, username, password);
+  await page.waitForURL((url) => !url.pathname.endsWith("/sign-in"), {
+    timeout: 10_000,
+  });
+}

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -57,3 +57,134 @@ export async function revokeAllSessions(username: string): Promise<void> {
     await client.end();
   }
 }
+
+/**
+ * Set `failed_sign_in_count` to a specific value.
+ */
+export async function setFailedSignInCount(
+  username: string,
+  count: number,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET failed_sign_in_count = $2 WHERE username = $1",
+      [username, count],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Set account status and optionally `locked_until`.
+ */
+export async function setAccountStatus(
+  username: string,
+  status: string,
+  lockedUntil?: Date | null,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `UPDATE accounts
+       SET status = $2, locked_until = $3
+       WHERE username = $1`,
+      [username, status, lockedUntil ?? null],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Create fake (non-revoked) sessions for a user.
+ */
+export async function createFakeSessions(
+  username: string,
+  count: number,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `INSERT INTO sessions (sid, account_id, ip_address, user_agent)
+       SELECT gen_random_uuid(),
+              (SELECT id FROM accounts WHERE username = $1),
+              '127.0.0.1',
+              'e2e-fake-session'
+       FROM generate_series(1, $2)`,
+      [username, count],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Set `max_sessions` for an account (null to remove the limit).
+ */
+export async function setMaxSessions(
+  username: string,
+  limit: number | null,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET max_sessions = $2 WHERE username = $1",
+      [username, limit],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Set `must_change_password` flag on an account.
+ */
+export async function setMustChangePassword(
+  username: string,
+  value: boolean,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET must_change_password = $2 WHERE username = $1",
+      [username, value],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Reset an account to clean defaults: active, no lockout, no
+ * must-change-password, no max-sessions, and revoke all sessions.
+ */
+export async function resetAccountDefaults(username: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `UPDATE accounts
+       SET status = 'active',
+           failed_sign_in_count = 0,
+           locked_until = NULL,
+           must_change_password = false,
+           max_sessions = NULL
+       WHERE username = $1`,
+      [username],
+    );
+    await client.query(
+      `DELETE FROM sessions
+       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+      [username],
+    );
+  } finally {
+    await client.end();
+  }
+}

--- a/e2e/i18n-errors.spec.ts
+++ b/e2e/i18n-errors.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInKo,
+} from "./helpers/auth";
+import {
+  createFakeSessions,
+  resetAccountDefaults,
+  setAccountStatus,
+  setMaxSessions,
+} from "./helpers/setup-db";
+
+const alert = (page: import("@playwright/test").Page) =>
+  page.locator("p[role='alert']");
+
+test.describe("Korean error messages", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+  });
+
+  test.afterEach(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("/ko wrong credentials shows Korean error", async ({ page }) => {
+    await signInKo(page, ADMIN_USERNAME, "WrongPassword!");
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText(
+      "잘못된 계정 ID 또는 비밀번호입니다",
+    );
+  });
+
+  test("/ko locked account shows Korean error", async ({ page }) => {
+    await setAccountStatus(ADMIN_USERNAME, "locked", null);
+
+    await signInKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText(
+      "계정이 잠겨 있습니다. 나중에 다시 시도해 주세요.",
+    );
+  });
+
+  test("/ko inactive account shows Korean error", async ({ page }) => {
+    await setAccountStatus(ADMIN_USERNAME, "disabled");
+
+    await signInKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText("계정이 활성 상태가 아닙니다");
+  });
+
+  test("/ko max sessions shows Korean error", async ({ page }) => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await setMaxSessions(ADMIN_USERNAME, 1);
+    await createFakeSessions(ADMIN_USERNAME, 1);
+
+    await signInKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText("최대 활성 세션 수에 도달했습니다");
+  });
+});

--- a/e2e/lockout.spec.ts
+++ b/e2e/lockout.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signIn,
+} from "./helpers/auth";
+import {
+  resetAccountDefaults,
+  setAccountStatus,
+  setFailedSignInCount,
+} from "./helpers/setup-db";
+
+const alert = (page: import("@playwright/test").Page) =>
+  page.locator("p[role='alert']");
+
+test.describe("Account lockout", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("temp locked account shows lockout message", async ({ page }) => {
+    // Lock the account with a future expiry via DB.
+    const future = new Date(Date.now() + 30 * 60_000);
+    await setAccountStatus(ADMIN_USERNAME, "locked", future);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText(
+      "Account is locked. Please try again later.",
+    );
+  });
+
+  test("permanent lock (no locked_until)", async ({ page }) => {
+    await setAccountStatus(ADMIN_USERNAME, "locked", null);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText(
+      "Account is locked. Please try again later.",
+    );
+  });
+
+  test("temp lock auto-expires and sign-in succeeds", async ({ page }) => {
+    // Set locked_until to 1 minute in the past so it's already expired.
+    const past = new Date(Date.now() - 60_000);
+    await setAccountStatus(ADMIN_USERNAME, "locked", past);
+    await setFailedSignInCount(ADMIN_USERNAME, 0);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+  });
+
+  test("wrong password at threshold triggers lockout on next attempt", async ({
+    page,
+  }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    // Set count to 4, so the next wrong password is the 5th failure.
+    await setFailedSignInCount(ADMIN_USERNAME, 4);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, "WrongPassword!");
+
+    // The 5th failure returns INVALID_CREDENTIALS (lockout happens
+    // server-side but the current response is still "invalid creds").
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText("Invalid account ID or password");
+
+    // The NEXT sign-in attempt should see the lockout message.
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await expect(alert(page)).toContainText(
+      "Account is locked. Please try again later.",
+    );
+  });
+});

--- a/e2e/must-change-password.spec.ts
+++ b/e2e/must-change-password.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signIn,
+} from "./helpers/auth";
+import {
+  clearMustChangePassword,
+  resetAccountDefaults,
+  setMustChangePassword,
+} from "./helpers/setup-db";
+
+test.describe("Must-change-password flow", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await setMustChangePassword(ADMIN_USERNAME, true);
+  });
+
+  test.afterAll(async () => {
+    await clearMustChangePassword(ADMIN_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("sign-in redirects to /change-password", async ({ page }) => {
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await page.waitForURL("**/change-password", { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/change-password/);
+  });
+
+  test("API returns 403 while must_change_password is true", async ({
+    page,
+  }) => {
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.waitForURL("**/change-password", { timeout: 10_000 });
+
+    // Attempt to access a protected API endpoint.
+    const response = await page.request.get("/api/audit-logs");
+    expect(response.status()).toBe(403);
+
+    const body = await response.json();
+    expect(body.redirect).toBe("/change-password");
+  });
+
+  test("sign-out still works when must_change_password is true", async ({
+    page,
+  }) => {
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.waitForURL("**/change-password", { timeout: 10_000 });
+
+    // Sign out via API (should succeed despite must_change_password).
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+    const response = await page.request.post("/api/auth/sign-out", {
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Verify we're signed out: protected route redirects to sign-in.
+    await page.goto("/audit-logs");
+    await page.waitForURL("**/sign-in");
+    await expect(page).toHaveURL(/\/sign-in$/);
+  });
+});

--- a/e2e/rate-limit.spec.ts
+++ b/e2e/rate-limit.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+import { resetRateLimits, signIn } from "./helpers/auth";
+
+test.describe("Rate limiting", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+  });
+
+  test("per-account+IP: 429 after exceeding limit", async ({
+    page,
+    request,
+  }) => {
+    // The per-account+IP limit is 5 per 5 minutes.
+    // Use a fake username so we don't trigger account lockout.
+    const fakeUser = "ratelimit-acctip-test";
+
+    // Submit 5 attempts via API (fast).
+    for (let i = 0; i < 5; i++) {
+      await request.post("/api/auth/sign-in", {
+        data: { username: fakeUser, password: "wrong" },
+      });
+    }
+
+    // 6th attempt via the UI form → should show rate-limit message.
+    await page.goto("/sign-in");
+    await signIn(page, fakeUser, "wrong");
+
+    const alert = page.locator("p[role='alert']");
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText(
+      "Too many attempts. Please wait and try again.",
+    );
+  });
+
+  test("per-IP: 429 after exhausting per-IP bucket", async ({ request }) => {
+    // Reset counters to start clean.
+    await resetRateLimits();
+
+    // The per-IP limit is 20 per 5 minutes.
+    // Use different fake usernames (5 attempts each) to stay under
+    // the per-account+IP limit of 5 while building up the per-IP count.
+    for (let batch = 0; batch < 4; batch++) {
+      const user = `ratelimit-ip-test-${batch}`;
+      for (let i = 0; i < 5; i++) {
+        await request.post("/api/auth/sign-in", {
+          data: { username: user, password: "wrong" },
+        });
+      }
+    }
+
+    // per-IP count is now 20. The next request should be rate-limited.
+    const response = await request.post("/api/auth/sign-in", {
+      data: { username: "ratelimit-ip-final", password: "wrong" },
+    });
+
+    expect(response.status()).toBe(429);
+  });
+});

--- a/e2e/sign-out-all.spec.ts
+++ b/e2e/sign-out-all.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signIn,
+} from "./helpers/auth";
+import { resetAccountDefaults } from "./helpers/setup-db";
+
+test.describe("Sign-out-all", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("sign-out-all invalidates other sessions", async ({ browser }) => {
+    // Create two independent browser contexts (separate cookie jars).
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+
+    try {
+      const pageA = await contextA.newPage();
+      const pageB = await contextB.newPage();
+
+      // Sign in on context A.
+      await pageA.goto("http://localhost:3000/sign-in");
+      await signIn(pageA, ADMIN_USERNAME, ADMIN_PASSWORD);
+      await expect(pageA).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+
+      // Sign in on context B.
+      await pageB.goto("http://localhost:3000/sign-in");
+      await signIn(pageB, ADMIN_USERNAME, ADMIN_PASSWORD);
+      await expect(pageB).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+
+      // From context A: call sign-out-all.
+      const cookiesA = await contextA.cookies();
+      const csrfA = cookiesA.find((c) => c.name === "csrf");
+      const response = await pageA.request.post("/api/auth/sign-out-all", {
+        headers: {
+          "x-csrf-token": csrfA?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      });
+      expect(response.ok()).toBeTruthy();
+
+      // Context B should be invalidated: API call should return 401
+      // because the server-side guard checks session existence in the DB.
+      // (The proxy only does stateless JWT verification, so page navigation
+      // still succeeds – but the API guard catches revoked sessions.)
+      const apiResponse = await pageB.request.get(
+        "http://localhost:3000/api/audit-logs",
+      );
+      expect(apiResponse.status()).toBe(401);
+    } finally {
+      await contextA.close();
+      await contextB.close();
+    }
+  });
+});

--- a/src/app/api/e2e/reset-rate-limits/route.ts
+++ b/src/app/api/e2e/reset-rate-limits/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+import { resetRateLimiter } from "@/lib/rate-limit/limiter";
+
+export async function POST(): Promise<NextResponse> {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  resetRateLimiter();
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/auth/jwt-verify-stateless.ts
+++ b/src/lib/auth/jwt-verify-stateless.ts
@@ -22,9 +22,18 @@ interface VerificationKeyEntry {
   publicKey: CryptoKey;
 }
 
-// ── Module state ────────────────────────────────────────────────
+// ── Global state ────────────────────────────────────────────────
+// Keys are stored on globalThis so they survive module
+// re-instantiation across Next.js server chunks (the middleware
+// bundle uses a separate module instance from the Node.js runtime).
 
-let verificationKeys: VerificationKeyEntry[] = [];
+const g = globalThis as unknown as {
+  __jwtStatelessVerificationKeys?: VerificationKeyEntry[];
+};
+
+function getVerificationKeys(): VerificationKeyEntry[] {
+  return g.__jwtStatelessVerificationKeys ?? [];
+}
 
 // ── Public API ──────────────────────────────────────────────────
 
@@ -36,7 +45,7 @@ let verificationKeys: VerificationKeyEntry[] = [];
 export async function initStatelessKeys(
   keys: Array<{ kid: string; algorithm: string; publicKey: JWK }>,
 ): Promise<void> {
-  verificationKeys = await Promise.all(
+  g.__jwtStatelessVerificationKeys = await Promise.all(
     keys.map(async (k) => ({
       kid: k.kid,
       algorithm: k.algorithm,
@@ -59,7 +68,7 @@ export async function verifyJwtStateless(
     throw new Error("JWT header missing kid");
   }
 
-  const keyEntry = verificationKeys.find((k) => k.kid === kid);
+  const keyEntry = getVerificationKeys().find((k) => k.kid === kid);
   if (!keyEntry) {
     throw new Error(`No verification key found for kid: ${kid}`);
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,7 +24,8 @@ export default async function proxy(request: NextRequest) {
 
   try {
     await verifyJwtStateless(token);
-  } catch {
+  } catch (err) {
+    console.error("[proxy] JWT verification failed:", (err as Error).message);
     return redirectToSignIn(request);
   }
 


### PR DESCRIPTION
## Summary
- Add 23 new Playwright E2E tests across 8 spec files: account lockout (4), sign-in error messages (2), rate limiting (2), CSRF protection (3), sign-out-all (1), must-change-password (3), audit log page (4), and Korean i18n error messages (4)
- Add test helpers (`e2e/helpers/auth.ts`, `e2e/helpers/setup-db.ts`) and a rate-limit reset API endpoint (`/api/e2e/reset-rate-limits`) used only in non-production
- Fix pre-existing bug: middleware JWT verification always failed because the Edge Runtime module instance never received signing keys — use `globalThis` to share keys across module boundaries
- Fix existing `auth.spec.ts` to reset rate limits in `beforeAll` to prevent cross-file test pollution

## Test plan
- [x] All 28 E2E tests pass (`pnpm exec playwright test --config=e2e/playwright.config.ts`)
- [x] All 427 unit tests pass (`pnpm test`)
- [x] TypeScript type check passes (`pnpm typecheck`)
- [x] Biome lint/format passes (`pnpm biome check`)
- [x] Production build succeeds (`pnpm build`)

Closes #78