### PR TITLE
Add session extension dialog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
-    branches: [main]
+    branches:
+      - "**"
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@
   If there is no related issue, ask the user how to proceed before creating the
   branch.
 
+## Package manager
+
+- This project uses **pnpm** exclusively. NEVER use `npm`, `bun`, `yarn`, or
+  any other package manager.
+
 ## CI requirements
 
 - Before committing, ensure all CI lint/check steps (e.g., Biome, type checks)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@
   If there is no related issue, ask the user how to proceed before creating the
   branch.
 
+## Package manager
+
+- This project uses **pnpm** exclusively. NEVER use `npm`, `bun`, `yarn`, or
+  any other package manager.
+
 ## CI requirements
 
 - Before committing, ensure all CI lint/check steps (e.g., Biome, type checks)

--- a/e2e/session-extension.spec.ts
+++ b/e2e/session-extension.spec.ts
@@ -38,8 +38,11 @@ async function setTokenExpCookie(
 
 test.describe("Session Extension Dialog", () => {
   test.beforeAll(async () => {
-    await resetRateLimits();
     await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test.beforeEach(async () => {
+    await resetRateLimits();
   });
 
   test.afterAll(async () => {

--- a/e2e/session-extension.spec.ts
+++ b/e2e/session-extension.spec.ts
@@ -1,0 +1,301 @@
+import { expect, test } from "@playwright/test";
+
+import { resetRateLimits } from "./helpers/auth";
+import { resetAccountDefaults, revokeAllSessions } from "./helpers/setup-db";
+
+const ADMIN_USERNAME = "admin";
+const ADMIN_PASSWORD = "Admin1234!";
+
+/**
+ * Helper: sign in via the UI and wait until redirected away from sign-in.
+ */
+async function signIn(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/sign-in");
+  await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
+  await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+  await page.getByRole("button", { name: "Sign In" }).click();
+  await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+}
+
+/**
+ * Helper: set the token_exp cookie to a specific timestamp to simulate
+ * near-expiry without waiting 12+ minutes.
+ */
+async function setTokenExpCookie(
+  page: import("@playwright/test").Page,
+  expSeconds: number,
+): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: "token_exp",
+      value: String(expSeconds),
+      domain: "localhost",
+      path: "/",
+      sameSite: "Strict",
+    },
+  ]);
+}
+
+test.describe("Session Extension Dialog", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  // ── 1. Dialog appears when session nears expiry ───────────────
+
+  test("dialog appears when JWT remaining ≤ 1/5 of lifetime", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 2 minutes from now (< 3 min threshold)
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    // Wait for the session monitor to detect near-expiry (ticks every 1s)
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Verify dialog content
+    await expect(dialog.getByText(/session expir|세션 만료/i)).toBeVisible();
+
+    // Verify both buttons are present
+    await expect(
+      dialog.getByRole("button", { name: /extend|연장/i }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /sign out|로그아웃/i }),
+    ).toBeVisible();
+  });
+
+  // ── 2. Dialog does NOT appear when plenty of time ─────────────
+
+  test("dialog does not appear when JWT has plenty of time remaining", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 10 minutes from now (well above 3 min threshold)
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    await setTokenExpCookie(page, exp);
+
+    // Wait a moment to give the monitor time to tick
+    await page.waitForTimeout(2_000);
+
+    // Dialog should NOT be visible
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).not.toBeVisible();
+  });
+
+  // ── 3. [Extend] click calls /api/auth/me and closes dialog ────
+
+  test("clicking Extend calls /api/auth/me and closes the dialog", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 2 minutes from now
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    // Wait for dialog to appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Intercept the /api/auth/me call to verify it happens
+    const mePromise = page.waitForResponse(
+      (res) => res.url().includes("/api/auth/me") && res.status() === 200,
+    );
+
+    // Click Extend
+    await dialog.getByRole("button", { name: /extend|연장/i }).click();
+
+    // Verify /api/auth/me was called successfully
+    const meResponse = await mePromise;
+    expect(meResponse.ok()).toBeTruthy();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // User should still be on the dashboard (not redirected)
+    await expect(page).not.toHaveURL(/sign-in/);
+  });
+
+  // ── 4. [Sign out] click signs out and redirects ───────────────
+
+  test("clicking Sign Out signs out and redirects to sign-in", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 2 minutes from now
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    // Wait for dialog to appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Click Sign Out
+    await dialog.getByRole("button", { name: /sign out|로그아웃/i }).click();
+
+    // Should redirect to sign-in page
+    await expect(page).toHaveURL(/sign-in/, { timeout: 10_000 });
+  });
+
+  // ── 5. Countdown expires → redirect ───────────────────────────
+
+  test("when countdown reaches zero, user is redirected to sign-in", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 3 seconds from now — dialog appears, then expires
+    const exp = Math.floor(Date.now() / 1000) + 3;
+    await setTokenExpCookie(page, exp);
+
+    // Dialog should appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Wait for expiry — should redirect to sign-in
+    await expect(page).toHaveURL(/sign-in/, { timeout: 10_000 });
+  });
+
+  // ── 6. Countdown display shows correct format ─────────────────
+
+  test("dialog displays countdown in MM:SS format", async ({ page }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 90 seconds from now
+    const exp = Math.floor(Date.now() / 1000) + 90;
+    await setTokenExpCookie(page, exp);
+
+    // Wait for dialog to appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Verify countdown format (MM:SS — should show something like 01:29 or 01:30)
+    await expect(dialog.locator(".font-mono")).toHaveText(/^0[12]:\d{2}$/);
+  });
+
+  // ── 7. Dialog stays dismissed after extend ───────────────────
+
+  test("dialog stays dismissed after extend even while near-expiry", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Set token_exp to 2 minutes from now
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    // Wait for dialog to appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Click Extend
+    await dialog.getByRole("button", { name: /extend|연장/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // Wait 2 more seconds — dialog should NOT reappear (same exp)
+    await page.waitForTimeout(2_000);
+    await expect(dialog).not.toBeVisible();
+  });
+
+  // ── 8. Rapid clicks on Extend only trigger one request ──────
+
+  test("rapid double-click on Extend only triggers one /api/auth/me", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Collect all /api/auth/me requests
+    const meRequests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/api/auth/me")) meRequests.push(req.url());
+    });
+
+    // Rapid double-click — button should disable after first click
+    const extendBtn = dialog.getByRole("button", { name: /extend|연장/i });
+    await extendBtn.dblclick();
+
+    // Wait for the request to complete
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // Only one request should have been sent
+    expect(meRequests.length).toBe(1);
+  });
+
+  // ── 9. Sign-out works without CSRF cookie ───────────────────
+
+  test("sign-out succeeds even when CSRF cookie is missing", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signIn(page);
+
+    // Delete CSRF cookies before triggering dialog
+    await page.context().clearCookies({ name: "csrf" });
+    await page.context().clearCookies({ name: "__Host-csrf" });
+
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Click Sign Out — should still redirect despite missing CSRF
+    await dialog.getByRole("button", { name: /sign out|로그아웃/i }).click();
+    await expect(page).toHaveURL(/sign-in/, { timeout: 10_000 });
+  });
+
+  // ── 10. i18n: dialog renders in Korean locale ──────────────────
+
+  test("dialog renders correctly in Korean locale", async ({ page }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+
+    // Sign in via Korean locale
+    await page.goto("/ko/sign-in");
+    await page.getByLabel("계정 ID").fill(ADMIN_USERNAME);
+    await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+    await page.getByRole("button", { name: "로그인" }).click();
+    await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+
+    // Set token_exp to 2 minutes from now
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    await setTokenExpCookie(page, exp);
+
+    // Wait for dialog to appear
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Verify Korean text
+    await expect(dialog.getByText(/세션 만료/)).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /세션 연장/ }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: /로그아웃/ }),
+    ).toBeVisible();
+  });
+});

