### PR TITLE
Stabilize local typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "markdownlint": "markdownlint-cli2 '**/*.md'",
     "test": "vitest run",
     "e2e": "playwright test --config e2e/playwright.config.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", ".next/dev/types/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- run  before local type checking
- use a dedicated  that excludes stale  outputs
- keep the base  aligned with Next's generated include list

## Testing
- pnpm typecheck
- pnpm check
- pnpm test
- pnpm build
- pnpm e2e

Closes #115