### PR TITLE
Add per-account locale and timezone preferences

### DIFF
--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -497,6 +497,22 @@ export async function getCustomerIdByName(
   }
 }
 
+/**
+ * Reset locale and timezone preferences for an account.
+ */
+export async function resetAccountPreferences(username: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET locale = NULL, timezone = NULL WHERE username = $1",
+      [username],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
 function escapeIdentifier(str: string): string {
   return `"${str.replace(/"/g, '""')}"`;
 }

--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -290,7 +290,7 @@ test.describe("Preferences", () => {
 
     await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
     await expect(page.getByText("Language")).toBeVisible();
-    await expect(page.getByText("Timezone")).toBeVisible();
+    await expect(page.getByLabel("Timezone")).toBeVisible();
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
   });
 
@@ -330,9 +330,11 @@ test.describe("Preferences", () => {
 
     // After router.refresh(), the page should switch to Korean
     // Wait for Korean labels to appear
-    await expect(page.getByText("프로필")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("언어")).toBeVisible();
-    await expect(page.getByText("시간대")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "프로필" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByLabel("언어")).toBeVisible();
+    await expect(page.getByLabel("시간대")).toBeVisible();
   });
 
   test("locale change persists after page reload", async ({ page }) => {

--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -1,0 +1,425 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "@playwright/test";
+import pg from "pg";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import {
+  clearMustChangePassword,
+  resetAccountDefaults,
+  resetAccountPreferences,
+  revokeAllSessions,
+} from "./helpers/setup-db";
+
+// ── DB helpers ────────────────────────────────────────────────
+
+function getDatabaseUrl(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  try {
+    const envFile = readFileSync(resolve(__dirname, "../.env.local"), "utf8");
+    const match = envFile.match(/^DATABASE_URL=(.+)$/m);
+    if (match) return match[1].trim();
+  } catch {
+    // .env.local not found
+  }
+  return "postgres://postgres:postgres@localhost:5432/auth_db";
+}
+
+async function setAccountLocale(
+  username: string,
+  locale: string,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: getDatabaseUrl() });
+  await client.connect();
+  try {
+    await client.query("UPDATE accounts SET locale = $2 WHERE username = $1", [
+      username,
+      locale,
+    ]);
+  } finally {
+    await client.end();
+  }
+}
+
+async function setAccountTimezone(
+  username: string,
+  timezone: string,
+): Promise<void> {
+  const client = new pg.Client({ connectionString: getDatabaseUrl() });
+  await client.connect();
+  try {
+    await client.query(
+      "UPDATE accounts SET timezone = $2 WHERE username = $1",
+      [username, timezone],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+test.describe("Preferences", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await clearMustChangePassword(ADMIN_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountPreferences(ADMIN_USERNAME);
+  });
+
+  test.beforeEach(async () => {
+    await resetRateLimits();
+    await revokeAllSessions(ADMIN_USERNAME);
+    await resetAccountPreferences(ADMIN_USERNAME);
+  });
+
+  // ── API tests ─────────────────────────────────────────────────
+
+  test("GET returns null when preferences are not set", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const res = await page.request.get("/api/accounts/me/preferences");
+    expect(res.status()).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.locale).toBeNull();
+    expect(body.data.timezone).toBeNull();
+  });
+
+  test("PATCH sets locale and NEXT_LOCALE cookie", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const res = await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: "ko" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.data.locale).toBe("ko");
+
+    // Verify NEXT_LOCALE cookie is set
+    const updatedCookies = await page.context().cookies();
+    const localeCookie = updatedCookies.find((c) => c.name === "NEXT_LOCALE");
+    expect(localeCookie).toBeDefined();
+    expect(localeCookie?.value).toBe("ko");
+  });
+
+  test("PATCH sets timezone", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const res = await page.request.patch("/api/accounts/me/preferences", {
+      data: { timezone: "Asia/Seoul" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.data.timezone).toBe("Asia/Seoul");
+  });
+
+  test("PATCH sets both locale and timezone simultaneously", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const res = await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: "ko", timezone: "Asia/Seoul" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.data.locale).toBe("ko");
+    expect(body.data.timezone).toBe("Asia/Seoul");
+  });
+
+  test("PATCH rejects invalid locale", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const res = await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: "xx" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(res.status()).toBe(400);
+  });
+
+  test("PATCH rejects invalid timezone", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const res = await page.request.patch("/api/accounts/me/preferences", {
+      data: { timezone: "Not/A/Zone" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(res.status()).toBe(400);
+  });
+
+  test("PATCH null locale deletes NEXT_LOCALE cookie", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // First set locale
+    await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: "ko" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    // Then clear it
+    const res = await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: null },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(res.status()).toBe(200);
+    expect((await res.json()).data.locale).toBeNull();
+
+    // NEXT_LOCALE cookie should be deleted
+    const updatedCookies = await page.context().cookies();
+    const localeCookie = updatedCookies.find((c) => c.name === "NEXT_LOCALE");
+    expect(localeCookie).toBeUndefined();
+  });
+
+  test("GET returns updated values after PATCH", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // Set preferences
+    await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: "ko", timezone: "America/New_York" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    // Read them back
+    const res = await page.request.get("/api/accounts/me/preferences");
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.data.locale).toBe("ko");
+    expect(body.data.timezone).toBe("America/New_York");
+  });
+
+  test("unauthenticated request returns 401", async ({ request }) => {
+    const res = await request.get(
+      "http://localhost:3000/api/accounts/me/preferences",
+    );
+    // withAuth redirects or returns 401/403
+    expect([401, 403, 302]).toContain(res.status());
+  });
+
+  // ── Sign-in locale cookie ────────────────────────────────────
+
+  test("sign-in sets NEXT_LOCALE cookie when account has stored locale", async ({
+    page,
+  }) => {
+    await setAccountLocale(ADMIN_USERNAME, "ko");
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const localeCookie = cookies.find((c) => c.name === "NEXT_LOCALE");
+    expect(localeCookie).toBeDefined();
+    expect(localeCookie?.value).toBe("ko");
+  });
+
+  test("sign-in does not set NEXT_LOCALE cookie when locale is null", async ({
+    page,
+  }) => {
+    await resetAccountPreferences(ADMIN_USERNAME);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const localeCookie = cookies.find((c) => c.name === "NEXT_LOCALE");
+    expect(localeCookie).toBeUndefined();
+  });
+
+  // ── UI tests ──────────────────────────────────────────────────
+
+  test("profile page shows preferences form", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/profile");
+
+    await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
+    await expect(page.getByText("Language")).toBeVisible();
+    await expect(page.getByText("Timezone")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
+  });
+
+  test("profile page displays stored preferences on load", async ({ page }) => {
+    // Pre-set preferences in DB
+    await setAccountLocale(ADMIN_USERNAME, "ko");
+    await setAccountTimezone(ADMIN_USERNAME, "Asia/Seoul");
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/profile");
+
+    // Form should show stored values
+    await expect(page.getByRole("combobox").first()).toHaveText("한국어", {
+      timeout: 5_000,
+    });
+  });
+
+  test("locale change via UI switches page language to Korean", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/profile");
+
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
+
+    // Select Korean locale
+    await page.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: "한국어" }).click();
+
+    // Save
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Wait for success message
+    await expect(page.getByText("Preferences saved")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // After router.refresh(), the page should switch to Korean
+    // Wait for Korean labels to appear
+    await expect(page.getByText("프로필")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("언어")).toBeVisible();
+    await expect(page.getByText("시간대")).toBeVisible();
+  });
+
+  test("locale change persists after page reload", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // Set Korean via API
+    await page.request.patch("/api/accounts/me/preferences", {
+      data: { locale: "ko" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    // Reload the profile page
+    await page.goto("/profile");
+
+    // Should still show Korean
+    await expect(page.getByRole("combobox").first()).toHaveText("한국어", {
+      timeout: 5_000,
+    });
+  });
+
+  test("timezone preference persists after page reload", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // Set timezone via API
+    await page.request.patch("/api/accounts/me/preferences", {
+      data: { timezone: "America/New_York" },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    // Verify via GET
+    const res = await page.request.get("/api/accounts/me/preferences");
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.data.timezone).toBe("America/New_York");
+  });
+
+  // ── Timezone display integration ────────────────────────────────
+
+  test("audit log timestamps reflect timezone preference", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+    const csrfHeader = {
+      "x-csrf-token": csrfCookie?.value ?? "",
+      Origin: "http://localhost:3000",
+    };
+
+    // Set timezone to America/New_York and load audit logs
+    await page.request.patch("/api/accounts/me/preferences", {
+      data: { timezone: "America/New_York" },
+      headers: csrfHeader,
+    });
+    await page.goto("/audit-logs");
+
+    // Wait for the table to render and capture the first timestamp
+    const firstTimestamp = page.locator(
+      "table tbody tr:first-child td:first-child",
+    );
+    await expect(firstTimestamp).toBeVisible({ timeout: 10_000 });
+    const timestampNY = await firstTimestamp.textContent();
+
+    // Switch to Asia/Seoul (16–17 hours ahead of NY)
+    await page.request.patch("/api/accounts/me/preferences", {
+      data: { timezone: "Asia/Seoul" },
+      headers: csrfHeader,
+    });
+    await page.reload();
+
+    await expect(firstTimestamp).toBeVisible({ timeout: 10_000 });
+    const timestampSeoul = await firstTimestamp.textContent();
+
+    // The same underlying UTC timestamp should display differently
+    expect(timestampNY).toBeTruthy();
+    expect(timestampSeoul).toBeTruthy();
+    expect(timestampNY).not.toBe(timestampSeoul);
+  });
+});

