### PR TITLE
Add two-stage lockout with lockout_count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 
 - This project uses **pnpm** exclusively. NEVER use `npm`, `bun`, `yarn`, or
   any other package manager.
+- Run CLI tools via `pnpm` (e.g., `pnpm vitest run`, `pnpm tsc --noEmit`,
+  `pnpm biome check`). NEVER use `npx`.
 
 ## CI requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@
 
 - This project uses **pnpm** exclusively. NEVER use `npm`, `bun`, `yarn`, or
   any other package manager.
+- Run CLI tools via `pnpm` (e.g., `pnpm vitest run`, `pnpm tsc --noEmit`,
+  `pnpm biome check`). NEVER use `npx`.
 
 ## CI requirements
 

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -79,6 +79,25 @@ export async function setFailedSignInCount(
 }
 
 /**
+ * Set `lockout_count` to a specific value.
+ */
+export async function setLockoutCount(
+  username: string,
+  count: number,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET lockout_count = $2 WHERE username = $1",
+      [username, count],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
  * Set account status and optionally `locked_until`.
  */
 export async function setAccountStatus(
@@ -174,6 +193,7 @@ export async function resetAccountDefaults(username: string): Promise<void> {
       `UPDATE accounts
        SET status = 'active',
            failed_sign_in_count = 0,
+           lockout_count = 0,
            locked_until = NULL,
            must_change_password = false,
            max_sessions = NULL
@@ -361,6 +381,24 @@ export async function clearPasswordHistory(username: string): Promise<void> {
       "DELETE FROM password_history WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
       [username],
     );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Get the UUID of an account by username.
+ */
+export async function getAccountId(username: string): Promise<string> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ id: string }>(
+      "SELECT id FROM accounts WHERE username = $1",
+      [username],
+    );
+    if (rows.length === 0) throw new Error(`Account "${username}" not found`);
+    return rows[0].id;
   } finally {
     await client.end();
   }

--- a/e2e/lockout.spec.ts
+++ b/e2e/lockout.spec.ts
@@ -94,9 +94,7 @@ test.describe("Account lockout", () => {
     await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
 
     await expect(alert(page)).toBeVisible();
-    await expect(alert(page)).toContainText(
-      "Account is not active",
-    );
+    await expect(alert(page)).toContainText("Account is not active");
   });
 
   test("stage2 triggers suspension when lockout_count >= 1", async ({
@@ -117,9 +115,7 @@ test.describe("Account lockout", () => {
 
     // The NEXT attempt should see the inactive (suspended) message.
     await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
-    await expect(alert(page)).toContainText(
-      "Account is not active",
-    );
+    await expect(alert(page)).toContainText("Account is not active");
   });
 
   test("auto-unlock after stage1 preserves lockout_count for stage2", async ({

--- a/e2e/lockout.spec.ts
+++ b/e2e/lockout.spec.ts
@@ -10,6 +10,7 @@ import {
   resetAccountDefaults,
   setAccountStatus,
   setFailedSignInCount,
+  setLockoutCount,
 } from "./helpers/setup-db";
 
 const alert = (page: import("@playwright/test").Page) =>
@@ -84,5 +85,57 @@ test.describe("Account lockout", () => {
     await expect(alert(page)).toContainText(
       "Account is locked. Please try again later.",
     );
+  });
+
+  test("suspended account shows inactive message", async ({ page }) => {
+    await setAccountStatus(ADMIN_USERNAME, "suspended", null);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText(
+      "Account is not active",
+    );
+  });
+
+  test("stage2 triggers suspension when lockout_count >= 1", async ({
+    page,
+  }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    // Simulate: previously locked once, auto-unlocked, now at threshold again
+    await setFailedSignInCount(ADMIN_USERNAME, 4);
+    await setLockoutCount(ADMIN_USERNAME, 1);
+
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, "WrongPassword!");
+
+    // The 5th failure suspends the account (lockout_count >= 1).
+    await expect(alert(page)).toBeVisible();
+    await expect(alert(page)).toContainText("Invalid account ID or password");
+
+    // The NEXT attempt should see the inactive (suspended) message.
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await expect(alert(page)).toContainText(
+      "Account is not active",
+    );
+  });
+
+  test("auto-unlock after stage1 preserves lockout_count for stage2", async ({
+    page,
+  }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    // Simulate: stage1 lock expired (past locked_until), lockout_count = 1
+    const past = new Date(Date.now() - 60_000);
+    await setAccountStatus(ADMIN_USERNAME, "locked", past);
+    await setFailedSignInCount(ADMIN_USERNAME, 0);
+    await setLockoutCount(ADMIN_USERNAME, 1);
+
+    // Auto-unlock should succeed (correct password)
+    await page.goto("/sign-in");
+    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
   });
 });

--- a/e2e/unlock.spec.ts
+++ b/e2e/unlock.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+  signOut,
+} from "./helpers/auth";
+import {
+  createTestAccount,
+  deleteTestAccount,
+  getAccountId,
+  resetAccountDefaults,
+  setAccountStatus,
+  setLockoutCount,
+} from "./helpers/setup-db";
+
+const MONITOR_USERNAME = "e2e-unlock-monitor";
+const MONITOR_PASSWORD = "Monitor1234!";
+const TARGET_USERNAME = "e2e-unlock-target";
+const TARGET_PASSWORD = "Target1234!";
+
+test.describe("Account unlock/restore API", () => {
+  let targetAccountId: string;
+
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await createTestAccount(
+      MONITOR_USERNAME,
+      MONITOR_PASSWORD,
+      "Security Monitor",
+    );
+    await createTestAccount(
+      TARGET_USERNAME,
+      TARGET_PASSWORD,
+      "Security Monitor",
+    );
+    targetAccountId = await getAccountId(TARGET_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await deleteTestAccount(MONITOR_USERNAME);
+    await deleteTestAccount(TARGET_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+  });
+
+  test("admin can unlock a locked account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Get target account ID
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // Lock the target account via DB
+    await setAccountStatus(
+      TARGET_USERNAME,
+      "locked",
+      new Date(Date.now() + 30 * 60_000),
+    );
+    await setLockoutCount(TARGET_USERNAME, 1);
+
+    // Call unlock API
+    const response = await page.request.post(
+      `/api/accounts/${targetAccountId}/unlock`,
+      {
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      },
+    );
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, action: "unlocked" });
+
+    await signOut(page);
+  });
+
+  test("admin can restore a suspended account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // Suspend the target account
+    await setAccountStatus(TARGET_USERNAME, "suspended", null);
+    await setLockoutCount(TARGET_USERNAME, 2);
+
+    const response = await page.request.post(
+      `/api/accounts/${targetAccountId}/unlock`,
+      {
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      },
+    );
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, action: "restored" });
+
+    await signOut(page);
+  });
+
+  test("restored account can sign in again", async ({ page }) => {
+    // Target was just restored in the previous test
+    await resetAccountDefaults(TARGET_USERNAME);
+
+    await page.goto("/sign-in");
+    await page.getByLabel("Account ID").fill(TARGET_USERNAME);
+    await page.locator("input[name='password']").fill(TARGET_PASSWORD);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
+  });
+
+  test("non-admin cannot unlock accounts (403)", async ({ page }) => {
+    await signInAndWait(page, MONITOR_USERNAME, MONITOR_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    await setAccountStatus(
+      TARGET_USERNAME,
+      "locked",
+      new Date(Date.now() + 30 * 60_000),
+    );
+
+    const response = await page.request.post(
+      `/api/accounts/${targetAccountId}/unlock`,
+      {
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      },
+    );
+
+    expect(response.status()).toBe(403);
+
+    await signOut(page);
+    await resetAccountDefaults(TARGET_USERNAME);
+  });
+
+  test("unlock returns 400 for active account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    await resetAccountDefaults(TARGET_USERNAME);
+
+    const response = await page.request.post(
+      `/api/accounts/${targetAccountId}/unlock`,
+      {
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      },
+    );
+
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Account is not locked or suspended");
+
+    await signOut(page);
+  });
+
+  test("unlock returns 404 for non-existent account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post(
+      "/api/accounts/00000000-0000-0000-0000-000000000000/unlock",
+      {
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      },
+    );
+
+    expect(response.status()).toBe(404);
+
+    await signOut(page);
+  });
+});

--- a/migrations/auth/0009_lockout_count.sql
+++ b/migrations/auth/0009_lockout_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts ADD COLUMN lockout_count INTEGER NOT NULL DEFAULT 0;

--- a/src/__tests__/app/api/accounts/[id]/unlock/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/unlock/route.test.ts
@@ -1,0 +1,293 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+describe("POST /api/accounts/[id]/unlock", () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  const adminSession: AuthSession = {
+    accountId: "admin-1",
+    sessionId: "session-1",
+    roles: ["System Administrator"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+    iat: now,
+    exp: now + 900,
+    sessionIp: "127.0.0.1",
+    sessionUserAgent: "Mozilla/5.0",
+    sessionBrowserFingerprint: "Chrome/131",
+    needsReauth: false,
+    sessionCreatedAt: new Date(),
+    sessionLastActiveAt: new Date(),
+  };
+
+  const targetAccountId = "target-account-1";
+
+  function makeRequest() {
+    return new NextRequest(
+      `http://localhost:3000/api/accounts/${targetAccountId}/unlock`,
+      { method: "POST" },
+    );
+  }
+
+  function makeContext() {
+    return { params: Promise.resolve({ id: targetAccountId }) };
+  }
+
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+  });
+
+  it("returns 403 when user lacks accounts:write permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when account does not exist", async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Account not found");
+  });
+
+  it("unlocks a locked account", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT")) {
+        return {
+          rows: [{ id: targetAccountId, status: "locked", lockout_count: 1 }],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, action: "unlocked" });
+
+    // Verify UPDATE preserves lockout_count
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("status = 'active'"),
+      [targetAccountId],
+    );
+    const updateCall = mockQuery.mock.calls.find(
+      (args: unknown[]) =>
+        typeof args[0] === "string" &&
+        args[0].includes("UPDATE") &&
+        args[0].includes("status = 'active'"),
+    );
+    expect(updateCall?.[0]).not.toContain("lockout_count");
+
+    // Verify audit event
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "account.unlock",
+        actor: "admin-1",
+        target: "account",
+        targetId: targetAccountId,
+        details: { previousLockoutCount: 1 },
+      }),
+    );
+  });
+
+  it("restores a suspended account", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT")) {
+        return {
+          rows: [
+            { id: targetAccountId, status: "suspended", lockout_count: 2 },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, action: "restored" });
+
+    // Verify UPDATE resets lockout_count
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("lockout_count = 0"),
+      [targetAccountId],
+    );
+
+    // Verify audit event
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "account.restore",
+        actor: "admin-1",
+        target: "account",
+        targetId: targetAccountId,
+        details: { previousLockoutCount: 2 },
+      }),
+    );
+  });
+
+  it("unlocks a locked account with lockout_count=0", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT")) {
+        return {
+          rows: [{ id: targetAccountId, status: "locked", lockout_count: 0 }],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, action: "unlocked" });
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "account.unlock",
+        details: { previousLockoutCount: 0 },
+      }),
+    );
+  });
+
+  it("unlock resets failed_sign_in_count for locked account", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT")) {
+        return {
+          rows: [{ id: targetAccountId, status: "locked", lockout_count: 1 }],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    await POST(makeRequest(), makeContext());
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("failed_sign_in_count = 0"),
+      [targetAccountId],
+    );
+  });
+
+  it("restore resets both failed_sign_in_count and lockout_count", async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("SELECT")) {
+        return {
+          rows: [
+            { id: targetAccountId, status: "suspended", lockout_count: 1 },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    await POST(makeRequest(), makeContext());
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("failed_sign_in_count = 0"),
+      [targetAccountId],
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("lockout_count = 0"),
+      [targetAccountId],
+    );
+  });
+
+  it("returns 400 for active account", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: targetAccountId, status: "active", lockout_count: 0 }],
+      rowCount: 1,
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Account is not locked or suspended");
+  });
+
+  it("returns 400 for disabled account", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: targetAccountId, status: "disabled", lockout_count: 0 }],
+      rowCount: 1,
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/__tests__/app/api/auth/sign-in/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-in/route.test.ts
@@ -80,6 +80,7 @@ const activeAccount = {
   token_version: 0,
   must_change_password: false,
   failed_sign_in_count: 0,
+  lockout_count: 0,
   locked_until: null,
   max_sessions: null,
   allowed_ips: null,
@@ -90,7 +91,6 @@ const lockoutPolicy = {
   value: {
     stage1_threshold: 5,
     stage1_duration_minutes: 30,
-    stage2_threshold: 3,
   },
 };
 
@@ -306,6 +306,48 @@ describe("POST /api/auth/sign-in", () => {
       expect(response.status).toBe(200);
     });
 
+    it("auto-unlock preserves lockout_count", async () => {
+      const past = new Date(Date.now() - 60_000).toISOString();
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM accounts")) {
+          return {
+            rows: [
+              {
+                ...activeAccount,
+                status: "locked",
+                locked_until: past,
+                lockout_count: 1,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        if (sql.includes("SET status = 'active'")) {
+          return { rows: [], rowCount: 1 };
+        }
+        if (sql.includes("INSERT INTO sessions")) {
+          return { rows: [{ sid: "sess-1" }], rowCount: 1 };
+        }
+        if (sql.includes("failed_sign_in_count = 0")) {
+          return { rows: [], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      await POST(makeRequest({ username: "admin", password: "pass" }));
+
+      // Auto-unlock UPDATE should NOT reset lockout_count
+      const autoUnlockCall = mockQuery.mock.calls.find(
+        (args: unknown[]) =>
+          typeof args[0] === "string" &&
+          args[0].includes("SET status = 'active'") &&
+          args[0].includes("failed_sign_in_count = 0"),
+      );
+      expect(autoUnlockCall).toBeDefined();
+      expect(autoUnlockCall?.[0]).not.toContain("lockout_count");
+    });
+
     it("returns 403 for inactive account (suspended)", async () => {
       mockQuery.mockImplementation(async (sql: string) => {
         if (sql.includes("FROM accounts")) {
@@ -387,9 +429,13 @@ describe("POST /api/auth/sign-in", () => {
       const { POST } = await import("@/app/api/auth/sign-in/route");
       await POST(makeRequest({ username: "admin", password: "wrong" }));
 
-      // Should lock with temporary duration (count reaches 5 = stage1_threshold)
+      // Should lock with temporary duration and increment lockout_count
       expect(mockQuery).toHaveBeenCalledWith(
         expect.stringContaining("status = 'locked'"),
+        expect.arrayContaining([5, 30]),
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("lockout_count = lockout_count + 1"),
         expect.arrayContaining([5, 30]),
       );
       expect(mockAuditRecord).toHaveBeenCalledWith(
@@ -397,12 +443,18 @@ describe("POST /api/auth/sign-in", () => {
       );
     });
 
-    it("triggers stage2 permanent lock", async () => {
+    it("triggers stage2 suspension when lockout_count >= 1", async () => {
       mockVerifyPassword.mockResolvedValue(false);
       mockQuery.mockImplementation(async (sql: string) => {
         if (sql.includes("FROM accounts")) {
           return {
-            rows: [{ ...activeAccount, failed_sign_in_count: 7 }],
+            rows: [
+              {
+                ...activeAccount,
+                failed_sign_in_count: 4,
+                lockout_count: 1,
+              },
+            ],
             rowCount: 1,
           };
         }
@@ -415,11 +467,120 @@ describe("POST /api/auth/sign-in", () => {
       const { POST } = await import("@/app/api/auth/sign-in/route");
       await POST(makeRequest({ username: "admin", password: "wrong" }));
 
-      // Count reaches 8 = 5 + 3 = stage1 + stage2 threshold
+      // Should suspend (not lock) when lockout_count >= 1
       expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining("locked_until = NULL"),
-        expect.arrayContaining([8]),
+        expect.stringContaining("status = 'suspended'"),
+        expect.arrayContaining([5]),
       );
+      expect(mockAuditRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "account.suspend" }),
+      );
+    });
+
+    it("triggers stage2 suspension with lockout_count > 1", async () => {
+      mockVerifyPassword.mockResolvedValue(false);
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM accounts")) {
+          return {
+            rows: [
+              {
+                ...activeAccount,
+                failed_sign_in_count: 4,
+                lockout_count: 3,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        if (sql.includes("system_settings")) {
+          return { rows: [lockoutPolicy], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      await POST(makeRequest({ username: "admin", password: "wrong" }));
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("status = 'suspended'"),
+        expect.arrayContaining([5]),
+      );
+      expect(mockAuditRecord).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "account.suspend",
+          details: expect.objectContaining({ lockoutCount: 3 }),
+        }),
+      );
+    });
+
+    it("stage1 lock does not suspend when lockout_count is 0", async () => {
+      mockVerifyPassword.mockResolvedValue(false);
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM accounts")) {
+          return {
+            rows: [
+              {
+                ...activeAccount,
+                failed_sign_in_count: 4,
+                lockout_count: 0,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        if (sql.includes("system_settings")) {
+          return { rows: [lockoutPolicy], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      const response = await POST(
+        makeRequest({ username: "admin", password: "wrong" }),
+      );
+
+      expect(response.status).toBe(401);
+
+      // Should lock, NOT suspend
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("status = 'locked'"),
+        expect.arrayContaining([5, 30]),
+      );
+      expect(mockQuery).not.toHaveBeenCalledWith(
+        expect.stringContaining("status = 'suspended'"),
+        expect.anything(),
+      );
+    });
+
+    it("returns 401 for wrong password during stage2 suspension", async () => {
+      mockVerifyPassword.mockResolvedValue(false);
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM accounts")) {
+          return {
+            rows: [
+              {
+                ...activeAccount,
+                failed_sign_in_count: 4,
+                lockout_count: 1,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        if (sql.includes("system_settings")) {
+          return { rows: [lockoutPolicy], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      const response = await POST(
+        makeRequest({ username: "admin", password: "wrong" }),
+      );
+
+      expect(response.status).toBe(401);
+      const body = await response.json();
+      expect(body.code).toBe("INVALID_CREDENTIALS");
     });
   });
 
@@ -529,12 +690,16 @@ describe("POST /api/auth/sign-in", () => {
       );
     });
 
-    it("resets failed_sign_in_count on success", async () => {
+    it("resets failed_sign_in_count and lockout_count on success", async () => {
       const { POST } = await import("@/app/api/auth/sign-in/route");
       await POST(makeRequest({ username: "admin", password: "pass" }));
 
       expect(mockQuery).toHaveBeenCalledWith(
         expect.stringContaining("failed_sign_in_count = 0"),
+        ["acc-1"],
+      );
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("lockout_count = 0"),
         ["acc-1"],
       );
     });

--- a/src/__tests__/lib/audit/logger.test.ts
+++ b/src/__tests__/lib/audit/logger.test.ts
@@ -464,6 +464,8 @@ describe("auditLog", () => {
       "account.create",
       "account.lock",
       "account.unlock",
+      "account.suspend",
+      "account.restore",
     ];
 
     for (const action of PHASE_1_ACTIONS) {

--- a/src/app/api/accounts/[id]/unlock/route.ts
+++ b/src/app/api/accounts/[id]/unlock/route.ts
@@ -1,0 +1,96 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { query } from "@/lib/db/client";
+
+// ── Route Handler ────────────────────────────────────────────────
+
+/**
+ * POST /api/accounts/[id]/unlock
+ *
+ * Unlock a locked account or restore a suspended account.
+ *
+ * - `locked` → `active`: clears lockout timer, resets failed count,
+ *   preserves `lockout_count` (Stage 2 may still engage on next lockout).
+ * - `suspended` → `active`: full restore, resets both `lockout_count`
+ *   and `failed_sign_in_count`.
+ *
+ * Requires `accounts:write` permission.
+ */
+export const POST = withAuth(
+  async (request, context, session) => {
+    const { id: accountId } = await context.params;
+
+    // Step 1: Fetch account status
+    const { rows } = await query<{
+      id: string;
+      status: string;
+      lockout_count: number;
+    }>("SELECT id, status, lockout_count FROM accounts WHERE id = $1", [
+      accountId,
+    ]);
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    const account = rows[0];
+    const ip = extractClientIp(request);
+
+    // Step 2: Dispatch by status
+    if (account.status === "locked") {
+      await query(
+        `UPDATE accounts
+         SET status = 'active', locked_until = NULL,
+             failed_sign_in_count = 0
+         WHERE id = $1`,
+        [accountId],
+      );
+
+      await auditLog.record({
+        actor: session.accountId,
+        action: "account.unlock",
+        target: "account",
+        targetId: accountId,
+        ip,
+        sid: session.sessionId,
+        details: { previousLockoutCount: account.lockout_count },
+      });
+
+      return NextResponse.json({ success: true, action: "unlocked" });
+    }
+
+    if (account.status === "suspended") {
+      await query(
+        `UPDATE accounts
+         SET status = 'active', locked_until = NULL,
+             failed_sign_in_count = 0, lockout_count = 0
+         WHERE id = $1`,
+        [accountId],
+      );
+
+      await auditLog.record({
+        actor: session.accountId,
+        action: "account.restore",
+        target: "account",
+        targetId: accountId,
+        ip,
+        sid: session.sessionId,
+        details: { previousLockoutCount: account.lockout_count },
+      });
+
+      return NextResponse.json({ success: true, action: "restored" });
+    }
+
+    // Account is neither locked nor suspended
+    return NextResponse.json(
+      { error: "Account is not locked or suspended" },
+      { status: 400 },
+    );
+  },
+  { requiredPermissions: ["accounts:write"] },
+);

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -38,6 +38,8 @@ const ALLOWED_ACTIONS = new Set([
   "account.create",
   "account.lock",
   "account.unlock",
+  "account.suspend",
+  "account.restore",
   "password.change",
   "password.reset",
 ]);

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -29,19 +29,16 @@ import { checkSignInRateLimit } from "@/lib/rate-limit/limiter";
 interface LockoutPolicy {
   stage1Threshold: number;
   stage1DurationMinutes: number;
-  stage2Threshold: number;
 }
 
 const DEFAULT_LOCKOUT: LockoutPolicy = {
   stage1Threshold: 5,
   stage1DurationMinutes: 30,
-  stage2Threshold: 3,
 };
 
 interface LockoutPolicyRow {
   stage1_threshold: number;
   stage1_duration_minutes: number;
-  stage2_threshold: number;
 }
 
 // ── Account row type ────────────────────────────────────────────
@@ -53,6 +50,7 @@ interface AccountRow {
   token_version: number;
   must_change_password: boolean;
   failed_sign_in_count: number;
+  lockout_count: number;
   locked_until: string | null;
   max_sessions: number | null;
   allowed_ips: string[] | null;
@@ -73,7 +71,6 @@ async function loadLockoutPolicy(): Promise<LockoutPolicy> {
         stage1Threshold: db.stage1_threshold ?? DEFAULT_LOCKOUT.stage1Threshold,
         stage1DurationMinutes:
           db.stage1_duration_minutes ?? DEFAULT_LOCKOUT.stage1DurationMinutes,
-        stage2Threshold: db.stage2_threshold ?? DEFAULT_LOCKOUT.stage2Threshold,
       };
     }
   } catch {
@@ -162,42 +159,51 @@ async function applyFailedLogin(
   const newFailCount = account.failed_sign_in_count + 1;
   const lockout = await loadLockoutPolicy();
 
-  if (newFailCount >= lockout.stage1Threshold + lockout.stage2Threshold) {
-    // Stage 2 — permanent lock
-    await query(
-      `UPDATE accounts
-       SET failed_sign_in_count = $1, status = 'locked', locked_until = NULL
-       WHERE id = $2`,
-      [newFailCount, account.id],
-    );
-    await auditLog.record({
-      actor: account.id,
-      action: "account.lock",
-      target: "account",
-      targetId: account.id,
-      details: { reason: "stage2_permanent", failedCount: newFailCount, ip },
-    });
-  } else if (newFailCount >= lockout.stage1Threshold) {
-    // Stage 1 — temporary lock
-    await query(
-      `UPDATE accounts
-       SET failed_sign_in_count = $1, status = 'locked',
-           locked_until = NOW() + $2 * INTERVAL '1 minute'
-       WHERE id = $3`,
-      [newFailCount, lockout.stage1DurationMinutes, account.id],
-    );
-    await auditLog.record({
-      actor: account.id,
-      action: "account.lock",
-      target: "account",
-      targetId: account.id,
-      details: {
-        reason: "stage1_temporary",
-        failedCount: newFailCount,
-        durationMinutes: lockout.stage1DurationMinutes,
-        ip,
-      },
-    });
+  if (newFailCount >= lockout.stage1Threshold) {
+    if (account.lockout_count >= 1) {
+      // Stage 2 — suspend (no auto-recovery)
+      await query(
+        `UPDATE accounts
+         SET failed_sign_in_count = $1, status = 'suspended',
+             locked_until = NULL
+         WHERE id = $2`,
+        [newFailCount, account.id],
+      );
+      await auditLog.record({
+        actor: account.id,
+        action: "account.suspend",
+        target: "account",
+        targetId: account.id,
+        details: {
+          reason: "stage2_suspended",
+          failedCount: newFailCount,
+          lockoutCount: account.lockout_count,
+          ip,
+        },
+      });
+    } else {
+      // Stage 1 — temporary lock
+      await query(
+        `UPDATE accounts
+         SET failed_sign_in_count = $1, status = 'locked',
+             locked_until = NOW() + $2 * INTERVAL '1 minute',
+             lockout_count = lockout_count + 1
+         WHERE id = $3`,
+        [newFailCount, lockout.stage1DurationMinutes, account.id],
+      );
+      await auditLog.record({
+        actor: account.id,
+        action: "account.lock",
+        target: "account",
+        targetId: account.id,
+        details: {
+          reason: "stage1_temporary",
+          failedCount: newFailCount,
+          durationMinutes: lockout.stage1DurationMinutes,
+          ip,
+        },
+      });
+    }
   } else {
     // Below threshold — just increment
     await query("UPDATE accounts SET failed_sign_in_count = $1 WHERE id = $2", [
@@ -241,10 +247,10 @@ async function createSessionAndIssueTokens(params: {
     userAgent,
   } = params;
 
-  // Reset failed count and update last_sign_in_at
+  // Reset failed count, lockout count, and update last_sign_in_at
   await query(
     `UPDATE accounts
-     SET failed_sign_in_count = 0, last_sign_in_at = NOW()
+     SET failed_sign_in_count = 0, lockout_count = 0, last_sign_in_at = NOW()
      WHERE id = $1`,
     [accountId],
   );
@@ -347,8 +353,8 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
   const { rows: accountRows } = await query<AccountRow>(
     `SELECT a.id, a.password_hash, a.status, a.token_version,
             a.must_change_password, a.failed_sign_in_count,
-            a.locked_until, a.max_sessions, a.allowed_ips,
-            r.name AS role_name
+            a.lockout_count, a.locked_until, a.max_sessions,
+            a.allowed_ips, r.name AS role_name
      FROM accounts a
      JOIN roles r ON a.role_id = r.id
      WHERE a.username = $1`,

--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -64,6 +64,8 @@ const ACTION_KEYS = [
   "account.create",
   "account.lock",
   "account.unlock",
+  "account.suspend",
+  "account.restore",
   "password.change",
   "password.reset",
 ] as const;

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -92,6 +92,8 @@
       "account_create": "Account create",
       "account_lock": "Account lock",
       "account_unlock": "Account unlock",
+      "account_suspend": "Account suspend",
+      "account_restore": "Account restore",
       "password_change": "Password change",
       "password_reset": "Password reset"
     },

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -92,6 +92,8 @@
       "account_create": "계정 생성",
       "account_lock": "계정 잠금",
       "account_unlock": "계정 잠금 해제",
+      "account_suspend": "계정 정지",
+      "account_restore": "계정 복원",
       "password_change": "비밀번호 변경",
       "password_reset": "비밀번호 초기화"
     },

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -74,8 +74,13 @@ type SessionAction =
   | "session.idle_timeout"
   | "session.absolute_timeout";
 
-/** Phase 1 account event actions. */
-type AccountAction = "account.create" | "account.lock" | "account.unlock";
+/** Account event actions. */
+type AccountAction =
+  | "account.create"
+  | "account.lock"
+  | "account.unlock"
+  | "account.suspend"
+  | "account.restore";
 
 /** Phase 2 password event actions. */
 type PasswordAction = "password.change" | "password.reset";


### PR DESCRIPTION
## Summary
- Add `lockout_count` column to track repeat lockouts and enable two-stage escalation (temporary lock → suspension)
- Rework sign-in lockout logic: Stage 1 (lockout_count=0) triggers 30-min lock; Stage 2 (lockout_count≥1) triggers permanent suspension
- Add `POST /api/accounts/[id]/unlock` endpoint for admin unlock (locked→active) and restore (suspended→active)
- Add `account.suspend` and `account.restore` audit actions with i18n (en/ko)
- Add pnpm CLI tool usage guideline to CLAUDE.md and AGENTS.md

## Test plan
- 600 unit tests pass (47 files), including 9 new unlock API tests and updated sign-in lockout tests
- 58 E2E tests pass with no regression, including 7 lockout tests and 6 unlock API tests
- Biome lint and TypeScript type check clean

Closes #96