### PR TITLE
Enforce tenant account update boundaries

### DIFF
--- a/src/__tests__/app/api/accounts/[id]/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/route.test.ts
@@ -537,6 +537,31 @@ describe("PATCH /api/accounts/[id]", () => {
     expect(response.status).toBe(200);
   });
 
+  it("allows Tenant Admin to update status for in-scope Security Monitor", async () => {
+    currentSession = tenantSession;
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+    const lockedTarget = { ...targetRow, status: "locked" };
+    mockQuery.mockResolvedValueOnce({ rows: [lockedTarget], rowCount: 1 });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: TARGET_UUID }], rowCount: 1 }) // update
+      .mockResolvedValueOnce({
+        rows: [{ ...lockedTarget, status: "active" }],
+        rowCount: 1,
+      }); // refetch
+
+    const response = await PATCH(
+      new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status: "active" }),
+      }),
+      makeContext(),
+    );
+    expect(response.status).toBe(200);
+  });
+
   it("returns 404 when Tenant Admin tries to update out-of-scope account", async () => {
     currentSession = tenantSession;
     const { PATCH } = await import("@/app/api/accounts/[id]/route");
@@ -553,6 +578,54 @@ describe("PATCH /api/accounts/[id]", () => {
       makeContext(),
     );
     expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when Tenant Admin tries to update in-scope Tenant Administrator account", async () => {
+    currentSession = tenantSession;
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+    const tenantAdminTarget = {
+      ...targetRow,
+      role_name: "Tenant Administrator",
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [tenantAdminTarget], rowCount: 1 });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
+
+    const response = await PATCH(
+      new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
+        method: "PATCH",
+        body: JSON.stringify({ displayName: "Changed" }),
+      }),
+      makeContext(),
+    );
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Security Monitor");
+  });
+
+  it("returns 403 when Tenant Admin tries to change status of in-scope Tenant Administrator account", async () => {
+    currentSession = tenantSession;
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+    const tenantAdminTarget = {
+      ...targetRow,
+      role_name: "Tenant Administrator",
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [tenantAdminTarget], rowCount: 1 });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
+
+    const response = await PATCH(
+      new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status: "disabled" }),
+      }),
+      makeContext(),
+    );
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Security Monitor");
   });
 
   it("updates status and bumps token_version when disabling", async () => {
@@ -593,6 +666,54 @@ describe("PATCH /api/accounts/[id]", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toContain("Invalid status");
+  });
+
+  it("returns 403 when Tenant Admin tries to assign System Administrator role", async () => {
+    currentSession = tenantSession;
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+    mockQuery.mockResolvedValueOnce({ rows: [targetRow], rowCount: 1 });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 1, name: "System Administrator" }],
+      rowCount: 1,
+    });
+
+    const response = await PATCH(
+      new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
+        method: "PATCH",
+        body: JSON.stringify({ roleId: 1 }),
+      }),
+      makeContext(),
+    );
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Security Monitor");
+  });
+
+  it("returns 403 when Tenant Admin tries to assign Tenant Administrator role", async () => {
+    currentSession = tenantSession;
+    const { PATCH } = await import("@/app/api/accounts/[id]/route");
+    mockQuery.mockResolvedValueOnce({ rows: [targetRow], rowCount: 1 });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 2, name: "Tenant Administrator" }],
+      rowCount: 1,
+    });
+
+    const response = await PATCH(
+      new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
+        method: "PATCH",
+        body: JSON.stringify({ roleId: 2 }),
+      }),
+      makeContext(),
+    );
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Security Monitor");
   });
 
   it("returns existing data when no updates provided", async () => {

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -32,6 +32,7 @@ const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const SYSTEM_ADMIN_ROLE = "System Administrator";
+const SECURITY_MONITOR_ROLE = "Security Monitor";
 const VALID_STATUSES = new Set(["active", "locked", "suspended", "disabled"]);
 
 // ── Helpers ─────────────────────────────────────────────────────
@@ -113,6 +114,7 @@ export const GET = withAuth(
  * - Updating other accounts or changing role/status requires
  *   `accounts:write`.
  * - Cannot change own role or status.
+ * - Tenant-scoped operators can only manage Security Monitor accounts.
  */
 export const PATCH = withAuth(async (request, context, session) => {
   const { id: accountId } = await context.params;
@@ -130,6 +132,7 @@ export const PATCH = withAuth(async (request, context, session) => {
 
   const isSelf = accountId === session.accountId;
   const hasWritePerm = await hasPermission(session.roles, "accounts:write");
+  let accessAll = false;
 
   // Fetch target account
   const { rows: existing } = await query<AccountDetailRow>(
@@ -149,10 +152,7 @@ export const PATCH = withAuth(async (request, context, session) => {
     if (!hasWritePerm) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    const accessAll = await hasPermission(
-      session.roles,
-      "customers:access-all",
-    );
+    accessAll = await hasPermission(session.roles, "customers:access-all");
     if (!accessAll) {
       const callerCustomerIds = await getAccountCustomerIds(session.accountId);
       const targetCustomerIds = await getAccountCustomerIds(accountId);
@@ -165,6 +165,16 @@ export const PATCH = withAuth(async (request, context, session) => {
           { status: 404 },
         );
       }
+    }
+
+    if (!accessAll && existing[0].role_name !== SECURITY_MONITOR_ROLE) {
+      return NextResponse.json(
+        {
+          error:
+            "Tenant Administrator can only manage Security Monitor accounts",
+        },
+        { status: 403 },
+      );
     }
   }
 
@@ -220,6 +230,12 @@ export const PATCH = withAuth(async (request, context, session) => {
     );
     if (roleRows.length === 0) {
       return NextResponse.json({ error: "Role not found" }, { status: 400 });
+    }
+    if (!accessAll && roleRows[0].name !== SECURITY_MONITOR_ROLE) {
+      return NextResponse.json(
+        { error: "Tenant Administrator can only assign Security Monitor role" },
+        { status: 403 },
+      );
     }
     // System Admin count check if changing away from SysAdmin
     if (


### PR DESCRIPTION
## Summary
- enforce PATCH /api/accounts/[id] boundaries to match the existing tenant account management policy
- allow tenant-scoped operators to manage only in-scope Security Monitor accounts, including status changes
- add regression tests for forbidden role escalation and the chosen Tenant Admin status policy

## Testing
- pnpm check
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm e2e
- docker-based nginx config validation (dev and prod)
- docker buildx build --progress=plain --load -t aice-web-next:ci-local .

Closes #118