--- a/src/__tests__/app/api/accounts/me/preferences/route.test.ts
+++ b/src/__tests__/app/api/accounts/me/preferences/route.test.ts
@@ -1,0 +1,340 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockCookiesSet = vi.hoisted(() => vi.fn());
+const mockCookiesDelete = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() =>
+    Promise.resolve({
+      set: mockCookiesSet,
+      delete: mockCookiesDelete,
+    }),
+  ),
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  routing: {
+    locales: ["en", "ko"],
+    defaultLocale: "en",
+  },
+}));
+
+const defaultSession: AuthSession = {
+  accountId: "00000000-0000-0000-0000-000000000001",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: Math.floor(Date.now() / 1000),
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "test",
+  sessionBrowserFingerprint: "test",
+  needsReauth: false,
+};
+
+const emptyContext = { params: Promise.resolve({}) };
+
+describe("GET /api/accounts/me/preferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSession = { ...defaultSession };
+  });
+
+  it("returns stored locale and timezone", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: "ko", timezone: "Asia/Seoul" }],
+    });
+
+    const { GET } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await GET(
+      new NextRequest("http://localhost/api/accounts/me/preferences"),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.locale).toBe("ko");
+    expect(body.data.timezone).toBe("Asia/Seoul");
+  });
+
+  it("returns null when preferences are not set", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: null, timezone: null }],
+    });
+
+    const { GET } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await GET(
+      new NextRequest("http://localhost/api/accounts/me/preferences"),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.locale).toBeNull();
+    expect(body.data.timezone).toBeNull();
+  });
+
+  it("returns 404 when account not found", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { GET } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await GET(
+      new NextRequest("http://localhost/api/accounts/me/preferences"),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/accounts/me/preferences", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSession = { ...defaultSession };
+  });
+
+  it("updates locale and sets NEXT_LOCALE cookie", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: "ko", timezone: null }],
+    });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: "ko" }),
+      }),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.locale).toBe("ko");
+    expect(mockCookiesSet).toHaveBeenCalledWith("NEXT_LOCALE", "ko", {
+      path: "/",
+      maxAge: 365 * 24 * 60 * 60,
+    });
+  });
+
+  it("updates timezone", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: null, timezone: "America/New_York" }],
+    });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ timezone: "America/New_York" }),
+      }),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.timezone).toBe("America/New_York");
+  });
+
+  it("rejects invalid locale", async () => {
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: "fr" }),
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("Invalid locale");
+  });
+
+  it("rejects invalid timezone", async () => {
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ timezone: "Invalid/Zone" }),
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid timezone");
+  });
+
+  it("allows null locale and deletes NEXT_LOCALE cookie", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: null, timezone: null }],
+    });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: null }),
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCookiesDelete).toHaveBeenCalledWith("NEXT_LOCALE");
+  });
+
+  it("allows null timezone", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: null, timezone: null }],
+    });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ timezone: null }),
+      }),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.timezone).toBeNull();
+  });
+
+  it("returns current preferences when no fields provided", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: "en", timezone: "UTC" }],
+    });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({}),
+      }),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.locale).toBe("en");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: "not-json",
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-string locale type", async () => {
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: 123 }),
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("locale must be a string or null");
+  });
+
+  it("rejects non-string timezone type", async () => {
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ timezone: 123 }),
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("timezone must be a string or null");
+  });
+
+  it("updates both locale and timezone simultaneously", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ locale: "ko", timezone: "Asia/Seoul" }],
+    });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: "ko", timezone: "Asia/Seoul" }),
+      }),
+      emptyContext,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.locale).toBe("ko");
+    expect(body.data.timezone).toBe("Asia/Seoul");
+    expect(mockCookiesSet).toHaveBeenCalledWith("NEXT_LOCALE", "ko", {
+      path: "/",
+      maxAge: 365 * 24 * 60 * 60,
+    });
+    // Verify SQL includes both columns
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("locale"),
+      expect.arrayContaining(["ko", "Asia/Seoul"]),
+    );
+  });
+
+  it("returns 404 when account not found during update", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const { PATCH } = await import("@/app/api/accounts/me/preferences/route");
+    const res = await PATCH(
+      new NextRequest("http://localhost/api/accounts/me/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ locale: "en" }),
+      }),
+      emptyContext,
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/__tests__/app/api/auth/sign-in/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-in/route.test.ts
@@ -85,6 +85,7 @@ const activeAccount = {
   max_sessions: null,
   allowed_ips: null,
   role_name: "System Administrator",
+  locale: null,
 };
 
 const lockoutPolicy = {
@@ -713,6 +714,55 @@ describe("POST /api/auth/sign-in", () => {
         "corr-id-1",
         expect.any(Function),
       );
+    });
+
+    it("sets NEXT_LOCALE cookie when account has stored locale", async () => {
+      mockQuery.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM accounts")) {
+          return {
+            rows: [{ ...activeAccount, locale: "ko" }],
+            rowCount: 1,
+          };
+        }
+        if (sql.includes("system_settings") && sql.includes("lockout_policy")) {
+          return { rows: [lockoutPolicy], rowCount: 1 };
+        }
+        if (sql.includes("system_settings") && sql.includes("session_policy")) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (sql.includes("COUNT(*)")) {
+          return { rows: [{ count: "0" }], rowCount: 1 };
+        }
+        if (sql.includes("INSERT INTO sessions")) {
+          return { rows: [{ sid: "sess-1" }], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      const res = await POST(
+        makeRequest({ username: "admin", password: "pass" }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockCookieSet).toHaveBeenCalledWith("NEXT_LOCALE", "ko", {
+        path: "/",
+        maxAge: 365 * 24 * 60 * 60,
+      });
+    });
+
+    it("does not set NEXT_LOCALE cookie when locale is null", async () => {
+      const { POST } = await import("@/app/api/auth/sign-in/route");
+      const res = await POST(
+        makeRequest({ username: "admin", password: "pass" }),
+      );
+
+      expect(res.status).toBe(200);
+      // NEXT_LOCALE should not be set (activeAccount.locale is null)
+      const nextLocaleCalls = mockCookieSet.mock.calls.filter(
+        (call: unknown[]) => call[0] === "NEXT_LOCALE",
+      );
+      expect(nextLocaleCalls).toHaveLength(0);
     });
   });
 });

