### PR TITLE
Add multi-tenant access control APIs

### DIFF
--- a/e2e/account-customers.spec.ts
+++ b/e2e/account-customers.spec.ts
@@ -1,0 +1,458 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import {
+  clearMustChangePassword,
+  createTestAccount,
+  deleteCustomersByPrefix,
+  deleteTestAccount,
+  getAccountId,
+  getCustomerIdByName,
+  removeAccountCustomerAssignments,
+  resetAccountDefaults,
+  revokeAllSessions,
+} from "./helpers/setup-db";
+
+const TEST_PREFIX = "E2E-AC-";
+const TENANT_USERNAME = "e2e-tenant-ac";
+const TENANT_PASSWORD = "TenantAC1234!";
+const SECMON_USERNAME = "e2e-secmon-ac";
+const SECMON_PASSWORD = "SecMon1234!";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
+
+async function getCsrf(page: import("@playwright/test").Page): Promise<string> {
+  const cookies = await page.context().cookies();
+  return cookies.find((c) => c.name === "csrf")?.value ?? "";
+}
+
+function mutationHeaders(csrf: string) {
+  return { "x-csrf-token": csrf, Origin: BASE_URL };
+}
+
+// ── Setup / Teardown ────────────────────────────────────────────
+
+test.describe("Account-customer assignments", () => {
+  let adminAccountId: string;
+  let tenantAccountId: string;
+  let secmonAccountId: string;
+
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await clearMustChangePassword(ADMIN_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+
+    // Clean up previous test data
+    await deleteTestAccount(TENANT_USERNAME);
+    await deleteTestAccount(SECMON_USERNAME);
+    await deleteCustomersByPrefix(TEST_PREFIX);
+
+    // Create test accounts
+    await createTestAccount(
+      TENANT_USERNAME,
+      TENANT_PASSWORD,
+      "Tenant Administrator",
+    );
+    await createTestAccount(
+      SECMON_USERNAME,
+      SECMON_PASSWORD,
+      "Security Monitor",
+    );
+
+    adminAccountId = await getAccountId(ADMIN_USERNAME);
+    tenantAccountId = await getAccountId(TENANT_USERNAME);
+    secmonAccountId = await getAccountId(SECMON_USERNAME);
+  });
+
+  test.beforeEach(async () => {
+    await resetRateLimits();
+    await revokeAllSessions(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await removeAccountCustomerAssignments(tenantAccountId);
+    await removeAccountCustomerAssignments(secmonAccountId);
+    await removeAccountCustomerAssignments(adminAccountId);
+    await deleteTestAccount(TENANT_USERNAME);
+    await deleteTestAccount(SECMON_USERNAME);
+    await deleteCustomersByPrefix(TEST_PREFIX);
+  });
+
+  // ── API: POST assign ─────────────────────────────────────────
+
+  test("POST assigns customers to an account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Create test customers
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const c1Res = await page.request.post("/api/customers", {
+      data: { name: `${TEST_PREFIX}Assign1` },
+      headers,
+    });
+    expect(c1Res.status()).toBe(201);
+    const c1 = (await c1Res.json()).data;
+
+    const c2Res = await page.request.post("/api/customers", {
+      data: { name: `${TEST_PREFIX}Assign2` },
+      headers,
+    });
+    expect(c2Res.status()).toBe(201);
+    const c2 = (await c2Res.json()).data;
+
+    // Assign both customers to the tenant account
+    const assignRes = await page.request.post(
+      `/api/accounts/${tenantAccountId}/customers`,
+      {
+        data: { customerIds: [c1.id, c2.id] },
+        headers,
+      },
+    );
+    expect(assignRes.status()).toBe(201);
+    const assignBody = await assignRes.json();
+    expect(assignBody.success).toBe(true);
+    expect(assignBody.assigned).toContain(c1.id);
+    expect(assignBody.assigned).toContain(c2.id);
+  });
+
+  // ── API: GET list ─────────────────────────────────────────────
+
+  test("GET lists customer assignments for an account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const listRes = await page.request.get(
+      `/api/accounts/${tenantAccountId}/customers`,
+    );
+    expect(listRes.status()).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.data.length).toBeGreaterThanOrEqual(2);
+
+    const names = listBody.data.map(
+      (d: { customer_name: string }) => d.customer_name,
+    );
+    expect(names).toContain(`${TEST_PREFIX}Assign1`);
+    expect(names).toContain(`${TEST_PREFIX}Assign2`);
+  });
+
+  // ── API: POST idempotent ──────────────────────────────────────
+
+  test("POST is idempotent (ON CONFLICT DO NOTHING)", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const c1Id = await getCustomerIdByName(`${TEST_PREFIX}Assign1`);
+    expect(c1Id).not.toBeNull();
+
+    // Re-assign the same customer — should succeed without error
+    const res = await page.request.post(
+      `/api/accounts/${tenantAccountId}/customers`,
+      {
+        data: { customerIds: [c1Id] },
+        headers,
+      },
+    );
+    expect(res.status()).toBe(201);
+  });
+
+  // ── API: DELETE unassign ──────────────────────────────────────
+
+  test("DELETE removes a customer assignment", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const c2Id = await getCustomerIdByName(`${TEST_PREFIX}Assign2`);
+    expect(c2Id).not.toBeNull();
+
+    const delRes = await page.request.delete(
+      `/api/accounts/${tenantAccountId}/customers/${c2Id}`,
+      { headers },
+    );
+    expect(delRes.status()).toBe(200);
+    const delBody = await delRes.json();
+    expect(delBody.success).toBe(true);
+
+    // Verify it's gone
+    const listRes = await page.request.get(
+      `/api/accounts/${tenantAccountId}/customers`,
+    );
+    const listBody = await listRes.json();
+    const ids = listBody.data.map(
+      (d: { customer_id: number }) => d.customer_id,
+    );
+    expect(ids).not.toContain(c2Id);
+  });
+
+  // ── API: DELETE 404 for non-existent assignment ───────────────
+
+  test("DELETE returns 404 for non-existent assignment", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const res = await page.request.delete(
+      `/api/accounts/${tenantAccountId}/customers/999999`,
+      { headers },
+    );
+    expect(res.status()).toBe(404);
+  });
+
+  // ── Security Monitor: single customer constraint ──────────────
+
+  test("Security Monitor cannot be assigned more than 1 customer", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const c1Id = await getCustomerIdByName(`${TEST_PREFIX}Assign1`);
+    const c2Id = await getCustomerIdByName(`${TEST_PREFIX}Assign2`);
+    expect(c1Id).not.toBeNull();
+    expect(c2Id).not.toBeNull();
+
+    // Clean up any existing assignments for secmon
+    await removeAccountCustomerAssignments(secmonAccountId);
+
+    // Assign first customer — should succeed
+    const res1 = await page.request.post(
+      `/api/accounts/${secmonAccountId}/customers`,
+      {
+        data: { customerIds: [c1Id] },
+        headers,
+      },
+    );
+    expect(res1.status()).toBe(201);
+
+    // Assign second customer — should fail
+    const res2 = await page.request.post(
+      `/api/accounts/${secmonAccountId}/customers`,
+      {
+        data: { customerIds: [c2Id] },
+        headers,
+      },
+    );
+    expect(res2.status()).toBe(400);
+    const body = await res2.json();
+    expect(body.error).toContain("single customer");
+  });
+
+  // ── Security Monitor: assigning 2 at once is rejected ─────────
+
+  test("Security Monitor cannot be assigned 2 customers at once", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const c1Id = await getCustomerIdByName(`${TEST_PREFIX}Assign1`);
+    const c2Id = await getCustomerIdByName(`${TEST_PREFIX}Assign2`);
+
+    // Clean assignments
+    await removeAccountCustomerAssignments(secmonAccountId);
+
+    const res = await page.request.post(
+      `/api/accounts/${secmonAccountId}/customers`,
+      {
+        data: { customerIds: [c1Id, c2Id] },
+        headers,
+      },
+    );
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("single customer");
+  });
+
+  // ── Validation: bad request body ──────────────────────────────
+
+  test("POST returns 400 for empty customerIds array", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const res = await page.request.post(
+      `/api/accounts/${tenantAccountId}/customers`,
+      {
+        data: { customerIds: [] },
+        headers,
+      },
+    );
+    expect(res.status()).toBe(400);
+  });
+
+  test("POST returns 400 for non-existent customer IDs", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const res = await page.request.post(
+      `/api/accounts/${tenantAccountId}/customers`,
+      {
+        data: { customerIds: [999999] },
+        headers,
+      },
+    );
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("999999");
+  });
+
+  test("POST returns 400 for invalid UUID account", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const res = await page.request.post("/api/accounts/not-a-uuid/customers", {
+      data: { customerIds: [1] },
+      headers,
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  // ── Audit log verification ────────────────────────────────────
+
+  test("customer.assign and customer.unassign appear in audit logs", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Check audit logs for customer.assign
+    const assignRes = await page.request.get(
+      "/api/audit-logs?action=customer.assign",
+    );
+    expect(assignRes.status()).toBe(200);
+    const assignBody = await assignRes.json();
+    expect(assignBody.data.length).toBeGreaterThanOrEqual(1);
+    expect(assignBody.data[0].action).toBe("customer.assign");
+    expect(assignBody.data[0].target_type).toBe("account");
+
+    // Check audit logs for customer.unassign
+    const unassignRes = await page.request.get(
+      "/api/audit-logs?action=customer.unassign",
+    );
+    expect(unassignRes.status()).toBe(200);
+    const unassignBody = await unassignRes.json();
+    expect(unassignBody.data.length).toBeGreaterThanOrEqual(1);
+    expect(unassignBody.data[0].action).toBe("customer.unassign");
+    expect(unassignBody.data[0].target_type).toBe("account");
+  });
+
+  // ── Tenant scope: Tenant Admin access control ─────────────────
+
+  test("Tenant Admin can only see accounts that share their customers", async ({
+    page,
+  }) => {
+    // Sign in as Tenant Admin
+    await revokeAllSessions(TENANT_USERNAME);
+    await clearMustChangePassword(TENANT_USERNAME);
+    await signInAndWait(page, TENANT_USERNAME, TENANT_PASSWORD);
+
+    // Tenant admin viewing their own assignments — should work
+    const selfRes = await page.request.get(
+      `/api/accounts/${tenantAccountId}/customers`,
+    );
+    expect(selfRes.status()).toBe(200);
+
+    // Tenant admin viewing admin account that has no shared customers — should get 404
+    // First ensure admin has no overlapping customers
+    await removeAccountCustomerAssignments(adminAccountId);
+
+    const otherRes = await page.request.get(
+      `/api/accounts/${adminAccountId}/customers`,
+    );
+    expect(otherRes.status()).toBe(404);
+  });
+
+  test("Tenant Admin cannot assign customers outside their scope", async ({
+    page,
+  }) => {
+    // Create a customer not assigned to tenant
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    const outRes = await page.request.post("/api/customers", {
+      data: { name: `${TEST_PREFIX}OutOfScope` },
+      headers,
+    });
+    expect(outRes.status()).toBe(201);
+    const outCustomer = (await outRes.json()).data;
+
+    // Sign in as Tenant Admin
+    await revokeAllSessions(TENANT_USERNAME);
+    await clearMustChangePassword(TENANT_USERNAME);
+    await signInAndWait(page, TENANT_USERNAME, TENANT_PASSWORD);
+
+    const tenantCsrf = await getCsrf(page);
+    const tenantHeaders = mutationHeaders(tenantCsrf);
+
+    // Try to assign out-of-scope customer to secmon — should fail
+    const res = await page.request.post(
+      `/api/accounts/${secmonAccountId}/customers`,
+      {
+        data: { customerIds: [outCustomer.id] },
+        headers: tenantHeaders,
+      },
+    );
+    expect(res.status()).toBe(403);
+  });
+
+  // ── DELETE with customer linked to account blocks customer delete ──
+
+  test("Cannot delete customer with active account assignments", async ({
+    page,
+  }) => {
+    await revokeAllSessions(ADMIN_USERNAME);
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const csrf = await getCsrf(page);
+    const headers = mutationHeaders(csrf);
+
+    // Create a customer and assign it
+    const cRes = await page.request.post("/api/customers", {
+      data: { name: `${TEST_PREFIX}Linked` },
+      headers,
+    });
+    expect(cRes.status()).toBe(201);
+    const linkedCustomer = (await cRes.json()).data;
+
+    // Assign to tenant account
+    const assignRes = await page.request.post(
+      `/api/accounts/${tenantAccountId}/customers`,
+      {
+        data: { customerIds: [linkedCustomer.id] },
+        headers,
+      },
+    );
+    expect(assignRes.status()).toBe(201);
+
+    // Try to delete the customer — should fail because it has assignments
+    const delRes = await page.request.delete(
+      `/api/customers/${linkedCustomer.id}`,
+      { headers },
+    );
+    expect(delRes.status()).toBe(400);
+    const delBody = await delRes.json();
+    expect(delBody.error).toContain("active account assignments");
+  });
+});

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -3,7 +3,7 @@ import type { Page } from "@playwright/test";
 export const ADMIN_USERNAME = "admin";
 export const ADMIN_PASSWORD = "Admin1234!";
 
