### PR TITLE
Fix skills update workflow to restore from lock file

### DIFF
--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
+      - name: Restore skills from lock file
+        run: npx -y skills experimental_install -y
       - name: Update skills
         run: npx -y skills update -y
       - name: Check for changes


### PR DESCRIPTION
## Summary

- Add `npx skills experimental_install` step before `npx skills update` in the update-skills workflow
- The skills CLI doesn't recognize project-level skills in a clean CI checkout without first restoring them from `skills-lock.json`

Closes #107