### PR TITLE
Improve auth flow screens and form UX

### DIFF
--- a/e2e/session-extension.spec.ts
+++ b/e2e/session-extension.spec.ts
@@ -66,7 +66,7 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Verify dialog content
-    await expect(dialog.getByText(/taking a break|쉬고 계신/i)).toBeVisible();
+    await expect(dialog.getByText(/session is about to expire|세션이 곧 만료/i)).toBeVisible();
 
     // Verify both buttons are present
     await expect(
@@ -293,7 +293,7 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Verify Korean text
-    await expect(dialog.getByText(/쉬고 계신/)).toBeVisible();
+    await expect(dialog.getByText(/세션이 곧 만료/)).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /로그인 유지/ }),
     ).toBeVisible();

--- a/e2e/session-extension.spec.ts
+++ b/e2e/session-extension.spec.ts
@@ -66,7 +66,9 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Verify dialog content
-    await expect(dialog.getByText(/session is about to expire|세션이 곧 만료/i)).toBeVisible();
+    await expect(
+      dialog.getByText(/session is about to expire|세션이 곧 만료/i),
+    ).toBeVisible();
 
     // Verify both buttons are present
     await expect(
@@ -119,7 +121,9 @@ test.describe("Session Extension Dialog", () => {
     );
 
     // Click Extend
-    await dialog.getByRole("button", { name: /stay signed in|로그인 유지/i }).click();
+    await dialog
+      .getByRole("button", { name: /stay signed in|로그인 유지/i })
+      .click();
 
     // Verify /api/auth/me was called successfully
     const meResponse = await mePromise;
@@ -210,7 +214,9 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Click Extend
-    await dialog.getByRole("button", { name: /stay signed in|로그인 유지/i }).click();
+    await dialog
+      .getByRole("button", { name: /stay signed in|로그인 유지/i })
+      .click();
     await expect(dialog).not.toBeVisible({ timeout: 5_000 });
 
     // Wait 2 more seconds — dialog should NOT reappear (same exp)
@@ -239,7 +245,9 @@ test.describe("Session Extension Dialog", () => {
     });
 
     // Rapid double-click — button should disable after first click
-    const extendBtn = dialog.getByRole("button", { name: /stay signed in|로그인 유지/i });
+    const extendBtn = dialog.getByRole("button", {
+      name: /stay signed in|로그인 유지/i,
+    });
     await extendBtn.dblclick();
 
     // Wait for the request to complete

--- a/e2e/session-extension.spec.ts
+++ b/e2e/session-extension.spec.ts
@@ -66,11 +66,11 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Verify dialog content
-    await expect(dialog.getByText(/session expir|세션 만료/i)).toBeVisible();
+    await expect(dialog.getByText(/taking a break|쉬고 계신/i)).toBeVisible();
 
     // Verify both buttons are present
     await expect(
-      dialog.getByRole("button", { name: /extend|연장/i }),
+      dialog.getByRole("button", { name: /stay signed in|로그인 유지/i }),
     ).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /sign out|로그아웃/i }),
