### PR TITLE
Align audit log action filters

### DIFF
--- a/src/__tests__/app/api/audit-logs/route.test.ts
+++ b/src/__tests__/app/api/audit-logs/route.test.ts
@@ -270,6 +270,24 @@ describe("GET /api/audit-logs", () => {
       );
     });
 
+    it("accepts session actions that the UI exposes", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { GET } = await import("@/app/api/audit-logs/route");
+      const response = await GET(
+        makeRequest("action=session.reauth_required"),
+        makeContext(),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockQueryAudit).toHaveBeenCalledWith(
+        expect.stringContaining("action = $1"),
+        ["session.reauth_required"],
+      );
+    });
+
     it("applies correlation ID filter", async () => {
       const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
       mockQueryAudit

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { queryAudit } from "@/lib/audit/client";
+import { AUDIT_ACTIONS, AUDIT_TARGET_TYPES } from "@/lib/audit/schema";
 import { withAuth } from "@/lib/auth/guard";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -27,32 +28,9 @@ interface CountRow {
 
 // ── Constants ────────────────────────────────────────────────────
 
-const ALLOWED_ACTIONS = new Set([
-  "auth.sign_in.success",
-  "auth.sign_in.failure",
-  "auth.sign_out",
-  "auth.session_extend",
-  "session.ip_mismatch",
-  "session.ua_mismatch",
-  "session.revoke",
-  "account.create",
-  "account.update",
-  "account.disable",
-  "account.delete",
-  "account.lock",
-  "account.unlock",
-  "account.suspend",
-  "account.restore",
-  "password.change",
-  "password.reset",
-  "customer.create",
-  "customer.update",
-  "customer.delete",
-  "customer.assign",
-  "customer.unassign",
-]);
+const ALLOWED_ACTIONS = new Set(AUDIT_ACTIONS);
 
-const ALLOWED_TARGET_TYPES = new Set(["account", "session", "customer"]);
+const ALLOWED_TARGET_TYPES = new Set(AUDIT_TARGET_TYPES);
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 20;
@@ -63,6 +41,18 @@ const MAX_PAGE_SIZE = 100;
 function isValidISODate(value: string): boolean {
   const d = new Date(value);
   return !Number.isNaN(d.getTime());
+}
+
+function isAllowedAction(
+  value: string,
+): value is (typeof AUDIT_ACTIONS)[number] {
+  return ALLOWED_ACTIONS.has(value as (typeof AUDIT_ACTIONS)[number]);
+}
+
+function isAllowedTargetType(
+  value: string,
+): value is (typeof AUDIT_TARGET_TYPES)[number] {
+  return ALLOWED_TARGET_TYPES.has(value as (typeof AUDIT_TARGET_TYPES)[number]);
 }
 
 const UUID_RE =
@@ -139,7 +129,7 @@ export const GET = withAuth(
     // Action (validated)
     const action = url.searchParams.get("action");
     if (action) {
-      if (!ALLOWED_ACTIONS.has(action)) {
+      if (!isAllowedAction(action)) {
         return NextResponse.json(
           { error: "Invalid action type" },
           { status: 400 },
@@ -152,7 +142,7 @@ export const GET = withAuth(
     // Target type (validated)
     const targetType = url.searchParams.get("targetType");
     if (targetType) {
-      if (!ALLOWED_TARGET_TYPES.has(targetType)) {
+      if (!isAllowedTargetType(targetType)) {
         return NextResponse.json(
           { error: "Invalid target type" },
           { status: 400 },

--- a/src/components/audit/audit-log-table.tsx
+++ b/src/components/audit/audit-log-table.tsx
@@ -24,6 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { AUDIT_ACTIONS, AUDIT_TARGET_TYPES } from "@/lib/audit/schema";
 import { formatDateTime } from "@/lib/format-date";
 
 // ── Types ────────────────────────────────────────────────────────
@@ -49,38 +50,9 @@ interface SearchResult {
 
 // ── Constants ────────────────────────────────────────────────────
 
-const ACTION_KEYS = [
-  "auth.sign_in.success",
-  "auth.sign_in.failure",
-  "auth.sign_out",
-  "auth.session_extend",
-  "session.ip_mismatch",
-  "session.ua_mismatch",
-  "session.ip_ua_mismatch",
-  "session.revoke",
-  "session.reauth_required",
-  "session.reauth_success",
-  "session.reauth_failure",
-  "session.idle_timeout",
-  "session.absolute_timeout",
-  "account.create",
-  "account.update",
-  "account.disable",
-  "account.delete",
-  "account.lock",
-  "account.unlock",
-  "account.suspend",
-  "account.restore",
-  "password.change",
-  "password.reset",
-  "customer.create",
-  "customer.update",
-  "customer.delete",
-  "customer.assign",
-  "customer.unassign",
-] as const;
+const ACTION_KEYS = AUDIT_ACTIONS;
 
-const TARGET_TYPE_KEYS = ["account", "session", "customer"] as const;
+const TARGET_TYPE_KEYS = AUDIT_TARGET_TYPES;
 
 /** Convert a dotted DB action key to an i18n-safe underscore key. */
 function actionToI18nKey(action: string): string {

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -3,7 +3,10 @@ import "server-only";
 import type pg from "pg";
 
 import { getCorrelationId } from "@/lib/audit/correlation";
+import type { AuditAction, AuditTargetType } from "@/lib/audit/schema";
 import { connectTo } from "@/lib/db/client";
+
+export type { AuditAction, AuditTargetType } from "@/lib/audit/schema";
 
 // ── Sensitive Field Redaction ─────────────────────────────────────
 
@@ -54,58 +57,6 @@ function sanitizeDetails(
 }
 
 // ── Types ─────────────────────────────────────────────────────────
-
-/** Phase 1 authentication event actions. */
-type AuthAction =
-  | "auth.sign_in.success"
-  | "auth.sign_in.failure"
-  | "auth.sign_out"
-  | "auth.session_extend";
-
-/** Phase 1 session event actions. */
-type SessionAction =
-  | "session.ip_mismatch"
-  | "session.ua_mismatch"
-  | "session.ip_ua_mismatch"
-  | "session.revoke"
-  | "session.reauth_required"
-  | "session.reauth_success"
-  | "session.reauth_failure"
-  | "session.idle_timeout"
-  | "session.absolute_timeout";
-
-/** Account event actions. */
-type AccountAction =
-  | "account.create"
-  | "account.update"
-  | "account.disable"
-  | "account.delete"
-  | "account.lock"
-  | "account.unlock"
-  | "account.suspend"
-  | "account.restore";
-
-/** Phase 2 password event actions. */
-type PasswordAction = "password.change" | "password.reset";
-
-/** Customer event actions. */
-type CustomerAction =
-  | "customer.create"
-  | "customer.update"
-  | "customer.delete"
-  | "customer.assign"
-  | "customer.unassign";
-
-/** All audit event actions. */
-export type AuditAction =
-  | AuthAction
-  | SessionAction
-  | AccountAction
-  | PasswordAction
-  | CustomerAction;
-
-/** Target entity types for audit events. */
-export type AuditTargetType = "account" | "session" | "customer";
 
 /**
  * Parameters for recording a single audit log entry.

--- a/src/lib/audit/schema.ts
+++ b/src/lib/audit/schema.ts
@@ -1,0 +1,90 @@
+/** Phase 1 authentication event actions. */
+type AuthAction =
+  | "auth.sign_in.success"
+  | "auth.sign_in.failure"
+  | "auth.sign_out"
+  | "auth.session_extend";
+
+/** Phase 1 session event actions. */
+type SessionAction =
+  | "session.ip_mismatch"
+  | "session.ua_mismatch"
+  | "session.ip_ua_mismatch"
+  | "session.revoke"
+  | "session.reauth_required"
+  | "session.reauth_success"
+  | "session.reauth_failure"
+  | "session.idle_timeout"
+  | "session.absolute_timeout";
+
+/** Account event actions. */
+type AccountAction =
+  | "account.create"
+  | "account.update"
+  | "account.disable"
+  | "account.delete"
+  | "account.lock"
+  | "account.unlock"
+  | "account.suspend"
+  | "account.restore";
+
+/** Phase 2 password event actions. */
+type PasswordAction = "password.change" | "password.reset";
+
+/** Customer event actions. */
+type CustomerAction =
+  | "customer.create"
+  | "customer.update"
+  | "customer.delete"
+  | "customer.assign"
+  | "customer.unassign";
+
+/** All audit event actions. */
+export type AuditAction =
+  | AuthAction
+  | SessionAction
+  | AccountAction
+  | PasswordAction
+  | CustomerAction;
+
+/** Target entity types for audit events. */
+export type AuditTargetType = "account" | "session" | "customer";
+
+/** Canonical runtime list of supported audit actions. */
+export const AUDIT_ACTIONS = [
+  "auth.sign_in.success",
+  "auth.sign_in.failure",
+  "auth.sign_out",
+  "auth.session_extend",
+  "session.ip_mismatch",
+  "session.ua_mismatch",
+  "session.ip_ua_mismatch",
+  "session.revoke",
+  "session.reauth_required",
+  "session.reauth_success",
+  "session.reauth_failure",
+  "session.idle_timeout",
+  "session.absolute_timeout",
+  "account.create",
+  "account.update",
+  "account.disable",
+  "account.delete",
+  "account.lock",
+  "account.unlock",
+  "account.suspend",
+  "account.restore",
+  "password.change",
+  "password.reset",
+  "customer.create",
+  "customer.update",
+  "customer.delete",
+  "customer.assign",
+  "customer.unassign",
+] as const satisfies readonly AuditAction[];
+
+/** Canonical runtime list of supported audit target types. */
+export const AUDIT_TARGET_TYPES = [
+  "account",
+  "session",
+  "customer",
+] as const satisfies readonly AuditTargetType[];


### PR DESCRIPTION
## Summary
- move audit action and target-type definitions into a shared schema module
- use the shared action list in both the audit log API and the audit log UI filter
- add route coverage for session-related action filters that previously returned 400

## Testing
- pnpm check
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm e2e
- pnpm exec vitest run 'src/__tests__/app/api/audit-logs/route.test.ts' 'src/__tests__/lib/audit/logger.test.ts'

Closes #113