-const BASE_URL = "http://localhost:3000";
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
 
 /**
  * Reset the in-memory rate limiter via the test-only API endpoint.

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -320,6 +320,10 @@ export async function deleteTestAccount(username: string): Promise<void> {
       [username],
     );
     await client.query(
+      "DELETE FROM account_customer WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
+      [username],
+    );
+    await client.query(
       "DELETE FROM password_history WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
       [username],
     );
@@ -433,6 +437,61 @@ export async function deleteCustomersByPrefix(prefix: string): Promise<void> {
         `${prefix}%`,
       ]);
     }
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Assign a customer to an account via direct DB insert.
+ */
+export async function assignCustomerToAccount(
+  accountId: string,
+  customerId: number,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "INSERT INTO account_customer (account_id, customer_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+      [accountId, customerId],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Remove all customer assignments for an account.
+ */
+export async function removeAccountCustomerAssignments(
+  accountId: string,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query("DELETE FROM account_customer WHERE account_id = $1", [
+      accountId,
+    ]);
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Get customer ID by name.
+ */
+export async function getCustomerIdByName(
+  name: string,
+): Promise<number | null> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ id: number }>(
+      "SELECT id FROM customers WHERE name = $1",
+      [name],
+    );
+    return rows.length > 0 ? rows[0].id : null;
   } finally {
     await client.end();
   }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     ? [["html", { open: "never" }], ["github"]]
     : [["html", { open: "on-failure" }]],
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },

--- a/src/__tests__/app/api/accounts/[id]/customers/[customerId]/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/customers/[customerId]/route.test.ts
@@ -1,0 +1,292 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockGetAccountCustomerIds = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/customer-scope", () => ({
+  getAccountCustomerIds: vi.fn((...args: unknown[]) =>
+    mockGetAccountCustomerIds(...args),
+  ),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const now = Math.floor(Date.now() / 1000);
+
+const ACCOUNT_UUID = "00000000-0000-0000-0000-000000000001";
+
+const adminSession: AuthSession = {
+  accountId: ACCOUNT_UUID,
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const tenantAdminSession: AuthSession = {
+  ...adminSession,
+  accountId: "00000000-0000-0000-0000-000000000003",
+  roles: ["Tenant Administrator"],
+};
+
+const TARGET_UUID = "00000000-0000-0000-0000-000000000002";
+
+function makeContext(id = TARGET_UUID, customerId = "1") {
+  return { params: Promise.resolve({ id, customerId }) };
+}
+
+// ── DELETE /api/accounts/[id]/customers/[customerId] ────────────
+
+describe("DELETE /api/accounts/[id]/customers/[customerId]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetAccountCustomerIds.mockReset();
+  });
+
+  it("removes assignment as System Administrator", async () => {
+    // Assignment exists
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ account_id: TARGET_UUID, customer_id: 1 }],
+      })
+      // DELETE
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/1`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.unassign",
+        target: "account",
+        targetId: TARGET_UUID,
+        details: { customerId: 1 },
+      }),
+    );
+  });
+
+  it("returns 404 when assignment does not exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/999`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext(TARGET_UUID, "999"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when Tenant Admin unassigns out-of-scope customer", async () => {
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Assignment exists
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ account_id: TARGET_UUID, customer_id: 5 }],
+    });
+
+    // Caller's customers don't include 5
+    mockGetAccountCustomerIds.mockResolvedValue([1, 2]);
+
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/5`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext(TARGET_UUID, "5"));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for invalid account ID", async () => {
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      "http://localhost:3000/api/accounts/not-uuid/customers/1",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext("not-uuid", "1"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for invalid customer ID", async () => {
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/abc`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext(TARGET_UUID, "abc"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 403 without accounts:write permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/1`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("removes assignment as Tenant Admin within scope", async () => {
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Assignment exists
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ account_id: TARGET_UUID, customer_id: 1 }],
+      })
+      // DELETE
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+    // Caller has customer 1 in scope
+    mockGetAccountCustomerIds.mockResolvedValue([1, 2]);
+
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/1`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.unassign",
+        target: "account",
+        targetId: TARGET_UUID,
+        details: { customerId: 1 },
+      }),
+    );
+  });
+
+  it("returns 400 for zero customer ID", async () => {
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/0`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext(TARGET_UUID, "0"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for negative customer ID", async () => {
+    const { DELETE } = await import(
+      "@/app/api/accounts/[id]/customers/[customerId]/route"
+    );
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers/-1`,
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext(TARGET_UUID, "-1"));
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/__tests__/app/api/accounts/[id]/customers/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/customers/route.test.ts
@@ -1,0 +1,665 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockGetAccountCustomerIds = vi.hoisted(() => vi.fn());
+const mockWithTransaction = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/customer-scope", () => ({
+  getAccountCustomerIds: vi.fn((...args: unknown[]) =>
+    mockGetAccountCustomerIds(...args),
+  ),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+  withTransaction: vi.fn((...args: unknown[]) => mockWithTransaction(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const now = Math.floor(Date.now() / 1000);
+
+const VALID_UUID = "00000000-0000-0000-0000-000000000001";
+const TARGET_UUID = "00000000-0000-0000-0000-000000000002";
+
+const adminSession: AuthSession = {
+  accountId: VALID_UUID,
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const tenantAdminSession: AuthSession = {
+  ...adminSession,
+  accountId: "00000000-0000-0000-0000-000000000003",
+  roles: ["Tenant Administrator"],
+};
+
+function makeContext(id = TARGET_UUID) {
+  return { params: Promise.resolve({ id }) };
+}
+
+// ── GET /api/accounts/[id]/customers ────────────────────────────
+
+describe("GET /api/accounts/[id]/customers", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetAccountCustomerIds.mockReset();
+  });
+
+  it("returns customer assignments for System Administrator", async () => {
+    // SELECT account exists
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: TARGET_UUID }] })
+      // SELECT assignments
+      .mockResolvedValueOnce({
+        rows: [
+          { customer_id: 1, customer_name: "Acme Corp" },
+          { customer_id: 2, customer_name: "Beta Inc" },
+        ],
+      });
+
+    const { GET } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+    );
+    const response = await GET(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].customer_name).toBe("Acme Corp");
+  });
+
+  it("scopes by tenant for Tenant Administrator", async () => {
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Account exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: TARGET_UUID }] });
+
+    // Caller has customers [1, 2], target has [2, 3] → overlap on 2
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller
+      .mockResolvedValueOnce([2, 3]); // target
+
+    // Assignments query
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ customer_id: 2, customer_name: "Beta Inc" }],
+    });
+
+    const { GET } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+    );
+    const response = await GET(request, makeContext());
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 when Tenant Admin has no overlap", async () => {
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: TARGET_UUID }] });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller
+      .mockResolvedValueOnce([3, 4]); // target — no overlap
+
+    const { GET } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+    );
+    const response = await GET(request, makeContext());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when account does not exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { GET } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+    );
+    const response = await GET(request, makeContext());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for invalid UUID", async () => {
+    const { GET } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/accounts/not-a-uuid/customers",
+    );
+    const response = await GET(request, makeContext("not-a-uuid"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 403 without accounts:read permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { GET } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+    );
+    const response = await GET(request, makeContext());
+
+    expect(response.status).toBe(403);
+  });
+});
+
+// ── POST /api/accounts/[id]/customers ───────────────────────────
+
+describe("POST /api/accounts/[id]/customers", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetAccountCustomerIds.mockReset();
+    mockWithTransaction.mockReset();
+  });
+
+  it("assigns customers as System Administrator", async () => {
+    // Account exists with role
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+    });
+    // Customers exist
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1 }, { id: 2 }],
+    });
+
+    // withTransaction executes the callback
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: unknown) => unknown) => {
+        const mockClient = {
+          query: vi.fn().mockResolvedValue({ rows: [] }),
+        };
+        return fn(mockClient);
+      },
+    );
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1, 2] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.assigned).toEqual([1, 2]);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.assign",
+        target: "account",
+        targetId: TARGET_UUID,
+      }),
+    );
+  });
+
+  it("returns 403 when Tenant Admin assigns out-of-scope customer", async () => {
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Account exists
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+    });
+    // Customers exist
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1 }, { id: 5 }],
+    });
+    // Caller only has customer 1
+    mockGetAccountCustomerIds.mockResolvedValue([1]);
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1, 5] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 when Security Monitor would exceed single customer", async () => {
+    // Account exists as Security Monitor
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+    });
+    // Customers exist
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1 }, { id: 2 }],
+    });
+
+    // withTransaction: already has 0 assignments, but trying to add 2
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: unknown) => unknown) => {
+        const mockClient = {
+          query: vi
+            .fn()
+            .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // COUNT
+            .mockResolvedValueOnce({ rows: [] }), // SELECT existing
+        };
+        return fn(mockClient);
+      },
+    );
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1, 2] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("single customer");
+  });
+
+  it("returns 400 when customerIds is missing", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({}),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when customerIds is empty", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 when account does not exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when a customer does not exist", async () => {
+    // Account exists
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+    });
+    // Only customer 1 found out of [1, 999]
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1 }],
+    });
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1, 999] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("999");
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: "not json",
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 403 without accounts:write permission", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for invalid UUID", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/accounts/not-a-uuid/customers",
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1] }),
+      },
+    );
+    const response = await POST(request, makeContext("not-a-uuid"));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("assigns customer as Tenant Admin within scope", async () => {
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Account exists
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+    });
+    // Customer exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+    // Caller has customer 1 in their scope
+    mockGetAccountCustomerIds.mockResolvedValue([1, 2]);
+
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: unknown) => unknown) => {
+        const mockClient = {
+          query: vi.fn().mockResolvedValue({ rows: [] }),
+        };
+        return fn(mockClient);
+      },
+    );
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.assigned).toEqual([1]);
+  });
+
+  it("deduplicates customerIds", async () => {
+    // Account exists
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+    });
+    // Only unique IDs should be checked — [1, 2] not [1, 2, 1, 2]
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }] });
+
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: unknown) => unknown) => {
+        const mockClient = {
+          query: vi.fn().mockResolvedValue({ rows: [] }),
+        };
+        return fn(mockClient);
+      },
+    );
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1, 2, 1, 2] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.assigned).toEqual([1, 2]);
+  });
+
+  it("returns 400 when Security Monitor already has 1 customer and adds another", async () => {
+    // Account exists as Security Monitor
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+    });
+    // Customer exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 2 }] });
+
+    // Already has 1 assignment, trying to add 1 new one → total 2 > 1
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: unknown) => unknown) => {
+        const mockClient = {
+          query: vi
+            .fn()
+            .mockResolvedValueOnce({ rows: [{ count: "1" }] }) // COUNT existing
+            .mockResolvedValueOnce({ rows: [] }), // SELECT already assigned (none of requested)
+        };
+        return fn(mockClient);
+      },
+    );
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [2] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("single customer");
+  });
+
+  it("allows Security Monitor to re-assign already assigned customer (idempotent)", async () => {
+    // Account exists as Security Monitor
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+    });
+    // Customer exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+    // Already has 1 assignment, but the requested ID is the same one → no new IDs
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: unknown) => unknown) => {
+        const mockClient = {
+          query: vi
+            .fn()
+            .mockResolvedValueOnce({ rows: [{ count: "1" }] }) // COUNT existing
+            .mockResolvedValueOnce({ rows: [{ customer_id: 1 }] }) // already assigned
+            .mockResolvedValueOnce({ rows: [] }), // INSERT ON CONFLICT DO NOTHING
+        };
+        return fn(mockClient);
+      },
+    );
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 400 when customerIds contains zero", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [0] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when customerIds contains non-integers", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [1.5] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when customerIds contains negative numbers", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: [-1] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when customerIds contains strings", async () => {
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        body: JSON.stringify({ customerIds: ["abc"] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/__tests__/app/api/customers/[id]/route.test.ts
+++ b/src/__tests__/app/api/customers/[id]/route.test.ts
@@ -214,6 +214,29 @@ describe("PATCH /api/customers/[id]", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 404 when Tenant Admin updates customer outside their scope", async () => {
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Customer exists, but no account_customer link
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 }) // SELECT customer
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // SELECT account_customer
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "New Name" }),
+    });
+    const response = await PATCH(request, makeContext());
+
+    expect(response.status).toBe(404);
+  });
+
   it("returns existing customer when no fields to update", async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [sampleCustomer],

--- a/src/__tests__/lib/auth/customer-scope.test.ts
+++ b/src/__tests__/lib/auth/customer-scope.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+describe("getAccountCustomerIds", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns assigned customer IDs in order", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ customer_id: 2 }, { customer_id: 5 }, { customer_id: 10 }],
+    });
+
+    const { getAccountCustomerIds } = await import("@/lib/auth/customer-scope");
+    const result = await getAccountCustomerIds("account-1");
+
+    expect(result).toEqual([2, 5, 10]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("account_customer"),
+      ["account-1"],
+    );
+  });
+
+  it("returns empty array for unassigned account", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const { getAccountCustomerIds } = await import("@/lib/auth/customer-scope");
+    const result = await getAccountCustomerIds("account-2");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("resolveEffectiveCustomerIds", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockHasPermission.mockReset();
+  });
+
+  it("returns undefined when account has customers:access-all", async () => {
+    mockHasPermission.mockResolvedValue(true);
+
+    const { resolveEffectiveCustomerIds } = await import(
+      "@/lib/auth/customer-scope"
+    );
+    const result = await resolveEffectiveCustomerIds("account-1", [
+      "System Administrator",
+    ]);
+
+    expect(result).toBeUndefined();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns customer IDs when account lacks customers:access-all", async () => {
+    mockHasPermission.mockResolvedValue(false);
+    mockQuery.mockResolvedValue({
+      rows: [{ customer_id: 3 }, { customer_id: 7 }],
+    });
+
+    const { resolveEffectiveCustomerIds } = await import(
+      "@/lib/auth/customer-scope"
+    );
+    const result = await resolveEffectiveCustomerIds("account-1", [
+      "Tenant Administrator",
+    ]);
+
+    expect(result).toEqual([3, 7]);
+  });
+});