@@ -119,7 +119,7 @@ test.describe("Session Extension Dialog", () => {
     );
 
     // Click Extend
-    await dialog.getByRole("button", { name: /extend|연장/i }).click();
+    await dialog.getByRole("button", { name: /stay signed in|로그인 유지/i }).click();
 
     // Verify /api/auth/me was called successfully
     const meResponse = await mePromise;
@@ -210,7 +210,7 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Click Extend
-    await dialog.getByRole("button", { name: /extend|연장/i }).click();
+    await dialog.getByRole("button", { name: /stay signed in|로그인 유지/i }).click();
     await expect(dialog).not.toBeVisible({ timeout: 5_000 });
 
     // Wait 2 more seconds — dialog should NOT reappear (same exp)
@@ -239,7 +239,7 @@ test.describe("Session Extension Dialog", () => {
     });
 
     // Rapid double-click — button should disable after first click
-    const extendBtn = dialog.getByRole("button", { name: /extend|연장/i });
+    const extendBtn = dialog.getByRole("button", { name: /stay signed in|로그인 유지/i });
     await extendBtn.dblclick();
 
     // Wait for the request to complete
@@ -293,9 +293,9 @@ test.describe("Session Extension Dialog", () => {
     await expect(dialog).toBeVisible({ timeout: 5_000 });
 
     // Verify Korean text
-    await expect(dialog.getByText(/세션 만료/)).toBeVisible();
+    await expect(dialog.getByText(/쉬고 계신/)).toBeVisible();
     await expect(
-      dialog.getByRole("button", { name: /세션 연장/ }),
+      dialog.getByRole("button", { name: /로그인 유지/ }),
     ).toBeVisible();
     await expect(
       dialog.getByRole("button", { name: /로그아웃/ }),

--- a/src/__tests__/hooks/use-session-monitor.test.ts
+++ b/src/__tests__/hooks/use-session-monitor.test.ts
@@ -150,7 +150,9 @@ describe("useSessionMonitor", () => {
     useSessionMonitor();
     runEffect();
 
-    expect(mockRouterPush).toHaveBeenCalledWith("/sign-in");
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/sign-in?reason=session-ended",
+    );
     expect(setShowDialog).toHaveBeenCalledWith(false);
   });
 

--- a/src/app/[locale]/(auth)/sign-in/page.tsx
+++ b/src/app/[locale]/(auth)/sign-in/page.tsx
@@ -1,5 +1,26 @@
 import { SignInForm } from "@/components/auth/sign-in-form";
+import {
+  type SignInReason,
+  SignInReasonScreen,
+} from "@/components/auth/sign-in-reason-screen";
 
-export default function SignInPage() {
+const VALID_REASONS = new Set<SignInReason>(["signed-out", "session-ended"]);
+
+export default async function SignInPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const raw = typeof params.reason === "string" ? params.reason : undefined;
+  const reason =
+    raw && VALID_REASONS.has(raw as SignInReason)
+      ? (raw as SignInReason)
+      : undefined;
+
+  if (reason) {
+    return <SignInReasonScreen reason={reason} />;
+  }
+
   return <SignInForm />;
 }

--- a/src/components/auth/change-password-form.tsx
+++ b/src/components/auth/change-password-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { AlertCircle, Eye, EyeOff, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -122,7 +122,7 @@ export function ChangePasswordForm() {
           name="currentPassword"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{t("currentPassword")}</FormLabel>
+              <FormLabel required>{t("currentPassword")}</FormLabel>
               <FormControl>
                 <div className="relative">
                   <Input
@@ -161,7 +161,7 @@ export function ChangePasswordForm() {
           name="newPassword"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{t("newPassword")}</FormLabel>
+              <FormLabel required>{t("newPassword")}</FormLabel>
               <FormControl>
                 <div className="relative">
                   <Input
@@ -199,7 +199,7 @@ export function ChangePasswordForm() {
           name="confirmPassword"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{t("confirmPassword")}</FormLabel>
+              <FormLabel required>{t("confirmPassword")}</FormLabel>
               <FormControl>
                 <Input
                   type="password"
@@ -217,7 +217,11 @@ export function ChangePasswordForm() {
         />
 
         {serverError && (
-          <p className="text-destructive text-sm" role="alert">
+          <p
+            className="text-destructive flex items-center gap-1 text-sm"
+            role="alert"
+          >
+            <AlertCircle className="size-3.5 shrink-0" />
             {serverError}
           </p>
         )}

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Eye, EyeOff, Loader2 } from "lucide-react";
+import { AlertCircle, Eye, EyeOff, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -111,7 +111,7 @@ export function SignInForm() {
           name="username"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{t("username")}</FormLabel>
+              <FormLabel required>{t("username")}</FormLabel>
               <FormControl>
                 <Input
                   autoComplete="username"
@@ -133,7 +133,7 @@ export function SignInForm() {
           name="password"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>{t("password")}</FormLabel>
+              <FormLabel required>{t("password")}</FormLabel>
               <FormControl>
                 <div className="relative">
                   <Input
@@ -170,7 +170,11 @@ export function SignInForm() {
         />
 
         {serverError && (
-          <p className="text-destructive text-sm" role="alert">
+          <p
+            className="text-destructive flex items-center gap-1 text-sm"
+            role="alert"
+          >
+            <AlertCircle className="size-3.5 shrink-0" />
             {serverError}
           </p>
         )}

--- a/src/components/auth/sign-in-reason-screen.tsx
+++ b/src/components/auth/sign-in-reason-screen.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Clock, LogOut } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
+
+const SCREENS = {
+  "signed-out": {
+    icon: LogOut,
+    headingKey: "signedOutHeading",
+    descriptionKey: "signedOutDescription",
+  },
+  "session-ended": {
+    icon: Clock,
+    headingKey: "sessionEndedHeading",
+    descriptionKey: "sessionEndedDescription",
+  },
+} as const;
+
+export type SignInReason = keyof typeof SCREENS;
+
+export function SignInReasonScreen({ reason }: { reason: SignInReason }) {
+  const t = useTranslations("auth");
+  const screen = SCREENS[reason];
+  const Icon = screen.icon;
+
+  return (
+    <div className="grid gap-6 text-center">
+      <div className="flex justify-center">
+        <div className="bg-muted flex size-12 items-center justify-center rounded-full">
+          <Icon className="text-muted-foreground size-6" />
+        </div>
+      </div>
+
+      <div className="grid gap-2">
+        <h1 className="text-xl font-semibold tracking-tight">
+          {t(screen.headingKey)}
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          {t(screen.descriptionKey)}
+        </p>
+      </div>
+
+      <Button asChild className="w-full">
+        <Link href="/sign-in">{t("signInAgain")}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/session/session-extension-dialog.tsx
+++ b/src/components/session/session-extension-dialog.tsx
@@ -62,11 +62,11 @@ export function SessionExtensionDialog() {
       } else {
         // Token already expired or invalid — redirect to sign-in
         clearTokenExpCookie();
-        router.push("/sign-in");
+        router.push("/sign-in?reason=session-ended");
       }
     } catch {
       clearTokenExpCookie();
-      router.push("/sign-in");
+      router.push("/sign-in?reason=session-ended");
     } finally {
       setExtending(false);
     }
@@ -84,7 +84,7 @@ export function SessionExtensionDialog() {
       // Best-effort sign-out; redirect regardless
     } finally {
       clearTokenExpCookie();
-      router.push("/sign-in");
+      router.push("/sign-in?reason=signed-out");
     }
   }, [router]);
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AlertCircle } from "lucide-react";
 import type { Label as LabelPrimitive } from "radix-ui";
 import { Slot } from "radix-ui";
 import * as React from "react";
@@ -88,8 +89,10 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
 
 function FormLabel({
   className,
+  required,
+  children,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.ComponentProps<typeof LabelPrimitive.Root> & { required?: boolean }) {
   const { error, formItemId } = useFormField();
 
   return (
@@ -99,7 +102,14 @@ function FormLabel({
       className={cn("data-[error=true]:text-destructive", className)}
       htmlFor={formItemId}
       {...props}
-    />
+    >
+      {children}
+      {required && (
+        <span aria-hidden="true" className="text-destructive ml-0.5">
+          *
+        </span>
+      )}
+    </Label>
   );
 }
 
@@ -147,9 +157,13 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-destructive text-sm", className)}
+      className={cn(
+        "text-destructive flex items-center gap-1 text-sm",
+        className,
+      )}
       {...props}
     >
+      <AlertCircle className="size-3.5 shrink-0" />
       {body}
     </p>
   );

--- a/src/hooks/use-session-monitor.ts
+++ b/src/hooks/use-session-monitor.ts
@@ -80,7 +80,7 @@ export function useSessionMonitor(): SessionMonitorState {
       if (remaining <= 0) {
         // JWT has expired — redirect to sign-in
         setShowDialog(false);
-        router.push("/sign-in");
+        router.push("/sign-in?reason=session-ended");
         return;
       }
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -28,9 +28,14 @@
     "resetPassword": "Reset your password",
     "sessionTimeout": "Session timeout",
     "sessionEnded": "Session ended",
-    "sessionExpiring": "Session expiring",
-    "sessionExpiringDescription": "Your session will expire in {seconds} seconds. Would you like to extend it?",
-    "extendSession": "Extend session"
+    "signedOutHeading": "You've been signed out",
+    "signedOutDescription": "You have successfully signed out.",
+    "sessionEndedHeading": "Your session has ended",
+    "sessionEndedDescription": "Your session expired due to inactivity. Please sign in again to continue.",
+    "signInAgain": "Sign in again",
+    "sessionExpiring": "Taking a break?",
+    "sessionExpiringDescription": "Your session will expire in {seconds} seconds. Stay signed in to keep working.",
+    "extendSession": "Stay signed in"
   },
   "nav": {
     "home": "Home",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -33,8 +33,8 @@
     "sessionEndedHeading": "Your session has ended",
     "sessionEndedDescription": "Your session expired due to inactivity. Please sign in again to continue.",
     "signInAgain": "Sign in again",
-    "sessionExpiring": "Taking a break?",
-    "sessionExpiringDescription": "Your session will expire in {seconds} seconds. Stay signed in to keep working.",
+    "sessionExpiring": "Your session is about to expire",
+    "sessionExpiringDescription": "Your session will expire in {seconds} seconds. Would you like to stay signed in?",
     "extendSession": "Stay signed in"
   },
   "nav": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -28,9 +28,14 @@
     "resetPassword": "비밀번호 재설정",
     "sessionTimeout": "세션 시간 초과",
     "sessionEnded": "세션 종료",
-    "sessionExpiring": "세션 만료 임박",
-    "sessionExpiringDescription": "세션이 {seconds}초 후에 만료됩니다. 연장하시겠습니까?",
-    "extendSession": "세션 연장"
+    "signedOutHeading": "로그아웃되었습니다",
+    "signedOutDescription": "성공적으로 로그아웃되었습니다.",
+    "sessionEndedHeading": "세션이 종료되었습니다",
+    "sessionEndedDescription": "비활성으로 인해 세션이 만료되었습니다. 계속하려면 다시 로그인해 주세요.",
+    "signInAgain": "다시 로그인",
+    "sessionExpiring": "잠시 쉬고 계신가요?",
+    "sessionExpiringDescription": "세션이 {seconds}초 후에 만료됩니다. 계속 작업하려면 로그인을 유지하세요.",
+    "extendSession": "로그인 유지"
   },
   "nav": {
     "home": "홈",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -33,8 +33,8 @@
     "sessionEndedHeading": "세션이 종료되었습니다",
     "sessionEndedDescription": "비활성으로 인해 세션이 만료되었습니다. 계속하려면 다시 로그인해 주세요.",
     "signInAgain": "다시 로그인",
-    "sessionExpiring": "잠시 쉬고 계신가요?",
-    "sessionExpiringDescription": "세션이 {seconds}초 후에 만료됩니다. 계속 작업하려면 로그인을 유지하세요.",
+    "sessionExpiring": "세션이 곧 만료됩니다",
+    "sessionExpiringDescription": "세션이 {seconds}초 후에 만료됩니다. 로그인을 유지하시겠습니까?",
     "extendSession": "로그인 유지"
   },
   "nav": {


### PR DESCRIPTION
## Summary

- Add signed-out / session-ended intermediate screens on the sign-in page (`?reason=signed-out`, `?reason=session-ended`) so users understand why they were redirected
- Update session extension dialog wording to match Figma's friendly tone ("Taking a break?" / "Stay signed in")
- Add red `*` required marker to `FormLabel` and `AlertCircle` icon to `FormMessage` error display
- Apply required markers and error icons to sign-in and change-password forms

## Test plan

- [x] Navigate to `/sign-in?reason=signed-out` — shows "You've been signed out" screen with "Sign in again" button
- [x] Navigate to `/sign-in?reason=session-ended` — shows "Your session has ended" screen with "Sign in again" button
- [x] Navigate to `/sign-in` (no reason) — shows normal sign-in form
- [x] Let session expire — redirected to `/sign-in?reason=session-ended`
- [x] Click "Sign Out" in session dialog — redirected to `/sign-in?reason=signed-out`
- [x] Session dialog shows "Taking a break?" title and "Stay signed in" button
- [x] Sign-in form labels show red `*` next to "Account ID" and "Password"
- [x] Change-password form labels show red `*` next to all three fields
- [x] Submit empty sign-in form — error messages show `AlertCircle` icon
- [x] Trigger server error on sign-in — error message shows `AlertCircle` icon
- [x] Korean locale shows correct translations for all new strings

Closes #131