--- a/src/__tests__/app/api/auth/sign-in/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-in/route.test.ts
@@ -9,6 +9,7 @@ const mockVerifyPassword = vi.hoisted(() => vi.fn());
 const mockIssueAccessToken = vi.hoisted(() => vi.fn());
 const mockGenerateCsrfToken = vi.hoisted(() => vi.fn());
 const mockSetAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockSetTokenExpCookie = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockIsIpAllowed = vi.hoisted(() => vi.fn());
 const mockExtractClientIp = vi.hoisted(() => vi.fn());
@@ -46,6 +47,7 @@ vi.mock("@/lib/auth/csrf", () => ({
 
 vi.mock("@/lib/auth/cookies", () => ({
   setAccessTokenCookie: mockSetAccessTokenCookie,
+  setTokenExpCookie: mockSetTokenExpCookie,
 }));
 
 vi.mock("@/lib/audit/logger", () => ({
@@ -500,6 +502,19 @@ describe("POST /api/auth/sign-in", () => {
         "csrf-token",
         expect.objectContaining({ maxAge: 900 }),
       );
+    });
+
+    it("sets token_exp cookie with expiry timestamp", async () => {
+      const before = Math.floor(Date.now() / 1000) + 900;
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      await POST(makeRequest({ username: "admin", password: "pass" }));
+      const after = Math.floor(Date.now() / 1000) + 900;
+
+      expect(mockSetTokenExpCookie).toHaveBeenCalledTimes(1);
+      const [expArg, maxAgeArg] = mockSetTokenExpCookie.mock.calls[0];
+      expect(expArg).toBeGreaterThanOrEqual(before);
+      expect(expArg).toBeLessThanOrEqual(after);
+      expect(maxAgeArg).toBe(900);
     });
 
     it("records audit success", async () => {

--- a/src/__tests__/app/api/auth/sign-out-all/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-out-all/route.test.ts
@@ -11,6 +11,7 @@ type HandlerFn = (
 
 const mockQuery = vi.hoisted(() => vi.fn());
 const mockDeleteAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockDeleteTokenExpCookie = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockExtractClientIp = vi.hoisted(() => vi.fn());
 const mockCookieDelete = vi.hoisted(() => vi.fn());
@@ -34,6 +35,9 @@ vi.mock("@/lib/db/client", () => ({
 vi.mock("@/lib/auth/cookies", () => ({
   deleteAccessTokenCookie: vi.fn((...args: unknown[]) =>
     mockDeleteAccessTokenCookie(...args),
+  ),
+  deleteTokenExpCookie: vi.fn((...args: unknown[]) =>
+    mockDeleteTokenExpCookie(...args),
   ),
 }));
 
@@ -119,10 +123,11 @@ describe("POST /api/auth/sign-out-all", () => {
     );
   });
 
-  it("deletes both cookies", async () => {
+  it("deletes all session cookies", async () => {
     currentSession = validSession;
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
     mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
+    mockDeleteTokenExpCookie.mockResolvedValueOnce(undefined);
     mockAuditRecord.mockResolvedValueOnce(undefined);
     mockExtractClientIp.mockReturnValue("127.0.0.1");
 
@@ -130,6 +135,7 @@ describe("POST /api/auth/sign-out-all", () => {
     await POST(makeRequest(), makeContext());
 
     expect(mockDeleteAccessTokenCookie).toHaveBeenCalled();
+    expect(mockDeleteTokenExpCookie).toHaveBeenCalled();
     expect(mockCookieDelete).toHaveBeenCalledWith("csrf");
   });
 

--- a/src/__tests__/app/api/auth/sign-out/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-out/route.test.ts
@@ -11,6 +11,7 @@ type HandlerFn = (
 
 const mockQuery = vi.hoisted(() => vi.fn());
 const mockDeleteAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockDeleteTokenExpCookie = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockExtractClientIp = vi.hoisted(() => vi.fn());
 const mockCookieDelete = vi.hoisted(() => vi.fn());
@@ -34,6 +35,9 @@ vi.mock("@/lib/db/client", () => ({
 vi.mock("@/lib/auth/cookies", () => ({
   deleteAccessTokenCookie: vi.fn((...args: unknown[]) =>
     mockDeleteAccessTokenCookie(...args),
+  ),
+  deleteTokenExpCookie: vi.fn((...args: unknown[]) =>
+    mockDeleteTokenExpCookie(...args),
   ),
 }));
 
@@ -130,6 +134,20 @@ describe("POST /api/auth/sign-out", () => {
     await POST(makeRequest(), makeContext());
 
     expect(mockDeleteAccessTokenCookie).toHaveBeenCalled();
+  });
+
+  it("deletes the token_exp cookie", async () => {
+    currentSession = validSession;
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
+    mockDeleteTokenExpCookie.mockResolvedValueOnce(undefined);
+    mockAuditRecord.mockResolvedValueOnce(undefined);
+    mockExtractClientIp.mockReturnValue("127.0.0.1");
+
+    const { POST } = await import("@/app/api/auth/sign-out/route");
+    await POST(makeRequest(), makeContext());
+
+    expect(mockDeleteTokenExpCookie).toHaveBeenCalled();
   });
 
   it("deletes the CSRF cookie", async () => {

--- a/src/__tests__/components/session/session-extension-dialog.test.ts
+++ b/src/__tests__/components/session/session-extension-dialog.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock "use client" modules so we can import the pure helpers without
+// pulling in React / Next.js runtime.
+vi.mock("next-intl", () => ({ useTranslations: () => (k: string) => k }));
+vi.mock("react", () => ({
+  useCallback: (fn: unknown) => fn,
+  useState: (v: unknown) => [v, vi.fn()],
+  useEffect: vi.fn(),
+  useRef: (v: unknown) => ({ current: v }),
+}));
+vi.mock("@/i18n/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/hooks/use-session-monitor", () => ({
+  useSessionMonitor: () => ({
+    remainingSeconds: 120,
+    showDialog: false,
+    dismiss: vi.fn(),
+  }),
+}));
+vi.mock("lucide-react", () => ({ Loader2: "div" }));
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: "div",
+  AlertDialogAction: "button",
+  AlertDialogCancel: "button",
+  AlertDialogContent: "div",
+  AlertDialogDescription: "div",
+  AlertDialogFooter: "div",
+  AlertDialogHeader: "div",
+  AlertDialogTitle: "div",
+}));
+
+// ── formatCountdown ─────────────────────────────────
+
+describe("formatCountdown", () => {
+  let formatCountdown: (s: number) => string;
+
+  it("loads module", async () => {
+    const mod = await import("@/components/session/session-extension-dialog");
+    formatCountdown = mod.formatCountdown;
+  });
+
+  it("formats 0 seconds as 00:00", () => {
+    expect(formatCountdown(0)).toBe("00:00");
+  });
+
+  it("formats 59 seconds as 00:59", () => {
+    expect(formatCountdown(59)).toBe("00:59");
+  });
+
+  it("formats 60 seconds as 01:00", () => {
+    expect(formatCountdown(60)).toBe("01:00");
+  });
+
+  it("formats 90 seconds as 01:30", () => {
+    expect(formatCountdown(90)).toBe("01:30");
+  });
+
+  it("formats 180 seconds as 03:00", () => {
+    expect(formatCountdown(180)).toBe("03:00");
+  });
+
+  it("formats 599 seconds as 09:59", () => {
+    expect(formatCountdown(599)).toBe("09:59");
+  });
+
+  it("formats 900 seconds as 15:00", () => {
+    expect(formatCountdown(900)).toBe("15:00");
+  });
+});
+
+// ── readCsrfToken ───────────────────────────────────
+
+describe("readCsrfToken", () => {
+  let readCsrfToken: () => string | null;
+
+  let fakeCookie = "";
+  vi.stubGlobal("document", {
+    get cookie() {
+      return fakeCookie;
+    },
+    set cookie(val: string) {
+      fakeCookie = val;
+    },
+  });
+
+  it("loads module", async () => {
+    const mod = await import("@/components/session/session-extension-dialog");
+    readCsrfToken = mod.readCsrfToken;
+  });
+
+  it("returns null when no CSRF cookie exists", () => {
+    fakeCookie = "";
+    expect(readCsrfToken()).toBeNull();
+  });
+
+  it("returns null when only unrelated cookies exist", () => {
+    fakeCookie = "token_exp=12345; other=value";
+    expect(readCsrfToken()).toBeNull();
+  });
+
+  it("reads csrf cookie (development)", () => {
+    fakeCookie = "csrf=dev-token-123";
+    expect(readCsrfToken()).toBe("dev-token-123");
+  });
+
+  it("reads __Host-csrf cookie (production)", () => {
+    fakeCookie = "__Host-csrf=prod-token-456";
+    expect(readCsrfToken()).toBe("prod-token-456");
+  });
+
+  it("prefers __Host-csrf over csrf when both present", () => {
+    fakeCookie = "__Host-csrf=prod; csrf=dev";
+    expect(readCsrfToken()).toBe("prod");
+  });
+
+  it("reads csrf from among multiple cookies", () => {
+    fakeCookie = "token_exp=999; csrf=my-token; other=abc";
+    expect(readCsrfToken()).toBe("my-token");
+  });
+});

--- a/src/__tests__/hooks/use-session-monitor.test.ts
+++ b/src/__tests__/hooks/use-session-monitor.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── document.cookie mock ─────────────────────────
+
+let fakeCookie = "";
+
+vi.stubGlobal("document", {
+  get cookie() {
+    return fakeCookie;
+  },
+  set cookie(val: string) {
+    fakeCookie = val;
+  },
+});
+
+// ── React hooks mock ─────────────────────────────
+
+let remainingState = 900;
+const setRemaining = vi.fn((v: number | ((p: number) => number)) => {
+  remainingState = typeof v === "function" ? v(remainingState) : v;
+});
+
+let showDialogState = false;
+const setShowDialog = vi.fn((v: boolean | ((p: boolean) => boolean)) => {
+  showDialogState = typeof v === "function" ? v(showDialogState) : v;
+});
+
+const refObject = { current: null as number | null };
+
+const useEffectCallbacks: Array<() => (() => void) | undefined> = [];
+
+const mockRouterPush = vi.fn();
+
+vi.mock("react", () => {
+  let stateCallIndex = 0;
+  return {
+    useState: (initial: unknown) => {
+      const idx = stateCallIndex++;
+      if (idx % 2 === 0) {
+        // First useState = remainingSeconds
+        remainingState = initial as number;
+        return [remainingState, setRemaining] as const;
+      }
+      // Second useState = showDialog
+      showDialogState = initial as boolean;
+      return [showDialogState, setShowDialog] as const;
+    },
+    useRef: (initial: unknown) => {
+      refObject.current = initial as number | null;
+      return refObject;
+    },
+    useCallback: (fn: (...args: unknown[]) => unknown) => fn,
+    useEffect: (cb: () => (() => void) | undefined) => {
+      useEffectCallbacks.push(cb);
+    },
+  };
+});
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+// ── Tests ────────────────────────────────────────
+
+describe("useSessionMonitor", () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  beforeEach(() => {
+    fakeCookie = "";
+    remainingState = 900;
+    showDialogState = false;
+    refObject.current = null;
+    useEffectCallbacks.length = 0;
+    mockRouterPush.mockClear();
+    setRemaining.mockClear();
+    setShowDialog.mockClear();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function runEffect() {
+    for (const cb of useEffectCallbacks) {
+      cb();
+    }
+  }
+
+  it("returns initial state with full remaining time", async () => {
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    const result = useSessionMonitor();
+
+    expect(result.remainingSeconds).toBe(900);
+    expect(result.showDialog).toBe(false);
+    expect(typeof result.dismiss).toBe("function");
+  });
+
+  it("does not show dialog when no token_exp cookie is present", async () => {
+    fakeCookie = "";
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("does not show dialog when remaining > threshold (180s)", async () => {
+    const exp = now + 600; // 10 min remaining — well above threshold
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+  });
+
+  it("shows dialog when remaining ≤ threshold (180s)", async () => {
+    const exp = now + 120; // 2 min remaining — below threshold
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    expect(setShowDialog).toHaveBeenCalledWith(true);
+  });
+
+  it("shows dialog at exactly the threshold boundary", async () => {
+    const exp = now + 180; // exactly 3 min = 180s = threshold
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    expect(setShowDialog).toHaveBeenCalledWith(true);
+  });
+
+  it("redirects to sign-in when JWT is expired", async () => {
+    const exp = now - 10; // expired 10 seconds ago
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/sign-in");
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+  });
+
+  it("sets remainingSeconds to 0 when expired", async () => {
+    const exp = now - 10;
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    expect(setRemaining).toHaveBeenCalledWith(0);
+  });
+
+  it("dismiss() records the current exp and prevents re-show", async () => {
+    const exp = now + 100;
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    const { dismiss } = useSessionMonitor();
+
+    // Dismiss records current exp in ref
+    dismiss();
+    expect(refObject.current).toBe(exp);
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+
+    // Next tick: same exp → should not show dialog because dismissed
+    setShowDialog.mockClear();
+    runEffect();
+
+    // After dismiss, showDialog set to false (dismissed for this exp)
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+  });
+
+  it("clears dismissed state when token_exp changes (rotation)", async () => {
+    const oldExp = now + 100;
+    fakeCookie = `token_exp=${oldExp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    const { dismiss } = useSessionMonitor();
+
+    // Dismiss for the old exp
+    dismiss();
+    expect(refObject.current).toBe(oldExp);
+
+    // Simulate rotation: token_exp changes to a new value
+    const newExp = now + 900;
+    fakeCookie = `token_exp=${newExp}`;
+
+    setShowDialog.mockClear();
+    runEffect();
+
+    // The dismissedExpRef should be cleared because exp changed
+    expect(refObject.current).toBeNull();
+  });
+
+  it("handles non-numeric cookie values gracefully", async () => {
+    fakeCookie = "token_exp=not-a-number";
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    // Should behave like no cookie — no dialog, no redirect
+    expect(setShowDialog).toHaveBeenCalledWith(false);
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("reads token_exp from among multiple cookies", async () => {
+    const exp = now + 60;
+    fakeCookie = `other=value; token_exp=${exp}; csrf=abc123`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    // 60s remaining < 180s threshold → dialog should show
+    expect(setShowDialog).toHaveBeenCalledWith(true);
+  });
+
+  it("updates remainingSeconds to correct non-zero value", async () => {
+    const remaining = 120;
+    const exp = now + remaining;
+    fakeCookie = `token_exp=${exp}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+    runEffect();
+
+    // setRemaining should be called with approximately 120
+    // (allow ±1s for timing)
+    const call = setRemaining.mock.calls.find(
+      (c: [number | ((p: number) => number)]) => {
+        const v = c[0];
+        return typeof v === "number" && v >= remaining - 1 && v <= remaining;
+      },
+    );
+    expect(call).toBeDefined();
+  });
+
+  it("useEffect returns a cleanup function", async () => {
+    fakeCookie = `token_exp=${now + 600}`;
+
+    const { useSessionMonitor } = await import("@/hooks/use-session-monitor");
+    useSessionMonitor();
+
+    // Each useEffect callback should return a function (clearInterval)
+    for (const cb of useEffectCallbacks) {
+      const cleanup = cb();
+      expect(typeof cleanup).toBe("function");
+    }
+  });
+});

--- a/src/__tests__/lib/auth/cookies.test.ts
+++ b/src/__tests__/lib/auth/cookies.test.ts
@@ -77,4 +77,44 @@ describe("cookies", () => {
       expect(mockDelete).toHaveBeenCalledWith("at");
     });
   });
+
+  // ── token_exp cookie ──────────────────────────────────────────
+
+  describe("TOKEN_EXP_COOKIE", () => {
+    it("is 'token_exp'", () => {
+      expect(cookiesMod.TOKEN_EXP_COOKIE).toBe("token_exp");
+    });
+  });
+
+  describe("setTokenExpCookie", () => {
+    it("sets the cookie with correct name, value, and non-httpOnly options", async () => {
+      await cookiesMod.setTokenExpCookie(1700000000, 900);
+
+      expect(mockSet).toHaveBeenCalledWith("token_exp", "1700000000", {
+        httpOnly: false,
+        secure: false,
+        sameSite: "strict",
+        path: "/",
+        maxAge: 900,
+      });
+    });
+
+    it("converts expSeconds to string", async () => {
+      await cookiesMod.setTokenExpCookie(1700000999, 600);
+
+      expect(mockSet).toHaveBeenCalledWith(
+        "token_exp",
+        "1700000999",
+        expect.objectContaining({ maxAge: 600 }),
+      );
+    });
+  });
+
+  describe("deleteTokenExpCookie", () => {
+    it("calls delete with the correct cookie name", async () => {
+      await cookiesMod.deleteTokenExpCookie();
+
+      expect(mockDelete).toHaveBeenCalledWith("token_exp");
+    });
+  });
 });

--- a/src/__tests__/lib/auth/rotation.test.ts
+++ b/src/__tests__/lib/auth/rotation.test.ts
@@ -5,6 +5,7 @@ import type { AuthSession } from "@/lib/auth/jwt";
 const mockIssueAccessToken = vi.hoisted(() => vi.fn());
 const mockGenerateCsrfToken = vi.hoisted(() => vi.fn());
 const mockSetAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockSetTokenExpCookie = vi.hoisted(() => vi.fn());
 const mockCookiesSet = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth/jwt", () => ({
@@ -24,6 +25,7 @@ vi.mock("@/lib/auth/csrf", () => ({
 
 vi.mock("@/lib/auth/cookies", () => ({
   setAccessTokenCookie: mockSetAccessTokenCookie,
+  setTokenExpCookie: mockSetTokenExpCookie,
 }));
 
 vi.mock("next/headers", () => ({
@@ -55,6 +57,7 @@ describe("rotation", () => {
     mockIssueAccessToken.mockReset().mockResolvedValue("new-jwt-token");
     mockGenerateCsrfToken.mockReset().mockReturnValue({ token: "new-csrf" });
     mockSetAccessTokenCookie.mockReset().mockResolvedValue(undefined);
+    mockSetTokenExpCookie.mockReset().mockResolvedValue(undefined);
     mockCookiesSet.mockReset();
 
     process.env.CSRF_SECRET = "test-csrf-secret";
@@ -141,6 +144,18 @@ describe("rotation", () => {
       );
     });
 
+    it("sets token_exp cookie with new expiry", async () => {
+      const before = Math.floor(Date.now() / 1000) + 900;
+      await rotation.rotateTokens(validSession);
+      const after = Math.floor(Date.now() / 1000) + 900;
+
+      expect(mockSetTokenExpCookie).toHaveBeenCalledTimes(1);
+      const [expArg, maxAgeArg] = mockSetTokenExpCookie.mock.calls[0];
+      expect(expArg).toBeGreaterThanOrEqual(before);
+      expect(expArg).toBeLessThanOrEqual(after);
+      expect(maxAgeArg).toBe(900);
+    });
+
     it("sets CSRF cookie with correct options", async () => {
       await rotation.rotateTokens(validSession);
 
@@ -160,6 +175,7 @@ describe("rotation", () => {
 
       expect(mockIssueAccessToken).not.toHaveBeenCalled();
       expect(mockGenerateCsrfToken).not.toHaveBeenCalled();
+      expect(mockSetTokenExpCookie).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -5,7 +5,6 @@ import { useState } from "react";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { MobileHeader } from "@/components/layout/mobile-header";
 import { Sidebar } from "@/components/layout/sidebar";
-import { SessionExtensionDialog } from "@/components/session/session-extension-dialog";
 import { useSidebar } from "@/hooks/use-sidebar";
 
 export default function DashboardLayout({
@@ -38,8 +37,6 @@ export default function DashboardLayout({
           <div className="flex-1 overflow-y-auto p-6">{children}</div>
         </main>
       </div>
-
-      <SessionExtensionDialog />
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { MobileHeader } from "@/components/layout/mobile-header";
 import { Sidebar } from "@/components/layout/sidebar";
+import { SessionExtensionDialog } from "@/components/session/session-extension-dialog";
 import { useSidebar } from "@/hooks/use-sidebar";
 
 export default function DashboardLayout({
@@ -37,6 +38,8 @@ export default function DashboardLayout({
           <div className="flex-1 overflow-y-auto p-6">{children}</div>
         </main>
       </div>
+
+      <SessionExtensionDialog />
     </div>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { ThemeProvider } from "next-themes";
 
+import { SessionExtensionDialog } from "@/components/session/session-extension-dialog";
 import { routing } from "@/i18n/routing";
 import { themeConfig } from "@/lib/theme";
 
@@ -43,7 +44,10 @@ export default async function LocaleLayout({
     <html lang={locale} suppressHydrationWarning>
       <body className={roboto.className}>
         <ThemeProvider {...themeConfig}>
-          <NextIntlClientProvider>{children}</NextIntlClientProvider>
+          <NextIntlClientProvider>
+            {children}
+            <SessionExtensionDialog />
+          </NextIntlClientProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/audit/correlation";
 import { auditLog } from "@/lib/audit/logger";
 import { isIpAllowed } from "@/lib/auth/cidr";
-import { setAccessTokenCookie } from "@/lib/auth/cookies";
+import { setAccessTokenCookie, setTokenExpCookie } from "@/lib/auth/cookies";
 import {
   CSRF_COOKIE_NAME,
   CSRF_COOKIE_OPTIONS,
@@ -371,7 +371,9 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
   const { token: csrfToken } = generateCsrfToken(sessionId, csrfSecret);
 
   // 9e. Set cookies
+  const tokenExp = Math.floor(Date.now() / 1000) + TOKEN_MAX_AGE_SECONDS;
   await setAccessTokenCookie(jwt, TOKEN_MAX_AGE_SECONDS);
+  await setTokenExpCookie(tokenExp, TOKEN_MAX_AGE_SECONDS);
   const cookieStore = await cookies();
   cookieStore.set(CSRF_COOKIE_NAME, csrfToken, {
     ...CSRF_COOKIE_OPTIONS,

--- a/src/app/api/auth/sign-out-all/route.ts
+++ b/src/app/api/auth/sign-out-all/route.ts
@@ -2,7 +2,10 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
-import { deleteAccessTokenCookie } from "@/lib/auth/cookies";
+import {
+  deleteAccessTokenCookie,
+  deleteTokenExpCookie,
+} from "@/lib/auth/cookies";
 import { CSRF_COOKIE_NAME } from "@/lib/auth/csrf";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
@@ -18,6 +21,7 @@ export const POST = withAuth(
 
     // Clear current session cookies
     await deleteAccessTokenCookie();
+    await deleteTokenExpCookie();
     const cookieStore = await cookies();
     cookieStore.delete(CSRF_COOKIE_NAME);
 

--- a/src/app/api/auth/sign-out/route.ts
+++ b/src/app/api/auth/sign-out/route.ts
@@ -2,7 +2,10 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
-import { deleteAccessTokenCookie } from "@/lib/auth/cookies";
+import {
+  deleteAccessTokenCookie,
+  deleteTokenExpCookie,
+} from "@/lib/auth/cookies";
 import { CSRF_COOKIE_NAME } from "@/lib/auth/csrf";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
@@ -17,6 +20,7 @@ export const POST = withAuth(
 
     // Clear cookies
     await deleteAccessTokenCookie();
+    await deleteTokenExpCookie();
     const cookieStore = await cookies();
     cookieStore.delete(CSRF_COOKIE_NAME);
 

--- a/src/components/session/session-extension-dialog.tsx
+++ b/src/components/session/session-extension-dialog.tsx
@@ -31,6 +31,12 @@ export function readCsrfToken(): string | null {
   return null;
 }
 
+/** Delete the token_exp cookie client-side to prevent the dialog from re-appearing. */
+function clearTokenExpCookie(): void {
+  // biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API not universally supported
+  document.cookie = "token_exp=; path=/; max-age=0";
+}
+
 export function formatCountdown(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
@@ -55,9 +61,11 @@ export function SessionExtensionDialog() {
         dismiss();
       } else {
         // Token already expired or invalid — redirect to sign-in
+        clearTokenExpCookie();
         router.push("/sign-in");
       }
     } catch {
+      clearTokenExpCookie();
       router.push("/sign-in");
     } finally {
       setExtending(false);
@@ -75,6 +83,7 @@ export function SessionExtensionDialog() {
     } catch {
       // Best-effort sign-out; redirect regardless
     } finally {
+      clearTokenExpCookie();
       router.push("/sign-in");
     }
   }, [router]);

--- a/src/components/session/session-extension-dialog.tsx
+++ b/src/components/session/session-extension-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useSessionMonitor } from "@/hooks/use-session-monitor";
+import { useRouter } from "@/i18n/navigation";
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/** Read the CSRF token from the cookie (non-httpOnly). */
+export function readCsrfToken(): string | null {
+  // Production uses "__Host-csrf", development uses "csrf"
+  for (const name of ["__Host-csrf", "csrf"]) {
+    const match = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith(`${name}=`));
+    if (match) return match.split("=")[1];
+  }
+  return null;
+}
+
+export function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+// ── Component ──────────────────────────────────────────────────
+
+export function SessionExtensionDialog() {
+  const t = useTranslations();
+  const router = useRouter();
+  const { remainingSeconds, showDialog, dismiss } = useSessionMonitor();
+
+  const [extending, setExtending] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+
+  const handleExtend = useCallback(async () => {
+    setExtending(true);
+    try {
+      const res = await fetch("/api/auth/me");
+      if (res.ok) {
+        dismiss();
+      } else {
+        // Token already expired or invalid — redirect to sign-in
+        router.push("/sign-in");
+      }
+    } catch {
+      router.push("/sign-in");
+    } finally {
+      setExtending(false);
+    }
+  }, [dismiss, router]);
+
+  const handleSignOut = useCallback(async () => {
+    setSigningOut(true);
+    try {
+      const csrfToken = readCsrfToken();
+      await fetch("/api/auth/sign-out", {
+        method: "POST",
+        headers: csrfToken ? { "x-csrf-token": csrfToken } : {},
+      });
+    } catch {
+      // Best-effort sign-out; redirect regardless
+    } finally {
+      router.push("/sign-in");
+    }
+  }, [router]);
+
+  return (
+    <AlertDialog open={showDialog}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("auth.sessionExpiring")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("auth.sessionExpiringDescription", {
+              seconds: remainingSeconds,
+            })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="text-center text-2xl font-mono font-semibold tabular-nums">
+          {formatCountdown(remainingSeconds)}
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            onClick={handleSignOut}
+            disabled={signingOut || extending}
+          >
+            {signingOut ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            {t("common.signOut")}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleExtend}
+            disabled={extending || signingOut}
+          >
+            {extending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            {t("auth.extendSession")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  );
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Content>
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action data-slot="alert-dialog-action" {...props} />
+  );
+}
+
+function AlertDialogCancel({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel data-slot="alert-dialog-cancel" {...props} />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/hooks/use-session-monitor.ts
+++ b/src/hooks/use-session-monitor.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useRouter } from "@/i18n/navigation";
+
+// ── Constants ──────────────────────────────────────────────────
+
+/** JWT lifetime in seconds — must match the server-side value. */
+const TOKEN_LIFETIME_SECONDS = 15 * 60; // 900s
+
+/** Show the dialog when remaining ≤ 1/DIALOG_FRACTION of total. */
+const DIALOG_FRACTION = 5; // 1/5 = 180s = 3 minutes
+
+const DIALOG_THRESHOLD_SECONDS = TOKEN_LIFETIME_SECONDS / DIALOG_FRACTION;
+
+const TOKEN_EXP_COOKIE = "token_exp";
+
+// ── Cookie helper ──────────────────────────────────────────────
+
+function readTokenExp(): number | null {
+  const match = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${TOKEN_EXP_COOKIE}=`));
+  if (!match) return null;
+  const value = Number(match.split("=")[1]);
+  return Number.isNaN(value) ? null : value;
+}
+
+// ── Hook ───────────────────────────────────────────────────────
+
+interface SessionMonitorState {
+  /** Seconds remaining until the JWT expires. */
+  remainingSeconds: number;
+  /** Whether the session extension dialog should be shown. */
+  showDialog: boolean;
+  /** Dismiss the dialog (e.g. after a successful extend). */
+  dismiss: () => void;
+}
+
+export function useSessionMonitor(): SessionMonitorState {
+  const router = useRouter();
+  const [remainingSeconds, setRemainingSeconds] = useState(
+    TOKEN_LIFETIME_SECONDS,
+  );
+  const [showDialog, setShowDialog] = useState(false);
+  const dismissedExpRef = useRef<number | null>(null);
+
+  const dismiss = useCallback(() => {
+    setShowDialog(false);
+    // Remember which exp we dismissed for, so we don't re-show
+    // until the cookie updates (i.e. rotation happens).
+    dismissedExpRef.current = readTokenExp();
+  }, []);
+
+  useEffect(() => {
+    const tick = () => {
+      const exp = readTokenExp();
+      if (exp === null) {
+        // No token_exp cookie — user is not authenticated or cookie
+        // was cleared.  Nothing to monitor.
+        setShowDialog(false);
+        return;
+      }
+
+      const now = Math.floor(Date.now() / 1000);
+      const remaining = exp - now;
+
+      setRemainingSeconds(Math.max(0, remaining));
+
+      if (remaining <= 0) {
+        // JWT has expired — redirect to sign-in
+        setShowDialog(false);
+        router.push("/sign-in");
+        return;
+      }
+
+      // If the token_exp changed (rotation happened), dismiss any
+      // previously shown dialog.
+      if (dismissedExpRef.current !== null && exp !== dismissedExpRef.current) {
+        dismissedExpRef.current = null;
+      }
+
+      // Show dialog when remaining ≤ threshold and we haven't
+      // dismissed for this particular exp value.
+      if (
+        remaining <= DIALOG_THRESHOLD_SECONDS &&
+        dismissedExpRef.current !== exp
+      ) {
+        setShowDialog(true);
+      } else {
+        setShowDialog(false);
+      }
+    };
+
+    // Run immediately, then every second
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [router]);
+
+  return { remainingSeconds, showDialog, dismiss };
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -27,7 +27,10 @@
     "serverError": "An unexpected error occurred. Please try again.",
     "resetPassword": "Reset your password",
     "sessionTimeout": "Session timeout",
-    "sessionEnded": "Session ended"
+    "sessionEnded": "Session ended",
+    "sessionExpiring": "Session expiring",
+    "sessionExpiringDescription": "Your session will expire in {seconds} seconds. Would you like to extend it?",
+    "extendSession": "Extend session"
   },
   "nav": {
     "home": "Home",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -27,7 +27,10 @@
     "serverError": "예기치 않은 오류가 발생했습니다. 다시 시도해 주세요.",
     "resetPassword": "비밀번호 재설정",
     "sessionTimeout": "세션 시간 초과",
-    "sessionEnded": "세션 종료"
+    "sessionEnded": "세션 종료",
+    "sessionExpiring": "세션 만료 임박",
+    "sessionExpiringDescription": "세션이 {seconds}초 후에 만료됩니다. 연장하시겠습니까?",
+    "extendSession": "세션 연장"
   },
   "nav": {
     "home": "홈",

--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -4,8 +4,22 @@ import { cookies } from "next/headers";
 
 export const ACCESS_TOKEN_COOKIE = "at";
 
+/**
+ * Non-httpOnly cookie that exposes the JWT expiration timestamp
+ * (seconds since epoch) to client-side JavaScript.  The client
+ * uses this to display a session-extension dialog before expiry.
+ */
+export const TOKEN_EXP_COOKIE = "token_exp";
+
 const COOKIE_OPTIONS = {
   httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict" as const,
+  path: "/",
+};
+
+const TOKEN_EXP_COOKIE_OPTIONS = {
+  httpOnly: false,
   secure: process.env.NODE_ENV === "production",
   sameSite: "strict" as const,
   path: "/",
@@ -33,4 +47,22 @@ export async function getAccessTokenCookie(): Promise<string | undefined> {
 export async function deleteAccessTokenCookie(): Promise<void> {
   const cookieStore = await cookies();
   cookieStore.delete(ACCESS_TOKEN_COOKIE);
+}
+
+/** Set the token_exp cookie so the client can read the JWT expiry. */
+export async function setTokenExpCookie(
+  expSeconds: number,
+  maxAgeSeconds: number,
+): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(TOKEN_EXP_COOKIE, String(expSeconds), {
+    ...TOKEN_EXP_COOKIE_OPTIONS,
+    maxAge: maxAgeSeconds,
+  });
+}
+
+/** Delete the token_exp cookie. */
+export async function deleteTokenExpCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete(TOKEN_EXP_COOKIE);
 }

--- a/src/lib/auth/rotation.ts
+++ b/src/lib/auth/rotation.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { cookies } from "next/headers";
 
-import { setAccessTokenCookie } from "./cookies";
+import { setAccessTokenCookie, setTokenExpCookie } from "./cookies";
 import {
   CSRF_COOKIE_NAME,
   CSRF_COOKIE_OPTIONS,
@@ -69,7 +69,9 @@ export async function rotateTokens(session: AuthSession): Promise<void> {
   );
 
   // Set JWT cookie
+  const tokenExp = Math.floor(Date.now() / 1000) + DEFAULT_MAX_AGE_SECONDS;
   await setAccessTokenCookie(newToken, DEFAULT_MAX_AGE_SECONDS);
+  await setTokenExpCookie(tokenExp, DEFAULT_MAX_AGE_SECONDS);
 
   // Set CSRF cookie
   const cookieStore = await cookies();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
     },
   },
   test: {
-    exclude: ["node_modules", "e2e", ".next"],
+    exclude: ["node_modules", "e2e", ".next", ".claude/worktrees"],
   },
 });


### PR DESCRIPTION
## Summary

- Add a client-side dialog that warns users when their JWT is about to expire (≤ 3 minutes remaining) and lets them extend or sign out
- Expose JWT expiry to the client via a non-httpOnly `token_exp` cookie, set on sign-in and token rotation, deleted on sign-out
- Add `useSessionMonitor` hook that polls `token_exp` every 1 second to compute remaining time
- Mount `SessionExtensionDialog` in the locale layout with i18n support (English + Korean)

## Details

**Server-side:**
- `src/lib/auth/cookies.ts`: `setTokenExpCookie()` / `deleteTokenExpCookie()` helpers
- `src/app/api/auth/sign-in/route.ts`: set `token_exp` after JWT issuance
- `src/lib/auth/rotation.ts`: set `token_exp` after token rotation
- `src/app/api/auth/sign-out/route.ts` and `sign-out-all/route.ts`: delete `token_exp`

**Client-side:**
- `src/hooks/use-session-monitor.ts`: reads `token_exp` cookie, shows dialog at ≤ 180s remaining, redirects at 0
- `src/components/session/session-extension-dialog.tsx`: AlertDialog with Extend (calls `GET /api/auth/me`) and Sign Out buttons; clears `token_exp` client-side before redirecting to sign-in
- `src/components/ui/alert-dialog.tsx`: shadcn/ui AlertDialog wrapper (Radix UI)
- `src/app/[locale]/layout.tsx`: mount dialog in locale layout so it covers all authenticated pages

**Housekeeping:**
- Exclude `.claude/worktrees` from vitest to prevent test noise from leftover worktrees
- Add pnpm-only rule to `CLAUDE.md` and `AGENTS.md`

## Test plan

- [x] 534 unit tests pass (39 test files)
- [x] Biome lint clean (143 files)
- [x] Next.js production build succeeds
- [x] E2E tests: 10 Playwright tests in `e2e/session-extension.spec.ts` covering dialog appearance, extend, sign out, countdown expiry, rapid clicks, CSRF missing, Korean locale
- [x] Manual: sign in, wait for near-expiry, verify dialog → extend → dismiss, sign out → redirect, countdown → redirect

Closes #60