### PR TITLE
Improve sidebar and navigation UX

### DIFF
--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import DashboardLayoutClient from "@/components/layout/dashboard-layout";
 import { routing } from "@/i18n/routing";
 import { getCurrentSession } from "@/lib/auth/session";
+import { query } from "@/lib/db/client";
 
 export default async function DashboardLayout({
   children,
@@ -23,5 +24,21 @@ export default async function DashboardLayout({
     redirect(`${localePrefix}/change-password`);
   }
 
-  return <DashboardLayoutClient>{children}</DashboardLayoutClient>;
+  // Fetch username for sidebar display
+  let username: string | undefined;
+  try {
+    const { rows } = await query<{ username: string }>(
+      "SELECT username FROM accounts WHERE id = $1",
+      [session.accountId],
+    );
+    username = rows[0]?.username;
+  } catch {
+    // DB unavailable — fall back to no username
+  }
+
+  return (
+    <DashboardLayoutClient username={username}>
+      {children}
+    </DashboardLayoutClient>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,14 @@
   --btn-primary-bg-disabled: #c5e4f7;
   --danger: #db1d03;
   --neutral-40: #7c8492;
+
+  /* Sidebar — light variant (Figma NavBar page) */
+  --sidebar-bg: #ffffff;
+  --sidebar-fg: #212428;
+  --sidebar-muted: #7c8492;
+  --sidebar-active: #156ef2;
+  --sidebar-account-bg: #f5f6f7;
+  --sidebar-border: rgba(97, 105, 116, 0.16);
 }
 
 [data-theme="gray-dark"] {
@@ -50,6 +58,14 @@
   --danger: #fb2c10;
   --neutral-30: #8e97a5;
   --neutral-40: #7c8492;
+
+  /* Sidebar — dark variant (Figma Home page) */
+  --sidebar-bg: #212428;
+  --sidebar-fg: #fafafa;
+  --sidebar-muted: #7c8492;
+  --sidebar-active: #156ef2;
+  --sidebar-account-bg: #2f333a;
+  --sidebar-border: rgba(97, 105, 116, 0.24);
 }
 
 @theme inline {
@@ -76,13 +92,6 @@
   --radius-sm: calc(var(--radius) - 2px);
   --radius-md: var(--radius);
   --radius-lg: calc(var(--radius) + 2px);
-  /* Sidebar — always dark regardless of theme */
-  --color-sidebar: #212428;
-  --color-sidebar-foreground: #fafafa;
-  --color-sidebar-muted: #7c8492;
-  --color-sidebar-active: #156ef2;
-  --color-sidebar-account: #2f333a;
-  --color-sidebar-divider: rgba(97, 105, 116, 0.24);
   --breakpoint-desktop: 1280px;
   --breakpoint-wide: 2000px;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,14 +6,6 @@
   --btn-primary-bg: #156ef2;
   --btn-primary-fg: #ffffff;
 
-  /* Sidebar — always dark regardless of theme */
-  --sidebar-bg: #212428;
-  --sidebar-account-bg: #2f333a;
-  --sidebar-text: #fafafa;
-  --sidebar-text-muted: #7c8492;
-  --sidebar-divider: rgba(97, 105, 116, 0.24);
-  --sidebar-active-border: #156ef2;
-
   /* shadcn/ui semantic aliases */
   --background: var(--bg-canvas);
   --foreground: var(--text-primary);
@@ -84,12 +76,13 @@
   --radius-sm: calc(var(--radius) - 2px);
   --radius-md: var(--radius);
   --radius-lg: calc(var(--radius) + 2px);
-  --color-sidebar: var(--sidebar-bg);
-  --color-sidebar-foreground: var(--sidebar-text);
-  --color-sidebar-muted: var(--sidebar-text-muted);
-  --color-sidebar-active: var(--sidebar-active-border);
-  --color-sidebar-account: var(--sidebar-account-bg);
-  --color-sidebar-divider: var(--sidebar-divider);
+  /* Sidebar — always dark regardless of theme */
+  --color-sidebar: #212428;
+  --color-sidebar-foreground: #fafafa;
+  --color-sidebar-muted: #7c8492;
+  --color-sidebar-active: #156ef2;
+  --color-sidebar-account: #2f333a;
+  --color-sidebar-divider: rgba(97, 105, 116, 0.24);
   --breakpoint-desktop: 1280px;
   --breakpoint-wide: 2000px;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,14 @@
   --btn-primary-bg: #156ef2;
   --btn-primary-fg: #ffffff;
 
+  /* Sidebar — always dark regardless of theme */
+  --sidebar-bg: #212428;
+  --sidebar-account-bg: #2f333a;
+  --sidebar-text: #fafafa;
+  --sidebar-text-muted: #7c8492;
+  --sidebar-divider: rgba(97, 105, 116, 0.24);
+  --sidebar-active-border: #156ef2;
+
   /* shadcn/ui semantic aliases */
   --background: var(--bg-canvas);
   --foreground: var(--text-primary);
@@ -76,6 +84,12 @@
   --radius-sm: calc(var(--radius) - 2px);
   --radius-md: var(--radius);
   --radius-lg: calc(var(--radius) + 2px);
+  --color-sidebar: var(--sidebar-bg);
+  --color-sidebar-foreground: var(--sidebar-text);
+  --color-sidebar-muted: var(--sidebar-text-muted);
+  --color-sidebar-active: var(--sidebar-active-border);
+  --color-sidebar-account: var(--sidebar-account-bg);
+  --color-sidebar-divider: var(--sidebar-divider);
   --breakpoint-desktop: 1280px;
   --breakpoint-wide: 2000px;
 }

--- a/src/components/layout/dashboard-layout.tsx
+++ b/src/components/layout/dashboard-layout.tsx
@@ -8,11 +8,15 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { TimezoneProvider } from "@/components/providers/timezone-provider";
 import { useSidebar } from "@/hooks/use-sidebar";
 
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+  username?: string;
+}
+
 export default function DashboardLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+  username,
+}: Readonly<DashboardLayoutProps>) {
   const { collapsed, toggle } = useSidebar();
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -20,12 +24,20 @@ export default function DashboardLayout({
     <TimezoneProvider>
       <div className="flex h-screen flex-col">
         {/* Mobile header — visible only below desktop breakpoint */}
-        <MobileHeader open={mobileOpen} onOpenChange={setMobileOpen} />
+        <MobileHeader
+          open={mobileOpen}
+          onOpenChange={setMobileOpen}
+          username={username}
+        />
 
         <div className="flex flex-1 overflow-hidden">
           {/* Desktop sidebar — hidden below desktop breakpoint */}
           <div className="hidden desktop:flex">
-            <Sidebar collapsed={collapsed} onToggle={toggle} />
+            <Sidebar
+              collapsed={collapsed}
+              onToggle={toggle}
+              username={username}
+            />
           </div>
 
           {/* Main content */}

--- a/src/components/layout/logo.tsx
+++ b/src/components/layout/logo.tsx
@@ -5,10 +5,12 @@ import { cn } from "@/lib/utils";
 interface LogoProps {
   /** Show only the icon (no text). Used in collapsed sidebar. */
   collapsed?: boolean;
+  /** Force a specific variant instead of auto-detecting from theme. */
+  variant?: "light" | "dark";
   className?: string;
 }
 
-export function Logo({ collapsed = false, className }: LogoProps) {
+export function Logo({ collapsed = false, variant, className }: LogoProps) {
   if (collapsed) {
     return (
       <Image
@@ -17,6 +19,32 @@ export function Logo({ collapsed = false, className }: LogoProps) {
         width={26}
         height={28}
         className={cn("shrink-0", className)}
+      />
+    );
+  }
+
+  if (variant === "dark") {
+    return (
+      <Image
+        src="/logo-dark.svg"
+        alt="Clumit Security"
+        width={204}
+        height={28}
+        className={cn("h-7 w-auto", className)}
+        priority
+      />
+    );
+  }
+
+  if (variant === "light") {
+    return (
+      <Image
+        src="/logo.svg"
+        alt="Clumit Security"
+        width={204}
+        height={28}
+        className={cn("h-7 w-auto", className)}
+        priority
       />
     );
   }

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -14,7 +14,6 @@ import {
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import {
   Sheet,
   SheetContent,
@@ -42,16 +41,26 @@ const NAV_ITEMS = [
 interface MobileHeaderProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  username?: string;
 }
 
-export function MobileHeader({ open, onOpenChange }: MobileHeaderProps) {
+export function MobileHeader({
+  open,
+  onOpenChange,
+  username,
+}: MobileHeaderProps) {
   const t = useTranslations("nav");
   const pathname = usePathname();
 
   return (
     <>
-      <header className="bg-card flex h-14 items-center border-b px-4 desktop:hidden">
-        <Button variant="ghost" size="icon" onClick={() => onOpenChange(true)}>
+      <header className="flex h-14 items-center border-b bg-sidebar px-4 desktop:hidden">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => onOpenChange(true)}
+          className="text-sidebar-foreground hover:bg-sidebar-divider"
+        >
           <Menu className="h-5 w-5" />
           <span className="sr-only">Open menu</span>
         </Button>
@@ -59,14 +68,23 @@ export function MobileHeader({ open, onOpenChange }: MobileHeaderProps) {
       </header>
 
       <Sheet open={open} onOpenChange={onOpenChange}>
-        <SheetContent side="left" className="w-64 p-0">
-          <SheetHeader className="border-b px-4">
-            <SheetTitle>
+        <SheetContent
+          side="left"
+          className="w-64 border-none bg-sidebar p-0 text-sidebar-foreground"
+        >
+          <SheetHeader className="px-5 pt-6">
+            <SheetTitle className="text-sidebar-foreground">
               <Logo />
             </SheetTitle>
           </SheetHeader>
+
+          {/* Divider */}
+          <div className="px-4 pt-6">
+            <div className="h-px bg-sidebar-divider" />
+          </div>
+
           <TooltipProvider>
-            <nav className="flex-1 space-y-1 overflow-y-auto p-2">
+            <nav className="flex-1 space-y-3 overflow-y-auto pt-6">
               {NAV_ITEMS.map((item) => (
                 <SidebarItem
                   key={item.key}
@@ -77,12 +95,11 @@ export function MobileHeader({ open, onOpenChange }: MobileHeaderProps) {
                 />
               ))}
             </nav>
-            <div className="space-y-1 p-2">
-              <Separator className="mb-2" />
-              <div className="px-1">
-                <ThemeToggle />
+            <div className="space-y-4 p-4">
+              <div className="px-0">
+                <ThemeToggle className="text-sidebar-muted hover:bg-sidebar-divider hover:text-sidebar-foreground" />
               </div>
-              <NavUser />
+              <NavUser username={username} />
             </div>
           </TooltipProvider>
         </SheetContent>

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -54,12 +54,12 @@ export function MobileHeader({
 
   return (
     <>
-      <header className="flex h-14 items-center border-b bg-sidebar px-4 desktop:hidden">
+      <header className="flex h-14 items-center border-b bg-[var(--sidebar-bg)] px-4 desktop:hidden">
         <Button
           variant="ghost"
           size="icon"
           onClick={() => onOpenChange(true)}
-          className="text-sidebar-foreground hover:bg-sidebar-divider"
+          className="text-[var(--sidebar-fg)] hover:bg-[var(--sidebar-border)]"
         >
           <Menu className="h-5 w-5" />
           <span className="sr-only">Open menu</span>
@@ -70,17 +70,17 @@ export function MobileHeader({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent
           side="left"
-          className="w-64 border-none bg-sidebar p-0 text-sidebar-foreground"
+          className="w-64 border-none bg-[var(--sidebar-bg)] p-0 text-[var(--sidebar-fg)]"
         >
           <SheetHeader className="px-5 pt-6">
-            <SheetTitle className="text-sidebar-foreground">
+            <SheetTitle className="text-[var(--sidebar-fg)]">
               <Logo />
             </SheetTitle>
           </SheetHeader>
 
           {/* Divider */}
           <div className="px-4 pt-6">
-            <div className="h-px bg-sidebar-divider" />
+            <div className="h-px bg-[var(--sidebar-border)]" />
           </div>
 
           <TooltipProvider>
@@ -97,7 +97,7 @@ export function MobileHeader({
             </nav>
             <div className="space-y-4 p-4">
               <div className="px-0">
-                <ThemeToggle className="text-sidebar-muted hover:bg-sidebar-divider hover:text-sidebar-foreground" />
+                <ThemeToggle className="text-[var(--sidebar-muted)] hover:bg-[var(--sidebar-border)] hover:text-[var(--sidebar-fg)]" />
               </div>
               <NavUser username={username} />
             </div>

--- a/src/components/layout/nav-user.tsx
+++ b/src/components/layout/nav-user.tsx
@@ -20,37 +20,57 @@ import {
 import { cn } from "@/lib/utils";
 
 interface NavUserProps {
+  username?: string;
   collapsed?: boolean;
 }
 
-export function NavUser({ collapsed = false }: NavUserProps) {
+function getInitials(name: string): string {
+  return name
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0].toUpperCase())
+    .join("");
+}
+
+export function NavUser({ username, collapsed = false }: NavUserProps) {
   const t = useTranslations();
 
-  const initials = "U";
+  const displayName = username ?? t("settings.profile");
+  const initials = username ? getInitials(username) : "U";
+
+  const trigger = (
+    <DropdownMenuTrigger
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg bg-sidebar-account p-3 text-sm font-medium text-sidebar-foreground transition-colors",
+        "hover:brightness-125",
+        collapsed && "justify-center rounded-full bg-transparent p-0",
+      )}
+    >
+      <Avatar
+        className={cn(
+          "shrink-0 bg-primary text-primary-foreground",
+          collapsed ? "size-9" : "size-10",
+        )}
+      >
+        <AvatarFallback className="bg-primary text-sm font-medium text-primary-foreground">
+          {initials}
+        </AvatarFallback>
+      </Avatar>
+      {!collapsed && <span className="truncate">{displayName}</span>}
+    </DropdownMenuTrigger>
+  );
 
   return (
     <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger
-            className={cn(
-              "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-              "hover:bg-accent hover:text-accent-foreground text-muted-foreground",
-              collapsed && "justify-center px-2",
-            )}
-          >
-            <Avatar className="h-7 w-7 shrink-0">
-              <AvatarFallback className="text-xs">{initials}</AvatarFallback>
-            </Avatar>
-            {!collapsed && (
-              <span className="truncate">{t("settings.profile")}</span>
-            )}
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        {collapsed && (
-          <TooltipContent side="right">{t("settings.profile")}</TooltipContent>
-        )}
-      </Tooltip>
+      {collapsed ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent side="right">{displayName}</TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
       <DropdownMenuContent side="right" align="end" className="w-48">
         <DropdownMenuItem asChild>
           <Link href="/profile">

--- a/src/components/layout/nav-user.tsx
+++ b/src/components/layout/nav-user.tsx
@@ -42,7 +42,7 @@ export function NavUser({ username, collapsed = false }: NavUserProps) {
   const trigger = (
     <DropdownMenuTrigger
       className={cn(
-        "flex w-full items-center gap-3 rounded-lg bg-sidebar-account p-3 text-sm font-medium text-sidebar-foreground transition-colors",
+        "flex w-full items-center gap-3 rounded-lg bg-[var(--sidebar-account-bg)] p-3 text-sm font-medium text-[var(--sidebar-fg)] transition-colors",
         "hover:brightness-125",
         collapsed && "justify-center rounded-full bg-transparent p-0",
       )}

--- a/src/components/layout/sidebar-item.tsx
+++ b/src/components/layout/sidebar-item.tsx
@@ -30,14 +30,14 @@ export function SidebarItem({
       className={cn(
         "group relative flex h-12 items-center gap-3 px-4 text-base font-medium transition-colors",
         active
-          ? "text-sidebar-foreground"
-          : "text-sidebar-muted hover:text-sidebar-foreground",
+          ? "text-[var(--sidebar-fg)]"
+          : "text-[var(--sidebar-muted)] hover:text-[var(--sidebar-fg)]",
         collapsed && "justify-center px-0",
       )}
     >
       {/* Active indicator — blue left border bar */}
       {active && (
-        <span className="absolute top-0 left-0 h-full w-1 rounded-r-lg bg-sidebar-active" />
+        <span className="absolute top-0 left-0 h-full w-1 rounded-r-lg bg-[var(--sidebar-active)]" />
       )}
       {/* Active glow — radial gradient from left */}
       {active && (

--- a/src/components/layout/sidebar-item.tsx
+++ b/src/components/layout/sidebar-item.tsx
@@ -28,14 +28,31 @@ export function SidebarItem({
     <Link
       href={href}
       className={cn(
-        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-        "hover:bg-accent hover:text-accent-foreground",
-        active ? "bg-accent text-accent-foreground" : "text-muted-foreground",
-        collapsed && "justify-center px-2",
+        "group relative flex h-12 items-center gap-3 px-4 text-base font-medium transition-colors",
+        active
+          ? "text-sidebar-foreground"
+          : "text-sidebar-muted hover:text-sidebar-foreground",
+        collapsed && "justify-center px-0",
       )}
     >
-      <Icon className="h-5 w-5 shrink-0" />
-      {!collapsed && <span>{label}</span>}
+      {/* Active indicator — blue left border bar */}
+      {active && (
+        <span className="absolute top-0 left-0 h-full w-1 rounded-r-lg bg-sidebar-active" />
+      )}
+      {/* Active glow — radial gradient from left */}
+      {active && (
+        <span
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse at left center, rgba(21, 110, 242, 0.29) 0%, transparent 100%)",
+          }}
+        />
+      )}
+      <Icon
+        className={cn("relative z-10 size-5 shrink-0", collapsed && "size-6")}
+      />
+      {!collapsed && <span className="relative z-10">{label}</span>}
     </Link>
   );
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import {
-  ChevronLeft,
+  ArrowLeft,
+  ArrowRight,
   FileText,
   Home,
   LayoutDashboard,
@@ -13,8 +14,6 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { usePathname } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
@@ -26,6 +25,7 @@ import { SidebarItem } from "./sidebar-item";
 interface SidebarProps {
   collapsed: boolean;
   onToggle: () => void;
+  username?: string;
 }
 
 const NAV_ITEMS = [
@@ -39,7 +39,7 @@ const NAV_ITEMS = [
   { key: "settings", href: "/settings", icon: Settings },
 ] as const;
 
-export function Sidebar({ collapsed, onToggle }: SidebarProps) {
+export function Sidebar({ collapsed, onToggle, username }: SidebarProps) {
   const t = useTranslations("nav");
   const pathname = usePathname();
 
@@ -47,39 +47,27 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
     <TooltipProvider>
       <aside
         className={cn(
-          "bg-card flex h-full flex-col border-r transition-[width] duration-200",
+          "flex h-full flex-col bg-sidebar transition-[width] duration-200",
           collapsed ? "w-16" : "w-64",
         )}
       >
         {/* Logo / Header */}
         <div
           className={cn(
-            "flex h-16 items-center border-b px-4",
-            collapsed ? "justify-center" : "justify-between",
+            "flex shrink-0 items-center px-5 pt-6",
+            collapsed ? "justify-center px-0" : "h-16",
           )}
         >
-          {collapsed ? (
-            <button
-              type="button"
-              onClick={onToggle}
-              className="flex items-center justify-center"
-            >
-              <Logo collapsed />
-              <span className="sr-only">Toggle sidebar</span>
-            </button>
-          ) : (
-            <>
-              <Logo />
-              <Button variant="ghost" size="icon" onClick={onToggle}>
-                <ChevronLeft className="h-4 w-4" />
-                <span className="sr-only">Toggle sidebar</span>
-              </Button>
-            </>
-          )}
+          {collapsed ? <Logo collapsed /> : <Logo />}
+        </div>
+
+        {/* Divider */}
+        <div className={cn("px-4 pt-6", collapsed && "px-2")}>
+          <div className="h-px bg-sidebar-divider" />
         </div>
 
         {/* Navigation */}
-        <nav className="flex-1 space-y-1 overflow-y-auto p-2">
+        <nav className="flex-1 space-y-3 overflow-y-auto pt-6">
           {NAV_ITEMS.map((item) => (
             <SidebarItem
               key={item.key}
@@ -93,12 +81,23 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
         </nav>
 
         {/* Bottom section */}
-        <div className="space-y-1 p-2">
-          <Separator className="mb-2" />
-          <div className={cn("flex", collapsed ? "justify-center" : "px-1")}>
-            <ThemeToggle />
+        <div className={cn("space-y-4 p-4", collapsed && "px-2")}>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="flex size-8 items-center justify-center rounded-lg bg-sidebar-divider text-sidebar-muted transition-colors hover:text-sidebar-foreground"
+          >
+            {collapsed ? (
+              <ArrowRight className="size-4" />
+            ) : (
+              <ArrowLeft className="size-4" />
+            )}
+            <span className="sr-only">Toggle sidebar</span>
+          </button>
+          <div className={cn("flex", collapsed ? "justify-center" : "px-0")}>
+            <ThemeToggle className="text-sidebar-muted hover:bg-sidebar-divider hover:text-sidebar-foreground" />
           </div>
-          <NavUser collapsed={collapsed} />
+          <NavUser username={username} collapsed={collapsed} />
         </div>
       </aside>
     </TooltipProvider>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -47,7 +47,7 @@ export function Sidebar({ collapsed, onToggle, username }: SidebarProps) {
     <TooltipProvider>
       <aside
         className={cn(
-          "flex h-full flex-col bg-sidebar transition-[width] duration-200",
+          "flex h-full flex-col bg-[var(--sidebar-bg)] transition-[width] duration-200",
           collapsed ? "w-16" : "w-64",
         )}
       >
@@ -63,7 +63,7 @@ export function Sidebar({ collapsed, onToggle, username }: SidebarProps) {
 
         {/* Divider */}
         <div className={cn("px-4 pt-6", collapsed && "px-2")}>
-          <div className="h-px bg-sidebar-divider" />
+          <div className="h-px bg-[var(--sidebar-border)]" />
         </div>
 
         {/* Navigation */}
@@ -85,7 +85,7 @@ export function Sidebar({ collapsed, onToggle, username }: SidebarProps) {
           <button
             type="button"
             onClick={onToggle}
-            className="flex size-8 items-center justify-center rounded-lg bg-sidebar-divider text-sidebar-muted transition-colors hover:text-sidebar-foreground"
+            className="flex size-8 items-center justify-center rounded-lg bg-[var(--sidebar-border)] text-[var(--sidebar-muted)] transition-colors hover:text-[var(--sidebar-fg)]"
           >
             {collapsed ? (
               <ArrowRight className="size-4" />
@@ -95,7 +95,7 @@ export function Sidebar({ collapsed, onToggle, username }: SidebarProps) {
             <span className="sr-only">Toggle sidebar</span>
           </button>
           <div className={cn("flex", collapsed ? "justify-center" : "px-0")}>
-            <ThemeToggle className="text-sidebar-muted hover:bg-sidebar-divider hover:text-sidebar-foreground" />
+            <ThemeToggle className="text-[var(--sidebar-muted)] hover:bg-[var(--sidebar-account-bg)] hover:text-[var(--sidebar-fg)]" />
           </div>
           <NavUser username={username} collapsed={collapsed} />
         </div>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -4,14 +4,20 @@ import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-export function ThemeToggle() {
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme();
 
   return (
     <Button
       variant="ghost"
       size="icon"
+      className={cn(className)}
       onClick={() =>
         setTheme(theme === "gray-dark" ? "gray-light" : "gray-dark")
       }


### PR DESCRIPTION
## Summary

- Apply Figma sidebar design with theme-responsive colors: light theme uses white sidebar (Figma NavBar page), dark theme uses dark sidebar (Figma Home page)
- Add blue left border active indicator with radial gradient glow for current nav item
- Display real username with auto-generated initials avatar in NavUser card, fetched from DB in the server-side dashboard layout
- Add sidebar color tokens (`--sidebar-bg`, `--sidebar-fg`, etc.) per `[data-theme]` selector, referenced via CSS `var()` arbitrary values in Tailwind classes
- Add `variant` prop to Logo component for explicit light/dark override (used by auth pages)

Closes #130
Refs #39

## Test plan

- [x] Sign in and verify the active nav item shows a blue left border bar with gradient glow
- [x] Verify the NavUser card at the bottom displays the signed-in username with initials avatar
- [x] Toggle between gray-light and gray-dark themes — sidebar background and text colors should switch accordingly
- [x] Collapse/expand sidebar and verify layout, tooltips, and toggle arrow direction
- [x] Open the mobile drawer (< 1280px) and verify the same theme-responsive styling and username display