### PR TITLE
Add customer management CRUD and UI

### DIFF
--- a/e2e/customers.spec.ts
+++ b/e2e/customers.spec.ts
@@ -5,7 +5,6 @@ import {
   ADMIN_USERNAME,
   resetRateLimits,
   signInAndWait,
-  signOut,
 } from "./helpers/auth";
 import {
   clearMustChangePassword,
@@ -129,9 +128,7 @@ test.describe("Customer management", () => {
     expect(verifyRes.status()).toBe(404);
   });
 
-  test("POST /api/customers returns 400 for missing name", async ({
-    page,
-  }) => {
+  test("POST /api/customers returns 400 for missing name", async ({ page }) => {
     await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
 
     const cookies = await page.context().cookies();

--- a/e2e/customers.spec.ts
+++ b/e2e/customers.spec.ts
@@ -1,0 +1,259 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+  signOut,
+} from "./helpers/auth";
+import {
+  clearMustChangePassword,
+  deleteCustomersByPrefix,
+  resetAccountDefaults,
+  revokeAllSessions,
+} from "./helpers/setup-db";
+
+const TEST_PREFIX = "E2E-Cust-";
+
+test.describe("Customer management", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await clearMustChangePassword(ADMIN_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await deleteCustomersByPrefix(TEST_PREFIX);
+  });
+
+  test.beforeEach(async () => {
+    await resetRateLimits();
+    await revokeAllSessions(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await deleteCustomersByPrefix(TEST_PREFIX);
+  });
+
+  // ── API tests ─────────────────────────────────────────────────
+
+  test("POST /api/customers creates a customer", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post("/api/customers", {
+      data: { name: `${TEST_PREFIX}Alpha`, description: "Test customer" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.name).toBe(`${TEST_PREFIX}Alpha`);
+    expect(body.data.status).toBe("active");
+    expect(body.data.database_name).toContain("customer_");
+  });
+
+  test("GET /api/customers lists customers", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const response = await page.request.get("/api/customers");
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    const testCustomers = body.data.filter((c: { name: string }) =>
+      c.name.startsWith(TEST_PREFIX),
+    );
+    expect(testCustomers.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("PATCH /api/customers/[id] updates a customer", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Get customer ID
+    const listRes = await page.request.get("/api/customers");
+    const listBody = await listRes.json();
+    const customer = listBody.data.find(
+      (c: { name: string }) => c.name === `${TEST_PREFIX}Alpha`,
+    );
+    expect(customer).toBeDefined();
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.patch(`/api/customers/${customer.id}`, {
+      data: { name: `${TEST_PREFIX}Alpha-Updated` },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.name).toBe(`${TEST_PREFIX}Alpha-Updated`);
+  });
+
+  test("DELETE /api/customers/[id] deletes a customer", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Get customer ID
+    const listRes = await page.request.get("/api/customers");
+    const listBody = await listRes.json();
+    const customer = listBody.data.find(
+      (c: { name: string }) => c.name === `${TEST_PREFIX}Alpha-Updated`,
+    );
+    expect(customer).toBeDefined();
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.delete(
+      `/api/customers/${customer.id}`,
+      {
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      },
+    );
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    // Verify it's gone
+    const verifyRes = await page.request.get(`/api/customers/${customer.id}`);
+    expect(verifyRes.status()).toBe(404);
+  });
+
+  test("POST /api/customers returns 400 for missing name", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post("/api/customers", {
+      data: {},
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(400);
+  });
+
+  // ── UI tests ──────────────────────────────────────────────────
+
+  test("navigates to customers page and creates a customer via UI", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/customers");
+
+    // Verify page heading
+    await expect(
+      page.getByRole("heading", { name: "Customers" }),
+    ).toBeVisible();
+
+    // Click create button
+    await page.getByRole("button", { name: "Create Customer" }).click();
+
+    // Fill form
+    await page.getByLabel("Name").fill(`${TEST_PREFIX}UITest`);
+    await page.getByLabel("Description").fill("Created via E2E");
+
+    // Submit
+    await page.getByRole("button", { name: "Create Customer" }).click();
+
+    // Wait for dialog to close and table to update
+    await expect(
+      page.getByRole("cell", { name: `${TEST_PREFIX}UITest` }),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("edits a customer via UI", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/customers");
+
+    // Wait for table to load
+    await expect(
+      page.getByRole("cell", { name: `${TEST_PREFIX}UITest` }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click edit button on the row
+    const row = page.getByRole("row").filter({
+      hasText: `${TEST_PREFIX}UITest`,
+    });
+    await row.getByRole("button").first().click();
+
+    // Update name
+    const nameInput = page.getByLabel("Name");
+    await nameInput.clear();
+    await nameInput.fill(`${TEST_PREFIX}UITest-Edited`);
+
+    // Submit
+    await page.getByRole("button", { name: "Edit Customer" }).click();
+
+    // Verify update
+    await expect(
+      page.getByRole("cell", { name: `${TEST_PREFIX}UITest-Edited` }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("deletes a customer via UI", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/customers");
+
+    // Wait for table to load
+    await expect(
+      page.getByRole("cell", { name: `${TEST_PREFIX}UITest-Edited` }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Click delete button on the row (second button)
+    const row = page.getByRole("row").filter({
+      hasText: `${TEST_PREFIX}UITest-Edited`,
+    });
+    await row.getByRole("button").nth(1).click();
+
+    // Confirm deletion in alert dialog
+    await page.getByRole("button", { name: "Delete Customer" }).click();
+
+    // Verify removal
+    await expect(
+      page.getByRole("cell", { name: `${TEST_PREFIX}UITest-Edited` }),
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  // ── Audit log verification ────────────────────────────────────
+
+  test("customer audit events are visible in audit logs", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Create a customer so we have a fresh audit event
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    await page.request.post("/api/customers", {
+      data: { name: `${TEST_PREFIX}AuditCheck` },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    // Check audit logs API for customer.create
+    const auditRes = await page.request.get(
+      "/api/audit-logs?action=customer.create",
+    );
+    expect(auditRes.status()).toBe(200);
+    const auditBody = await auditRes.json();
+    expect(auditBody.data.length).toBeGreaterThanOrEqual(1);
+    expect(auditBody.data[0].target_type).toBe("customer");
+  });
+});

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -405,6 +405,44 @@ export async function getAccountId(username: string): Promise<string> {
 }
 
 /**
+ * Delete all customers whose name starts with a given prefix.
+ * Also drops the associated databases.
+ */
+export async function deleteCustomersByPrefix(prefix: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{
+      id: number;
+      database_name: string;
+    }>("SELECT id, database_name FROM customers WHERE name LIKE $1", [
+      `${prefix}%`,
+    ]);
+    for (const row of rows) {
+      // Remove account_customer links first (ON DELETE RESTRICT)
+      await client.query(
+        "DELETE FROM account_customer WHERE customer_id = $1",
+        [row.id],
+      );
+      await client.query(
+        `DROP DATABASE IF EXISTS ${escapeIdentifier(row.database_name)}`,
+      );
+    }
+    if (rows.length > 0) {
+      await client.query("DELETE FROM customers WHERE name LIKE $1", [
+        `${prefix}%`,
+      ]);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+function escapeIdentifier(str: string): string {
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+/**
  * Get session status for diagnostic/assertion purposes.
  */
 export async function getSessionStatus(username: string): Promise<{

--- a/migrations/auth/0010_customers_delete_permission.sql
+++ b/migrations/auth/0010_customers_delete_permission.sql
@@ -1,0 +1,4 @@
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, 'customers:delete'
+FROM roles r
+WHERE r.name = 'System Administrator';

--- a/migrations/customer/0001_init_schema.sql
+++ b/migrations/customer/0001_init_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS _schema_version (
+  version INTEGER PRIMARY KEY DEFAULT 1
+);
+
+INSERT INTO _schema_version (version) VALUES (1);

--- a/src/__tests__/app/api/customers/[id]/route.test.ts
+++ b/src/__tests__/app/api/customers/[id]/route.test.ts
@@ -1,0 +1,322 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockDropCustomerDb = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/db/migrate", () => ({
+  dropCustomerDb: vi.fn((...args: unknown[]) => mockDropCustomerDb(...args)),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const now = Math.floor(Date.now() / 1000);
+
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const sampleCustomer = {
+  id: 1,
+  name: "Acme Corp",
+  description: "A test customer",
+  database_name: "customer_acme_corp_abc123",
+  status: "active",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function makeContext(id = "1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+// ── GET /api/customers/[id] ─────────────────────────────────────
+
+describe("GET /api/customers/[id]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+  });
+
+  it("returns a customer by ID", async () => {
+    mockQuery.mockResolvedValue({ rows: [sampleCustomer], rowCount: 1 });
+
+    const { GET } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1");
+    const response = await GET(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe("Acme Corp");
+  });
+
+  it("returns 404 for non-existent customer", async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const { GET } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/999");
+    const response = await GET(request, makeContext("999"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for invalid ID", async () => {
+    const { GET } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/abc");
+    const response = await GET(request, makeContext("abc"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("scopes by tenant when lacking customers:access-all", async () => {
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // First: SELECT customer, then: SELECT account_customer link
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // no link
+
+    const { GET } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1");
+    const response = await GET(request, makeContext());
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ── PATCH /api/customers/[id] ───────────────────────────────────
+
+describe("PATCH /api/customers/[id]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+  });
+
+  it("updates name and description", async () => {
+    const updated = { ...sampleCustomer, name: "New Name" };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 }) // SELECT
+      .mockResolvedValueOnce({ rows: [updated], rowCount: 1 }); // UPDATE
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "New Name" }),
+    });
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe("New Name");
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.update",
+        target: "customer",
+        targetId: "1",
+      }),
+    );
+  });
+
+  it("returns 404 for non-existent customer", async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/999", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "X" }),
+    });
+    const response = await PATCH(request, makeContext("999"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for empty name", async () => {
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "  " }),
+    });
+    const response = await PATCH(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns existing customer when no fields to update", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [sampleCustomer],
+      rowCount: 1,
+    });
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({}),
+    });
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe("Acme Corp");
+  });
+});
+
+// ── DELETE /api/customers/[id] ──────────────────────────────────
+
+describe("DELETE /api/customers/[id]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockDropCustomerDb.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("deletes a customer and drops its database", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 }) // SELECT customer
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SELECT account_customer
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // DELETE
+
+    const { DELETE } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockDropCustomerDb).toHaveBeenCalledWith(
+      sampleCustomer.database_name,
+    );
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.delete",
+        target: "customer",
+        targetId: "1",
+      }),
+    );
+  });
+
+  it("returns 400 when customer has linked accounts", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 }) // SELECT customer
+      .mockResolvedValueOnce({
+        rows: [{ customer_id: 1 }],
+        rowCount: 1,
+      }); // SELECT account_customer
+
+    const { DELETE } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("active account assignments");
+    expect(mockDropCustomerDb).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for non-existent customer", async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const { DELETE } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/999", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, makeContext("999"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 without customers:delete permission", async () => {
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:delete") return false;
+        return true;
+      },
+    );
+
+    const { DELETE } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, makeContext());
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/__tests__/app/api/customers/route.test.ts
+++ b/src/__tests__/app/api/customers/route.test.ts
@@ -1,0 +1,257 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockProvisionCustomerDb = vi.hoisted(() => vi.fn());
+const mockDropCustomerDb = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/db/migrate", () => ({
+  provisionCustomerDb: vi.fn((...args: unknown[]) =>
+    mockProvisionCustomerDb(...args),
+  ),
+  dropCustomerDb: vi.fn((...args: unknown[]) => mockDropCustomerDb(...args)),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const now = Math.floor(Date.now() / 1000);
+
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const sampleCustomer = {
+  id: 1,
+  name: "Acme Corp",
+  description: "A test customer",
+  database_name: "customer_acme_corp_abc123",
+  status: "active",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function makeContext() {
+  return { params: Promise.resolve({}) };
+}
+
+// ── GET /api/customers ──────────────────────────────────────────
+
+describe("GET /api/customers", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+  });
+
+  it("returns all customers when user has customers:access-all", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [sampleCustomer],
+      rowCount: 1,
+    });
+
+    const { GET } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers");
+    const response = await GET(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("Acme Corp");
+  });
+
+  it("returns scoped customers when user lacks customers:access-all", async () => {
+    // First call: hasPermission for customers:read → true
+    // Second call: hasPermission for customers:access-all → false
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    mockQuery.mockResolvedValue({
+      rows: [sampleCustomer],
+      rowCount: 1,
+    });
+
+    const { GET } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers");
+    const response = await GET(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+
+    // Should have used JOIN with account_customer
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("account_customer"),
+      [adminSession.accountId],
+    );
+  });
+
+  it("returns 403 without customers:read permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { GET } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers");
+    const response = await GET(request, makeContext());
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ── POST /api/customers ─────────────────────────────────────────
+
+describe("POST /api/customers", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockProvisionCustomerDb.mockReset().mockResolvedValue(undefined);
+    mockDropCustomerDb.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("creates a customer and provisions its database", async () => {
+    const provisionedCustomer = { ...sampleCustomer, status: "provisioning" };
+    const activeCustomer = { ...sampleCustomer, status: "active" };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [provisionedCustomer], rowCount: 1 }) // INSERT
+      .mockResolvedValueOnce({ rows: [activeCustomer], rowCount: 1 }); // UPDATE
+
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({ name: "Acme Corp", description: "A test" }),
+    });
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.status).toBe("active");
+    expect(mockProvisionCustomerDb).toHaveBeenCalledTimes(1);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.create",
+        target: "customer",
+      }),
+    );
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("name");
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: "not json",
+    });
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid JSON");
+  });
+
+  it("cleans up on provisioning failure", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...sampleCustomer, id: 42, status: "provisioning" }],
+      rowCount: 1,
+    });
+    mockProvisionCustomerDb.mockRejectedValueOnce(
+      new Error("DB create failed"),
+    );
+
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({ name: "Bad Customer" }),
+    });
+
+    await expect(POST(request, makeContext())).rejects.toThrow(
+      "DB create failed",
+    );
+
+    // Should have deleted the row
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM customers"),
+      [42],
+    );
+  });
+});

