### PR TITLE
Enforce reset and unlock scope

### DIFF
--- a/src/__tests__/app/api/accounts/[id]/password-reset/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/password-reset/route.test.ts
@@ -19,6 +19,7 @@ const mockHashPassword = vi.hoisted(() => vi.fn());
 const mockValidatePassword = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockGetAccountCustomerIds = vi.hoisted(() => vi.fn());
 
 let currentSession: AuthSession;
 vi.mock("@/lib/auth/guard", () => ({
@@ -41,6 +42,12 @@ vi.mock("@/lib/auth/guard", () => ({
 
 vi.mock("@/lib/auth/permissions", () => ({
   hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/customer-scope", () => ({
+  getAccountCustomerIds: vi.fn((...args: unknown[]) =>
+    mockGetAccountCustomerIds(...args),
+  ),
 }));
 
 vi.mock("@/lib/db/client", () => ({
@@ -86,6 +93,11 @@ describe("POST /api/accounts/[id]/password-reset", () => {
     sessionCreatedAt: new Date(),
     sessionLastActiveAt: new Date(),
   };
+  const tenantSession: AuthSession = {
+    ...adminSession,
+    accountId: "tenant-1",
+    roles: ["Tenant Administrator"],
+  };
 
   const targetAccountId = "target-account-1";
   let mockClientQuery: ReturnType<typeof vi.fn>;
@@ -105,6 +117,10 @@ describe("POST /api/accounts/[id]/password-reset", () => {
     return { params: Promise.resolve({ id: targetAccountId }) };
   }
 
+  function makeSelfContext() {
+    return { params: Promise.resolve({ id: currentSession.accountId }) };
+  }
+
   beforeEach(() => {
     currentSession = adminSession;
     mockQuery.mockReset();
@@ -112,13 +128,28 @@ describe("POST /api/accounts/[id]/password-reset", () => {
     mockHashPassword.mockReset();
     mockValidatePassword.mockReset();
     mockAuditRecord.mockReset();
-    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetAccountCustomerIds.mockReset();
+    mockHasPermission
+      .mockReset()
+      .mockImplementation(async (roles: string[], perm: string) => {
+        if (perm === "accounts:write") {
+          return (
+            roles.includes("System Administrator") ||
+            roles.includes("Tenant Administrator")
+          );
+        }
+        return (
+          perm === "customers:access-all" &&
+          roles.includes("System Administrator")
+        );
+      });
 
     // Default: account exists
     mockQuery.mockResolvedValue({
-      rows: [{ id: targetAccountId }],
+      rows: [{ id: targetAccountId, role_name: "Security Monitor" }],
       rowCount: 1,
     });
+    mockGetAccountCustomerIds.mockResolvedValue([1]);
     mockValidatePassword.mockResolvedValue({ valid: true, errors: [] });
     mockHashPassword.mockResolvedValue("$argon2id$newhash");
     mockClientQuery = vi.fn();
@@ -154,6 +185,61 @@ describe("POST /api/accounts/[id]/password-reset", () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when attempting to reset own password", async () => {
+    const { POST } = await import(
+      "@/app/api/accounts/[id]/password-reset/route"
+    );
+    const response = await POST(
+      makeRequest({ newPassword: "TempPass123!abc" }),
+      makeSelfContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Cannot reset own password");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when Tenant Admin targets an out-of-scope account", async () => {
+    currentSession = tenantSession;
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2])
+      .mockResolvedValueOnce([3]);
+
+    const { POST } = await import(
+      "@/app/api/accounts/[id]/password-reset/route"
+    );
+    const response = await POST(
+      makeRequest({ newPassword: "TempPass123!abc" }),
+      makeContext(),
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when Tenant Admin targets an in-scope Tenant Administrator", async () => {
+    currentSession = tenantSession;
+    mockQuery.mockResolvedValue({
+      rows: [{ id: targetAccountId, role_name: "Tenant Administrator" }],
+      rowCount: 1,
+    });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2])
+      .mockResolvedValueOnce([1]);
+
+    const { POST } = await import(
+      "@/app/api/accounts/[id]/password-reset/route"
+    );
+    const response = await POST(
+      makeRequest({ newPassword: "TempPass123!abc" }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain("Security Monitor");
   });
 
   it("returns 400 when password violates policy", async () => {

--- a/src/__tests__/app/api/accounts/[id]/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/route.test.ts
@@ -881,7 +881,7 @@ describe("DELETE /api/accounts/[id]", () => {
     expect(body.error).toContain("last System Administrator");
   });
 
-  it("returns 403 when lower-rank tries to delete higher-rank", async () => {
+  it("returns 403 when Tenant Admin tries to delete in-scope System Administrator", async () => {
     currentSession = tenantSession;
     const { DELETE } = await import("@/app/api/accounts/[id]/route");
     const sysAdminTarget = {
@@ -892,6 +892,9 @@ describe("DELETE /api/accounts/[id]", () => {
       rows: [sysAdminTarget],
       rowCount: 1,
     });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
 
     const response = await DELETE(
       new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
@@ -900,6 +903,34 @@ describe("DELETE /api/accounts/[id]", () => {
       makeContext(),
     );
     expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Security Monitor");
+  });
+
+  it("returns 403 when Tenant Admin tries to delete in-scope Tenant Administrator", async () => {
+    currentSession = tenantSession;
+    const { DELETE } = await import("@/app/api/accounts/[id]/route");
+    const tenantAdminTarget = {
+      ...targetRow,
+      role_name: "Tenant Administrator",
+    };
+    mockQuery.mockResolvedValueOnce({
+      rows: [tenantAdminTarget],
+      rowCount: 1,
+    });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2]) // caller customers
+      .mockResolvedValueOnce([1]); // target customers (overlap)
+
+    const response = await DELETE(
+      new NextRequest(`http://localhost:3000/api/accounts/${TARGET_UUID}`, {
+        method: "DELETE",
+      }),
+      makeContext(),
+    );
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Security Monitor");
   });
 
   it("returns 404 when Tenant Admin deletes out-of-scope account", async () => {

--- a/src/__tests__/app/api/accounts/[id]/unlock/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/unlock/route.test.ts
@@ -16,6 +16,7 @@ interface WithAuthOptions {
 const mockQuery = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockGetAccountCustomerIds = vi.hoisted(() => vi.fn());
 
 let currentSession: AuthSession;
 vi.mock("@/lib/auth/guard", () => ({
@@ -38,6 +39,12 @@ vi.mock("@/lib/auth/guard", () => ({
 
 vi.mock("@/lib/auth/permissions", () => ({
   hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/customer-scope", () => ({
+  getAccountCustomerIds: vi.fn((...args: unknown[]) =>
+    mockGetAccountCustomerIds(...args),
+  ),
 }));
 
 vi.mock("@/lib/db/client", () => ({
@@ -72,6 +79,11 @@ describe("POST /api/accounts/[id]/unlock", () => {
     sessionCreatedAt: new Date(),
     sessionLastActiveAt: new Date(),
   };
+  const tenantSession: AuthSession = {
+    ...adminSession,
+    accountId: "tenant-1",
+    roles: ["Tenant Administrator"],
+  };
 
   const targetAccountId = "target-account-1";
 
@@ -90,7 +102,22 @@ describe("POST /api/accounts/[id]/unlock", () => {
     currentSession = adminSession;
     mockQuery.mockReset();
     mockAuditRecord.mockReset();
-    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetAccountCustomerIds.mockReset();
+    mockHasPermission
+      .mockReset()
+      .mockImplementation(async (roles: string[], perm: string) => {
+        if (perm === "accounts:write") {
+          return (
+            roles.includes("System Administrator") ||
+            roles.includes("Tenant Administrator")
+          );
+        }
+        return (
+          perm === "customers:access-all" &&
+          roles.includes("System Administrator")
+        );
+      });
+    mockGetAccountCustomerIds.mockResolvedValue([1]);
   });
 
   it("returns 403 when user lacks accounts:write permission", async () => {
@@ -113,11 +140,66 @@ describe("POST /api/accounts/[id]/unlock", () => {
     expect(body.error).toBe("Account not found");
   });
 
+  it("returns 404 when Tenant Admin targets an out-of-scope account", async () => {
+    currentSession = tenantSession;
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: targetAccountId,
+          role_name: "Security Monitor",
+          status: "locked",
+          lockout_count: 1,
+        },
+      ],
+      rowCount: 1,
+    });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2])
+      .mockResolvedValueOnce([3]);
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when Tenant Admin targets an in-scope Tenant Administrator", async () => {
+    currentSession = tenantSession;
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: targetAccountId,
+          role_name: "Tenant Administrator",
+          status: "locked",
+          lockout_count: 1,
+        },
+      ],
+      rowCount: 1,
+    });
+    mockGetAccountCustomerIds
+      .mockResolvedValueOnce([1, 2])
+      .mockResolvedValueOnce([1]);
+
+    const { POST } = await import("@/app/api/accounts/[id]/unlock/route");
+    const response = await POST(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain("Security Monitor");
+  });
+
   it("unlocks a locked account", async () => {
     mockQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("SELECT")) {
         return {
-          rows: [{ id: targetAccountId, status: "locked", lockout_count: 1 }],
+          rows: [
+            {
+              id: targetAccountId,
+              role_name: "Security Monitor",
+              status: "locked",
+              lockout_count: 1,
+            },
+          ],
           rowCount: 1,
         };
       }
@@ -161,7 +243,12 @@ describe("POST /api/accounts/[id]/unlock", () => {
       if (sql.includes("SELECT")) {
         return {
           rows: [
-            { id: targetAccountId, status: "suspended", lockout_count: 2 },
+            {
+              id: targetAccountId,
+              role_name: "Security Monitor",
+              status: "suspended",
+              lockout_count: 2,
+            },
           ],
           rowCount: 1,
         };
@@ -198,7 +285,14 @@ describe("POST /api/accounts/[id]/unlock", () => {
     mockQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("SELECT")) {
         return {
-          rows: [{ id: targetAccountId, status: "locked", lockout_count: 0 }],
+          rows: [
+            {
+              id: targetAccountId,
+              role_name: "Security Monitor",
+              status: "locked",
+              lockout_count: 0,
+            },
+          ],
           rowCount: 1,
         };
       }
@@ -223,7 +317,14 @@ describe("POST /api/accounts/[id]/unlock", () => {
     mockQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("SELECT")) {
         return {
-          rows: [{ id: targetAccountId, status: "locked", lockout_count: 1 }],
+          rows: [
+            {
+              id: targetAccountId,
+              role_name: "Security Monitor",
+              status: "locked",
+              lockout_count: 1,
+            },
+          ],
           rowCount: 1,
         };
       }
@@ -244,7 +345,12 @@ describe("POST /api/accounts/[id]/unlock", () => {
       if (sql.includes("SELECT")) {
         return {
           rows: [
-            { id: targetAccountId, status: "suspended", lockout_count: 1 },
+            {
+              id: targetAccountId,
+              role_name: "Security Monitor",
+              status: "suspended",
+              lockout_count: 1,
+            },
           ],
           rowCount: 1,
         };
@@ -267,7 +373,14 @@ describe("POST /api/accounts/[id]/unlock", () => {
 
   it("returns 400 for active account", async () => {
     mockQuery.mockResolvedValue({
-      rows: [{ id: targetAccountId, status: "active", lockout_count: 0 }],
+      rows: [
+        {
+          id: targetAccountId,
+          role_name: "Security Monitor",
+          status: "active",
+          lockout_count: 0,
+        },
+      ],
       rowCount: 1,
     });
 
@@ -281,7 +394,14 @@ describe("POST /api/accounts/[id]/unlock", () => {
 
   it("returns 400 for disabled account", async () => {
     mockQuery.mockResolvedValue({
-      rows: [{ id: targetAccountId, status: "disabled", lockout_count: 0 }],
+      rows: [
+        {
+          id: targetAccountId,
+          role_name: "Security Monitor",
+          status: "disabled",
+          lockout_count: 0,
+        },
+      ],
       rowCount: 1,
     });
 

--- a/src/app/api/accounts/[id]/password-reset/route.ts
+++ b/src/app/api/accounts/[id]/password-reset/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
+import { validateManagedAccountTarget } from "@/lib/auth/account-management";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { hashPassword } from "@/lib/auth/password";
@@ -38,13 +39,37 @@ export const POST = withAuth(
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
+    if (accountId === session.accountId) {
+      return NextResponse.json(
+        { error: "Cannot reset own password" },
+        { status: 400 },
+      );
+    }
+
     // Step 2: Validate account exists
-    const { rows: accountRows } = await query<{ id: string }>(
-      "SELECT id FROM accounts WHERE id = $1",
+    const { rows: accountRows } = await query<{
+      id: string;
+      role_name: string;
+    }>(
+      `SELECT a.id, r.name AS role_name
+       FROM accounts a
+       JOIN roles r ON a.role_id = r.id
+       WHERE a.id = $1`,
       [accountId],
     );
     if (accountRows.length === 0) {
       return NextResponse.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    const accessError = await validateManagedAccountTarget(
+      session,
+      accountRows[0],
+    );
+    if (accessError) {
+      return NextResponse.json(
+        { error: accessError.error },
+        { status: accessError.status },
+      );
     }
 
     // Step 3: Validate new password against policy (skip reuse ban)

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
+import { validateManagedAccountTarget } from "@/lib/auth/account-management";
 import { MAX_SYSTEM_ADMINISTRATORS } from "@/lib/auth/bootstrap";
 import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
 import { withAuth } from "@/lib/auth/guard";
@@ -34,19 +35,6 @@ const UUID_RE =
 const SYSTEM_ADMIN_ROLE = "System Administrator";
 const SECURITY_MONITOR_ROLE = "Security Monitor";
 const VALID_STATUSES = new Set(["active", "locked", "suspended", "disabled"]);
-
-// ── Helpers ─────────────────────────────────────────────────────
-
-/** Role hierarchy (higher = more privileged). */
-const ROLE_RANK: Record<string, number> = {
-  "System Administrator": 3,
-  "Tenant Administrator": 2,
-  "Security Monitor": 1,
-};
-
-function getRoleRank(roleName: string): number {
-  return ROLE_RANK[roleName] ?? 0;
-}
 
 // ── Route Handlers ──────────────────────────────────────────────
 
@@ -132,7 +120,6 @@ export const PATCH = withAuth(async (request, context, session) => {
 
   const isSelf = accountId === session.accountId;
   const hasWritePerm = await hasPermission(session.roles, "accounts:write");
-  let accessAll = false;
 
   // Fetch target account
   const { rows: existing } = await query<AccountDetailRow>(
@@ -152,28 +139,14 @@ export const PATCH = withAuth(async (request, context, session) => {
     if (!hasWritePerm) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    accessAll = await hasPermission(session.roles, "customers:access-all");
-    if (!accessAll) {
-      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
-      const targetCustomerIds = await getAccountCustomerIds(accountId);
-      const overlap = targetCustomerIds.some((id) =>
-        callerCustomerIds.includes(id),
-      );
-      if (!overlap) {
-        return NextResponse.json(
-          { error: "Account not found" },
-          { status: 404 },
-        );
-      }
-    }
-
-    if (!accessAll && existing[0].role_name !== SECURITY_MONITOR_ROLE) {
+    const accessError = await validateManagedAccountTarget(
+      session,
+      existing[0],
+    );
+    if (accessError) {
       return NextResponse.json(
-        {
-          error:
-            "Tenant Administrator can only manage Security Monitor accounts",
-        },
-        { status: 403 },
+        { error: accessError.error },
+        { status: accessError.status },
       );
     }
   }
@@ -231,7 +204,11 @@ export const PATCH = withAuth(async (request, context, session) => {
     if (roleRows.length === 0) {
       return NextResponse.json({ error: "Role not found" }, { status: 400 });
     }
-    if (!accessAll && roleRows[0].name !== SECURITY_MONITOR_ROLE) {
+    const callerAccessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!callerAccessAll && roleRows[0].name !== SECURITY_MONITOR_ROLE) {
       return NextResponse.json(
         { error: "Tenant Administrator can only assign Security Monitor role" },
         { status: 403 },
@@ -359,8 +336,7 @@ export const PATCH = withAuth(async (request, context, session) => {
  * Constraints:
  * - Cannot delete own account
  * - Last System Administrator cannot be deleted
- * - Role hierarchy: caller must outrank or match target
- * - Tenant Admin can only delete within their customer scope
+ * - Tenant-scoped operators can only delete Security Monitor accounts
  */
 export const DELETE = withAuth(
   async (request, context, session) => {
@@ -403,30 +379,13 @@ export const DELETE = withAuth(
       );
     }
 
-    // Role hierarchy check
-    const callerRank = Math.max(...session.roles.map((r) => getRoleRank(r)));
-    const targetRank = getRoleRank(target.role_name);
-    if (callerRank < targetRank) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    // Tenant scope check
-    const accessAll = await hasPermission(
-      session.roles,
-      "customers:access-all",
-    );
-    if (!accessAll) {
-      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
-      const targetCustomerIds = await getAccountCustomerIds(accountId);
-      const overlap = targetCustomerIds.some((id) =>
-        callerCustomerIds.includes(id),
+    // Scope + role boundary check
+    const accessError = await validateManagedAccountTarget(session, target);
+    if (accessError) {
+      return NextResponse.json(
+        { error: accessError.error },
+        { status: accessError.status },
       );
-      if (!overlap) {
-        return NextResponse.json(
-          { error: "Account not found" },
-          { status: 404 },
-        );
-      }
     }
 
     // Last System Administrator check

--- a/src/app/api/accounts/[id]/unlock/route.ts
+++ b/src/app/api/accounts/[id]/unlock/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
+import { validateManagedAccountTarget } from "@/lib/auth/account-management";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { query } from "@/lib/db/client";
@@ -28,17 +29,29 @@ export const POST = withAuth(
     // Step 1: Fetch account status
     const { rows } = await query<{
       id: string;
+      role_name: string;
       status: string;
       lockout_count: number;
-    }>("SELECT id, status, lockout_count FROM accounts WHERE id = $1", [
-      accountId,
-    ]);
+    }>(
+      `SELECT a.id, r.name AS role_name, a.status, a.lockout_count
+       FROM accounts a
+       JOIN roles r ON a.role_id = r.id
+       WHERE a.id = $1`,
+      [accountId],
+    );
 
     if (rows.length === 0) {
       return NextResponse.json({ error: "Account not found" }, { status: 404 });
     }
 
     const account = rows[0];
+    const accessError = await validateManagedAccountTarget(session, account);
+    if (accessError) {
+      return NextResponse.json(
+        { error: accessError.error },
+        { status: accessError.status },
+      );
+    }
     const ip = extractClientIp(request);
 
     // Step 2: Dispatch by status

--- a/src/lib/auth/account-management.ts
+++ b/src/lib/auth/account-management.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import { getAccountCustomerIds } from "./customer-scope";
+import type { AuthSession } from "./jwt";
+import { hasPermission } from "./permissions";
+
+export const SECURITY_MONITOR_ROLE = "Security Monitor";
+
+export interface ManagedAccountTarget {
+  id: string;
+  role_name: string;
+}
+
+export interface ManagedAccountPolicyError {
+  error: string;
+  status: 403 | 404;
+}
+
+/**
+ * Enforce tenant-scoped account management boundaries.
+ *
+ * Callers with `customers:access-all` are treated as unrestricted
+ * account managers. In the current role matrix that is limited to
+ * System Administrator.
+ */
+export async function validateManagedAccountTarget(
+  session: Pick<AuthSession, "accountId" | "roles">,
+  account: ManagedAccountTarget,
+): Promise<ManagedAccountPolicyError | null> {
+  const accessAll = await hasPermission(session.roles, "customers:access-all");
+  if (accessAll) {
+    return null;
+  }
+
+  const callerCustomerIds = await getAccountCustomerIds(session.accountId);
+  const targetCustomerIds = await getAccountCustomerIds(account.id);
+  const overlap = targetCustomerIds.some((id) =>
+    callerCustomerIds.includes(id),
+  );
+
+  if (!overlap) {
+    return { error: "Account not found", status: 404 };
+  }
+
+  if (account.role_name !== SECURITY_MONITOR_ROLE) {
+    return {
+      error: "Tenant Administrator can only manage Security Monitor accounts",
+      status: 403,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add shared tenant account-management validation for admin password reset and unlock flows
- restrict Tenant Admin actions to eligible in-scope Security Monitor accounts and reject out-of-scope or higher-privilege targets
- block self-targeted admin password reset and add regression coverage for tenant and System Administrator paths

## Testing
- pnpm check
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm e2e

Closes #117
Closes #121