### PR TITLE
Reissue auth after password change

### DIFF
--- a/e2e/change-password.spec.ts
+++ b/e2e/change-password.spec.ts
@@ -14,6 +14,7 @@ import {
   setPassword,
 } from "./helpers/setup-db";
 
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
 const NEW_PASSWORD = "NewSecurePass123!";
 
 test.describe("Change password flow", () => {
@@ -21,6 +22,10 @@ test.describe("Change password flow", () => {
     await resetRateLimits();
     await resetAccountDefaults(ADMIN_USERNAME);
     await clearPasswordHistory(ADMIN_USERNAME);
+  });
+
+  test.beforeEach(async () => {
+    await resetRateLimits();
   });
 
   test.afterAll(async () => {
@@ -98,9 +103,70 @@ test.describe("Change password flow", () => {
       { timeout: 10_000 },
     );
 
+    const meResponse = await page.request.get("/api/auth/me");
+    expect(meResponse.status()).toBe(200);
+
     // Restore password for subsequent tests
     await setPassword(ADMIN_USERNAME, ADMIN_PASSWORD);
     await clearPasswordHistory(ADMIN_USERNAME);
+  });
+
+  test("password change keeps the current session and revokes others", async ({
+    browser,
+  }) => {
+    await setMustChangePassword(ADMIN_USERNAME, true);
+
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+
+    try {
+      const pageA = await contextA.newPage();
+      const pageB = await contextB.newPage();
+
+      await pageA.goto(`${BASE_URL}/sign-in`);
+      await signIn(pageA, ADMIN_USERNAME, ADMIN_PASSWORD);
+      await pageA.waitForURL("**/change-password", { timeout: 10_000 });
+
+      await pageB.goto(`${BASE_URL}/sign-in`);
+      await signIn(pageB, ADMIN_USERNAME, ADMIN_PASSWORD);
+      await pageB.waitForURL("**/change-password", { timeout: 10_000 });
+
+      await pageA
+        .locator("input[autocomplete='current-password']")
+        .fill(ADMIN_PASSWORD);
+      await pageA
+        .locator("input[autocomplete='new-password']")
+        .first()
+        .fill(NEW_PASSWORD);
+      await pageA
+        .locator("input[autocomplete='new-password']")
+        .nth(1)
+        .fill(NEW_PASSWORD);
+      await pageA.getByRole("button", { name: /change password/i }).click();
+
+      await pageA.waitForURL(
+        (url) =>
+          !url.pathname.includes("/change-password") &&
+          !url.pathname.includes("/sign-in"),
+        { timeout: 10_000 },
+      );
+
+      const currentSessionResponse = await pageA.request.get(
+        `${BASE_URL}/api/auth/me`,
+      );
+      expect(currentSessionResponse.status()).toBe(200);
+
+      const revokedSessionResponse = await pageB.request.get(
+        `${BASE_URL}/api/auth/me`,
+      );
+      expect(revokedSessionResponse.status()).toBe(401);
+    } finally {
+      await contextA.close();
+      await contextB.close();
+      await setPassword(ADMIN_USERNAME, ADMIN_PASSWORD);
+      await clearPasswordHistory(ADMIN_USERNAME);
+      await resetAccountDefaults(ADMIN_USERNAME);
+    }
   });
 
   test("blocklisted password shows error", async ({ page }) => {

--- a/e2e/change-password.spec.ts
+++ b/e2e/change-password.spec.ts
@@ -14,7 +14,6 @@ import {
   setPassword,
 } from "./helpers/setup-db";
 
-const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000";
 const NEW_PASSWORD = "NewSecurePass123!";
 
 test.describe("Change password flow", () => {
@@ -123,11 +122,11 @@ test.describe("Change password flow", () => {
       const pageA = await contextA.newPage();
       const pageB = await contextB.newPage();
 
-      await pageA.goto(`${BASE_URL}/sign-in`);
+      await pageA.goto("/sign-in");
       await signIn(pageA, ADMIN_USERNAME, ADMIN_PASSWORD);
       await pageA.waitForURL("**/change-password", { timeout: 10_000 });
 
-      await pageB.goto(`${BASE_URL}/sign-in`);
+      await pageB.goto("/sign-in");
       await signIn(pageB, ADMIN_USERNAME, ADMIN_PASSWORD);
       await pageB.waitForURL("**/change-password", { timeout: 10_000 });
 
@@ -151,14 +150,10 @@ test.describe("Change password flow", () => {
         { timeout: 10_000 },
       );
 
-      const currentSessionResponse = await pageA.request.get(
-        `${BASE_URL}/api/auth/me`,
-      );
+      const currentSessionResponse = await pageA.request.get("/api/auth/me");
       expect(currentSessionResponse.status()).toBe(200);
 
-      const revokedSessionResponse = await pageB.request.get(
-        `${BASE_URL}/api/auth/me`,
-      );
+      const revokedSessionResponse = await pageB.request.get("/api/auth/me");
       expect(revokedSessionResponse.status()).toBe(401);
     } finally {
       await contextA.close();

--- a/src/__tests__/app/api/auth/password/route.test.ts
+++ b/src/__tests__/app/api/auth/password/route.test.ts
@@ -16,6 +16,7 @@ const mockHashPassword = vi.hoisted(() => vi.fn());
 const mockValidatePassword = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockCheckSensitiveOpRateLimit = vi.hoisted(() => vi.fn());
+const mockReissueAuthCookies = vi.hoisted(() => vi.fn());
 
 let currentSession: AuthSession;
 vi.mock("@/lib/auth/guard", () => ({
@@ -58,6 +59,12 @@ vi.mock("@/lib/rate-limit/limiter", () => ({
   ),
 }));
 
+vi.mock("@/lib/auth/rotation", () => ({
+  reissueAuthCookies: vi.fn((...args: unknown[]) =>
+    mockReissueAuthCookies(...args),
+  ),
+}));
+
 describe("POST /api/auth/password", () => {
   const now = Math.floor(Date.now() / 1000);
 
@@ -92,7 +99,7 @@ describe("POST /api/auth/password", () => {
   let mockClientQuery: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    currentSession = session;
+    currentSession = { ...session, roles: [...session.roles] };
     mockQuery.mockReset();
     mockWithTransaction.mockReset();
     mockVerifyPassword.mockReset();
@@ -100,6 +107,7 @@ describe("POST /api/auth/password", () => {
     mockValidatePassword.mockReset();
     mockAuditRecord.mockReset();
     mockCheckSensitiveOpRateLimit.mockReset();
+    mockReissueAuthCookies.mockReset();
 
     // Defaults
     mockCheckSensitiveOpRateLimit.mockResolvedValue({ limited: false });
@@ -110,7 +118,13 @@ describe("POST /api/auth/password", () => {
     mockVerifyPassword.mockResolvedValue(true);
     mockValidatePassword.mockResolvedValue({ valid: true, errors: [] });
     mockHashPassword.mockResolvedValue("$argon2id$newhash");
-    mockClientQuery = vi.fn();
+    mockReissueAuthCookies.mockResolvedValue(true);
+    mockClientQuery = vi.fn(async (sql: string) => {
+      if (sql.includes("UPDATE accounts")) {
+        return { rows: [{ token_version: 1 }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
     mockWithTransaction.mockImplementation(
       async (fn: (client: { query: ReturnType<typeof vi.fn> }) => unknown) =>
         fn({ query: mockClientQuery }),
@@ -185,6 +199,12 @@ describe("POST /api/auth/password", () => {
         targetId: "account-1",
       }),
     );
+    expect(mockReissueAuthCookies).toHaveBeenCalledWith({
+      accountId: "account-1",
+      sessionId: "session-1",
+      roles: ["System Administrator"],
+      tokenVersion: 1,
+    });
   });
 
   it("transaction updates hash, clears must_change_password, bumps token_version", async () => {
@@ -216,6 +236,37 @@ describe("POST /api/auth/password", () => {
     expect(revokeCall[0]).toContain("UPDATE sessions SET revoked = true");
     expect(revokeCall[0]).toContain("sid != $2");
     expect(revokeCall[1]).toEqual(["account-1", "session-1"]);
+  });
+
+  it("updates the in-memory session after re-issuing auth cookies", async () => {
+    const { POST } = await import("@/app/api/auth/password/route");
+    await POST(
+      makeRequest({
+        currentPassword: "OldPass123!",
+        newPassword: "NewPass123!abc",
+      }),
+      makeContext(),
+    );
+
+    expect(currentSession.tokenVersion).toBe(1);
+    expect(currentSession.mustChangePassword).toBe(false);
+  });
+
+  it("returns 500 when auth cookies cannot be re-issued", async () => {
+    mockReissueAuthCookies.mockResolvedValue(false);
+
+    const { POST } = await import("@/app/api/auth/password/route");
+    const response = await POST(
+      makeRequest({
+        currentPassword: "OldPass123!",
+        newPassword: "NewPass123!abc",
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Server configuration error");
   });
 
   it("returns 404 when account not found", async () => {

--- a/src/__tests__/app/api/auth/password/route.test.ts
+++ b/src/__tests__/app/api/auth/password/route.test.ts
@@ -108,6 +108,7 @@ describe("POST /api/auth/password", () => {
     mockAuditRecord.mockReset();
     mockCheckSensitiveOpRateLimit.mockReset();
     mockReissueAuthCookies.mockReset();
+    process.env.CSRF_SECRET = "test-csrf-secret";
 
     // Defaults
     mockCheckSensitiveOpRateLimit.mockResolvedValue({ limited: false });
@@ -252,8 +253,8 @@ describe("POST /api/auth/password", () => {
     expect(currentSession.mustChangePassword).toBe(false);
   });
 
-  it("returns 500 when auth cookies cannot be re-issued", async () => {
-    mockReissueAuthCookies.mockResolvedValue(false);
+  it("returns 500 before mutating state when auth cookies cannot be re-issued", async () => {
+    delete process.env.CSRF_SECRET;
 
     const { POST } = await import("@/app/api/auth/password/route");
     const response = await POST(
@@ -267,6 +268,8 @@ describe("POST /api/auth/password", () => {
 
     expect(response.status).toBe(500);
     expect(body.error).toBe("Server configuration error");
+    expect(mockWithTransaction).not.toHaveBeenCalled();
+    expect(mockReissueAuthCookies).not.toHaveBeenCalled();
   });
 
   it("returns 404 when account not found", async () => {

--- a/src/__tests__/lib/auth/rotation.test.ts
+++ b/src/__tests__/lib/auth/rotation.test.ts
@@ -114,6 +114,25 @@ describe("rotation", () => {
 
   // ── rotateTokens() ───────────────────────────────────────────
 
+  describe("reissueAuthCookies()", () => {
+    it("returns true after issuing fresh auth cookies", async () => {
+      await expect(rotation.reissueAuthCookies(validSession)).resolves.toBe(
+        true,
+      );
+    });
+
+    it("returns false when CSRF_SECRET is missing", async () => {
+      delete process.env.CSRF_SECRET;
+
+      await expect(rotation.reissueAuthCookies(validSession)).resolves.toBe(
+        false,
+      );
+      expect(mockIssueAccessToken).not.toHaveBeenCalled();
+      expect(mockGenerateCsrfToken).not.toHaveBeenCalled();
+      expect(mockSetTokenExpCookie).not.toHaveBeenCalled();
+    });
+  });
+
   describe("rotateTokens()", () => {
     it("issues new JWT with correct session params", async () => {
       await rotation.rotateTokens(validSession);

--- a/src/app/api/auth/password/route.ts
+++ b/src/app/api/auth/password/route.ts
@@ -89,6 +89,14 @@ export const POST = withAuth(
       );
     }
 
+    // Fail before mutating state if auth cookies cannot be re-issued.
+    if (!process.env.CSRF_SECRET) {
+      return NextResponse.json(
+        { error: "Server configuration error" },
+        { status: 500 },
+      );
+    }
+
     // Step 6: Transaction — update password, history, revoke other sessions
     const newHash = await hashPassword(newPassword);
     let nextTokenVersion: number | null = null;

--- a/src/app/api/auth/password/route.ts
+++ b/src/app/api/auth/password/route.ts
@@ -3,10 +3,12 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
+import { TOKEN_EXPIRATION_SECONDS } from "@/lib/auth/constants";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { hashPassword, verifyPassword } from "@/lib/auth/password";
 import { validatePassword } from "@/lib/auth/password-validator";
+import { reissueAuthCookies } from "@/lib/auth/rotation";
 import { query, withTransaction } from "@/lib/db/client";
 import { checkSensitiveOpRateLimit } from "@/lib/rate-limit/limiter";
 
@@ -89,17 +91,22 @@ export const POST = withAuth(
 
     // Step 6: Transaction — update password, history, revoke other sessions
     const newHash = await hashPassword(newPassword);
+    let nextTokenVersion: number | null = null;
     await withTransaction(async (client) => {
       // Update password hash + clear must_change_password + bump token_version
-      await client.query(
+      const { rows: updatedRows } = await client.query<{
+        token_version: number;
+      }>(
         `UPDATE accounts
-         SET password_hash = $2,
-             must_change_password = false,
+           SET password_hash = $2,
+               must_change_password = false,
              password_changed_at = NOW(),
              token_version = token_version + 1
-         WHERE id = $1`,
+         WHERE id = $1
+         RETURNING token_version`,
         [session.accountId, newHash],
       );
+      nextTokenVersion = updatedRows[0]?.token_version ?? null;
 
       // Insert into password_history
       await client.query(
@@ -115,6 +122,12 @@ export const POST = withAuth(
         [session.accountId, session.sessionId],
       );
     });
+    if (nextTokenVersion === null) {
+      return NextResponse.json(
+        { error: "Password change failed" },
+        { status: 500 },
+      );
+    }
 
     // Step 7: Audit log
     await auditLog.record({
@@ -126,7 +139,29 @@ export const POST = withAuth(
       sid: session.sessionId,
     });
 
-    // Step 8: Success
+    // Step 8: Re-issue the current auth state with the new token_version
+    const reissued = await reissueAuthCookies({
+      accountId: session.accountId,
+      sessionId: session.sessionId,
+      roles: session.roles,
+      tokenVersion: nextTokenVersion,
+    });
+    if (!reissued) {
+      return NextResponse.json(
+        { error: "Server configuration error" },
+        { status: 500 },
+      );
+    }
+
+    // Keep the in-request session aligned so any post-handler rotation
+    // uses the new token_version instead of the stale JWT state.
+    const now = Math.floor(Date.now() / 1000);
+    session.tokenVersion = nextTokenVersion;
+    session.mustChangePassword = false;
+    session.iat = now;
+    session.exp = now + TOKEN_EXPIRATION_SECONDS;
+
+    // Step 9: Success
     return NextResponse.json({ success: true });
   },
   { skipPasswordCheck: true },

--- a/src/lib/auth/rotation.ts
+++ b/src/lib/auth/rotation.ts
@@ -21,6 +21,11 @@ import { issueAccessToken } from "./jwt";
  */
 const ROTATION_FRACTION = 3;
 
+type SessionTokenContext = Pick<
+  AuthSession,
+  "accountId" | "sessionId" | "roles" | "tokenVersion"
+>;
+
 // ── Public API ───────────────────────────────────────────────────
 
 /**
@@ -40,17 +45,12 @@ export function shouldRotate(iat: number, exp: number): boolean {
   return remaining > 0 && remaining <= total / ROTATION_FRACTION;
 }
 
-/**
- * Issue a new JWT + CSRF token pair and set them as cookies.
- *
- * Called by the `withAuth()` guard after the handler completes when
- * the current token is within the rotation window.  The previous
- * token is **not** revoked — it remains valid until its natural
- * expiration (automatic grace period).
- */
-export async function rotateTokens(session: AuthSession): Promise<void> {
+/** Issue a new JWT + CSRF token pair and set them as cookies. */
+export async function reissueAuthCookies(
+  session: SessionTokenContext,
+): Promise<boolean> {
   const csrfSecret = process.env.CSRF_SECRET;
-  if (!csrfSecret) return; // Cannot rotate without CSRF secret
+  if (!csrfSecret) return false;
 
   // Issue new JWT
   const newToken = await issueAccessToken({
@@ -77,4 +77,18 @@ export async function rotateTokens(session: AuthSession): Promise<void> {
     ...CSRF_COOKIE_OPTIONS,
     maxAge: TOKEN_EXPIRATION_SECONDS,
   });
+
+  return true;
+}
+
+/**
+ * Issue a new JWT + CSRF token pair and set them as cookies.
+ *
+ * Called by the `withAuth()` guard after the handler completes when
+ * the current token is within the rotation window.  The previous
+ * token is **not** revoked — it remains valid until its natural
+ * expiration (automatic grace period).
+ */
+export async function rotateTokens(session: AuthSession): Promise<void> {
+  await reissueAuthCookies(session);
 }


### PR DESCRIPTION
## Summary
- reissue auth cookies after self password change with the incremented token version
- keep the in-request session aligned so post-handler rotation uses the new auth state
- add route and E2E regression coverage for the first authenticated request and multi-session revocation

## Testing
- pnpm check
- pnpm typecheck
- pnpm test
- pnpm exec vitest run 'src/__tests__/lib/mtls-e2e.test.ts'
- pnpm build
- pnpm e2e

Closes #114