--- a/src/__tests__/components/layout/breadcrumbs.test.ts
+++ b/src/__tests__/components/layout/breadcrumbs.test.ts
@@ -92,7 +92,7 @@ describe("NAV_SEGMENTS", () => {
 
 describe("SETTINGS_SEGMENTS", () => {
   it("contains all expected settings keys", () => {
-    const expected = ["accounts", "roles", "profile"];
+    const expected = ["accounts", "roles", "profile", "customers"];
     for (const key of expected) {
       expect(SETTINGS_SEGMENTS.has(key)).toBe(true);
     }

--- a/src/__tests__/lib/db/migrate.test.ts
+++ b/src/__tests__/lib/db/migrate.test.ts
@@ -338,7 +338,13 @@ describe("migrate", () => {
         } as never;
       });
 
-      // customers query (called after auth + audit migrations)
+      // Crash recovery: SELECT provisioning customers → empty
+      vi.mocked(clientQuery).mockResolvedValueOnce({
+        rows: [],
+        rowCount: 0,
+      });
+
+      // Active customers query (called after auth + audit migrations)
       vi.mocked(clientQuery).mockResolvedValueOnce({
         rows: [{ database_name: "customer_1" }],
         rowCount: 1,

--- a/src/app/[locale]/(dashboard)/settings/customers/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/customers/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { CustomerTable } from "@/components/customers/customer-table";
+
+export default function CustomersPage() {
+  return (
+    <Suspense>
+      <CustomerTable />
+    </Suspense>
+  );
+}

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -42,9 +42,12 @@ const ALLOWED_ACTIONS = new Set([
   "account.restore",
   "password.change",
   "password.reset",
+  "customer.create",
+  "customer.update",
+  "customer.delete",
 ]);
 
-const ALLOWED_TARGET_TYPES = new Set(["account", "session"]);
+const ALLOWED_TARGET_TYPES = new Set(["account", "session", "customer"]);
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 20;

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -1,0 +1,243 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+import { dropCustomerDb } from "@/lib/db/migrate";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface CustomerRow {
+  id: number;
+  name: string;
+  description: string | null;
+  database_name: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// ── Route Handlers ──────────────────────────────────────────────
+
+/**
+ * GET /api/customers/[id]
+ *
+ * Fetch a single customer. Tenant-scoped unless the caller holds
+ * `customers:access-all`.
+ *
+ * Requires `customers:read` permission.
+ */
+export const GET = withAuth(
+  async (_request, context, session) => {
+    const { id } = await context.params;
+    const customerId = Number(id);
+    if (!Number.isFinite(customerId)) {
+      return NextResponse.json(
+        { error: "Invalid customer ID" },
+        { status: 400 },
+      );
+    }
+
+    const { rows } = await query<CustomerRow>(
+      "SELECT * FROM customers WHERE id = $1",
+      [customerId],
+    );
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Customer not found" },
+        { status: 404 },
+      );
+    }
+
+    // Tenant scope check
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!accessAll) {
+      const { rows: linkRows } = await query<{ customer_id: number }>(
+        "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+        [session.accountId, customerId],
+      );
+      if (linkRows.length === 0) {
+        return NextResponse.json(
+          { error: "Customer not found" },
+          { status: 404 },
+        );
+      }
+    }
+
+    return NextResponse.json({ data: rows[0] });
+  },
+  { requiredPermissions: ["customers:read"] },
+);
+
+/**
+ * PATCH /api/customers/[id]
+ *
+ * Update a customer's name and/or description.
+ *
+ * Body: `{ name?: string, description?: string }`
+ *
+ * Requires `customers:write` permission.
+ */
+export const PATCH = withAuth(
+  async (request, context, session) => {
+    const { id } = await context.params;
+    const customerId = Number(id);
+    if (!Number.isFinite(customerId)) {
+      return NextResponse.json(
+        { error: "Invalid customer ID" },
+        { status: 400 },
+      );
+    }
+
+    // Parse body
+    let name: string | undefined;
+    let description: string | undefined;
+    try {
+      const body = await request.json();
+      name = body.name;
+      description = body.description;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    if (
+      name !== undefined &&
+      (!name || typeof name !== "string" || !name.trim())
+    ) {
+      return NextResponse.json(
+        { error: "Name must be a non-empty string" },
+        { status: 400 },
+      );
+    }
+
+    // Check existence
+    const { rows: existing } = await query<CustomerRow>(
+      "SELECT * FROM customers WHERE id = $1",
+      [customerId],
+    );
+    if (existing.length === 0) {
+      return NextResponse.json(
+        { error: "Customer not found" },
+        { status: 404 },
+      );
+    }
+
+    // Build update
+    const updates: string[] = [];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (name !== undefined) {
+      updates.push(`name = $${idx++}`);
+      params.push(name.trim());
+    }
+    if (description !== undefined) {
+      updates.push(`description = $${idx++}`);
+      params.push(description?.trim() || null);
+    }
+
+    if (updates.length === 0) {
+      return NextResponse.json({ data: existing[0] });
+    }
+
+    updates.push(`updated_at = NOW()`);
+    params.push(customerId);
+
+    const { rows } = await query<CustomerRow>(
+      `UPDATE customers SET ${updates.join(", ")} WHERE id = $${idx} RETURNING *`,
+      params,
+    );
+
+    // Audit
+    await auditLog.record({
+      actor: session.accountId,
+      action: "customer.update",
+      target: "customer",
+      targetId: String(customerId),
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: {
+        ...(name !== undefined && { name: name.trim() }),
+        ...(description !== undefined && {
+          description: description?.trim() || null,
+        }),
+      },
+    });
+
+    return NextResponse.json({ data: rows[0] });
+  },
+  { requiredPermissions: ["customers:write"] },
+);
+
+/**
+ * DELETE /api/customers/[id]
+ *
+ * Delete a customer and drop its database.
+ *
+ * Fails if the customer has linked accounts in `account_customer`.
+ *
+ * Requires `customers:delete` permission.
+ */
+export const DELETE = withAuth(
+  async (request, context, session) => {
+    const { id } = await context.params;
+    const customerId = Number(id);
+    if (!Number.isFinite(customerId)) {
+      return NextResponse.json(
+        { error: "Invalid customer ID" },
+        { status: 400 },
+      );
+    }
+
+    // Check existence
+    const { rows } = await query<CustomerRow>(
+      "SELECT * FROM customers WHERE id = $1",
+      [customerId],
+    );
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Customer not found" },
+        { status: 404 },
+      );
+    }
+
+    const customer = rows[0];
+
+    // Check for linked accounts
+    const { rows: linkRows } = await query<{ customer_id: number }>(
+      "SELECT customer_id FROM account_customer WHERE customer_id = $1 LIMIT 1",
+      [customerId],
+    );
+    if (linkRows.length > 0) {
+      return NextResponse.json(
+        { error: "Cannot delete customer with active account assignments" },
+        { status: 400 },
+      );
+    }
+
+    // Drop database first, then delete the row
+    await dropCustomerDb(customer.database_name);
+    await query("DELETE FROM customers WHERE id = $1", [customerId]);
+
+    // Audit
+    await auditLog.record({
+      actor: session.accountId,
+      action: "customer.delete",
+      target: "customer",
+      targetId: String(customerId),
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { name: customer.name, databaseName: customer.database_name },
+    });
+
+    return NextResponse.json({ success: true });
+  },
+  { requiredPermissions: ["customers:delete"] },
+);

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,0 +1,159 @@
+import "server-only";
+
+import { randomBytes } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+import { provisionCustomerDb } from "@/lib/db/migrate";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+interface CustomerRow {
+  id: number;
+  name: string;
+  description: string | null;
+  database_name: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Generate a database-safe name from a customer name.
+ *
+ * Lowercases, replaces non-alphanumeric runs with `_`, trims to 40 chars,
+ * and appends a 6-char random hex suffix for uniqueness.
+ */
+function generateDatabaseName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_|_$/g, "")
+    .slice(0, 40);
+  const suffix = randomBytes(3).toString("hex");
+  return `customer_${slug || "db"}_${suffix}`;
+}
+
+// ── Route Handlers ──────────────────────────────────────────────
+
+/**
+ * GET /api/customers
+ *
+ * List all customers. If the caller lacks `customers:access-all`,
+ * results are scoped to customers linked via `account_customer`.
+ *
+ * Requires `customers:read` permission.
+ */
+export const GET = withAuth(
+  async (_request, _context, session) => {
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+
+    let rows: CustomerRow[];
+    if (accessAll) {
+      const result = await query<CustomerRow>(
+        "SELECT * FROM customers ORDER BY id",
+      );
+      rows = result.rows;
+    } else {
+      const result = await query<CustomerRow>(
+        `SELECT c.* FROM customers c
+         JOIN account_customer ac ON ac.customer_id = c.id
+         WHERE ac.account_id = $1
+         ORDER BY c.id`,
+        [session.accountId],
+      );
+      rows = result.rows;
+    }
+
+    return NextResponse.json({ data: rows });
+  },
+  { requiredPermissions: ["customers:read"] },
+);
+
+/**
+ * POST /api/customers
+ *
+ * Create a new customer and provision its database.
+ *
+ * Body: `{ name: string, description?: string }`
+ *
+ * Flow:
+ *  1. Insert row with `status = 'provisioning'`
+ *  2. Provision the customer database (CREATE DATABASE + migrations)
+ *  3. Update status to `'active'`
+ *
+ * On failure the row and database are cleaned up.
+ *
+ * Requires `customers:write` permission.
+ */
+export const POST = withAuth(
+  async (request, _context, session) => {
+    // Step 1: Parse body
+    let name: string;
+    let description: string | undefined;
+    try {
+      const body = await request.json();
+      name = body.name;
+      description = body.description;
+      if (!name || typeof name !== "string" || !name.trim()) {
+        return NextResponse.json(
+          { error: "Missing required field: name" },
+          { status: 400 },
+        );
+      }
+      name = name.trim();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // Step 2: Insert as provisioning
+    const databaseName = generateDatabaseName(name);
+    const { rows } = await query<CustomerRow>(
+      `INSERT INTO customers (name, description, database_name, status)
+       VALUES ($1, $2, $3, 'provisioning')
+       RETURNING *`,
+      [name, description?.trim() || null, databaseName],
+    );
+    const customer = rows[0];
+
+    // Step 3: Provision the database
+    try {
+      await provisionCustomerDb(databaseName);
+    } catch (err) {
+      // Clean up the row on provision failure
+      await query("DELETE FROM customers WHERE id = $1", [customer.id]);
+      throw err;
+    }
+
+    // Step 4: Activate
+    const { rows: activeRows } = await query<CustomerRow>(
+      `UPDATE customers
+       SET status = 'active', updated_at = NOW()
+       WHERE id = $1
+       RETURNING *`,
+      [customer.id],
+    );
+
+    // Step 5: Audit
+    await auditLog.record({
+      actor: session.accountId,
+      action: "customer.create",
+      target: "customer",
+      targetId: String(customer.id),
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { name, databaseName },
+    });
+
+    return NextResponse.json({ data: activeRows[0] }, { status: 201 });
+  },
+  { requiredPermissions: ["customers:write"] },
+);

--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -68,9 +68,12 @@ const ACTION_KEYS = [
   "account.restore",
   "password.change",
   "password.reset",
+  "customer.create",
+  "customer.update",
+  "customer.delete",
 ] as const;
 
-const TARGET_TYPE_KEYS = ["account", "session"] as const;
+const TARGET_TYPE_KEYS = ["account", "session", "customer"] as const;
 
 /** Convert a dotted DB action key to an i18n-safe underscore key. */
 function actionToI18nKey(action: string): string {

--- a/src/components/customers/customer-form-dialog.tsx
+++ b/src/components/customers/customer-form-dialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface Customer {
+  id: number;
+  name: string;
+  description: string | null;
+}
+
+interface CustomerFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  customer?: Customer;
+  onSuccess: () => void;
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+export function CustomerFormDialog({
+  open,
+  onOpenChange,
+  customer,
+  onSuccess,
+}: CustomerFormDialogProps) {
+  const t = useTranslations("customers");
+  const isEdit = !!customer;
+
+  const [name, setName] = useState(customer?.name ?? "");
+  const [description, setDescription] = useState(customer?.description ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (csrfToken) {
+        headers["X-CSRF-Token"] = csrfToken;
+      }
+
+      const url = isEdit ? `/api/customers/${customer.id}` : "/api/customers";
+      const method = isEdit ? "PATCH" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers,
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+
+      onOpenChange(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setName(customer?.name ?? "");
+      setDescription(customer?.description ?? "");
+      setError(null);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? t("edit") : t("create")}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="customer-name">{t("name")}</Label>
+            <Input
+              id="customer-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="customer-description">{t("description")}</Label>
+            <Input
+              id="customer-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          {error && <p className="text-destructive text-sm">{error}</p>}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={submitting}>
+                {t("cancel")}
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={submitting || !name.trim()}>
+              {submitting ? t("loading") : isEdit ? t("edit") : t("create")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/customers/customer-table.tsx
+++ b/src/components/customers/customer-table.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { Pencil, Plus, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+
+import { CustomerFormDialog } from "@/components/customers/customer-form-dialog";
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface Customer {
+  id: number;
+  name: string;
+  description: string | null;
+  database_name: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+export function CustomerTable() {
+  const t = useTranslations("customers");
+
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingCustomer, setEditingCustomer] = useState<
+    Customer | undefined
+  >();
+  const [deleteTarget, setDeleteTarget] = useState<Customer | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // ── Fetch ──────────────────────────────────────────────────────
+
+  const fetchCustomers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/customers");
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+      const body = await res.json();
+      setCustomers(body.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    fetchCustomers();
+  }, [fetchCustomers]);
+
+  // ── Handlers ───────────────────────────────────────────────────
+
+  const handleCreate = () => {
+    setEditingCustomer(undefined);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (customer: Customer) => {
+    setEditingCustomer(customer);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {};
+      if (csrfToken) {
+        headers["X-CSRF-Token"] = csrfToken;
+      }
+
+      const res = await fetch(`/api/customers/${deleteTarget.id}`, {
+        method: "DELETE",
+        headers,
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+
+      setDeleteTarget(null);
+      fetchCustomers();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : t("error"));
+    }
+  };
+
+  // ── Render ─────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-foreground text-2xl font-bold">{t("title")}</h1>
+        <Button onClick={handleCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          {t("create")}
+        </Button>
+      </div>
+
+      {loading && (
+        <p className="text-muted-foreground text-sm">{t("loading")}</p>
+      )}
+      {error && <p className="text-destructive text-sm">{error}</p>}
+
+      {!loading && !error && customers.length === 0 && (
+        <p className="text-muted-foreground text-sm">{t("noResults")}</p>
+      )}
+
+      {!loading && customers.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t("name")}</TableHead>
+              <TableHead>{t("description")}</TableHead>
+              <TableHead>{t("status")}</TableHead>
+              <TableHead>{t("databaseName")}</TableHead>
+              <TableHead className="w-[100px]" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {customers.map((customer) => (
+              <TableRow key={customer.id}>
+                <TableCell className="font-medium">{customer.name}</TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {customer.description ?? "-"}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant={
+                      customer.status === "active" ? "default" : "secondary"
+                    }
+                    className="text-xs"
+                  >
+                    {t(customer.status as "active" | "provisioning")}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground text-xs">
+                  {customer.database_name}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleEdit(customer)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setDeleteTarget(customer)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Create/Edit Dialog */}
+      <CustomerFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        customer={editingCustomer}
+        onSuccess={fetchCustomers}
+      />
+
+      {/* Delete Confirmation */}
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("delete")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteConfirm")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError && (
+            <p className="text-destructive text-sm">{deleteError}</p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>
+              {t("delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Dialog as DialogPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -45,7 +45,8 @@
   "settings": {
     "accounts": "Accounts",
     "roles": "Roles",
-    "profile": "Profile"
+    "profile": "Profile",
+    "customers": "Customers"
   },
   "validation": {
     "required": "{field} is required",
@@ -95,12 +96,37 @@
       "account_suspend": "Account suspend",
       "account_restore": "Account restore",
       "password_change": "Password change",
-      "password_reset": "Password reset"
+      "password_reset": "Password reset",
+      "customer_create": "Customer create",
+      "customer_update": "Customer update",
+      "customer_delete": "Customer delete"
     },
     "targetTypes": {
       "account": "Account",
-      "session": "Session"
+      "session": "Session",
+      "customer": "Customer"
     }
+  },
+  "customers": {
+    "title": "Customers",
+    "name": "Name",
+    "description": "Description",
+    "databaseName": "Database Name",
+    "status": "Status",
+    "active": "Active",
+    "provisioning": "Provisioning",
+    "create": "Create Customer",
+    "edit": "Edit Customer",
+    "delete": "Delete Customer",
+    "cancel": "Cancel",
+    "deleteConfirm": "Are you sure you want to delete this customer? This will permanently remove the customer database.",
+    "deleteLinked": "Cannot delete customer with active account assignments.",
+    "noResults": "No customers found.",
+    "loading": "Loading...",
+    "error": "Failed to load customers",
+    "created": "Customer created successfully",
+    "updated": "Customer updated successfully",
+    "deleted": "Customer deleted successfully"
   },
   "changePassword": {
     "heading": "Change Password",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -45,7 +45,8 @@
   "settings": {
     "accounts": "계정",
     "roles": "역할",
-    "profile": "프로필"
+    "profile": "프로필",
+    "customers": "고객"
   },
   "validation": {
     "required": "{field}은(는) 필수입니다",
@@ -95,12 +96,37 @@
       "account_suspend": "계정 정지",
       "account_restore": "계정 복원",
       "password_change": "비밀번호 변경",
-      "password_reset": "비밀번호 초기화"
+      "password_reset": "비밀번호 초기화",
+      "customer_create": "고객 생성",
+      "customer_update": "고객 수정",
+      "customer_delete": "고객 삭제"
     },
     "targetTypes": {
       "account": "계정",
-      "session": "세션"
+      "session": "세션",
+      "customer": "고객"
     }
+  },
+  "customers": {
+    "title": "고객",
+    "name": "이름",
+    "description": "설명",
+    "databaseName": "데이터베이스 이름",
+    "status": "상태",
+    "active": "활성",
+    "provisioning": "프로비저닝",
+    "create": "고객 생성",
+    "edit": "고객 수정",
+    "delete": "고객 삭제",
+    "cancel": "취소",
+    "deleteConfirm": "이 고객을 삭제하시겠습니까? 고객 데이터베이스가 영구적으로 삭제됩니다.",
+    "deleteLinked": "활성 계정이 할당된 고객은 삭제할 수 없습니다.",
+    "noResults": "고객이 없습니다.",
+    "loading": "로딩 중...",
+    "error": "고객 목록을 불러오지 못했습니다",
+    "created": "고객이 생성되었습니다",
+    "updated": "고객이 수정되었습니다",
+    "deleted": "고객이 삭제되었습니다"
   },
   "changePassword": {
     "heading": "비밀번호 변경",

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -85,15 +85,19 @@ type AccountAction =
 /** Phase 2 password event actions. */
 type PasswordAction = "password.change" | "password.reset";
 
+/** Customer event actions. */
+type CustomerAction = "customer.create" | "customer.update" | "customer.delete";
+
 /** All audit event actions. */
 export type AuditAction =
   | AuthAction
   | SessionAction
   | AccountAction
-  | PasswordAction;
+  | PasswordAction
+  | CustomerAction;
 
-/** Target entity types for Phase 1 events. */
-export type AuditTargetType = "account" | "session";
+/** Target entity types for audit events. */
+export type AuditTargetType = "account" | "session" | "customer";
 
 /**
  * Parameters for recording a single audit log entry.

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -11,7 +11,12 @@ export const NAV_SEGMENTS = new Set([
 ]);
 
 /** Segments that map to translation keys in "settings" namespace. */
-export const SETTINGS_SEGMENTS = new Set(["accounts", "roles", "profile"]);
+export const SETTINGS_SEGMENTS = new Set([
+  "accounts",
+  "roles",
+  "profile",
+  "customers",
+]);
 
 export interface BreadcrumbSegment {
   label: string;

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -178,6 +178,19 @@ export async function runStartupMigrations(): Promise<void> {
   await migrateAuthDb();
   await migrateAuditDb();
 
+  // Clean up stale provisioning rows (crashed mid-provision)
+  const stale = await query<{ database_name: string }>(
+    "SELECT database_name FROM customers WHERE status = 'provisioning'",
+  );
+  for (const row of stale.rows) {
+    await query(
+      `DROP DATABASE IF EXISTS ${escapeIdentifier(row.database_name)}`,
+    );
+  }
+  if (stale.rows.length > 0) {
+    await query("DELETE FROM customers WHERE status = 'provisioning'");
+  }
+
   const result = await query<{ database_name: string }>(
     "SELECT database_name FROM customers WHERE status = 'active'",
   );


### PR DESCRIPTION
## Summary

Implements tenant lifecycle management for issue #97 (Phase 2 of #39):

- **API endpoints**: GET/POST `/api/customers`, GET/PATCH/DELETE `/api/customers/[id]` with permission-based access control and tenant scoping
- **Provisioning flow**: Creates customer DB on POST, drops on DELETE, with crash recovery for stale `provisioning` rows on startup
- **UI**: Customer management table under Settings with create/edit dialog and delete confirmation
- **Audit logging**: `customer.create`, `customer.update`, `customer.delete` events integrated into audit log API and UI
- **Migrations**: `customers:delete` permission for System Administrator, placeholder customer DB schema
- **i18n**: English and Korean translations
- **Dialog component**: New shadcn Dialog primitive using radix-ui

## Test plan

- [x] 7 unit tests for GET/POST `/api/customers` (list, tenant scoping, create with provisioning, validation, rollback)
- [x] 12 unit tests for GET/PATCH/DELETE `/api/customers/[id]` (CRUD, permissions, linked account check, audit events)
- [x] 9 E2E tests (5 API + 3 UI + 1 audit log verification)
- [x] All 619 unit tests pass (`pnpm vitest run`)
- [x] All 67 E2E tests pass (`pnpm playwright test`)
- [x] Biome lint/format: 0 errors
- [x] TypeScript: 0 errors

Closes #97