### PR TITLE
Redirect invalidated sessions from protected pages

### DIFF
--- a/e2e/sign-out-all.spec.ts
+++ b/e2e/sign-out-all.spec.ts
@@ -56,6 +56,11 @@ test.describe("Sign-out-all", () => {
         "http://localhost:3000/api/audit-logs",
       );
       expect(apiResponse.status()).toBe(401);
+
+      // Protected page navigation should also redirect to localized sign-in
+      // because the dashboard layout now rejects invalidated DB sessions.
+      await pageB.goto("http://localhost:3000/ko/audit-logs");
+      await expect(pageB).toHaveURL(/\/ko\/sign-in$/, { timeout: 10_000 });
     } finally {
       await contextA.close();
       await contextB.close();

--- a/src/__tests__/app/dashboard-layout.test.ts
+++ b/src/__tests__/app/dashboard-layout.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const mockGetCurrentSession = vi.hoisted(() => vi.fn());
+const mockRedirect = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/session", () => ({
+  getCurrentSession: mockGetCurrentSession,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock("@/components/layout/dashboard-layout", () => ({
+  default: ({ children }: { children: unknown }) => children,
+}));
+
+const now = Math.floor(Date.now() / 1000);
+
+const validSession: AuthSession = {
+  accountId: "account-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0 Chrome/131",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+beforeEach(() => {
+  mockGetCurrentSession.mockReset();
+  mockRedirect.mockReset();
+  mockRedirect.mockImplementation((path: string) => {
+    throw new Error(`redirect:${path}`);
+  });
+  vi.resetModules();
+});
+
+describe("DashboardLayout", () => {
+  it("redirects to default-locale sign-in when session is missing", async () => {
+    mockGetCurrentSession.mockResolvedValue(null);
+
+    const DashboardLayout = (await import("@/app/[locale]/(dashboard)/layout"))
+      .default;
+
+    await expect(
+      DashboardLayout({
+        children: "child",
+        params: Promise.resolve({ locale: "en" }),
+      }),
+    ).rejects.toThrow("redirect:/sign-in");
+  });
+
+  it("redirects to localized sign-in when session is missing", async () => {
+    mockGetCurrentSession.mockResolvedValue(null);
+
+    const DashboardLayout = (await import("@/app/[locale]/(dashboard)/layout"))
+      .default;
+
+    await expect(
+      DashboardLayout({
+        children: "child",
+        params: Promise.resolve({ locale: "ko" }),
+      }),
+    ).rejects.toThrow("redirect:/ko/sign-in");
+  });
+
+  it("redirects must-change-password sessions to localized change-password", async () => {
+    mockGetCurrentSession.mockResolvedValue({
+      ...validSession,
+      mustChangePassword: true,
+    });
+
+    const DashboardLayout = (await import("@/app/[locale]/(dashboard)/layout"))
+      .default;
+
+    await expect(
+      DashboardLayout({
+        children: "child",
+        params: Promise.resolve({ locale: "ko" }),
+      }),
+    ).rejects.toThrow("redirect:/ko/change-password");
+  });
+
+  it("renders children when session is valid", async () => {
+    mockGetCurrentSession.mockResolvedValue(validSession);
+
+    const DashboardLayout = (await import("@/app/[locale]/(dashboard)/layout"))
+      .default;
+
+    const result = await DashboardLayout({
+      children: "child",
+      params: Promise.resolve({ locale: "en" }),
+    });
+
+    expect(result.props.children).toBe("child");
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -1,16 +1,26 @@
 import { redirect } from "next/navigation";
 
 import DashboardLayoutClient from "@/components/layout/dashboard-layout";
+import { routing } from "@/i18n/routing";
 import { getCurrentSession } from "@/lib/auth/session";
 
 export default async function DashboardLayout({
   children,
+  params,
 }: Readonly<{
   children: React.ReactNode;
+  params: Promise<{ locale: string }>;
 }>) {
+  const { locale } = await params;
   const session = await getCurrentSession();
+  const localePrefix = locale === routing.defaultLocale ? "" : `/${locale}`;
+
+  if (!session) {
+    redirect(`${localePrefix}/sign-in`);
+  }
+
   if (session?.mustChangePassword) {
-    redirect("/change-password");
+    redirect(`${localePrefix}/change-password`);
   }
 
   return <DashboardLayoutClient>{children}</DashboardLayoutClient>;


### PR DESCRIPTION
## Summary
- redirect dashboard layouts to the locale-aware sign-in page when the DB-backed session is no longer valid
- preserve locale-aware change-password redirects in the same layout guard
- add unit and E2E coverage for invalidated-session redirects after sign-out-all

## Testing
- pnpm check
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm e2e
- pnpm exec vitest run 'src/__tests__/app/dashboard-layout.test.ts'
- pnpm exec playwright test --config e2e/playwright.config.ts e2e/sign-out-all.spec.ts

Closes #116