### PR TITLE
Add permission-based RBAC middleware

### DIFF
--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import argon2 from "argon2";
 import pg from "pg";
 
 /**
@@ -250,6 +251,59 @@ export async function changeSessionFingerprint(
          AND revoked = false`,
       [username, newFingerprint],
     );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Create a test account with the given role.
+ * Skips if an account with the username already exists.
+ */
+export async function createTestAccount(
+  username: string,
+  password: string,
+  roleName: string,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    const { rows: roleRows } = await client.query<{ id: number }>(
+      "SELECT id FROM roles WHERE name = $1",
+      [roleName],
+    );
+    if (roleRows.length === 0) {
+      throw new Error(`Role "${roleName}" not found`);
+    }
+    const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
+    await client.query(
+      `INSERT INTO accounts (username, display_name, password_hash, role_id, must_change_password)
+       VALUES ($1, $1, $2, $3, false)
+       ON CONFLICT (username) DO NOTHING`,
+      [username, passwordHash, roleRows[0].id],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Delete a test account and its sessions.
+ */
+export async function deleteTestAccount(username: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `DELETE FROM sessions
+       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+      [username],
+    );
+    await client.query(
+      "DELETE FROM password_history WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
+      [username],
+    );
+    await client.query("DELETE FROM accounts WHERE username = $1", [username]);
   } finally {
     await client.end();
   }

--- a/e2e/rbac.spec.ts
+++ b/e2e/rbac.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import {
+  createTestAccount,
+  deleteTestAccount,
+  resetAccountDefaults,
+} from "./helpers/setup-db";
+
+const MONITOR_USERNAME = "e2e-monitor";
+const MONITOR_PASSWORD = "Monitor1234!";
+
+test.describe("RBAC permission enforcement", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await createTestAccount(
+      MONITOR_USERNAME,
+      MONITOR_PASSWORD,
+      "Security Monitor",
+    );
+  });
+
+  test.afterAll(async () => {
+    await deleteTestAccount(MONITOR_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("admin can access audit-logs API", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const response = await page.request.get("/api/audit-logs");
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveProperty("data");
+    expect(body).toHaveProperty("total");
+  });
+
+  test("non-admin user gets 403 on audit-logs API", async ({ page }) => {
+    await signInAndWait(page, MONITOR_USERNAME, MONITOR_PASSWORD);
+
+    const response = await page.request.get("/api/audit-logs");
+
+    expect(response.status()).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Forbidden");
+  });
+});

--- a/src/__tests__/app/api/audit-logs/route.test.ts
+++ b/src/__tests__/app/api/audit-logs/route.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthSession } from "@/lib/auth/jwt";
@@ -9,12 +9,28 @@ type HandlerFn = (
   session: AuthSession,
 ) => Promise<Response>;
 
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
 const mockQueryAudit = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
 
 let currentSession: AuthSession;
 vi.mock("@/lib/auth/guard", () => ({
-  withAuth: vi.fn((handler: HandlerFn) => {
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
     return async (request: NextRequest, context: unknown) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
       return handler(request, context, currentSession);
     };
   }),
@@ -60,6 +76,7 @@ describe("GET /api/audit-logs", () => {
 
   beforeEach(() => {
     mockQueryAudit.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
     currentSession = adminSession;
 
     // Default: COUNT returns 0, data returns empty
@@ -71,6 +88,7 @@ describe("GET /api/audit-logs", () => {
   describe("permission", () => {
     it("returns 403 when user lacks System Administrator role", async () => {
       currentSession = viewerSession;
+      mockHasPermission.mockResolvedValue(false);
       const { GET } = await import("@/app/api/audit-logs/route");
       const response = await GET(makeRequest(), makeContext());
       const body = await response.json();

--- a/src/__tests__/lib/auth/guard.test.ts
+++ b/src/__tests__/lib/auth/guard.test.ts
@@ -18,6 +18,7 @@ const mockAssessIpUaRisk = vi.hoisted(() => vi.fn());
 const mockExtractBrowserFingerprint = vi.hoisted(() => vi.fn());
 const mockExtractClientIp = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth/cookies", () => ({
   getAccessTokenCookie: mockGetAccessTokenCookie,
@@ -71,6 +72,10 @@ vi.mock("@/lib/audit/logger", () => ({
   auditLog: {
     record: mockAuditRecord,
   },
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
 }));
 
 describe("withAuth", () => {
@@ -137,6 +142,7 @@ describe("withAuth", () => {
     mockExtractBrowserFingerprint.mockReset().mockReturnValue("Chrome/131");
     mockExtractClientIp.mockReset().mockReturnValue("127.0.0.1");
     mockAuditRecord.mockReset().mockResolvedValue(undefined);
+    mockHasPermission.mockReset().mockResolvedValue(true);
 
     process.env.CSRF_SECRET = "test-csrf-secret";
 
@@ -940,6 +946,102 @@ describe("withAuth", () => {
       expect(response.status).toBe(403);
       expect(body.error).toBe("Password change required");
       expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Permission check (requiredPermissions) ─────────────────────
+
+  describe("requiredPermissions", () => {
+    it("returns 403 when required permission is missing", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockHasPermission.mockResolvedValue(false);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler, {
+        requiredPermissions: ["accounts:write"],
+      });
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Forbidden");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("passes when all required permissions are present", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockHasPermission.mockResolvedValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler, {
+        requiredPermissions: ["accounts:read", "accounts:write"],
+      });
+      const response = await wrapped(makeRequest(), makeContext());
+
+      expect(response.status).toBe(200);
+      expect(handler).toHaveBeenCalled();
+      expect(mockHasPermission).toHaveBeenCalledTimes(2);
+    });
+
+    it("enforces AND semantics — fails if any permission is missing", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      // First permission passes, second fails
+      mockHasPermission
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      const handler = vi.fn();
+      const wrapped = guard.withAuth(handler, {
+        requiredPermissions: ["accounts:read", "accounts:delete"],
+      });
+      const response = await wrapped(makeRequest(), makeContext());
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe("Forbidden");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("skips permission check when requiredPermissions is not set", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      const response = await wrapped(makeRequest(), makeContext());
+
+      expect(response.status).toBe(200);
+      expect(handler).toHaveBeenCalled();
+      expect(mockHasPermission).not.toHaveBeenCalled();
+    });
+
+    it("passes session roles to hasPermission", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue({
+        ...validSession,
+        roles: ["System Administrator"],
+      });
+      mockHasPermission.mockResolvedValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler, {
+        requiredPermissions: ["audit-logs:read"],
+      });
+      await wrapped(makeRequest(), makeContext());
+
+      expect(mockHasPermission).toHaveBeenCalledWith(
+        ["System Administrator"],
+        "audit-logs:read",
+      );
     });
   });
 });

--- a/src/__tests__/lib/auth/permissions.test.ts
+++ b/src/__tests__/lib/auth/permissions.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPoolQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockPoolQuery(...args)),
+}));
+
+describe("permissions", () => {
+  let permissions: typeof import("@/lib/auth/permissions");
+
+  beforeEach(async () => {
+    mockPoolQuery.mockReset();
+    // Dynamic import to get a fresh module with clean cache
+    vi.resetModules();
+    permissions = await import("@/lib/auth/permissions");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getPermissions", () => {
+    it("returns permissions for a single role", async () => {
+      mockPoolQuery.mockResolvedValue({
+        rows: [
+          { permission: "accounts:read" },
+          { permission: "accounts:write" },
+        ],
+      });
+
+      const perms = await permissions.getPermissions(["System Administrator"]);
+
+      expect(perms).toEqual(new Set(["accounts:read", "accounts:write"]));
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("role_permissions"),
+        ["System Administrator"],
+      );
+    });
+
+    it("returns union of permissions for multiple roles", async () => {
+      mockPoolQuery
+        .mockResolvedValueOnce({
+          rows: [
+            { permission: "accounts:read" },
+            { permission: "accounts:write" },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { permission: "accounts:read" },
+            { permission: "customers:read" },
+          ],
+        });
+
+      const perms = await permissions.getPermissions([
+        "System Administrator",
+        "Tenant Administrator",
+      ]);
+
+      expect(perms).toEqual(
+        new Set(["accounts:read", "accounts:write", "customers:read"]),
+      );
+    });
+
+    it("returns empty set for unknown role", async () => {
+      mockPoolQuery.mockResolvedValue({ rows: [] });
+
+      const perms = await permissions.getPermissions(["NonExistentRole"]);
+
+      expect(perms).toEqual(new Set());
+    });
+
+    it("caches results — second call does not query DB", async () => {
+      mockPoolQuery.mockResolvedValue({
+        rows: [{ permission: "accounts:read" }],
+      });
+
+      await permissions.getPermissions(["System Administrator"]);
+      await permissions.getPermissions(["System Administrator"]);
+
+      expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches only cache-missing roles", async () => {
+      // First call: loads System Administrator
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ permission: "accounts:read" }],
+      });
+      await permissions.getPermissions(["System Administrator"]);
+
+      // Second call: System Administrator cached, Tenant Administrator fetched
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ permission: "customers:read" }],
+      });
+      const perms = await permissions.getPermissions([
+        "System Administrator",
+        "Tenant Administrator",
+      ]);
+
+      expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+      expect(mockPoolQuery).toHaveBeenLastCalledWith(expect.any(String), [
+        "Tenant Administrator",
+      ]);
+      expect(perms).toEqual(new Set(["accounts:read", "customers:read"]));
+    });
+  });
+
+  describe("hasPermission", () => {
+    it("returns true when role has the permission", async () => {
+      mockPoolQuery.mockResolvedValue({
+        rows: [
+          { permission: "accounts:read" },
+          { permission: "accounts:write" },
+        ],
+      });
+
+      const result = await permissions.hasPermission(
+        ["System Administrator"],
+        "accounts:write",
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when role lacks the permission", async () => {
+      mockPoolQuery.mockResolvedValue({
+        rows: [{ permission: "accounts:read" }],
+      });
+
+      const result = await permissions.hasPermission(
+        ["Security Monitor"],
+        "accounts:write",
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("invalidatePermissionCache", () => {
+    it("clears a specific role from cache", async () => {
+      mockPoolQuery.mockResolvedValue({
+        rows: [{ permission: "accounts:read" }],
+      });
+
+      await permissions.getPermissions(["System Administrator"]);
+      expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+
+      permissions.invalidatePermissionCache("System Administrator");
+
+      await permissions.getPermissions(["System Administrator"]);
+      expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears entire cache when no role specified", async () => {
+      mockPoolQuery
+        .mockResolvedValueOnce({
+          rows: [{ permission: "accounts:read" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ permission: "customers:read" }],
+        });
+
+      await permissions.getPermissions(["System Administrator"]);
+      await permissions.getPermissions(["Tenant Administrator"]);
+      expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+
+      permissions.invalidatePermissionCache();
+
+      mockPoolQuery
+        .mockResolvedValueOnce({
+          rows: [{ permission: "accounts:read" }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ permission: "customers:read" }],
+        });
+
+      await permissions.getPermissions([
+        "System Administrator",
+        "Tenant Administrator",
+      ]);
+      expect(mockPoolQuery).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/__tests__/lib/auth/session.test.ts
+++ b/src/__tests__/lib/auth/session.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const mockGetAccessTokenCookie = vi.hoisted(() => vi.fn());
+const mockVerifyJwtFull = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockRedirect = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/cookies", () => ({
+  getAccessTokenCookie: mockGetAccessTokenCookie,
+}));
+
+vi.mock("@/lib/auth/jwt", () => ({
+  verifyJwtFull: mockVerifyJwtFull,
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn(),
+}));
+
+beforeEach(() => {
+  mockGetAccessTokenCookie.mockReset();
+  mockVerifyJwtFull.mockReset();
+  mockHasPermission.mockReset();
+  mockRedirect.mockReset();
+  vi.resetModules();
+});
+
+const now = Math.floor(Date.now() / 1000);
+
+const validSession: AuthSession = {
+  accountId: "account-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0 Chrome/131",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+describe("session helpers", () => {
+  describe("getCurrentSession", () => {
+    it("returns session when cookie and JWT are valid", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("valid-token");
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+
+      const { getCurrentSession } = await import("@/lib/auth/session");
+      const session = await getCurrentSession();
+
+      expect(session).toEqual(validSession);
+    });
+
+    it("returns null when no cookie is present", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue(undefined);
+
+      const { getCurrentSession } = await import("@/lib/auth/session");
+      const session = await getCurrentSession();
+
+      expect(session).toBeNull();
+      expect(mockVerifyJwtFull).not.toHaveBeenCalled();
+    });
+
+    it("returns null when JWT verification fails", async () => {
+      mockGetAccessTokenCookie.mockResolvedValue("bad-token");
+      mockVerifyJwtFull.mockRejectedValue(new Error("Invalid token"));
+
+      const { getCurrentSession } = await import("@/lib/auth/session");
+      const session = await getCurrentSession();
+
+      expect(session).toBeNull();
+    });
+  });
+
+  describe("requirePermission", () => {
+    it("does not redirect when permission is present", async () => {
+      mockHasPermission.mockResolvedValue(true);
+
+      const { requirePermission } = await import("@/lib/auth/session");
+      await requirePermission(validSession, "audit-logs:read");
+
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("redirects to root when permission is missing", async () => {
+      mockHasPermission.mockResolvedValue(false);
+
+      const { requirePermission } = await import("@/lib/auth/session");
+      await requirePermission(validSession, "accounts:delete");
+
+      expect(mockRedirect).toHaveBeenCalledWith("/");
+    });
+
+    it("passes correct roles and permission to hasPermission", async () => {
+      mockHasPermission.mockResolvedValue(true);
+
+      const { requirePermission } = await import("@/lib/auth/session");
+      await requirePermission(validSession, "audit-logs:read");
+
+      expect(mockHasPermission).toHaveBeenCalledWith(
+        ["System Administrator"],
+        "audit-logs:read",
+      );
+    });
+  });
+});

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -67,132 +67,133 @@ const UUID_RE =
  *   page, pageSize, from, to, actor, action, targetType, targetId,
  *   correlationId
  */
-export const GET = withAuth(async (request, _context, session) => {
-  // Permission check
-  if (!session.roles.includes("System Administrator")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+export const GET = withAuth(
+  async (request, _context, _session) => {
+    const url = request.nextUrl;
 
-  const url = request.nextUrl;
+    // ── Parse pagination ──────────────────────────────────────────
 
-  // ── Parse pagination ────────────────────────────────────────────
+    const page = Math.max(
+      DEFAULT_PAGE,
+      Number.parseInt(url.searchParams.get("page") ?? "", 10) || DEFAULT_PAGE,
+    );
+    const pageSize = Math.min(
+      MAX_PAGE_SIZE,
+      Math.max(
+        1,
+        Number.parseInt(url.searchParams.get("pageSize") ?? "", 10) ||
+          DEFAULT_PAGE_SIZE,
+      ),
+    );
 
-  const page = Math.max(
-    DEFAULT_PAGE,
-    Number.parseInt(url.searchParams.get("page") ?? "", 10) || DEFAULT_PAGE,
-  );
-  const pageSize = Math.min(
-    MAX_PAGE_SIZE,
-    Math.max(
-      1,
-      Number.parseInt(url.searchParams.get("pageSize") ?? "", 10) ||
-        DEFAULT_PAGE_SIZE,
-    ),
-  );
+    // ── Build dynamic WHERE clause ────────────────────────────────
 
-  // ── Build dynamic WHERE clause ──────────────────────────────────
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    let idx = 1;
 
-  const conditions: string[] = [];
-  const params: unknown[] = [];
-  let idx = 1;
-
-  // Date range
-  const from = url.searchParams.get("from");
-  if (from) {
-    if (!isValidISODate(from)) {
-      return NextResponse.json(
-        { error: "Invalid 'from' date" },
-        { status: 400 },
-      );
+    // Date range
+    const from = url.searchParams.get("from");
+    if (from) {
+      if (!isValidISODate(from)) {
+        return NextResponse.json(
+          { error: "Invalid 'from' date" },
+          { status: 400 },
+        );
+      }
+      conditions.push(`timestamp >= $${idx++}`);
+      params.push(from);
     }
-    conditions.push(`timestamp >= $${idx++}`);
-    params.push(from);
-  }
 
-  const to = url.searchParams.get("to");
-  if (to) {
-    if (!isValidISODate(to)) {
-      return NextResponse.json({ error: "Invalid 'to' date" }, { status: 400 });
+    const to = url.searchParams.get("to");
+    if (to) {
+      if (!isValidISODate(to)) {
+        return NextResponse.json(
+          { error: "Invalid 'to' date" },
+          { status: 400 },
+        );
+      }
+      conditions.push(`timestamp <= $${idx++}`);
+      params.push(to);
     }
-    conditions.push(`timestamp <= $${idx++}`);
-    params.push(to);
-  }
 
-  // Actor
-  const actor = url.searchParams.get("actor");
-  if (actor) {
-    conditions.push(`actor_id = $${idx++}`);
-    params.push(actor);
-  }
-
-  // Action (validated)
-  const action = url.searchParams.get("action");
-  if (action) {
-    if (!ALLOWED_ACTIONS.has(action)) {
-      return NextResponse.json(
-        { error: "Invalid action type" },
-        { status: 400 },
-      );
+    // Actor
+    const actor = url.searchParams.get("actor");
+    if (actor) {
+      conditions.push(`actor_id = $${idx++}`);
+      params.push(actor);
     }
-    conditions.push(`action = $${idx++}`);
-    params.push(action);
-  }
 
-  // Target type (validated)
-  const targetType = url.searchParams.get("targetType");
-  if (targetType) {
-    if (!ALLOWED_TARGET_TYPES.has(targetType)) {
-      return NextResponse.json(
-        { error: "Invalid target type" },
-        { status: 400 },
-      );
+    // Action (validated)
+    const action = url.searchParams.get("action");
+    if (action) {
+      if (!ALLOWED_ACTIONS.has(action)) {
+        return NextResponse.json(
+          { error: "Invalid action type" },
+          { status: 400 },
+        );
+      }
+      conditions.push(`action = $${idx++}`);
+      params.push(action);
     }
-    conditions.push(`target_type = $${idx++}`);
-    params.push(targetType);
-  }
 
-  // Target ID
-  const targetId = url.searchParams.get("targetId");
-  if (targetId) {
-    conditions.push(`target_id = $${idx++}`);
-    params.push(targetId);
-  }
-
-  // Correlation ID (validated as UUID)
-  const correlationId = url.searchParams.get("correlationId");
-  if (correlationId) {
-    if (!UUID_RE.test(correlationId)) {
-      return NextResponse.json(
-        { error: "Invalid correlation ID format" },
-        { status: 400 },
-      );
+    // Target type (validated)
+    const targetType = url.searchParams.get("targetType");
+    if (targetType) {
+      if (!ALLOWED_TARGET_TYPES.has(targetType)) {
+        return NextResponse.json(
+          { error: "Invalid target type" },
+          { status: 400 },
+        );
+      }
+      conditions.push(`target_type = $${idx++}`);
+      params.push(targetType);
     }
-    conditions.push(`correlation_id = $${idx++}`);
-    params.push(correlationId);
-  }
 
-  // ── Execute queries ─────────────────────────────────────────────
+    // Target ID
+    const targetId = url.searchParams.get("targetId");
+    if (targetId) {
+      conditions.push(`target_id = $${idx++}`);
+      params.push(targetId);
+    }
 
-  const where =
-    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    // Correlation ID (validated as UUID)
+    const correlationId = url.searchParams.get("correlationId");
+    if (correlationId) {
+      if (!UUID_RE.test(correlationId)) {
+        return NextResponse.json(
+          { error: "Invalid correlation ID format" },
+          { status: 400 },
+        );
+      }
+      conditions.push(`correlation_id = $${idx++}`);
+      params.push(correlationId);
+    }
 
-  // Total count (shares the same WHERE + params)
-  const { rows: countRows } = await queryAudit<CountRow>(
-    `SELECT COUNT(*) AS count FROM audit_logs ${where}`,
-    params,
-  );
-  const total = Number.parseInt(countRows[0].count, 10);
+    // ── Execute queries ───────────────────────────────────────────
 
-  // Data page
-  const offset = (page - 1) * pageSize;
-  const { rows } = await queryAudit<AuditLogRow>(
-    `SELECT id, timestamp, actor_id, action, target_type, target_id,
-            details, ip_address, sid, customer_id, correlation_id
-       FROM audit_logs ${where}
-      ORDER BY timestamp DESC
-      LIMIT $${idx++} OFFSET $${idx++}`,
-    [...params, pageSize, offset],
-  );
+    const where =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-  return NextResponse.json({ data: rows, total, page, pageSize });
-});
+    // Total count (shares the same WHERE + params)
+    const { rows: countRows } = await queryAudit<CountRow>(
+      `SELECT COUNT(*) AS count FROM audit_logs ${where}`,
+      params,
+    );
+    const total = Number.parseInt(countRows[0].count, 10);
+
+    // Data page
+    const offset = (page - 1) * pageSize;
+    const { rows } = await queryAudit<AuditLogRow>(
+      `SELECT id, timestamp, actor_id, action, target_type, target_id,
+              details, ip_address, sid, customer_id, correlation_id
+         FROM audit_logs ${where}
+        ORDER BY timestamp DESC
+        LIMIT $${idx++} OFFSET $${idx++}`,
+      [...params, pageSize, offset],
+    );
+
+    return NextResponse.json({ data: rows, total, page, pageSize });
+  },
+  { requiredPermissions: ["audit-logs:read"] },
+);

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -16,6 +16,7 @@ import {
 import { extractClientIp } from "./ip";
 import type { AuthSession } from "./jwt";
 import { verifyJwtFull } from "./jwt";
+import { hasPermission } from "./permissions";
 import { rotateTokens, shouldRotate } from "./rotation";
 import { revokeSession } from "./session";
 import {
@@ -54,6 +55,12 @@ interface WithAuthOptions {
    * avoid a deadlock where re-auth is blocked by the re-auth gate.
    */
   skipSessionPolicy?: boolean;
+  /**
+   * Permissions the caller must hold (AND semantics — all listed
+   * permissions must be present).  Checked after CSRF validation,
+   * before session policy enforcement.  Returns 403 on failure.
+   */
+  requiredPermissions?: string[];
 }
 
 // ── Public API ──────────────────────────────────────────────────
@@ -69,6 +76,8 @@ interface WithAuthOptions {
  *  4. For mutation methods (POST/PUT/PATCH/DELETE):
  *     a. Validates Origin/Referer header
  *     b. Validates CSRF token from X-CSRF-Token header
+ *  4.5. Permission check → 403 if any required permission is missing
+ *       (configurable via `options.requiredPermissions`, AND semantics)
  *  5. Session timeout check (idle + absolute)
  *  6. IP/UA change risk assessment
  *  7. Re-auth gate (if session.needs_reauth → 401)
@@ -156,6 +165,15 @@ export function withAuth(
           { error: "Invalid CSRF token" },
           { status: 403 },
         );
+      }
+    }
+
+    // Step 4.5: Permission check (AND semantics)
+    if (options?.requiredPermissions) {
+      for (const perm of options.requiredPermissions) {
+        if (!(await hasPermission(session.roles, perm))) {
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
       }
     }
 

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import { query } from "@/lib/db/client";
+
+// ── Cache ──────────────────────────────────────────────────────
+
+/**
+ * In-memory cache: role name → set of permission strings.
+ *
+ * Lazy-loaded on first permission check per role.  Next.js may spin up
+ * multiple runtime instances, each with its own cache — this is
+ * acceptable because the cache is read-only until a role is modified
+ * (Phase 3-2), at which point `invalidatePermissionCache()` is called.
+ */
+const rolePermissionCache = new Map<string, Set<string>>();
+
+// ── Internal ───────────────────────────────────────────────────
+
+async function loadRolePermissions(roleName: string): Promise<Set<string>> {
+  const cached = rolePermissionCache.get(roleName);
+  if (cached) return cached;
+
+  const { rows } = await query<{ permission: string }>(
+    `SELECT rp.permission
+     FROM role_permissions rp
+     JOIN roles r ON rp.role_id = r.id
+     WHERE r.name = $1`,
+    [roleName],
+  );
+
+  const permissions = new Set(rows.map((r) => r.permission));
+  rolePermissionCache.set(roleName, permissions);
+  return permissions;
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * Return the union of all permissions for the given role names.
+ *
+ * Results are cached per role name; only cache-missing roles trigger a
+ * database query.
+ */
+export async function getPermissions(
+  roleNames: string[],
+): Promise<Set<string>> {
+  const union = new Set<string>();
+
+  for (const roleName of roleNames) {
+    const perms = await loadRolePermissions(roleName);
+    for (const p of perms) {
+      union.add(p);
+    }
+  }
+
+  return union;
+}
+
+/**
+ * Check whether the given roles collectively grant the specified
+ * permission.
+ */
+export async function hasPermission(
+  roleNames: string[],
+  permission: string,
+): Promise<boolean> {
+  const perms = await getPermissions(roleNames);
+  return perms.has(permission);
+}
+
+/**
+ * Clear cached permissions for a specific role, or the entire cache if
+ * no role name is provided.
+ *
+ * Call this when roles or role_permissions are modified (Phase 3-2).
+ */
+export function invalidatePermissionCache(roleName?: string): void {
+  if (roleName) {
+    rolePermissionCache.delete(roleName);
+  } else {
+    rolePermissionCache.clear();
+  }
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,10 +1,54 @@
 import "server-only";
 
+import { redirect } from "next/navigation";
+
 import { query } from "@/lib/db/client";
+
+import { getAccessTokenCookie } from "./cookies";
+import type { AuthSession } from "./jwt";
+import { verifyJwtFull } from "./jwt";
+import { hasPermission } from "./permissions";
+
+// ── Session mutations ──────────────────────────────────────────
 
 /**
  * Mark a session as revoked in the database.
  */
 export async function revokeSession(sid: string): Promise<void> {
   await query("UPDATE sessions SET revoked = true WHERE sid = $1", [sid]);
+}
+
+// ── RSC session helpers ────────────────────────────────────────
+
+/**
+ * Read and verify the current session from the auth cookie.
+ *
+ * Extracted from `withAuth` steps 1-2 as a pure function usable in
+ * Server Components and layouts.  Returns `null` when there is no
+ * valid session (missing cookie, expired token, revoked session, etc.).
+ */
+export async function getCurrentSession(): Promise<AuthSession | null> {
+  const token = await getAccessTokenCookie();
+  if (!token) return null;
+
+  try {
+    return await verifyJwtFull(token);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Assert that the session holds the given permission.
+ *
+ * Redirects to the root path if the permission is missing.  Intended
+ * for page-level guards in React Server Components.
+ */
+export async function requirePermission(
+  session: AuthSession,
+  permission: string,
+): Promise<void> {
+  if (!(await hasPermission(session.roles, permission))) {
+    redirect("/");
+  }
 }


### PR DESCRIPTION
## Summary
- Add `permissions.ts` with cached role-permission DB lookups (`getPermissions`, `hasPermission`, `invalidatePermissionCache`)
- Extend `withAuth` guard with `requiredPermissions` option (AND semantics, returns 403 on failure)
- Add `getCurrentSession()` and `requirePermission()` RSC helpers for page-level guards
- Replace hardcoded `roles.includes("System Administrator")` in audit-logs route with `requiredPermissions: ["audit-logs:read"]`

## Test plan
- [x] Unit tests: `permissions.test.ts` (9 tests), `guard.test.ts` (+5 tests), `session.test.ts` (6 tests)
- [x] Updated `audit-logs/route.test.ts` mock to honor `requiredPermissions`
- [x] E2E tests: admin gets 200, non-admin (Security Monitor) gets 403 on `/api/audit-logs`
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] All 554 unit tests pass
- [x] Grep for `roles.includes(` returns 0 hits

Closes #94