### PR TITLE
Add System Settings UI

### DIFF
--- a/src/__tests__/app/api/system-settings/[key]/route.test.ts
+++ b/src/__tests__/app/api/system-settings/[key]/route.test.ts
@@ -1,0 +1,222 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockUpdateSystemSetting = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/system-settings", () => ({
+  updateSystemSetting: mockUpdateSystemSetting,
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: { record: mockAuditRecord },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+describe("PATCH /api/system-settings/[key]", () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  const adminSession: AuthSession = {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["System Administrator"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+    iat: now,
+    exp: now + 900,
+    sessionIp: "127.0.0.1",
+    sessionUserAgent: "Mozilla/5.0 Chrome/131",
+    sessionBrowserFingerprint: "Chrome/131",
+    needsReauth: false,
+    sessionCreatedAt: new Date(),
+    sessionLastActiveAt: new Date(),
+  };
+
+  const viewerSession: AuthSession = {
+    ...adminSession,
+    roles: ["viewer"],
+  };
+
+  function makeRequest(body: unknown) {
+    return new NextRequest(
+      "http://localhost:3000/api/system-settings/password_policy",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+  }
+
+  function makeContext(key = "password_policy") {
+    return { params: Promise.resolve({ key }) };
+  }
+
+  beforeEach(() => {
+    mockUpdateSystemSetting.mockReset();
+    mockAuditRecord.mockReset().mockResolvedValue(undefined);
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  // ── Permission ──────────────────────────────────────────────────
+
+  it("returns 403 when user lacks system-settings:write", async () => {
+    currentSession = viewerSession;
+    mockHasPermission.mockResolvedValue(false);
+
+    const { PATCH } = await import("@/app/api/system-settings/[key]/route");
+    const response = await PATCH(makeRequest({ value: {} }), makeContext());
+
+    expect(response.status).toBe(403);
+  });
+
+  // ── Request validation ──────────────────────────────────────────
+
+  it("returns 400 for invalid JSON body", async () => {
+    const request = new NextRequest(
+      "http://localhost:3000/api/system-settings/password_policy",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: "not-json",
+      },
+    );
+
+    const { PATCH } = await import("@/app/api/system-settings/[key]/route");
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid JSON");
+  });
+
+  it("returns 400 when value field is missing", async () => {
+    const { PATCH } = await import("@/app/api/system-settings/[key]/route");
+    const response = await PATCH(makeRequest({}), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Missing required field: value");
+  });
+
+  // ── Validation failure ──────────────────────────────────────────
+
+  it("returns 400 with details when validation fails", async () => {
+    mockUpdateSystemSetting.mockResolvedValueOnce({
+      valid: false,
+      errors: ["min_length must be >= 8"],
+    });
+
+    const { PATCH } = await import("@/app/api/system-settings/[key]/route");
+    const response = await PATCH(
+      makeRequest({ value: { min_length: 3 } }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Validation failed");
+    expect(body.details).toContain("min_length must be >= 8");
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  // ── Success ─────────────────────────────────────────────────────
+
+  it("updates setting and records audit log on success", async () => {
+    const updatedSetting = {
+      key: "password_policy",
+      value: { min_length: 16, max_length: 128 },
+      updated_at: "2025-01-01",
+    };
+    mockUpdateSystemSetting.mockResolvedValueOnce({
+      valid: true,
+      data: updatedSetting,
+    });
+
+    const { PATCH } = await import("@/app/api/system-settings/[key]/route");
+    const response = await PATCH(
+      makeRequest({ value: { min_length: 16, max_length: 128 } }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.key).toBe("password_policy");
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: "account-1",
+        action: "system_settings.update",
+        target: "system_settings",
+        targetId: "password_policy",
+      }),
+    );
+  });
+
+  it("passes the correct key from URL params", async () => {
+    mockUpdateSystemSetting.mockResolvedValueOnce({
+      valid: true,
+      data: {
+        key: "jwt_policy",
+        value: { access_token_expiration_minutes: 30 },
+        updated_at: "2025-01-01",
+      },
+    });
+
+    const { PATCH } = await import("@/app/api/system-settings/[key]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/system-settings/jwt_policy",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          value: { access_token_expiration_minutes: 30 },
+        }),
+      },
+    );
+    await PATCH(request, makeContext("jwt_policy"));
+
+    expect(mockUpdateSystemSetting).toHaveBeenCalledWith("jwt_policy", {
+      access_token_expiration_minutes: 30,
+    });
+  });
+});

--- a/src/__tests__/app/api/system-settings/route.test.ts
+++ b/src/__tests__/app/api/system-settings/route.test.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: unknown,
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockGetSystemSettings = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (request: NextRequest, context: unknown) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/system-settings", () => ({
+  getSystemSettings: mockGetSystemSettings,
+}));
+
+describe("GET /api/system-settings", () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  const adminSession: AuthSession = {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["System Administrator"],
+    tokenVersion: 0,
+    mustChangePassword: false,
+    iat: now,
+    exp: now + 900,
+    sessionIp: "127.0.0.1",
+    sessionUserAgent: "Mozilla/5.0 Chrome/131",
+    sessionBrowserFingerprint: "Chrome/131",
+    needsReauth: false,
+    sessionCreatedAt: new Date(),
+    sessionLastActiveAt: new Date(),
+  };
+
+  const viewerSession: AuthSession = {
+    ...adminSession,
+    roles: ["viewer"],
+  };
+
+  function makeRequest() {
+    return new NextRequest("http://localhost:3000/api/system-settings");
+  }
+
+  function makeContext() {
+    return { params: Promise.resolve({}) };
+  }
+
+  beforeEach(() => {
+    mockGetSystemSettings.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  it("returns 403 when user lacks system-settings:read", async () => {
+    currentSession = viewerSession;
+    mockHasPermission.mockResolvedValue(false);
+    const { GET } = await import("@/app/api/system-settings/route");
+    const response = await GET(makeRequest(), makeContext());
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns all settings", async () => {
+    const settings = [
+      {
+        key: "jwt_policy",
+        value: { access_token_expiration_minutes: 15 },
+        updated_at: "2025-01-01",
+      },
+      {
+        key: "password_policy",
+        value: { min_length: 12 },
+        updated_at: "2025-01-01",
+      },
+    ];
+    mockGetSystemSettings.mockResolvedValueOnce(settings);
+
+    const { GET } = await import("@/app/api/system-settings/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].key).toBe("jwt_policy");
+    expect(body.data[1].key).toBe("password_policy");
+  });
+
+  it("returns empty array when no settings exist", async () => {
+    mockGetSystemSettings.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/system-settings/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([]);
+  });
+});

--- a/src/__tests__/components/layout/breadcrumbs.test.ts
+++ b/src/__tests__/components/layout/breadcrumbs.test.ts
@@ -92,7 +92,7 @@ describe("NAV_SEGMENTS", () => {
 
 describe("SETTINGS_SEGMENTS", () => {
   it("contains all expected settings keys", () => {
-    const expected = ["accounts", "roles", "profile", "customers"];
+    const expected = ["accounts", "roles", "profile", "customers", "system"];
     for (const key of expected) {
       expect(SETTINGS_SEGMENTS.has(key)).toBe(true);
     }

--- a/src/__tests__/lib/auth/system-settings.test.ts
+++ b/src/__tests__/lib/auth/system-settings.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit/limiter", () => ({
+  invalidateRateLimitConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/password-policy", () => ({
+  invalidatePasswordPolicy: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session-policy", () => ({
+  invalidateSessionPolicy: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/lockout-policy", () => ({
+  invalidateLockoutPolicy: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/jwt-policy", () => ({
+  invalidateJwtPolicy: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/mfa-policy", () => ({
+  invalidateMfaPolicy: vi.fn(),
+}));
+
+import { query } from "@/lib/db/client";
+
+const queryMock = vi.mocked(query);
+
+describe("system-settings", () => {
+  let mod: typeof import("@/lib/auth/system-settings");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mod = await import("@/lib/auth/system-settings");
+    queryMock.mockClear();
+  });
+
+  // ── validateSetting ───────────────────────────────────────────
+
+  describe("validateSetting", () => {
+    it("rejects unknown keys", () => {
+      const result = mod.validateSetting("unknown_key", {});
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/Unknown setting key/);
+    });
+
+    it("rejects non-object values", () => {
+      const result = mod.validateSetting("password_policy", "string");
+      expect(result.valid).toBe(false);
+    });
+
+    it("validates password_policy correctly", () => {
+      const valid = mod.validateSetting("password_policy", {
+        min_length: 12,
+        max_length: 128,
+        complexity_enabled: false,
+        reuse_ban_count: 5,
+      });
+      expect(valid.valid).toBe(true);
+
+      const invalid = mod.validateSetting("password_policy", {
+        min_length: 3,
+        max_length: 128,
+        complexity_enabled: false,
+        reuse_ban_count: 5,
+      });
+      expect(invalid.valid).toBe(false);
+      expect(invalid.errors?.[0]).toMatch(/min_length/);
+    });
+
+    it("validates max_length >= min_length", () => {
+      const result = mod.validateSetting("password_policy", {
+        min_length: 50,
+        max_length: 30,
+        complexity_enabled: false,
+        reuse_ban_count: 5,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some((e) => e.includes("max_length"))).toBe(true);
+    });
+
+    it("validates session_policy correctly", () => {
+      const valid = mod.validateSetting("session_policy", {
+        idle_timeout_minutes: 30,
+        absolute_timeout_hours: 8,
+        max_sessions: null,
+      });
+      expect(valid.valid).toBe(true);
+
+      const withMax = mod.validateSetting("session_policy", {
+        idle_timeout_minutes: 30,
+        absolute_timeout_hours: 8,
+        max_sessions: 5,
+      });
+      expect(withMax.valid).toBe(true);
+    });
+
+    it("validates lockout_policy correctly", () => {
+      const valid = mod.validateSetting("lockout_policy", {
+        stage1_threshold: 5,
+        stage1_duration_minutes: 30,
+      });
+      expect(valid.valid).toBe(true);
+
+      const invalid = mod.validateSetting("lockout_policy", {
+        stage1_threshold: 0,
+        stage1_duration_minutes: 30,
+      });
+      expect(invalid.valid).toBe(false);
+    });
+
+    it("validates jwt_policy correctly", () => {
+      const valid = mod.validateSetting("jwt_policy", {
+        access_token_expiration_minutes: 15,
+      });
+      expect(valid.valid).toBe(true);
+
+      const invalid = mod.validateSetting("jwt_policy", {
+        access_token_expiration_minutes: 0,
+      });
+      expect(invalid.valid).toBe(false);
+    });
+
+    it("validates mfa_policy correctly", () => {
+      const valid = mod.validateSetting("mfa_policy", {
+        allowed_methods: ["webauthn", "totp"],
+      });
+      expect(valid.valid).toBe(true);
+
+      const empty = mod.validateSetting("mfa_policy", {
+        allowed_methods: [],
+      });
+      expect(empty.valid).toBe(false);
+
+      const invalid = mod.validateSetting("mfa_policy", {
+        allowed_methods: ["sms"],
+      });
+      expect(invalid.valid).toBe(false);
+    });
+
+    it("validates signin_rate_limit correctly", () => {
+      const valid = mod.validateSetting("signin_rate_limit", {
+        per_ip_count: 20,
+        per_ip_window_minutes: 5,
+        per_account_ip_count: 5,
+        per_account_ip_window_minutes: 5,
+        global_count: 100,
+        global_window_minutes: 1,
+      });
+      expect(valid.valid).toBe(true);
+    });
+
+    it("validates api_rate_limit correctly", () => {
+      const valid = mod.validateSetting("api_rate_limit", {
+        per_user_count: 100,
+        per_user_window_minutes: 1,
+      });
+      expect(valid.valid).toBe(true);
+    });
+  });
+
+  // ── getSystemSettings ─────────────────────────────────────────
+
+  describe("getSystemSettings", () => {
+    it("returns all settings", async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            key: "jwt_policy",
+            value: { access_token_expiration_minutes: 15 },
+            updated_at: "2025-01-01",
+          },
+          {
+            key: "password_policy",
+            value: { min_length: 12 },
+            updated_at: "2025-01-01",
+          },
+        ],
+        rowCount: 2,
+      });
+
+      const result = await mod.getSystemSettings();
+      expect(result).toHaveLength(2);
+      expect(result[0].key).toBe("jwt_policy");
+    });
+  });
+
+  // ── updateSystemSetting ───────────────────────────────────────
+
+  describe("updateSystemSetting", () => {
+    it("returns validation errors for invalid value", async () => {
+      const result = await mod.updateSystemSetting("password_policy", {
+        min_length: 3,
+        max_length: 128,
+        complexity_enabled: false,
+        reuse_ban_count: 5,
+      });
+      expect(result.valid).toBe(false);
+      expect(queryMock).not.toHaveBeenCalled();
+    });
+
+    it("updates and invalidates cache on success", async () => {
+      const { invalidatePasswordPolicy } = await import(
+        "@/lib/auth/password-policy"
+      );
+
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            key: "password_policy",
+            value: {
+              min_length: 16,
+              max_length: 128,
+              complexity_enabled: true,
+              reuse_ban_count: 5,
+            },
+            updated_at: "2025-01-01",
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.updateSystemSetting("password_policy", {
+        min_length: 16,
+        max_length: 128,
+        complexity_enabled: true,
+        reuse_ban_count: 5,
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.key).toBe("password_policy");
+      expect(invalidatePasswordPolicy).toHaveBeenCalled();
+    });
+
+    it("returns error when setting not found in DB", async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const result = await mod.updateSystemSetting("jwt_policy", {
+        access_token_expiration_minutes: 15,
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/not found/);
+    });
+  });
+});