--- a/src/app/api/accounts/[id]/customers/[customerId]/route.ts
+++ b/src/app/api/accounts/[id]/customers/[customerId]/route.ts
@@ -1,0 +1,100 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ── Route Handler ───────────────────────────────────────────────
+
+/**
+ * DELETE /api/accounts/[id]/customers/[customerId]
+ *
+ * Remove a customer assignment from an account.
+ *
+ * Access scope rules:
+ * - System Administrator: can remove any assignment.
+ * - Tenant Administrator: can only remove assignments for customers
+ *   within their own set.
+ *
+ * Requires `accounts:write` permission.
+ */
+export const DELETE = withAuth(
+  async (request, context, session) => {
+    const { id: accountId, customerId: customerIdParam } = await context.params;
+
+    if (!UUID_RE.test(accountId)) {
+      return NextResponse.json(
+        { error: "Invalid account ID" },
+        { status: 400 },
+      );
+    }
+
+    const customerId = Number(customerIdParam);
+    if (!Number.isFinite(customerId) || customerId <= 0) {
+      return NextResponse.json(
+        { error: "Invalid customer ID" },
+        { status: 400 },
+      );
+    }
+
+    // Verify assignment exists
+    const { rows } = await query<{
+      account_id: string;
+      customer_id: number;
+    }>(
+      "SELECT account_id, customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+      [accountId, customerId],
+    );
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Assignment not found" },
+        { status: 404 },
+      );
+    }
+
+    // Tenant scope: Tenant Admin can only unassign their own customers
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!accessAll) {
+      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
+      if (!callerCustomerIds.includes(customerId)) {
+        return NextResponse.json(
+          { error: "Cannot unassign customers outside your scope" },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Remove assignment
+    await query(
+      "DELETE FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+      [accountId, customerId],
+    );
+
+    // Audit
+    await auditLog.record({
+      actor: session.accountId,
+      action: "customer.unassign",
+      target: "account",
+      targetId: accountId,
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { customerId },
+    });
+
+    return NextResponse.json({ success: true });
+  },
+  { requiredPermissions: ["accounts:write"] },
+);

--- a/src/app/api/accounts/[id]/customers/route.ts
+++ b/src/app/api/accounts/[id]/customers/route.ts
@@ -1,0 +1,245 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query, withTransaction } from "@/lib/db/client";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ── Route Handlers ──────────────────────────────────────────────
+
+/**
+ * GET /api/accounts/[id]/customers
+ *
+ * List customer assignments for an account.
+ *
+ * Tenant Administrator can only view accounts that share at least one
+ * customer with them.  System Administrator is unrestricted.
+ *
+ * Requires `accounts:read` permission.
+ */
+export const GET = withAuth(
+  async (_request, context, session) => {
+    const { id: accountId } = await context.params;
+    if (!UUID_RE.test(accountId)) {
+      return NextResponse.json(
+        { error: "Invalid account ID" },
+        { status: 400 },
+      );
+    }
+
+    // Verify account exists
+    const { rows: accountRows } = await query<{ id: string }>(
+      "SELECT id FROM accounts WHERE id = $1",
+      [accountId],
+    );
+    if (accountRows.length === 0) {
+      return NextResponse.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    // Tenant scope check
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!accessAll) {
+      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
+      const targetCustomerIds = await getAccountCustomerIds(accountId);
+      const overlap = targetCustomerIds.some((id) =>
+        callerCustomerIds.includes(id),
+      );
+      if (!overlap) {
+        return NextResponse.json(
+          { error: "Account not found" },
+          { status: 404 },
+        );
+      }
+    }
+
+    // Fetch assignments
+    const { rows } = await query<{
+      customer_id: number;
+      customer_name: string;
+    }>(
+      `SELECT ac.customer_id, c.name AS customer_name
+       FROM account_customer ac
+       JOIN customers c ON c.id = ac.customer_id
+       WHERE ac.account_id = $1
+       ORDER BY ac.customer_id`,
+      [accountId],
+    );
+
+    return NextResponse.json({ data: rows });
+  },
+  { requiredPermissions: ["accounts:read"] },
+);
+
+/**
+ * POST /api/accounts/[id]/customers
+ *
+ * Assign one or more customers to an account.
+ *
+ * Body: `{ customerIds: number[] }`
+ *
+ * Access scope rules:
+ * - System Administrator: can assign any customer.
+ * - Tenant Administrator: can only assign customers within their own set.
+ *
+ * Security Monitor accounts are restricted to a single customer.
+ *
+ * Requires `accounts:write` permission.
+ */
+export const POST = withAuth(
+  async (request, context, session) => {
+    const { id: accountId } = await context.params;
+    if (!UUID_RE.test(accountId)) {
+      return NextResponse.json(
+        { error: "Invalid account ID" },
+        { status: 400 },
+      );
+    }
+
+    // Parse body
+    let customerIds: number[];
+    try {
+      const body = await request.json();
+      customerIds = body.customerIds;
+      if (
+        !Array.isArray(customerIds) ||
+        customerIds.length === 0 ||
+        !customerIds.every(
+          (id) => typeof id === "number" && Number.isInteger(id) && id > 0,
+        )
+      ) {
+        return NextResponse.json(
+          {
+            error: "customerIds must be a non-empty array of positive integers",
+          },
+          { status: 400 },
+        );
+      }
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // Deduplicate
+    const uniqueIds = [...new Set(customerIds)];
+
+    // Verify account exists and get its role
+    const { rows: accountRows } = await query<{
+      id: string;
+      role_name: string;
+    }>(
+      `SELECT a.id, r.name AS role_name
+       FROM accounts a JOIN roles r ON a.role_id = r.id
+       WHERE a.id = $1`,
+      [accountId],
+    );
+    if (accountRows.length === 0) {
+      return NextResponse.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    // Verify all customer IDs exist
+    const { rows: existingCustomers } = await query<{ id: number }>(
+      `SELECT id FROM customers WHERE id = ANY($1)`,
+      [uniqueIds],
+    );
+    if (existingCustomers.length !== uniqueIds.length) {
+      const found = new Set(existingCustomers.map((r) => r.id));
+      const missing = uniqueIds.filter((id) => !found.has(id));
+      return NextResponse.json(
+        { error: `Customers not found: ${missing.join(", ")}` },
+        { status: 400 },
+      );
+    }
+
+    // Tenant scope: Tenant Admin can only assign their own customers
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!accessAll) {
+      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
+      const callerSet = new Set(callerCustomerIds);
+      const outOfScope = uniqueIds.filter((id) => !callerSet.has(id));
+      if (outOfScope.length > 0) {
+        return NextResponse.json(
+          { error: "Cannot assign customers outside your scope" },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Security Monitor: restricted to a single customer
+    const targetRole = accountRows[0].role_name;
+    const assigned = await withTransaction(async (client) => {
+      if (targetRole === "Security Monitor") {
+        const { rows: countRows } = await client.query<{ count: string }>(
+          "SELECT COUNT(*)::text AS count FROM account_customer WHERE account_id = $1",
+          [accountId],
+        );
+        const existingCount = Number.parseInt(countRows[0].count, 10);
+
+        // Count how many of the requested IDs are genuinely new
+        const { rows: alreadyRows } = await client.query<{
+          customer_id: number;
+        }>(
+          "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = ANY($2)",
+          [accountId, uniqueIds],
+        );
+        const alreadySet = new Set(alreadyRows.map((r) => r.customer_id));
+        const newIds = uniqueIds.filter((id) => !alreadySet.has(id));
+
+        if (existingCount + newIds.length > 1) {
+          return null; // signal constraint violation
+        }
+      }
+
+      // Insert assignments
+      const insertValues = uniqueIds
+        .map((_, i) => `($1, $${i + 2})`)
+        .join(", ");
+      const insertParams: (string | number)[] = [accountId, ...uniqueIds];
+      await client.query(
+        `INSERT INTO account_customer (account_id, customer_id)
+         VALUES ${insertValues}
+         ON CONFLICT DO NOTHING`,
+        insertParams,
+      );
+
+      return uniqueIds;
+    });
+
+    if (assigned === null) {
+      return NextResponse.json(
+        {
+          error:
+            "Security Monitor accounts can only be assigned to a single customer",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Audit
+    await auditLog.record({
+      actor: session.accountId,
+      action: "customer.assign",
+      target: "account",
+      targetId: accountId,
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { customerIds: assigned },
+    });
+
+    return NextResponse.json({ success: true, assigned }, { status: 201 });
+  },
+  { requiredPermissions: ["accounts:write"] },
+);

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -45,6 +45,8 @@ const ALLOWED_ACTIONS = new Set([
   "customer.create",
   "customer.update",
   "customer.delete",
+  "customer.assign",
+  "customer.unassign",
 ]);
 
 const ALLOWED_TARGET_TYPES = new Set(["account", "session", "customer"]);

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -129,6 +129,24 @@ export const PATCH = withAuth(
       );
     }
 
+    // Tenant scope check
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!accessAll) {
+      const { rows: linkRows } = await query<{ customer_id: number }>(
+        "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+        [session.accountId, customerId],
+      );
+      if (linkRows.length === 0) {
+        return NextResponse.json(
+          { error: "Customer not found" },
+          { status: 404 },
+        );
+      }
+    }
+
     // Build update
     const updates: string[] = [];
     const params: unknown[] = [];

--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -71,6 +71,8 @@ const ACTION_KEYS = [
   "customer.create",
   "customer.update",
   "customer.delete",
+  "customer.assign",
+  "customer.unassign",
 ] as const;
 
 const TARGET_TYPE_KEYS = ["account", "session", "customer"] as const;

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -99,7 +99,9 @@
       "password_reset": "Password reset",
       "customer_create": "Customer create",
       "customer_update": "Customer update",
-      "customer_delete": "Customer delete"
+      "customer_delete": "Customer delete",
+      "customer_assign": "Customer assign",
+      "customer_unassign": "Customer unassign"
     },
     "targetTypes": {
       "account": "Account",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -99,7 +99,9 @@
       "password_reset": "비밀번호 초기화",
       "customer_create": "고객 생성",
       "customer_update": "고객 수정",
-      "customer_delete": "고객 삭제"
+      "customer_delete": "고객 삭제",
+      "customer_assign": "고객 할당",
+      "customer_unassign": "고객 할당 해제"
     },
     "targetTypes": {
       "account": "계정",

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -86,7 +86,12 @@ type AccountAction =
 type PasswordAction = "password.change" | "password.reset";
 
 /** Customer event actions. */
-type CustomerAction = "customer.create" | "customer.update" | "customer.delete";
+type CustomerAction =
+  | "customer.create"
+  | "customer.update"
+  | "customer.delete"
+  | "customer.assign"
+  | "customer.unassign";
 
 /** All audit event actions. */
 export type AuditAction =

--- a/src/lib/auth/customer-scope.ts
+++ b/src/lib/auth/customer-scope.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { query } from "@/lib/db/client";
+
+import { hasPermission } from "./permissions";
+
+/**
+ * Return all customer IDs assigned to the given account via
+ * `account_customer`.  Returns an empty array if none.
+ */
+export async function getAccountCustomerIds(
+  accountId: string,
+): Promise<number[]> {
+  const { rows } = await query<{ customer_id: number }>(
+    "SELECT customer_id FROM account_customer WHERE account_id = $1 ORDER BY customer_id",
+    [accountId],
+  );
+  return rows.map((r) => r.customer_id);
+}
+
+/**
+ * Resolve the effective customer IDs for a session.
+ *
+ * - If the session holds `customers:access-all`, returns `undefined`
+ *   (meaning unrestricted access to all customers).
+ * - Otherwise returns the array of assigned customer IDs.
+ */
+export async function resolveEffectiveCustomerIds(
+  accountId: string,
+  roles: string[],
+): Promise<number[] | undefined> {
+  const accessAll = await hasPermission(roles, "customers:access-all");
+  if (accessAll) return undefined;
+  return getAccountCustomerIds(accountId);
+}


### PR DESCRIPTION
## Summary
- Account-customer assignment API (POST/GET/DELETE) with tenant-scoped access enforcement
- Security Monitor restricted to single customer assignment
- Context JWT enrichment via `resolveEffectiveCustomerIds` → `signContextJwt` pipeline
- PATCH `/api/customers/[id]` tenant scope check added
- Audit logging for `customer.assign` / `customer.unassign` with i18n (en, ko)
- 48 unit tests + 14 E2E tests covering assignments, validation, tenant scope, and audit

Items #5 (System Admin accounts don't require customer assignment) and #6 (non-SysAdmin creation without customer assignment rejected) are deferred to #99 — the account creation API does not exist yet.

Closes #98

## Test plan
- [x] `pnpm vitest run` — 657 unit tests pass (48 in account-customer test files)
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check` — no lint/format errors
- [x] `pnpm build` — build succeeds
- [x] Existing 67 E2E tests pass without regression
- [x] 14 new E2E tests pass (account-customer assignments)
- [x] API endpoints verified via preview server (assign, list, unassign, validation)