--- a/src/__tests__/lib/format-date.test.ts
+++ b/src/__tests__/lib/format-date.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDateTime } from "@/lib/format-date";
+
+describe("formatDateTime", () => {
+  // Use a fixed UTC date to avoid locale-dependent output
+  const isoString = "2024-06-15T12:30:45Z";
+  const dateObj = new Date(isoString);
+
+  it("formats an ISO string", () => {
+    const result = formatDateTime(isoString, "UTC");
+    expect(result).toContain("2024");
+    expect(result).toContain("30");
+    expect(result).toContain("45");
+  });
+
+  it("formats a Date object", () => {
+    const result = formatDateTime(dateObj, "UTC");
+    expect(result).toContain("2024");
+    expect(result).toContain("30");
+  });
+
+  it("applies the given timezone", () => {
+    // UTC 12:30 → Asia/Seoul is UTC+9, so 9:30 PM (or 21:30)
+    const seoul = formatDateTime(isoString, "Asia/Seoul");
+    expect(seoul).toContain("9");
+    expect(seoul).toContain("30");
+    // Verify it's not the UTC hour (12)
+    expect(seoul).not.toMatch(/\b12:/);
+
+    // UTC 12:30 → America/New_York is UTC-4 (EDT), so 8:30 AM
+    const ny = formatDateTime(isoString, "America/New_York");
+    expect(ny).toContain("8");
+    expect(ny).toContain("30");
+  });
+
+  it("falls back to runtime default when timezone is null", () => {
+    const result = formatDateTime(isoString, null);
+    // Should not throw and should return a non-empty string
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to runtime default when timezone is undefined", () => {
+    const result = formatDateTime(isoString);
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("includes year, month, day, hour, minute, second", () => {
+    const result = formatDateTime(isoString, "UTC");
+    // 2024-06-15 12:30:45 UTC — check all components are present
+    expect(result).toMatch(/2024/);
+    expect(result).toMatch(/6|06/); // month
+    expect(result).toMatch(/15/); // day
+    expect(result).toMatch(/12/); // hour
+    expect(result).toMatch(/30/); // minute
+    expect(result).toMatch(/45/); // second
+  });
+});

--- a/src/__tests__/lib/timezone.test.ts
+++ b/src/__tests__/lib/timezone.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getTimezones, isValidTimezone } from "@/lib/timezone";
+
+describe("isValidTimezone", () => {
+  it("returns true for valid IANA timezone", () => {
+    expect(isValidTimezone("America/New_York")).toBe(true);
+    expect(isValidTimezone("Asia/Seoul")).toBe(true);
+    expect(isValidTimezone("Europe/Paris")).toBe(true);
+    expect(isValidTimezone("Europe/London")).toBe(true);
+  });
+
+  it("returns false for invalid timezone", () => {
+    expect(isValidTimezone("Invalid/Zone")).toBe(false);
+    expect(isValidTimezone("")).toBe(false);
+    expect(isValidTimezone("Not_A_Timezone")).toBe(false);
+  });
+});
+
+describe("getTimezones", () => {
+  it("returns a non-empty array of timezone strings", () => {
+    const tzs = getTimezones();
+    expect(tzs.length).toBeGreaterThan(0);
+    expect(tzs).toContain("America/New_York");
+    expect(tzs).toContain("Asia/Seoul");
+  });
+});

--- a/src/app/[locale]/(dashboard)/profile/page.tsx
+++ b/src/app/[locale]/(dashboard)/profile/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { PreferencesForm } from "@/components/profile/preferences-form";
+
+export default function ProfilePage() {
+  return (
+    <Suspense>
+      <PreferencesForm />
+    </Suspense>
+  );
+}

--- a/src/app/api/accounts/me/preferences/route.ts
+++ b/src/app/api/accounts/me/preferences/route.ts
@@ -1,0 +1,146 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { routing } from "@/i18n/routing";
+import { withAuth } from "@/lib/auth/guard";
+import { query } from "@/lib/db/client";
+import { isValidTimezone } from "@/lib/timezone";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface PreferencesRow {
+  locale: string | null;
+  timezone: string | null;
+}
+
+// ── Constants ───────────────────────────────────────────────────
+
+const NEXT_LOCALE_COOKIE = "NEXT_LOCALE";
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+// ── Route Handlers ──────────────────────────────────────────────
+
+/**
+ * GET /api/accounts/me/preferences
+ *
+ * Returns the authenticated account's locale and timezone preferences.
+ * No special permission required — self-read only.
+ */
+export const GET = withAuth(async (_request, _context, session) => {
+  const { rows } = await query<PreferencesRow>(
+    "SELECT locale, timezone FROM accounts WHERE id = $1",
+    [session.accountId],
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ data: rows[0] });
+});
+
+/**
+ * PATCH /api/accounts/me/preferences
+ *
+ * Updates the authenticated account's locale and/or timezone.
+ * No special permission required — self-edit only.
+ *
+ * Body: `{ locale?: string | null, timezone?: string | null }`
+ */
+export const PATCH = withAuth(async (request, _context, session) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const updates: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  // Locale validation
+  if (body.locale !== undefined) {
+    if (body.locale === null) {
+      updates.push(`locale = $${idx++}`);
+      params.push(null);
+    } else if (typeof body.locale === "string") {
+      const locales: readonly string[] = routing.locales;
+      if (!locales.includes(body.locale)) {
+        return NextResponse.json(
+          {
+            error: `Invalid locale. Must be one of: ${routing.locales.join(", ")}`,
+          },
+          { status: 400 },
+        );
+      }
+      updates.push(`locale = $${idx++}`);
+      params.push(body.locale);
+    } else {
+      return NextResponse.json(
+        { error: "locale must be a string or null" },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Timezone validation
+  if (body.timezone !== undefined) {
+    if (body.timezone === null) {
+      updates.push(`timezone = $${idx++}`);
+      params.push(null);
+    } else if (typeof body.timezone === "string") {
+      if (!isValidTimezone(body.timezone)) {
+        return NextResponse.json(
+          { error: "Invalid timezone" },
+          { status: 400 },
+        );
+      }
+      updates.push(`timezone = $${idx++}`);
+      params.push(body.timezone);
+    } else {
+      return NextResponse.json(
+        { error: "timezone must be a string or null" },
+        { status: 400 },
+      );
+    }
+  }
+
+  if (updates.length === 0) {
+    // Nothing to update — return current values
+    const { rows } = await query<PreferencesRow>(
+      "SELECT locale, timezone FROM accounts WHERE id = $1",
+      [session.accountId],
+    );
+    return NextResponse.json({ data: rows[0] });
+  }
+
+  updates.push("updated_at = NOW()");
+  params.push(session.accountId);
+
+  const { rows } = await query<PreferencesRow>(
+    `UPDATE accounts SET ${updates.join(", ")} WHERE id = $${idx}
+     RETURNING locale, timezone`,
+    params,
+  );
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  // Set NEXT_LOCALE cookie when locale is updated
+  if (body.locale !== undefined) {
+    const cookieStore = await cookies();
+    if (body.locale === null) {
+      cookieStore.delete(NEXT_LOCALE_COOKIE);
+    } else {
+      cookieStore.set(NEXT_LOCALE_COOKIE, body.locale as string, {
+        path: "/",
+        maxAge: ONE_YEAR_SECONDS,
+      });
+    }
+  }
+
+  return NextResponse.json({ data: rows[0] });
+});

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -55,6 +55,7 @@ interface AccountRow {
   max_sessions: number | null;
   allowed_ips: string[] | null;
   role_name: string;
+  locale: string | null;
 }
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -235,6 +236,7 @@ async function createSessionAndIssueTokens(params: {
   roleName: string;
   tokenVersion: number;
   mustChangePassword: boolean;
+  locale: string | null;
   ip: string;
   userAgent: string;
 }): Promise<NextResponse> {
@@ -243,6 +245,7 @@ async function createSessionAndIssueTokens(params: {
     roleName,
     tokenVersion,
     mustChangePassword,
+    locale,
     ip,
     userAgent,
   } = params;
@@ -292,6 +295,14 @@ async function createSessionAndIssueTokens(params: {
     ...CSRF_COOKIE_OPTIONS,
     maxAge: TOKEN_EXPIRATION_SECONDS,
   });
+
+  // Set NEXT_LOCALE cookie for next-intl locale negotiation
+  if (locale) {
+    cookieStore.set("NEXT_LOCALE", locale, {
+      path: "/",
+      maxAge: 365 * 24 * 60 * 60,
+    });
+  }
 
   // Audit success
   await auditLog.record({
@@ -354,7 +365,7 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
     `SELECT a.id, a.password_hash, a.status, a.token_version,
             a.must_change_password, a.failed_sign_in_count,
             a.lockout_count, a.locked_until, a.max_sessions,
-            a.allowed_ips, r.name AS role_name
+            a.allowed_ips, r.name AS role_name, a.locale
      FROM accounts a
      JOIN roles r ON a.role_id = r.id
      WHERE a.username = $1`,
@@ -440,6 +451,7 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
     roleName: account.role_name,
     tokenVersion: account.token_version,
     mustChangePassword: account.must_change_password,
+    locale: account.locale,
     ip,
     userAgent,
   });

--- a/src/components/accounts/account-table.tsx
+++ b/src/components/accounts/account-table.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 
 import { AccountFormDialog } from "@/components/accounts/account-form-dialog";
+import { useTimezone } from "@/components/providers/timezone-provider";
 import { readCsrfToken } from "@/components/session/session-extension-dialog";
 import {
   AlertDialog,
@@ -34,6 +35,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { formatDateTime } from "@/lib/format-date";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -77,6 +79,7 @@ const STATUS_VARIANT: Record<
 
 export function AccountTable() {
   const t = useTranslations("accounts");
+  const tz = useTimezone();
 
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [total, setTotal] = useState(0);
@@ -322,7 +325,7 @@ export function AccountTable() {
                   </TableCell>
                   <TableCell className="text-muted-foreground text-sm">
                     {account.last_sign_in_at
-                      ? new Date(account.last_sign_in_at).toLocaleString()
+                      ? formatDateTime(account.last_sign_in_at, tz)
                       : t("never")}
                   </TableCell>
                   <TableCell>

--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 
+import { useTimezone } from "@/components/providers/timezone-provider";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -23,6 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { formatDateTime } from "@/lib/format-date";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -92,6 +94,7 @@ export function AuditLogTable() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const tz = useTimezone();
 
   const [result, setResult] = useState<SearchResult | null>(null);
   const [loading, setLoading] = useState(false);
@@ -335,7 +338,7 @@ export function AuditLogTable() {
               {result.data.map((entry) => (
                 <TableRow key={entry.id}>
                   <TableCell className="whitespace-nowrap text-xs">
-                    {new Date(entry.timestamp).toLocaleString()}
+                    {formatDateTime(entry.timestamp, tz)}
                   </TableCell>
                   <TableCell className="text-xs">{entry.actor_id}</TableCell>
                   <TableCell>

--- a/src/components/layout/dashboard-layout.tsx
+++ b/src/components/layout/dashboard-layout.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Breadcrumbs } from "@/components/layout/breadcrumbs";
 import { MobileHeader } from "@/components/layout/mobile-header";
 import { Sidebar } from "@/components/layout/sidebar";
+import { TimezoneProvider } from "@/components/providers/timezone-provider";
 import { useSidebar } from "@/hooks/use-sidebar";
 
 export default function DashboardLayout({
@@ -16,27 +17,29 @@ export default function DashboardLayout({
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <div className="flex h-screen flex-col">
-      {/* Mobile header — visible only below desktop breakpoint */}
-      <MobileHeader open={mobileOpen} onOpenChange={setMobileOpen} />
+    <TimezoneProvider>
+      <div className="flex h-screen flex-col">
+        {/* Mobile header — visible only below desktop breakpoint */}
+        <MobileHeader open={mobileOpen} onOpenChange={setMobileOpen} />
 
-      <div className="flex flex-1 overflow-hidden">
-        {/* Desktop sidebar — hidden below desktop breakpoint */}
-        <div className="hidden desktop:flex">
-          <Sidebar collapsed={collapsed} onToggle={toggle} />
-        </div>
-
-        {/* Main content */}
-        <main className="flex flex-1 flex-col overflow-hidden">
-          {/* Breadcrumb bar */}
-          <div className="flex h-16 shrink-0 items-center border-b px-6">
-            <Breadcrumbs />
+        <div className="flex flex-1 overflow-hidden">
+          {/* Desktop sidebar — hidden below desktop breakpoint */}
+          <div className="hidden desktop:flex">
+            <Sidebar collapsed={collapsed} onToggle={toggle} />
           </div>
 
-          {/* Page content */}
-          <div className="flex-1 overflow-y-auto p-6">{children}</div>
-        </main>
+          {/* Main content */}
+          <main className="flex flex-1 flex-col overflow-hidden">
+            {/* Breadcrumb bar */}
+            <div className="flex h-16 shrink-0 items-center border-b px-6">
+              <Breadcrumbs />
+            </div>
+
+            {/* Page content */}
+            <div className="flex-1 overflow-y-auto p-6">{children}</div>
+          </main>
+        </div>
       </div>
-    </div>
+    </TimezoneProvider>
   );
 }

--- a/src/components/layout/nav-user.tsx
+++ b/src/components/layout/nav-user.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LogOut, User } from "lucide-react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -51,9 +52,11 @@ export function NavUser({ collapsed = false }: NavUserProps) {
         )}
       </Tooltip>
       <DropdownMenuContent side="right" align="end" className="w-48">
-        <DropdownMenuItem>
-          <User className="mr-2 h-4 w-4" />
-          {t("settings.profile")}
+        <DropdownMenuItem asChild>
+          <Link href="/profile">
+            <User className="mr-2 h-4 w-4" />
+            {t("settings.profile")}
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem>

--- a/src/components/profile/preferences-form.tsx
+++ b/src/components/profile/preferences-form.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// ── Constants ───────────────────────────────────────────────────
+
+const LOCALE_LABELS: Record<string, string> = {
+  en: "English",
+  ko: "한국어",
+};
+
+// ── Component ───────────────────────────────────────────────────
+
+export function PreferencesForm() {
+  const t = useTranslations("profile");
+  const router = useRouter();
+
+  const [locale, setLocale] = useState<string>("");
+  const [timezone, setTimezone] = useState<string>("");
+  const [timezones, setTimezones] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  useEffect(() => {
+    // Build timezone list
+    try {
+      setTimezones(Intl.supportedValuesOf("timeZone"));
+    } catch {
+      setTimezones([browserTimezone]);
+    }
+
+    // Fetch current preferences
+    fetch("/api/accounts/me/preferences")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.data) {
+          setLocale(data.data.locale ?? "");
+          setTimezone(data.data.timezone ?? "");
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [browserTimezone]);
+
+  async function handleSave() {
+    setSaving(true);
+    setMessage("");
+
+    try {
+      const csrfToken = readCsrfToken();
+      const res = await fetch("/api/accounts/me/preferences", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "x-csrf-token": csrfToken } : {}),
+        },
+        body: JSON.stringify({
+          locale: locale || null,
+          timezone: timezone || null,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        setMessage(body?.error ?? "Failed to save preferences");
+        return;
+      }
+
+      setMessage(t("saved"));
+      router.refresh();
+    } catch {
+      setMessage("Failed to save preferences");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-8">
+      <h1 className="text-2xl font-semibold">{t("heading")}</h1>
+
+      <div className="space-y-6">
+        {/* Locale selector */}
+        <div className="space-y-2">
+          <Label htmlFor="locale">{t("locale")}</Label>
+          <Select value={locale} onValueChange={setLocale}>
+            <SelectTrigger id="locale">
+              <SelectValue placeholder={t("browserDefault")} />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(LOCALE_LABELS).map(([code, label]) => (
+                <SelectItem key={code} value={code}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Timezone selector */}
+        <div className="space-y-2">
+          <Label htmlFor="timezone">{t("timezone")}</Label>
+          <Select value={timezone} onValueChange={setTimezone}>
+            <SelectTrigger id="timezone">
+              <SelectValue placeholder={t("timezonePlaceholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {timezones.map((tz) => (
+                <SelectItem key={tz} value={tz}>
+                  {tz.replace(/_/g, " ")}
+                  {tz === browserTimezone ? ` (${t("browserDefault")})` : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {!timezone && (
+            <p className="text-muted-foreground text-sm">
+              {t("browserDefault")}: {browserTimezone}
+            </p>
+          )}
+        </div>
+
+        {/* Save */}
+        <div className="flex items-center gap-4">
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? t("saving") : t("save")}
+          </Button>
+          {message && (
+            <p className="text-sm text-muted-foreground">{message}</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/providers/timezone-provider.tsx
+++ b/src/components/providers/timezone-provider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface TimezoneContextValue {
+  timezone: string;
+}
+
+const TimezoneContext = createContext<TimezoneContextValue>({
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+});
+
+export function useTimezone(): string {
+  return useContext(TimezoneContext).timezone;
+}
+
+export function TimezoneProvider({ children }: { children: ReactNode }) {
+  const [timezone, setTimezone] = useState(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/accounts/me/preferences")
+      .then((res) => {
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then((data) => {
+        if (cancelled) return;
+        if (data?.data?.timezone) {
+          setTimezone(data.data.timezone);
+        }
+      })
+      .catch(() => {
+        // Fallback to browser timezone — already set
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <TimezoneContext.Provider value={{ timezone }}>
+      {children}
+    </TimezoneContext.Provider>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -166,6 +166,16 @@
     "previous": "Previous",
     "next": "Next"
   },
+  "profile": {
+    "heading": "Profile",
+    "locale": "Language",
+    "timezone": "Timezone",
+    "timezonePlaceholder": "Select timezone",
+    "browserDefault": "Browser default",
+    "saved": "Preferences saved",
+    "saving": "Saving...",
+    "save": "Save"
+  },
   "changePassword": {
     "heading": "Change Password",
     "currentPassword": "Current Password",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -166,6 +166,16 @@
     "previous": "이전",
     "next": "다음"
   },
+  "profile": {
+    "heading": "프로필",
+    "locale": "언어",
+    "timezone": "시간대",
+    "timezonePlaceholder": "시간대 선택",
+    "browserDefault": "브라우저 기본값",
+    "saved": "환경설정이 저장되었습니다",
+    "saving": "저장 중...",
+    "save": "저장"
+  },
   "changePassword": {
     "heading": "비밀번호 변경",
     "currentPassword": "현재 비밀번호",

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -1,0 +1,26 @@
+/**
+ * Timezone-aware date formatting utility.
+ */
+
+/**
+ * Format a date/time string for display.
+ *
+ * @param date       ISO string or Date object.
+ * @param timezone   IANA timezone identifier. When `null`/`undefined`,
+ *                   falls back to the runtime default (browser or server).
+ */
+export function formatDateTime(
+  date: string | Date,
+  timezone?: string | null,
+): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  return d.toLocaleString(undefined, {
+    timeZone: timezone ?? undefined,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+  });
+}

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,25 @@
+/**
+ * IANA timezone validation.
+ *
+ * Uses `Intl.supportedValuesOf("timeZone")` which is available in
+ * Node 18+ and all modern browsers.
+ */
+
+let cachedTimezones: Set<string> | null = null;
+
+function getTimezoneSet(): Set<string> {
+  if (!cachedTimezones) {
+    cachedTimezones = new Set(Intl.supportedValuesOf("timeZone"));
+  }
+  return cachedTimezones;
+}
+
+/** Returns `true` when `tz` is a recognized IANA timezone identifier. */
+export function isValidTimezone(tz: string): boolean {
+  return getTimezoneSet().has(tz);
+}
+
+/** Returns the full list of IANA timezone identifiers. */
+export function getTimezones(): string[] {
+  return Intl.supportedValuesOf("timeZone");
+}


### PR DESCRIPTION
## Summary
- Add GET/PATCH `/api/accounts/me/preferences` API for per-account locale and timezone
- Set `NEXT_LOCALE` cookie on sign-in and preference change for automatic locale negotiation
- Add profile page (`/profile`) with locale and timezone selectors
- Add `TimezoneProvider` context so audit-log and account tables display timezone-aware timestamps
- Add `formatDateTime` utility used by table components
- Wire up Profile link in nav-user dropdown
- Add i18n messages (en/ko) for profile page

## Test plan
- [x] Unit tests: preferences API (15 tests), sign-in NEXT_LOCALE cookie (2 tests), timezone validation (3 tests), formatDateTime (6 tests) — 749 total pass
- [x] E2E tests: 17 tests covering API, sign-in cookie integration, UI form, locale persistence, timezone display in audit-log table
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm biome check` clean
- [x] Preview verified: profile page, audit logs, accounts page all render correctly

Closes #100