--- a/src/app/[locale]/(dashboard)/settings/layout.tsx
+++ b/src/app/[locale]/(dashboard)/settings/layout.tsx
@@ -8,13 +8,24 @@ export default async function SettingsLayout({
   children: React.ReactNode;
 }>) {
   const session = await getCurrentSession();
+
+  const showAccounts = session
+    ? await hasPermission(session.roles, "accounts:read")
+    : false;
+  const showCustomers = session
+    ? await hasPermission(session.roles, "customers:read")
+    : false;
   const showSystem = session
     ? await hasPermission(session.roles, "system-settings:read")
     : false;
 
   return (
     <div className="space-y-6">
-      <SettingsNav showSystem={showSystem} />
+      <SettingsNav
+        showAccounts={showAccounts}
+        showCustomers={showCustomers}
+        showSystem={showSystem}
+      />
       {children}
     </div>
   );

--- a/src/app/[locale]/(dashboard)/settings/layout.tsx
+++ b/src/app/[locale]/(dashboard)/settings/layout.tsx
@@ -1,0 +1,21 @@
+import { SettingsNav } from "@/components/layout/settings-nav";
+import { hasPermission } from "@/lib/auth/permissions";
+import { getCurrentSession } from "@/lib/auth/session";
+
+export default async function SettingsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const session = await getCurrentSession();
+  const showSystem = session
+    ? await hasPermission(session.roles, "system-settings:read")
+    : false;
+
+  return (
+    <div className="space-y-6">
+      <SettingsNav showSystem={showSystem} />
+      {children}
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/settings/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function SettingsPage() {
+  redirect("/settings/accounts");
+}

--- a/src/app/[locale]/(dashboard)/settings/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/page.tsx
@@ -1,5 +1,23 @@
 import { redirect } from "next/navigation";
 
-export default function SettingsPage() {
+import { hasPermission } from "@/lib/auth/permissions";
+import { getCurrentSession } from "@/lib/auth/session";
+
+export default async function SettingsPage() {
+  const session = await getCurrentSession();
+
+  if (session) {
+    if (await hasPermission(session.roles, "accounts:read")) {
+      redirect("/settings/accounts");
+    }
+    if (await hasPermission(session.roles, "customers:read")) {
+      redirect("/settings/customers");
+    }
+    if (await hasPermission(session.roles, "system-settings:read")) {
+      redirect("/settings/system");
+    }
+  }
+
+  // Fallback: redirect to accounts (will show permission error)
   redirect("/settings/accounts");
 }

--- a/src/app/[locale]/(dashboard)/settings/system/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/system/page.tsx
@@ -1,0 +1,14 @@
+import { SystemSettingsPanel } from "@/components/settings/system-settings-panel";
+import { hasPermission } from "@/lib/auth/permissions";
+import { getCurrentSession, requirePermission } from "@/lib/auth/session";
+
+export default async function SystemSettingsPage() {
+  const session = await getCurrentSession();
+  if (!session) return null;
+
+  await requirePermission(session, "system-settings:read");
+
+  const canWrite = await hasPermission(session.roles, "system-settings:write");
+
+  return <SystemSettingsPanel readOnly={!canWrite} />;
+}

--- a/src/app/api/system-settings/[key]/route.ts
+++ b/src/app/api/system-settings/[key]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { updateSystemSetting } from "@/lib/auth/system-settings";
+
+export const PATCH = withAuth(
+  async (request, context, session) => {
+    const { key } = await context.params;
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const value = body.value;
+    if (value === undefined) {
+      return NextResponse.json(
+        { error: "Missing required field: value" },
+        { status: 400 },
+      );
+    }
+
+    const result = await updateSystemSetting(key, value);
+    if (!result.valid) {
+      return NextResponse.json(
+        { error: "Validation failed", details: result.errors },
+        { status: 400 },
+      );
+    }
+
+    await auditLog.record({
+      actor: session.accountId,
+      action: "system_settings.update",
+      target: "system_settings",
+      targetId: key,
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { key, value },
+    });
+
+    return NextResponse.json({ data: result.data });
+  },
+  { requiredPermissions: ["system-settings:write"] },
+);

--- a/src/app/api/system-settings/route.ts
+++ b/src/app/api/system-settings/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { getSystemSettings } from "@/lib/auth/system-settings";
+
+export const GET = withAuth(
+  async () => {
+    const settings = await getSystemSettings();
+    return NextResponse.json({ data: settings });
+  },
+  { requiredPermissions: ["system-settings:read"] },
+);

--- a/src/components/layout/settings-nav.tsx
+++ b/src/components/layout/settings-nav.tsx
@@ -5,21 +5,26 @@ import { Link, usePathname } from "@/i18n/navigation";
 import { cn } from "@/lib/utils";
 
 interface SettingsNavProps {
+  showAccounts?: boolean;
+  showCustomers?: boolean;
   showSystem?: boolean;
 }
 
-const ITEMS = [
-  { key: "accounts", href: "/settings/accounts" },
-  { key: "customers", href: "/settings/customers" },
-] as const;
-
-export function SettingsNav({ showSystem }: SettingsNavProps) {
+export function SettingsNav({
+  showAccounts,
+  showCustomers,
+  showSystem,
+}: SettingsNavProps) {
   const t = useTranslations("settings");
   const pathname = usePathname();
 
-  const items = showSystem
-    ? [...ITEMS, { key: "system" as const, href: "/settings/system" }]
-    : ITEMS;
+  const items: { key: string; href: string }[] = [];
+  if (showAccounts) items.push({ key: "accounts", href: "/settings/accounts" });
+  if (showCustomers)
+    items.push({ key: "customers", href: "/settings/customers" });
+  if (showSystem) items.push({ key: "system", href: "/settings/system" });
+
+  if (items.length === 0) return null;
 
   return (
     <nav className="flex gap-1 border-b">

--- a/src/components/layout/settings-nav.tsx
+++ b/src/components/layout/settings-nav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link, usePathname } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+
+interface SettingsNavProps {
+  showSystem?: boolean;
+}
+
+const ITEMS = [
+  { key: "accounts", href: "/settings/accounts" },
+  { key: "customers", href: "/settings/customers" },
+] as const;
+
+export function SettingsNav({ showSystem }: SettingsNavProps) {
+  const t = useTranslations("settings");
+  const pathname = usePathname();
+
+  const items = showSystem
+    ? [...ITEMS, { key: "system" as const, href: "/settings/system" }]
+    : ITEMS;
+
+  return (
+    <nav className="flex gap-1 border-b">
+      {items.map((item) => {
+        const active = pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.key}
+            href={item.href}
+            className={cn(
+              "border-b-2 px-4 py-2 text-sm font-medium transition-colors",
+              active
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t(item.key)}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/settings/system-settings-panel.tsx
+++ b/src/components/settings/system-settings-panel.tsx
@@ -1,0 +1,759 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Info, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface SystemSettingRow {
+  key: string;
+  value: Record<string, unknown>;
+  updated_at: string;
+}
+
+interface SystemSettingsPanelProps {
+  readOnly: boolean;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function toRecord(
+  rows: SystemSettingRow[],
+): Record<string, Record<string, unknown>> {
+  const map: Record<string, Record<string, unknown>> = {};
+  for (const row of rows) {
+    map[row.key] = row.value;
+  }
+  return map;
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+export function SystemSettingsPanel({ readOnly }: SystemSettingsPanelProps) {
+  const t = useTranslations("systemSettings");
+  const tc = useTranslations("common");
+
+  const [settings, setSettings] = useState<Record<
+    string,
+    Record<string, unknown>
+  > | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  useEffect(() => {
+    fetch("/api/system-settings")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.data) setSettings(toRecord(data.data));
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function saveSetting(key: string, value: Record<string, unknown>) {
+    setSaving(key);
+    setMessage(null);
+
+    try {
+      const csrfToken = readCsrfToken();
+      const res = await fetch(`/api/system-settings/${key}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "x-csrf-token": csrfToken } : {}),
+        },
+        body: JSON.stringify({ value }),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        const details = body?.details?.join(", ") ?? body?.error ?? t("error");
+        setMessage({ type: "error", text: details });
+        return;
+      }
+
+      const data = await res.json();
+      setSettings((prev) =>
+        prev ? { ...prev, [key]: data.data.value } : prev,
+      );
+      setMessage({ type: "success", text: t("saved") });
+    } catch {
+      setMessage({ type: "error", text: t("error") });
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-8 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" />
+        {tc("loading")}
+      </div>
+    );
+  }
+
+  if (!settings) {
+    return (
+      <p className="py-8 text-sm text-destructive">
+        <AlertCircle className="mr-1 inline size-4" />
+        {t("error")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">{t("title")}</h1>
+
+      {readOnly && (
+        <div className="flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
+          <Info className="size-4 shrink-0" />
+          {t("readOnlyNotice")}
+        </div>
+      )}
+
+      {message && (
+        <div
+          className={`flex items-center gap-2 rounded-md border px-4 py-3 text-sm ${
+            message.type === "success"
+              ? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200"
+              : "border-destructive/30 bg-destructive/10 text-destructive"
+          }`}
+        >
+          {message.type === "success" ? (
+            <CheckCircle2 className="size-4 shrink-0" />
+          ) : (
+            <AlertCircle className="size-4 shrink-0" />
+          )}
+          {message.text}
+        </div>
+      )}
+
+      <Tabs defaultValue="password">
+        <TabsList>
+          <TabsTrigger value="password">{t("tabs.password")}</TabsTrigger>
+          <TabsTrigger value="session">{t("tabs.session")}</TabsTrigger>
+          <TabsTrigger value="lockout">{t("tabs.lockout")}</TabsTrigger>
+          <TabsTrigger value="jwt">{t("tabs.jwt")}</TabsTrigger>
+          <TabsTrigger value="mfa">{t("tabs.mfa")}</TabsTrigger>
+          <TabsTrigger value="rateLimits">{t("tabs.rateLimits")}</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="password">
+          <PasswordPolicyForm
+            value={settings.password_policy}
+            readOnly={readOnly}
+            saving={saving === "password_policy"}
+            onSave={(v) => saveSetting("password_policy", v)}
+            t={t}
+          />
+        </TabsContent>
+
+        <TabsContent value="session">
+          <SessionPolicyForm
+            value={settings.session_policy}
+            readOnly={readOnly}
+            saving={saving === "session_policy"}
+            onSave={(v) => saveSetting("session_policy", v)}
+            t={t}
+          />
+        </TabsContent>
+
+        <TabsContent value="lockout">
+          <LockoutPolicyForm
+            value={settings.lockout_policy}
+            readOnly={readOnly}
+            saving={saving === "lockout_policy"}
+            onSave={(v) => saveSetting("lockout_policy", v)}
+            t={t}
+          />
+        </TabsContent>
+
+        <TabsContent value="jwt">
+          <JwtPolicyForm
+            value={settings.jwt_policy}
+            readOnly={readOnly}
+            saving={saving === "jwt_policy"}
+            onSave={(v) => saveSetting("jwt_policy", v)}
+            t={t}
+          />
+        </TabsContent>
+
+        <TabsContent value="mfa">
+          <MfaPolicyForm
+            value={settings.mfa_policy}
+            readOnly={readOnly}
+            saving={saving === "mfa_policy"}
+            onSave={(v) => saveSetting("mfa_policy", v)}
+            t={t}
+          />
+        </TabsContent>
+
+        <TabsContent value="rateLimits">
+          <RateLimitsForm
+            signinValue={settings.signin_rate_limit}
+            apiValue={settings.api_rate_limit}
+            readOnly={readOnly}
+            saving={
+              saving === "signin_rate_limit" || saving === "api_rate_limit"
+            }
+            onSaveSignIn={(v) => saveSetting("signin_rate_limit", v)}
+            onSaveApi={(v) => saveSetting("api_rate_limit", v)}
+            t={t}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// ── Shared field components ─────────────────────────────────────
+
+function NumberField({
+  id,
+  label,
+  description,
+  value,
+  onChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  value: number | string;
+  onChange: (v: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>
+        {label}
+        <span className="ml-0.5 text-destructive">*</span>
+      </Label>
+      <Input
+        id={id}
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="max-w-xs"
+      />
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+// ── Policy forms ────────────────────────────────────────────────
+
+interface PolicyFormProps {
+  value: Record<string, unknown>;
+  readOnly: boolean;
+  saving: boolean;
+  onSave: (value: Record<string, unknown>) => void;
+  t: ReturnType<typeof useTranslations<"systemSettings">>;
+}
+
+function PasswordPolicyForm({
+  value,
+  readOnly,
+  saving,
+  onSave,
+  t,
+}: PolicyFormProps) {
+  const [minLength, setMinLength] = useState(String(value.min_length ?? 12));
+  const [maxLength, setMaxLength] = useState(String(value.max_length ?? 128));
+  const [complexityEnabled, setComplexityEnabled] = useState(
+    Boolean(value.complexity_enabled),
+  );
+  const [reuseBanCount, setReuseBanCount] = useState(
+    String(value.reuse_ban_count ?? 5),
+  );
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div>
+        <h2 className="text-lg font-medium">{t("passwordPolicy.title")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("passwordPolicy.description")}
+        </p>
+      </div>
+
+      <NumberField
+        id="min_length"
+        label={t("passwordPolicy.minLength")}
+        description={t("passwordPolicy.minLengthDescription")}
+        value={minLength}
+        onChange={setMinLength}
+        disabled={readOnly}
+      />
+      <NumberField
+        id="max_length"
+        label={t("passwordPolicy.maxLength")}
+        description={t("passwordPolicy.maxLengthDescription")}
+        value={maxLength}
+        onChange={setMaxLength}
+        disabled={readOnly}
+      />
+      <div className="flex items-center gap-3">
+        <Switch
+          id="complexity_enabled"
+          checked={complexityEnabled}
+          onCheckedChange={setComplexityEnabled}
+          disabled={readOnly}
+        />
+        <div>
+          <Label htmlFor="complexity_enabled">
+            {t("passwordPolicy.complexityEnabled")}
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            {t("passwordPolicy.complexityEnabledDescription")}
+          </p>
+        </div>
+      </div>
+      <NumberField
+        id="reuse_ban_count"
+        label={t("passwordPolicy.reuseBanCount")}
+        description={t("passwordPolicy.reuseBanCountDescription")}
+        value={reuseBanCount}
+        onChange={setReuseBanCount}
+        disabled={readOnly}
+      />
+
+      {!readOnly && (
+        <Button
+          onClick={() =>
+            onSave({
+              min_length: Number(minLength),
+              max_length: Number(maxLength),
+              complexity_enabled: complexityEnabled,
+              reuse_ban_count: Number(reuseBanCount),
+            })
+          }
+          disabled={saving}
+        >
+          {saving ? t("saving") : t("tabs.password")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function SessionPolicyForm({
+  value,
+  readOnly,
+  saving,
+  onSave,
+  t,
+}: PolicyFormProps) {
+  const [idleTimeout, setIdleTimeout] = useState(
+    String(value.idle_timeout_minutes ?? 30),
+  );
+  const [absoluteTimeout, setAbsoluteTimeout] = useState(
+    String(value.absolute_timeout_hours ?? 8),
+  );
+  const [maxSessions, setMaxSessions] = useState(
+    value.max_sessions != null ? String(value.max_sessions) : "",
+  );
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div>
+        <h2 className="text-lg font-medium">{t("sessionPolicy.title")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("sessionPolicy.description")}
+        </p>
+      </div>
+
+      <NumberField
+        id="idle_timeout_minutes"
+        label={t("sessionPolicy.idleTimeoutMinutes")}
+        description={t("sessionPolicy.idleTimeoutMinutesDescription")}
+        value={idleTimeout}
+        onChange={setIdleTimeout}
+        disabled={readOnly}
+      />
+      <NumberField
+        id="absolute_timeout_hours"
+        label={t("sessionPolicy.absoluteTimeoutHours")}
+        description={t("sessionPolicy.absoluteTimeoutHoursDescription")}
+        value={absoluteTimeout}
+        onChange={setAbsoluteTimeout}
+        disabled={readOnly}
+      />
+      <div className="space-y-2">
+        <Label htmlFor="max_sessions">{t("sessionPolicy.maxSessions")}</Label>
+        <Input
+          id="max_sessions"
+          type="number"
+          value={maxSessions}
+          onChange={(e) => setMaxSessions(e.target.value)}
+          disabled={readOnly}
+          placeholder="∞"
+          className="max-w-xs"
+        />
+        <p className="text-xs text-muted-foreground">
+          {t("sessionPolicy.maxSessionsDescription")}
+        </p>
+      </div>
+
+      {!readOnly && (
+        <Button
+          onClick={() =>
+            onSave({
+              idle_timeout_minutes: Number(idleTimeout),
+              absolute_timeout_hours: Number(absoluteTimeout),
+              max_sessions: maxSessions ? Number(maxSessions) : null,
+            })
+          }
+          disabled={saving}
+        >
+          {saving ? t("saving") : t("tabs.session")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function LockoutPolicyForm({
+  value,
+  readOnly,
+  saving,
+  onSave,
+  t,
+}: PolicyFormProps) {
+  const [threshold, setThreshold] = useState(
+    String(value.stage1_threshold ?? 5),
+  );
+  const [duration, setDuration] = useState(
+    String(value.stage1_duration_minutes ?? 30),
+  );
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div>
+        <h2 className="text-lg font-medium">{t("lockoutPolicy.title")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("lockoutPolicy.description")}
+        </p>
+      </div>
+
+      <NumberField
+        id="stage1_threshold"
+        label={t("lockoutPolicy.stage1Threshold")}
+        description={t("lockoutPolicy.stage1ThresholdDescription")}
+        value={threshold}
+        onChange={setThreshold}
+        disabled={readOnly}
+      />
+      <NumberField
+        id="stage1_duration_minutes"
+        label={t("lockoutPolicy.stage1DurationMinutes")}
+        description={t("lockoutPolicy.stage1DurationMinutesDescription")}
+        value={duration}
+        onChange={setDuration}
+        disabled={readOnly}
+      />
+
+      {!readOnly && (
+        <Button
+          onClick={() =>
+            onSave({
+              stage1_threshold: Number(threshold),
+              stage1_duration_minutes: Number(duration),
+            })
+          }
+          disabled={saving}
+        >
+          {saving ? t("saving") : t("tabs.lockout")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function JwtPolicyForm({
+  value,
+  readOnly,
+  saving,
+  onSave,
+  t,
+}: PolicyFormProps) {
+  const [expiration, setExpiration] = useState(
+    String(value.access_token_expiration_minutes ?? 15),
+  );
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div>
+        <h2 className="text-lg font-medium">{t("jwtPolicy.title")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("jwtPolicy.description")}
+        </p>
+      </div>
+
+      <NumberField
+        id="access_token_expiration_minutes"
+        label={t("jwtPolicy.accessTokenExpirationMinutes")}
+        description={t("jwtPolicy.accessTokenExpirationMinutesDescription")}
+        value={expiration}
+        onChange={setExpiration}
+        disabled={readOnly}
+      />
+
+      {!readOnly && (
+        <Button
+          onClick={() =>
+            onSave({
+              access_token_expiration_minutes: Number(expiration),
+            })
+          }
+          disabled={saving}
+        >
+          {saving ? t("saving") : t("tabs.jwt")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function MfaPolicyForm({
+  value,
+  readOnly,
+  saving,
+  onSave,
+  t,
+}: PolicyFormProps) {
+  const methods = (value.allowed_methods as string[]) ?? ["webauthn", "totp"];
+  const [webauthn, setWebauthn] = useState(methods.includes("webauthn"));
+  const [totp, setTotp] = useState(methods.includes("totp"));
+
+  return (
+    <div className="space-y-6 pt-4">
+      <div>
+        <h2 className="text-lg font-medium">{t("mfaPolicy.title")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("mfaPolicy.description")}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <Label>{t("mfaPolicy.allowedMethods")}</Label>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="mfa_webauthn"
+            checked={webauthn}
+            onCheckedChange={(c) => setWebauthn(c === true)}
+            disabled={readOnly}
+          />
+          <Label htmlFor="mfa_webauthn" className="font-normal">
+            {t("mfaPolicy.webauthn")}
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="mfa_totp"
+            checked={totp}
+            onCheckedChange={(c) => setTotp(c === true)}
+            disabled={readOnly}
+          />
+          <Label htmlFor="mfa_totp" className="font-normal">
+            {t("mfaPolicy.totp")}
+          </Label>
+        </div>
+      </div>
+
+      {!readOnly && (
+        <Button
+          onClick={() => {
+            const allowed: string[] = [];
+            if (webauthn) allowed.push("webauthn");
+            if (totp) allowed.push("totp");
+            onSave({ allowed_methods: allowed });
+          }}
+          disabled={saving || (!webauthn && !totp)}
+        >
+          {saving ? t("saving") : t("tabs.mfa")}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+interface RateLimitsFormProps {
+  signinValue: Record<string, unknown>;
+  apiValue: Record<string, unknown>;
+  readOnly: boolean;
+  saving: boolean;
+  onSaveSignIn: (value: Record<string, unknown>) => void;
+  onSaveApi: (value: Record<string, unknown>) => void;
+  t: ReturnType<typeof useTranslations<"systemSettings">>;
+}
+
+function RateLimitsForm({
+  signinValue,
+  apiValue,
+  readOnly,
+  saving,
+  onSaveSignIn,
+  onSaveApi,
+  t,
+}: RateLimitsFormProps) {
+  const [perIpCount, setPerIpCount] = useState(
+    String(signinValue.per_ip_count ?? 20),
+  );
+  const [perIpWindow, setPerIpWindow] = useState(
+    String(signinValue.per_ip_window_minutes ?? 5),
+  );
+  const [perAccountIpCount, setPerAccountIpCount] = useState(
+    String(signinValue.per_account_ip_count ?? 5),
+  );
+  const [perAccountIpWindow, setPerAccountIpWindow] = useState(
+    String(signinValue.per_account_ip_window_minutes ?? 5),
+  );
+  const [globalCount, setGlobalCount] = useState(
+    String(signinValue.global_count ?? 100),
+  );
+  const [globalWindow, setGlobalWindow] = useState(
+    String(signinValue.global_window_minutes ?? 1),
+  );
+
+  const [perUserCount, setPerUserCount] = useState(
+    String(apiValue.per_user_count ?? 100),
+  );
+  const [perUserWindow, setPerUserWindow] = useState(
+    String(apiValue.per_user_window_minutes ?? 1),
+  );
+
+  return (
+    <div className="space-y-8 pt-4">
+      <div>
+        <h2 className="text-lg font-medium">{t("rateLimits.title")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("rateLimits.description")}
+        </p>
+      </div>
+
+      {/* Sign-in rate limits */}
+      <div className="space-y-6">
+        <h3 className="font-medium">{t("rateLimits.signInTitle")}</h3>
+
+        <NumberField
+          id="per_ip_count"
+          label={t("rateLimits.perIpCount")}
+          description={t("rateLimits.perIpCountDescription")}
+          value={perIpCount}
+          onChange={setPerIpCount}
+          disabled={readOnly}
+        />
+        <NumberField
+          id="per_ip_window_minutes"
+          label={t("rateLimits.perIpWindowMinutes")}
+          description={t("rateLimits.perIpWindowMinutesDescription")}
+          value={perIpWindow}
+          onChange={setPerIpWindow}
+          disabled={readOnly}
+        />
+        <NumberField
+          id="per_account_ip_count"
+          label={t("rateLimits.perAccountIpCount")}
+          description={t("rateLimits.perAccountIpCountDescription")}
+          value={perAccountIpCount}
+          onChange={setPerAccountIpCount}
+          disabled={readOnly}
+        />
+        <NumberField
+          id="per_account_ip_window_minutes"
+          label={t("rateLimits.perAccountIpWindowMinutes")}
+          description={t("rateLimits.perAccountIpWindowMinutesDescription")}
+          value={perAccountIpWindow}
+          onChange={setPerAccountIpWindow}
+          disabled={readOnly}
+        />
+        <NumberField
+          id="global_count"
+          label={t("rateLimits.globalCount")}
+          description={t("rateLimits.globalCountDescription")}
+          value={globalCount}
+          onChange={setGlobalCount}
+          disabled={readOnly}
+        />
+        <NumberField
+          id="global_window_minutes"
+          label={t("rateLimits.globalWindowMinutes")}
+          description={t("rateLimits.globalWindowMinutesDescription")}
+          value={globalWindow}
+          onChange={setGlobalWindow}
+          disabled={readOnly}
+        />
+
+        {!readOnly && (
+          <Button
+            onClick={() =>
+              onSaveSignIn({
+                per_ip_count: Number(perIpCount),
+                per_ip_window_minutes: Number(perIpWindow),
+                per_account_ip_count: Number(perAccountIpCount),
+                per_account_ip_window_minutes: Number(perAccountIpWindow),
+                global_count: Number(globalCount),
+                global_window_minutes: Number(globalWindow),
+              })
+            }
+            disabled={saving}
+          >
+            {saving ? t("saving") : t("rateLimits.signInTitle")}
+          </Button>
+        )}
+      </div>
+
+      {/* API rate limits */}
+      <div className="space-y-6">
+        <h3 className="font-medium">{t("rateLimits.apiTitle")}</h3>
+
+        <NumberField
+          id="per_user_count"
+          label={t("rateLimits.perUserCount")}
+          description={t("rateLimits.perUserCountDescription")}
+          value={perUserCount}
+          onChange={setPerUserCount}
+          disabled={readOnly}
+        />
+        <NumberField
+          id="per_user_window_minutes"
+          label={t("rateLimits.perUserWindowMinutes")}
+          description={t("rateLimits.perUserWindowMinutesDescription")}
+          value={perUserWindow}
+          onChange={setPerUserWindow}
+          disabled={readOnly}
+        />
+
+        {!readOnly && (
+          <Button
+            onClick={() =>
+              onSaveApi({
+                per_user_count: Number(perUserCount),
+                per_user_window_minutes: Number(perUserWindow),
+              })
+            }
+            disabled={saving}
+          >
+            {saving ? t("saving") : t("rateLimits.apiTitle")}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { Tabs as TabsPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants };

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -51,7 +51,8 @@
     "accounts": "Accounts",
     "roles": "Roles",
     "profile": "Profile",
-    "customers": "Customers"
+    "customers": "Customers",
+    "system": "System"
   },
   "validation": {
     "required": "{field} is required",
@@ -109,12 +110,18 @@
       "customer_update": "Customer update",
       "customer_delete": "Customer delete",
       "customer_assign": "Customer assign",
-      "customer_unassign": "Customer unassign"
+      "customer_unassign": "Customer unassign",
+      "system_settings_update": "Settings update",
+      "role_create": "Role create",
+      "role_update": "Role update",
+      "role_delete": "Role delete"
     },
     "targetTypes": {
       "account": "Account",
       "session": "Session",
-      "customer": "Customer"
+      "customer": "Customer",
+      "system_settings": "System Settings",
+      "role": "Role"
     }
   },
   "customers": {
@@ -180,6 +187,86 @@
     "saved": "Preferences saved",
     "saving": "Saving...",
     "save": "Save"
+  },
+  "systemSettings": {
+    "title": "System Settings",
+    "readOnlyNotice": "You do not have permission to modify these settings.",
+    "saved": "Setting updated successfully.",
+    "saving": "Saving...",
+    "error": "Failed to update setting.",
+    "tabs": {
+      "password": "Password",
+      "session": "Session",
+      "lockout": "Lockout",
+      "jwt": "JWT",
+      "mfa": "MFA",
+      "rateLimits": "Rate Limits"
+    },
+    "passwordPolicy": {
+      "title": "Password Policy",
+      "description": "Configure password requirements for all accounts.",
+      "minLength": "Minimum Length",
+      "minLengthDescription": "Minimum number of characters (8–128)",
+      "maxLength": "Maximum Length",
+      "maxLengthDescription": "Maximum number of characters (up to 256)",
+      "complexityEnabled": "Require Complexity",
+      "complexityEnabledDescription": "Require uppercase, lowercase, digit, and special character",
+      "reuseBanCount": "Password History",
+      "reuseBanCountDescription": "Number of previous passwords that cannot be reused (0–24)"
+    },
+    "sessionPolicy": {
+      "title": "Session Policy",
+      "description": "Control session timeouts and limits.",
+      "idleTimeoutMinutes": "Idle Timeout (minutes)",
+      "idleTimeoutMinutesDescription": "Minutes of inactivity before session expires (1–1440)",
+      "absoluteTimeoutHours": "Absolute Timeout (hours)",
+      "absoluteTimeoutHoursDescription": "Maximum session duration regardless of activity (1–720)",
+      "maxSessions": "Max Sessions",
+      "maxSessionsDescription": "Maximum concurrent sessions per account (leave empty for unlimited)"
+    },
+    "lockoutPolicy": {
+      "title": "Lockout Policy",
+      "description": "Configure account lockout after failed sign-in attempts.",
+      "stage1Threshold": "Failed Attempt Threshold",
+      "stage1ThresholdDescription": "Number of failed attempts before lockout (1–100)",
+      "stage1DurationMinutes": "Lockout Duration (minutes)",
+      "stage1DurationMinutesDescription": "Duration of account lockout (1–1440)"
+    },
+    "jwtPolicy": {
+      "title": "JWT Policy",
+      "description": "Configure JSON Web Token settings.",
+      "accessTokenExpirationMinutes": "Access Token Expiration (minutes)",
+      "accessTokenExpirationMinutesDescription": "Token lifetime before re-authentication is required (1–60)"
+    },
+    "mfaPolicy": {
+      "title": "MFA Policy",
+      "description": "Configure multi-factor authentication methods.",
+      "allowedMethods": "Allowed Methods",
+      "webauthn": "WebAuthn (passkeys)",
+      "totp": "TOTP (authenticator app)"
+    },
+    "rateLimits": {
+      "title": "Rate Limits",
+      "description": "Configure rate limiting for sign-in and API requests.",
+      "signInTitle": "Sign-in Rate Limits",
+      "apiTitle": "API Rate Limits",
+      "perIpCount": "Per-IP Limit",
+      "perIpCountDescription": "Max sign-in attempts per IP address",
+      "perIpWindowMinutes": "Per-IP Window (minutes)",
+      "perIpWindowMinutesDescription": "Time window for per-IP limit",
+      "perAccountIpCount": "Per-Account-IP Limit",
+      "perAccountIpCountDescription": "Max attempts per account+IP combination",
+      "perAccountIpWindowMinutes": "Per-Account-IP Window (minutes)",
+      "perAccountIpWindowMinutesDescription": "Time window for per-account-IP limit",
+      "globalCount": "Global Limit",
+      "globalCountDescription": "Max sign-in attempts globally",
+      "globalWindowMinutes": "Global Window (minutes)",
+      "globalWindowMinutesDescription": "Time window for global limit",
+      "perUserCount": "Per-User Limit",
+      "perUserCountDescription": "Max API requests per user",
+      "perUserWindowMinutes": "Per-User Window (minutes)",
+      "perUserWindowMinutesDescription": "Time window for per-user limit"
+    }
   },
   "changePassword": {
     "heading": "Change Password",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -51,7 +51,8 @@
     "accounts": "계정",
     "roles": "역할",
     "profile": "프로필",
-    "customers": "고객"
+    "customers": "고객",
+    "system": "시스템"
   },
   "validation": {
     "required": "{field}은(는) 필수입니다",
@@ -109,12 +110,18 @@
       "customer_update": "고객 수정",
       "customer_delete": "고객 삭제",
       "customer_assign": "고객 할당",
-      "customer_unassign": "고객 할당 해제"
+      "customer_unassign": "고객 할당 해제",
+      "system_settings_update": "설정 변경",
+      "role_create": "역할 생성",
+      "role_update": "역할 수정",
+      "role_delete": "역할 삭제"
     },
     "targetTypes": {
       "account": "계정",
       "session": "세션",
-      "customer": "고객"
+      "customer": "고객",
+      "system_settings": "시스템 설정",
+      "role": "역할"
     }
   },
   "customers": {
@@ -180,6 +187,86 @@
     "saved": "환경설정이 저장되었습니다",
     "saving": "저장 중...",
     "save": "저장"
+  },
+  "systemSettings": {
+    "title": "시스템 설정",
+    "readOnlyNotice": "이 설정을 수정할 권한이 없습니다.",
+    "saved": "설정이 업데이트되었습니다.",
+    "saving": "저장 중...",
+    "error": "설정 업데이트에 실패했습니다.",
+    "tabs": {
+      "password": "비밀번호",
+      "session": "세션",
+      "lockout": "잠금",
+      "jwt": "JWT",
+      "mfa": "MFA",
+      "rateLimits": "속도 제한"
+    },
+    "passwordPolicy": {
+      "title": "비밀번호 정책",
+      "description": "모든 계정의 비밀번호 요구사항을 설정합니다.",
+      "minLength": "최소 길이",
+      "minLengthDescription": "최소 문자 수 (8–128)",
+      "maxLength": "최대 길이",
+      "maxLengthDescription": "최대 문자 수 (최대 256)",
+      "complexityEnabled": "복잡성 요구",
+      "complexityEnabledDescription": "대문자, 소문자, 숫자, 특수문자 필수",
+      "reuseBanCount": "비밀번호 이력",
+      "reuseBanCountDescription": "재사용할 수 없는 이전 비밀번호 수 (0–24)"
+    },
+    "sessionPolicy": {
+      "title": "세션 정책",
+      "description": "세션 시간 초과 및 제한을 설정합니다.",
+      "idleTimeoutMinutes": "유휴 시간 초과 (분)",
+      "idleTimeoutMinutesDescription": "세션이 만료되기 전 비활성 시간 (1–1440)",
+      "absoluteTimeoutHours": "절대 시간 초과 (시간)",
+      "absoluteTimeoutHoursDescription": "활동 여부와 관계없이 최대 세션 지속 시간 (1–720)",
+      "maxSessions": "최대 세션 수",
+      "maxSessionsDescription": "계정당 최대 동시 세션 수 (비워두면 무제한)"
+    },
+    "lockoutPolicy": {
+      "title": "잠금 정책",
+      "description": "로그인 실패 시 계정 잠금을 설정합니다.",
+      "stage1Threshold": "실패 시도 임계값",
+      "stage1ThresholdDescription": "잠금 전 실패 시도 횟수 (1–100)",
+      "stage1DurationMinutes": "잠금 기간 (분)",
+      "stage1DurationMinutesDescription": "계정 잠금 기간 (1–1440)"
+    },
+    "jwtPolicy": {
+      "title": "JWT 정책",
+      "description": "JSON Web Token 설정을 구성합니다.",
+      "accessTokenExpirationMinutes": "액세스 토큰 만료 (분)",
+      "accessTokenExpirationMinutesDescription": "재인증이 필요하기 전 토큰 수명 (1–60)"
+    },
+    "mfaPolicy": {
+      "title": "MFA 정책",
+      "description": "다단계 인증 방법을 설정합니다.",
+      "allowedMethods": "허용된 방법",
+      "webauthn": "WebAuthn (패스키)",
+      "totp": "TOTP (인증 앱)"
+    },
+    "rateLimits": {
+      "title": "속도 제한",
+      "description": "로그인 및 API 요청의 속도 제한을 설정합니다.",
+      "signInTitle": "로그인 속도 제한",
+      "apiTitle": "API 속도 제한",
+      "perIpCount": "IP당 제한",
+      "perIpCountDescription": "IP 주소당 최대 로그인 시도 횟수",
+      "perIpWindowMinutes": "IP당 기간 (분)",
+      "perIpWindowMinutesDescription": "IP당 제한 시간 범위",
+      "perAccountIpCount": "계정+IP당 제한",
+      "perAccountIpCountDescription": "계정+IP 조합당 최대 시도 횟수",
+      "perAccountIpWindowMinutes": "계정+IP당 기간 (분)",
+      "perAccountIpWindowMinutesDescription": "계정+IP당 제한 시간 범위",
+      "globalCount": "전체 제한",
+      "globalCountDescription": "전체 최대 로그인 시도 횟수",
+      "globalWindowMinutes": "전체 기간 (분)",
+      "globalWindowMinutesDescription": "전체 제한 시간 범위",
+      "perUserCount": "사용자당 제한",
+      "perUserCountDescription": "사용자당 최대 API 요청 수",
+      "perUserWindowMinutes": "사용자당 기간 (분)",
+      "perUserWindowMinutesDescription": "사용자당 제한 시간 범위"
+    }
   },
   "changePassword": {
     "heading": "비밀번호 변경",

--- a/src/lib/auth/system-settings.ts
+++ b/src/lib/auth/system-settings.ts
@@ -1,0 +1,245 @@
+import "server-only";
+
+import { query } from "@/lib/db/client";
+import { invalidateRateLimitConfig } from "@/lib/rate-limit/limiter";
+
+import { invalidateJwtPolicy } from "./jwt-policy";
+import { invalidateLockoutPolicy } from "./lockout-policy";
+import { invalidateMfaPolicy } from "./mfa-policy";
+import { invalidatePasswordPolicy } from "./password-policy";
+import { invalidateSessionPolicy } from "./session-policy";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface SystemSettingRow {
+  key: string;
+  value: Record<string, unknown>;
+  updated_at: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+export interface UpdateResult {
+  valid: boolean;
+  errors?: string[];
+  data?: SystemSettingRow;
+}
+
+// ── Known setting keys ──────────────────────────────────────────
+
+const KNOWN_KEYS = new Set([
+  "password_policy",
+  "session_policy",
+  "lockout_policy",
+  "jwt_policy",
+  "mfa_policy",
+  "signin_rate_limit",
+  "api_rate_limit",
+]);
+
+// ── Cache invalidators ──────────────────────────────────────────
+
+const CACHE_INVALIDATORS: Record<string, () => void> = {
+  password_policy: invalidatePasswordPolicy,
+  session_policy: invalidateSessionPolicy,
+  lockout_policy: invalidateLockoutPolicy,
+  jwt_policy: invalidateJwtPolicy,
+  mfa_policy: invalidateMfaPolicy,
+  signin_rate_limit: () => invalidateRateLimitConfig("signin_rate_limit"),
+  api_rate_limit: () => invalidateRateLimitConfig("api_rate_limit"),
+};
+
+// ── Validators ──────────────────────────────────────────────────
+
+function isInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v);
+}
+
+const VALIDATORS: Record<string, (value: unknown) => ValidationResult> = {
+  password_policy(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (!isInt(v.min_length) || v.min_length < 8 || v.min_length > 128)
+      errors.push("min_length must be an integer between 8 and 128");
+    if (
+      !isInt(v.max_length) ||
+      v.max_length < (isInt(v.min_length) ? v.min_length : 8) ||
+      v.max_length > 256
+    )
+      errors.push("max_length must be an integer >= min_length and <= 256");
+    if (typeof v.complexity_enabled !== "boolean")
+      errors.push("complexity_enabled must be a boolean");
+    if (
+      !isInt(v.reuse_ban_count) ||
+      v.reuse_ban_count < 0 ||
+      v.reuse_ban_count > 24
+    )
+      errors.push("reuse_ban_count must be an integer between 0 and 24");
+    return { valid: errors.length === 0, errors };
+  },
+
+  session_policy(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (
+      !isInt(v.idle_timeout_minutes) ||
+      v.idle_timeout_minutes < 1 ||
+      v.idle_timeout_minutes > 1440
+    )
+      errors.push("idle_timeout_minutes must be an integer between 1 and 1440");
+    if (
+      !isInt(v.absolute_timeout_hours) ||
+      v.absolute_timeout_hours < 1 ||
+      v.absolute_timeout_hours > 720
+    )
+      errors.push(
+        "absolute_timeout_hours must be an integer between 1 and 720",
+      );
+    if (
+      v.max_sessions !== null &&
+      (!isInt(v.max_sessions) || v.max_sessions < 1 || v.max_sessions > 100)
+    )
+      errors.push("max_sessions must be null or an integer between 1 and 100");
+    return { valid: errors.length === 0, errors };
+  },
+
+  lockout_policy(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (
+      !isInt(v.stage1_threshold) ||
+      v.stage1_threshold < 1 ||
+      v.stage1_threshold > 100
+    )
+      errors.push("stage1_threshold must be an integer between 1 and 100");
+    if (
+      !isInt(v.stage1_duration_minutes) ||
+      v.stage1_duration_minutes < 1 ||
+      v.stage1_duration_minutes > 1440
+    )
+      errors.push(
+        "stage1_duration_minutes must be an integer between 1 and 1440",
+      );
+    return { valid: errors.length === 0, errors };
+  },
+
+  jwt_policy(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (
+      !isInt(v.access_token_expiration_minutes) ||
+      v.access_token_expiration_minutes < 1 ||
+      v.access_token_expiration_minutes > 60
+    )
+      errors.push(
+        "access_token_expiration_minutes must be an integer between 1 and 60",
+      );
+    return { valid: errors.length === 0, errors };
+  },
+
+  mfa_policy(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (!Array.isArray(v.allowed_methods) || v.allowed_methods.length === 0)
+      errors.push("allowed_methods must be a non-empty array");
+    else {
+      const valid = new Set(["webauthn", "totp"]);
+      for (const m of v.allowed_methods) {
+        if (!valid.has(m as string))
+          errors.push(`Invalid MFA method: ${String(m)}`);
+      }
+    }
+    return { valid: errors.length === 0, errors };
+  },
+
+  signin_rate_limit(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (!isInt(v.per_ip_count) || v.per_ip_count < 1)
+      errors.push("per_ip_count must be a positive integer");
+    if (!isInt(v.per_ip_window_minutes) || v.per_ip_window_minutes < 1)
+      errors.push("per_ip_window_minutes must be a positive integer");
+    if (!isInt(v.per_account_ip_count) || v.per_account_ip_count < 1)
+      errors.push("per_account_ip_count must be a positive integer");
+    if (
+      !isInt(v.per_account_ip_window_minutes) ||
+      v.per_account_ip_window_minutes < 1
+    )
+      errors.push("per_account_ip_window_minutes must be a positive integer");
+    if (!isInt(v.global_count) || v.global_count < 1)
+      errors.push("global_count must be a positive integer");
+    if (!isInt(v.global_window_minutes) || v.global_window_minutes < 1)
+      errors.push("global_window_minutes must be a positive integer");
+    return { valid: errors.length === 0, errors };
+  },
+
+  api_rate_limit(value) {
+    const errors: string[] = [];
+    const v = value as Record<string, unknown>;
+    if (!isInt(v.per_user_count) || v.per_user_count < 1)
+      errors.push("per_user_count must be a positive integer");
+    if (!isInt(v.per_user_window_minutes) || v.per_user_window_minutes < 1)
+      errors.push("per_user_window_minutes must be a positive integer");
+    return { valid: errors.length === 0, errors };
+  },
+};
+
+// ── Public API ──────────────────────────────────────────────────
+
+/** Fetch all system settings. */
+export async function getSystemSettings(): Promise<SystemSettingRow[]> {
+  const result = await query<SystemSettingRow>(
+    "SELECT key, value, updated_at FROM system_settings ORDER BY key",
+  );
+  return result.rows;
+}
+
+/** Fetch a single system setting by key. */
+export async function getSystemSetting(
+  key: string,
+): Promise<SystemSettingRow | null> {
+  const result = await query<SystemSettingRow>(
+    "SELECT key, value, updated_at FROM system_settings WHERE key = $1",
+    [key],
+  );
+  return result.rows[0] ?? null;
+}
+
+/** Validate a setting value against the known schema. */
+export function validateSetting(key: string, value: unknown): ValidationResult {
+  if (!KNOWN_KEYS.has(key)) {
+    return { valid: false, errors: [`Unknown setting key: ${key}`] };
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { valid: false, errors: ["Value must be a JSON object"] };
+  }
+  return VALIDATORS[key](value);
+}
+
+/** Update a system setting with validation and cache invalidation. */
+export async function updateSystemSetting(
+  key: string,
+  value: unknown,
+): Promise<UpdateResult> {
+  const validation = validateSetting(key, value);
+  if (!validation.valid) {
+    return validation;
+  }
+
+  const result = await query<SystemSettingRow>(
+    "UPDATE system_settings SET value = $2, updated_at = NOW() WHERE key = $1 RETURNING key, value, updated_at",
+    [key, JSON.stringify(value)],
+  );
+
+  if (result.rows.length === 0) {
+    return { valid: false, errors: [`Setting not found: ${key}`] };
+  }
+
+  // Invalidate the relevant policy cache
+  CACHE_INVALIDATORS[key]?.();
+
+  return { valid: true, data: result.rows[0] };
+}

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -16,6 +16,7 @@ export const SETTINGS_SEGMENTS = new Set([
   "roles",
   "profile",
   "customers",
+  "system",
 ]);
 
 export interface BreadcrumbSegment {


### PR DESCRIPTION
## Summary

- Add service layer (`system-settings.ts`) with `getSystemSettings()`, `getSystemSetting(key)`, `updateSystemSetting(key, value)` — includes per-key validation (ranges, types, constraints) and automatic cache invalidation of the relevant policy loader
- Add `GET /api/system-settings` (requires `system-settings:read`) and `PATCH /api/system-settings/[key]` (requires `system-settings:write`) with audit logging
- Add settings sub-navigation (Accounts, Customers, System) via a shared settings layout; redirect `/settings` to `/settings/accounts`
- Add tabbed System Settings page (Password, Session, Lockout, JWT, MFA, Rate Limits) with read-only mode for users without `system-settings:write`
- Install shadcn/ui `tabs` and `switch` components
- Add `systemSettings` i18n namespace (en + ko), `settings.system` breadcrumb key, and audit log translations for `system_settings` and `role` actions/targets

## Test plan

- [x] Navigate to `/settings` — redirects to `/settings/accounts`
- [x] Sub-navigation shows Accounts, Customers, System tabs
- [x] System tab only visible to users with `system-settings:read`
- [x] `/settings/system` — all 6 policy tabs render with current DB values
- [x] Change a password policy field and save — success message, value persists on reload
- [x] Submit invalid value (e.g. min_length=3) — error message with validation details
- [x] Toggle complexity switch and save — value updates correctly
- [x] MFA checkboxes: cannot save with no methods selected (button disabled)
- [x] Rate Limits tab: sign-in and API sections save independently
- [x] User without `system-settings:write` sees read-only view with info banner, no save buttons
- [x] Audit log shows `system_settings.update` entry after saving
- [x] Korean locale shows correct translations for all settings labels
- [x] `pnpm vitest run` — 808 tests pass
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check` — no lint/format issues

Closes #133