### PR TITLE
Add custom role management

### DIFF
--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -513,6 +513,88 @@ export async function resetAccountPreferences(username: string): Promise<void> {
   }
 }
 
+/**
+ * Create a custom role with the given permissions.
+ * Skips if a role with the name already exists.
+ * Returns the role ID.
+ */
+export async function createTestRole(
+  name: string,
+  permissions: string[],
+  description?: string,
+): Promise<number> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ id: number }>(
+      `INSERT INTO roles (name, description, is_builtin)
+       VALUES ($1, $2, false)
+       ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id`,
+      [name, description ?? null],
+    );
+    const roleId = rows[0].id;
+
+    // Replace permissions
+    await client.query("DELETE FROM role_permissions WHERE role_id = $1", [
+      roleId,
+    ]);
+    for (const perm of permissions) {
+      await client.query(
+        "INSERT INTO role_permissions (role_id, permission) VALUES ($1, $2)",
+        [roleId, perm],
+      );
+    }
+
+    return roleId;
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Delete a custom role by name. Silently ignores if not found.
+ */
+export async function deleteTestRole(name: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      "DELETE FROM role_permissions WHERE role_id = (SELECT id FROM roles WHERE name = $1)",
+      [name],
+    );
+    await client.query(
+      "DELETE FROM roles WHERE name = $1 AND is_builtin = false",
+      [name],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Delete all custom roles whose name starts with a given prefix.
+ */
+export async function deleteRolesByPrefix(prefix: string): Promise<void> {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `DELETE FROM role_permissions
+       WHERE role_id IN (
+         SELECT id FROM roles WHERE name LIKE $1 AND is_builtin = false
+       )`,
+      [`${prefix}%`],
+    );
+    await client.query(
+      "DELETE FROM roles WHERE name LIKE $1 AND is_builtin = false",
+      [`${prefix}%`],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
 function escapeIdentifier(str: string): string {
   return `"${str.replace(/"/g, '""')}"`;
 }

--- a/e2e/roles.spec.ts
+++ b/e2e/roles.spec.ts
@@ -476,9 +476,14 @@ test.describe("Role management", () => {
       const cookies = await page.context().cookies();
       const csrfCookie = cookies.find((c) => c.name === "csrf");
 
-      // GET /api/roles is open (needed for account forms), but POST requires roles:write
+      // GET /api/roles returns minimal data without roles:read
       const getRes = await page.request.get("/api/roles");
       expect(getRes.status()).toBe(200);
+      const getBody = await getRes.json();
+      // Should have role names but NOT permissions array or account_count
+      expect(getBody.data[0]).toHaveProperty("name");
+      expect(getBody.data[0]).not.toHaveProperty("permissions");
+      expect(getBody.data[0]).not.toHaveProperty("account_count");
 
       const postRes = await page.request.post("/api/roles", {
         data: { name: "hacked", permissions: [] },

--- a/e2e/roles.spec.ts
+++ b/e2e/roles.spec.ts
@@ -1,0 +1,537 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import {
+  clearMustChangePassword,
+  createTestAccount,
+  createTestRole,
+  deleteRolesByPrefix,
+  deleteTestAccount,
+  deleteTestRole,
+  resetAccountDefaults,
+  revokeAllSessions,
+} from "./helpers/setup-db";
+
+const TEST_PREFIX = "e2e-role-";
+
+function roleRow(page: Page, name: string): Locator {
+  return page.locator("tbody tr").filter({
+    has: page.locator("td.font-medium", { hasText: name }),
+  });
+}
+
+test.describe("Role management", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+    await clearMustChangePassword(ADMIN_USERNAME);
+    await resetAccountDefaults(ADMIN_USERNAME);
+    // Clean up leftover test data
+    await deleteTestAccount(`${TEST_PREFIX}secmon`);
+    await deleteRolesByPrefix(TEST_PREFIX);
+  });
+
+  test.beforeEach(async () => {
+    await resetRateLimits();
+    await revokeAllSessions(ADMIN_USERNAME);
+  });
+
+  test.afterAll(async () => {
+    await deleteTestAccount(`${TEST_PREFIX}secmon`);
+    await deleteRolesByPrefix(TEST_PREFIX);
+  });
+
+  // ── API tests ─────────────────────────────────────────────────
+
+  test("GET /api/roles returns all roles", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const response = await page.request.get("/api/roles");
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.length).toBeGreaterThanOrEqual(3);
+
+    // Verify built-in roles exist
+    const names = body.data.map((r: { name: string }) => r.name);
+    expect(names).toContain("System Administrator");
+    expect(names).toContain("Tenant Administrator");
+    expect(names).toContain("Security Monitor");
+  });
+
+  test("POST /api/roles creates a custom role", async ({ page }) => {
+    await deleteTestRole(`${TEST_PREFIX}api-create`);
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post("/api/roles", {
+      data: {
+        name: `${TEST_PREFIX}api-create`,
+        description: "E2E test role",
+        permissions: ["accounts:read", "customers:read"],
+      },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.name).toBe(`${TEST_PREFIX}api-create`);
+    expect(body.data.permissions).toContain("accounts:read");
+    expect(body.data.permissions).toContain("customers:read");
+  });
+
+  test("PATCH /api/roles/[id] updates a custom role", async ({ page }) => {
+    const roleId = await createTestRole(
+      `${TEST_PREFIX}api-update`,
+      ["accounts:read"],
+      "before update",
+    );
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.patch(`/api/roles/${roleId}`, {
+      data: {
+        name: `${TEST_PREFIX}api-update`,
+        permissions: ["accounts:read", "accounts:write", "roles:read"],
+      },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.permissions).toHaveLength(3);
+    expect(body.data.permissions).toContain("accounts:write");
+  });
+
+  test("PATCH /api/roles/[id] rejects built-in role modification", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    // Role ID 1 = System Administrator (built-in)
+    const response = await page.request.patch("/api/roles/1", {
+      data: { name: "Hacked", permissions: [] },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+
+  test("DELETE /api/roles/[id] deletes a custom role", async ({ page }) => {
+    const roleId = await createTestRole(`${TEST_PREFIX}api-delete`, [
+      "accounts:read",
+    ]);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.delete(`/api/roles/${roleId}`, {
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(200);
+
+    // Verify role is gone
+    const listRes = await page.request.get("/api/roles");
+    const listBody = await listRes.json();
+    const names = listBody.data.map((r: { name: string }) => r.name);
+    expect(names).not.toContain(`${TEST_PREFIX}api-delete`);
+  });
+
+  test("DELETE /api/roles/[id] rejects built-in role deletion", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.delete("/api/roles/1", {
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(403);
+  });
+
+  test("DELETE /api/roles/[id] rejects deletion of role in use", async ({
+    page,
+  }) => {
+    // Create a role and assign an account to it
+    const roleId = await createTestRole(`${TEST_PREFIX}in-use`, [
+      "accounts:read",
+    ]);
+    await createTestAccount(
+      `${TEST_PREFIX}secmon`,
+      "TestPass1234!",
+      `${TEST_PREFIX}in-use`,
+    );
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.delete(`/api/roles/${roleId}`, {
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/assigned to accounts/i);
+
+    // Clean up: delete account first, then role
+    await deleteTestAccount(`${TEST_PREFIX}secmon`);
+  });
+
+  test("POST /api/roles returns 400 for invalid permissions", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post("/api/roles", {
+      data: {
+        name: `${TEST_PREFIX}bad-perms`,
+        permissions: ["nonexistent:perm"],
+      },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(400);
+  });
+
+  test("POST /api/roles returns 400 for duplicate name", async ({ page }) => {
+    await createTestRole(`${TEST_PREFIX}dup`, ["accounts:read"]);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post("/api/roles", {
+      data: {
+        name: `${TEST_PREFIX}dup`,
+        permissions: ["accounts:read"],
+      },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(400);
+    const body = await response.json();
+    // Error message may be in body.error or body.details
+    const errorText = JSON.stringify(body);
+    expect(errorText).toMatch(/already exists/i);
+  });
+
+  // ── UI tests ──────────────────────────────────────────────────
+
+  test("navigates to roles page and displays built-in roles", async ({
+    page,
+  }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    await expect(page.getByRole("heading", { name: "Roles" })).toBeVisible();
+
+    // Verify built-in roles are listed
+    await expect(roleRow(page, "System Administrator")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(roleRow(page, "Tenant Administrator")).toBeVisible();
+    await expect(roleRow(page, "Security Monitor")).toBeVisible();
+
+    // Verify built-in badges
+    await expect(
+      roleRow(page, "System Administrator").getByText("Built-in"),
+    ).toBeVisible();
+  });
+
+  test("creates a custom role via UI", async ({ page }) => {
+    await deleteTestRole(`${TEST_PREFIX}ui-create`);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    await expect(page.getByRole("heading", { name: "Roles" })).toBeVisible();
+
+    // Click create button
+    await page.getByRole("button", { name: "Create Role" }).click();
+
+    // Fill form
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Name").fill(`${TEST_PREFIX}ui-create`);
+    await dialog.getByLabel("Description").fill("Created via E2E test");
+
+    // Select permissions
+    await dialog.locator("#perm-accounts\\:read").click();
+    await dialog.locator("#perm-customers\\:read").click();
+
+    // Submit
+    await dialog.getByRole("button", { name: "Create Role" }).click();
+
+    // Verify new role appears in table
+    await expect(roleRow(page, `${TEST_PREFIX}ui-create`)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(roleRow(page, `${TEST_PREFIX}ui-create`)).toContainText("2");
+  });
+
+  test("edits a custom role via UI", async ({ page }) => {
+    await createTestRole(
+      `${TEST_PREFIX}ui-edit`,
+      ["accounts:read"],
+      "Before edit",
+    );
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    const row = roleRow(page, `${TEST_PREFIX}ui-edit`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Click edit button (pencil icon, first button in actions)
+    await row.getByRole("button").first().click();
+
+    // Update name and add permission
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const nameInput = dialog.getByLabel("Name");
+    await nameInput.clear();
+    await nameInput.fill(`${TEST_PREFIX}ui-edited`);
+
+    // Add customers:read permission
+    await dialog.locator("#perm-customers\\:read").click();
+
+    // Submit
+    await dialog.getByRole("button", { name: "Edit Role" }).click();
+
+    // Verify updated name appears
+    await expect(roleRow(page, `${TEST_PREFIX}ui-edited`)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Clean up renamed role
+    await deleteTestRole(`${TEST_PREFIX}ui-edited`);
+  });
+
+  test("clones a built-in role via UI", async ({ page }) => {
+    await deleteTestRole(`${TEST_PREFIX}ui-clone`);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    const adminRow = roleRow(page, "System Administrator");
+    await expect(adminRow).toBeVisible({ timeout: 10_000 });
+
+    // Click clone button (copy icon — for built-in roles it's the only button)
+    await adminRow.getByRole("button").first().click();
+
+    // Verify dialog opened with "Clone Role" title
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText("Clone Role")).toBeVisible();
+
+    // Name should be empty, fill it
+    await dialog.getByLabel("Name").fill(`${TEST_PREFIX}ui-clone`);
+
+    // Wait for the clone response to complete
+    const createRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/api/roles"),
+    );
+
+    // Submit
+    await dialog.getByRole("button", { name: "Create Role" }).click();
+    const createResponse = await createRequest;
+
+    if (!createResponse.ok()) {
+      const errorBody = await createResponse.json();
+      throw new Error(
+        `Clone API failed (${createResponse.status()}): ${JSON.stringify(errorBody)}`,
+      );
+    }
+
+    // Wait for dialog to close
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // Verify cloned role appears with same permission count as System Administrator
+    const clonedRow = roleRow(page, `${TEST_PREFIX}ui-clone`);
+    await expect(clonedRow).toBeVisible({ timeout: 15_000 });
+    await expect(clonedRow).toContainText("15");
+  });
+
+  test("built-in roles have no edit or delete buttons", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    const adminRow = roleRow(page, "System Administrator");
+    await expect(adminRow).toBeVisible({ timeout: 10_000 });
+
+    // Built-in roles should have only 1 action button (clone)
+    const buttons = adminRow.getByRole("button");
+    await expect(buttons).toHaveCount(1);
+
+    // The button should have the clone title
+    await expect(buttons.first()).toHaveAttribute("title", "Clone Role");
+  });
+
+  test("custom roles have edit, clone, and delete buttons", async ({
+    page,
+  }) => {
+    await createTestRole(`${TEST_PREFIX}ui-buttons`, ["accounts:read"]);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    const row = roleRow(page, `${TEST_PREFIX}ui-buttons`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Custom roles should have 3 action buttons
+    const buttons = row.getByRole("button");
+    await expect(buttons).toHaveCount(3);
+
+    await expect(buttons.nth(0)).toHaveAttribute("title", "Edit Role");
+    await expect(buttons.nth(1)).toHaveAttribute("title", "Clone Role");
+    await expect(buttons.nth(2)).toHaveAttribute("title", "Delete Role");
+  });
+
+  test("deletes a custom role via UI", async ({ page }) => {
+    await createTestRole(`${TEST_PREFIX}ui-delete`, ["accounts:read"]);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/roles");
+
+    const row = roleRow(page, `${TEST_PREFIX}ui-delete`);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    // Click delete button (3rd button)
+    const deleteRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === "DELETE" &&
+        response.url().includes("/api/roles/"),
+    );
+    await row.getByRole("button").nth(2).click();
+
+    // Confirm deletion in alert dialog
+    await page.getByRole("button", { name: "Delete Role" }).click();
+    const deleteResponse = await deleteRequest;
+    expect(deleteResponse.ok()).toBeTruthy();
+
+    // Verify role is gone from table
+    await expect(row).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  // ── RBAC tests ────────────────────────────────────────────────
+
+  test("Security Monitor cannot modify roles", async ({ page }) => {
+    const secMonUser = `${TEST_PREFIX}rbac`;
+    const secMonPass = "SecMon1234!";
+    await createTestAccount(secMonUser, secMonPass, "Security Monitor");
+
+    try {
+      await signInAndWait(page, secMonUser, secMonPass);
+
+      const cookies = await page.context().cookies();
+      const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+      // GET /api/roles is open (needed for account forms), but POST requires roles:write
+      const getRes = await page.request.get("/api/roles");
+      expect(getRes.status()).toBe(200);
+
+      const postRes = await page.request.post("/api/roles", {
+        data: { name: "hacked", permissions: [] },
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      });
+      expect(postRes.status()).toBe(403);
+    } finally {
+      await deleteTestAccount(secMonUser);
+    }
+  });
+
+  test("Security Monitor cannot create roles", async ({ page }) => {
+    const secMonUser = `${TEST_PREFIX}rbac-write`;
+    const secMonPass = "SecMon1234!";
+    await createTestAccount(secMonUser, secMonPass, "Security Monitor");
+
+    try {
+      await signInAndWait(page, secMonUser, secMonPass);
+
+      const cookies = await page.context().cookies();
+      const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+      const response = await page.request.post("/api/roles", {
+        data: {
+          name: `${TEST_PREFIX}rbac-attempt`,
+          permissions: ["accounts:read"],
+        },
+        headers: {
+          "x-csrf-token": csrfCookie?.value ?? "",
+          Origin: "http://localhost:3000",
+        },
+      });
+
+      expect(response.status()).toBe(403);
+    } finally {
+      await deleteTestAccount(secMonUser);
+    }
+  });
+
+  // ── Audit log verification ──────────────────────────────────
+
+  test("role audit events are visible in audit logs", async ({ page }) => {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const auditRes = await page.request.get(
+      "/api/audit-logs?action=role.create",
+    );
+    expect(auditRes.status()).toBe(200);
+    const auditBody = await auditRes.json();
+    expect(auditBody.data.length).toBeGreaterThanOrEqual(1);
+    expect(auditBody.data[0].target_type).toBe("role");
+  });
+});

--- a/src/__tests__/app/api/roles/[id]/route.test.ts
+++ b/src/__tests__/app/api/roles/[id]/route.test.ts
@@ -1,0 +1,244 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockUpdateRole = vi.hoisted(() => vi.fn());
+const mockDeleteRole = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/role-management", () => ({
+  updateRole: mockUpdateRole,
+  deleteRole: mockDeleteRole,
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: { record: mockAuditRecord },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+const now = Math.floor(Date.now() / 1000);
+
+const adminSession: AuthSession = {
+  accountId: "account-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0 Chrome/131",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+function makeContext(id = "10") {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("PATCH /api/roles/[id]", () => {
+  beforeEach(() => {
+    mockUpdateRole.mockReset();
+    mockAuditRecord.mockReset().mockResolvedValue(undefined);
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  it("returns 403 without roles:write", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { PATCH } = await import("@/app/api/roles/[id]/route");
+    const response = await PATCH(
+      new NextRequest("http://localhost:3000/api/roles/10", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test", permissions: [] }),
+      }),
+      makeContext(),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for invalid role ID", async () => {
+    const { PATCH } = await import("@/app/api/roles/[id]/route");
+    const response = await PATCH(
+      new NextRequest("http://localhost:3000/api/roles/abc", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test", permissions: [] }),
+      }),
+      makeContext("abc"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid role ID");
+  });
+
+  it("returns 403 for built-in role modification", async () => {
+    mockUpdateRole.mockResolvedValueOnce({
+      valid: false,
+      errors: ["Built-in roles cannot be modified"],
+    });
+
+    const { PATCH } = await import("@/app/api/roles/[id]/route");
+    const response = await PATCH(
+      new NextRequest("http://localhost:3000/api/roles/1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test", permissions: [] }),
+      }),
+      makeContext("1"),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("updates role and records audit log", async () => {
+    mockUpdateRole.mockResolvedValueOnce({
+      valid: true,
+      data: { id: 10, name: "Updated", permissions: ["accounts:read"] },
+    });
+
+    const { PATCH } = await import("@/app/api/roles/[id]/route");
+    const response = await PATCH(
+      new NextRequest("http://localhost:3000/api/roles/10", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Updated",
+          permissions: ["accounts:read"],
+        }),
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe("Updated");
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "role.update", targetId: "10" }),
+    );
+  });
+});
+
+describe("DELETE /api/roles/[id]", () => {
+  beforeEach(() => {
+    mockDeleteRole.mockReset();
+    mockAuditRecord.mockReset().mockResolvedValue(undefined);
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  it("returns 403 without roles:delete", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { DELETE } = await import("@/app/api/roles/[id]/route");
+    const response = await DELETE(
+      new NextRequest("http://localhost:3000/api/roles/10", {
+        method: "DELETE",
+      }),
+      makeContext(),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 for built-in role deletion", async () => {
+    mockDeleteRole.mockResolvedValueOnce({
+      valid: false,
+      errors: ["Built-in roles cannot be deleted"],
+    });
+
+    const { DELETE } = await import("@/app/api/roles/[id]/route");
+    const response = await DELETE(
+      new NextRequest("http://localhost:3000/api/roles/1", {
+        method: "DELETE",
+      }),
+      makeContext("1"),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for role in use", async () => {
+    mockDeleteRole.mockResolvedValueOnce({
+      valid: false,
+      errors: [
+        "Cannot delete a role that is assigned to accounts. Reassign accounts first.",
+      ],
+    });
+
+    const { DELETE } = await import("@/app/api/roles/[id]/route");
+    const response = await DELETE(
+      new NextRequest("http://localhost:3000/api/roles/10", {
+        method: "DELETE",
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/assigned to accounts/);
+  });
+
+  it("deletes role and records audit log", async () => {
+    mockDeleteRole.mockResolvedValueOnce({ valid: true });
+
+    const { DELETE } = await import("@/app/api/roles/[id]/route");
+    const response = await DELETE(
+      new NextRequest("http://localhost:3000/api/roles/10", {
+        method: "DELETE",
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "role.delete", targetId: "10" }),
+    );
+  });
+});

--- a/src/__tests__/app/api/roles/route.test.ts
+++ b/src/__tests__/app/api/roles/route.test.ts
@@ -1,0 +1,189 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: unknown,
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockGetRolesWithDetails = vi.hoisted(() => vi.fn());
+const mockCreateRole = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (request: NextRequest, context: unknown) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/role-management", () => ({
+  getRolesWithDetails: mockGetRolesWithDetails,
+  createRole: mockCreateRole,
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: { record: mockAuditRecord },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+const now = Math.floor(Date.now() / 1000);
+
+const adminSession: AuthSession = {
+  accountId: "account-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0 Chrome/131",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+function makeContext() {
+  return { params: Promise.resolve({}) };
+}
+
+describe("GET /api/roles", () => {
+  beforeEach(() => {
+    mockGetRolesWithDetails.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  it("returns all roles", async () => {
+    const roles = [
+      {
+        id: 1,
+        name: "System Administrator",
+        is_builtin: true,
+        permissions: [],
+        account_count: 2,
+      },
+    ];
+    mockGetRolesWithDetails.mockResolvedValueOnce(roles);
+
+    const { GET } = await import("@/app/api/roles/route");
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/roles"),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+  });
+});
+
+describe("POST /api/roles", () => {
+  beforeEach(() => {
+    mockCreateRole.mockReset();
+    mockAuditRecord.mockReset().mockResolvedValue(undefined);
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  it("returns 403 without roles:write", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { POST } = await import("@/app/api/roles/route");
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test", permissions: [] }),
+      }),
+      makeContext(),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for missing name", async () => {
+    const { POST } = await import("@/app/api/roles/route");
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ permissions: [] }),
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/name/i);
+  });
+
+  it("returns 400 for missing permissions", async () => {
+    const { POST } = await import("@/app/api/roles/route");
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test" }),
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/permissions/i);
+  });
+
+  it("creates role and records audit log", async () => {
+    mockCreateRole.mockResolvedValueOnce({
+      valid: true,
+      data: { id: 10, name: "Custom Role", permissions: ["accounts:read"] },
+    });
+
+    const { POST } = await import("@/app/api/roles/route");
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Custom Role",
+          permissions: ["accounts:read"],
+        }),
+      }),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.name).toBe("Custom Role");
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "role.create", target: "role" }),
+    );
+  });
+});

--- a/src/__tests__/app/api/roles/route.test.ts
+++ b/src/__tests__/app/api/roles/route.test.ts
@@ -13,6 +13,7 @@ interface WithAuthOptions {
   requiredPermissions?: string[];
 }
 
+const mockGetRoles = vi.hoisted(() => vi.fn());
 const mockGetRolesWithDetails = vi.hoisted(() => vi.fn());
 const mockCreateRole = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
@@ -39,6 +40,7 @@ vi.mock("@/lib/auth/permissions", () => ({
 }));
 
 vi.mock("@/lib/auth/role-management", () => ({
+  getRoles: mockGetRoles,
   getRolesWithDetails: mockGetRolesWithDetails,
   createRole: mockCreateRole,
 }));
@@ -75,18 +77,19 @@ function makeContext() {
 
 describe("GET /api/roles", () => {
   beforeEach(() => {
+    mockGetRoles.mockReset();
     mockGetRolesWithDetails.mockReset();
     mockHasPermission.mockReset().mockResolvedValue(true);
     currentSession = adminSession;
   });
 
-  it("returns all roles", async () => {
+  it("returns detailed roles when user has roles:read", async () => {
     const roles = [
       {
         id: 1,
         name: "System Administrator",
         is_builtin: true,
-        permissions: [],
+        permissions: ["accounts:read"],
         account_count: 2,
       },
     ];
@@ -101,6 +104,39 @@ describe("GET /api/roles", () => {
 
     expect(response.status).toBe(200);
     expect(body.data).toHaveLength(1);
+    expect(body.data[0].permissions).toEqual(["accounts:read"]);
+    expect(body.data[0].account_count).toBe(2);
+    expect(mockGetRolesWithDetails).toHaveBeenCalledOnce();
+    expect(mockGetRoles).not.toHaveBeenCalled();
+  });
+
+  it("returns minimal roles when user lacks roles:read", async () => {
+    // hasPermission returns false for roles:read
+    mockHasPermission.mockResolvedValue(false);
+    const roles = [
+      {
+        id: 1,
+        name: "System Administrator",
+        description: "Full access",
+        is_builtin: true,
+      },
+    ];
+    mockGetRoles.mockResolvedValueOnce(roles);
+
+    const { GET } = await import("@/app/api/roles/route");
+    const response = await GET(
+      new NextRequest("http://localhost:3000/api/roles"),
+      makeContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("System Administrator");
+    expect(body.data[0]).not.toHaveProperty("permissions");
+    expect(body.data[0]).not.toHaveProperty("account_count");
+    expect(mockGetRoles).toHaveBeenCalledOnce();
+    expect(mockGetRolesWithDetails).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/lib/auth/role-management.test.ts
+++ b/src/__tests__/lib/auth/role-management.test.ts
@@ -2,13 +2,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockWithTransaction = vi.hoisted(() => vi.fn());
+
 vi.mock("@/lib/db/client", () => ({
-  query: vi.fn(),
+  query: mockQuery,
+  withTransaction: mockWithTransaction,
 }));
 
-import { query } from "@/lib/db/client";
-
-const queryMock = vi.mocked(query);
+/**
+ * Create a fake PoolClient that delegates to the shared mockQuery.
+ * This lets us verify that transactional writes use `client.query()`
+ * while keeping the mock assertions simple.
+ */
+function makeFakeClient() {
+  return { query: mockQuery };
+}
 
 describe("role-management", () => {
   let mod: typeof import("@/lib/auth/role-management");
@@ -16,14 +25,44 @@ describe("role-management", () => {
   beforeEach(async () => {
     vi.resetModules();
     mod = await import("@/lib/auth/role-management");
-    queryMock.mockClear();
+    mockQuery.mockClear();
+    mockWithTransaction.mockClear();
+    // Default: withTransaction executes the callback with a fake client
+    mockWithTransaction.mockImplementation(
+      async (fn: (...args: never[]) => unknown) => fn(makeFakeClient()),
+    );
+  });
+
+  // ── getRoles ──────────────────────────────────────────────────
+
+  describe("getRoles", () => {
+    it("returns minimal role list", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            name: "System Administrator",
+            description: "Full access",
+            is_builtin: true,
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.getRoles();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("System Administrator");
+      // Minimal: no permissions or account_count
+      expect(result[0]).not.toHaveProperty("permissions");
+      expect(result[0]).not.toHaveProperty("account_count");
+    });
   });
 
   // ── getRolesWithDetails ─────────────────────────────────────
 
   describe("getRolesWithDetails", () => {
     it("returns all roles with details", async () => {
-      queryMock.mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 1,
@@ -54,14 +93,14 @@ describe("role-management", () => {
 
   describe("getRoleWithPermissions", () => {
     it("returns null for non-existent role", async () => {
-      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
       const result = await mod.getRoleWithPermissions(999);
       expect(result).toBeNull();
     });
 
     it("returns role with permissions", async () => {
-      queryMock.mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 1,
@@ -99,32 +138,32 @@ describe("role-management", () => {
     });
 
     it("rejects duplicate name", async () => {
-      queryMock.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
 
       const result = await mod.createRole("Existing Role", null, []);
       expect(result.valid).toBe(false);
       expect(result.errors?.[0]).toMatch(/already exists/);
     });
 
-    it("creates role with permissions", async () => {
-      // Check duplicate name
-      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-      // Insert role
-      queryMock.mockResolvedValueOnce({
-        rows: [
-          {
-            id: 10,
-            name: "New Role",
-            description: "Test",
-            is_builtin: false,
-            created_at: "2025-01-01",
-            updated_at: "2025-01-01",
-          },
-        ],
-        rowCount: 1,
-      });
-      // Insert permissions
-      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    it("creates role with permissions inside a transaction", async () => {
+      // Check duplicate name (outside transaction)
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      // Inside transaction: insert role, then insert permissions
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 10,
+              name: "New Role",
+              description: "Test",
+              is_builtin: false,
+              created_at: "2025-01-01",
+              updated_at: "2025-01-01",
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const result = await mod.createRole("New Role", "Test", [
         "accounts:read",
@@ -132,6 +171,8 @@ describe("role-management", () => {
       expect(result.valid).toBe(true);
       expect(result.data?.name).toBe("New Role");
       expect(result.data?.permissions).toEqual(["accounts:read"]);
+      // Verify withTransaction was called
+      expect(mockWithTransaction).toHaveBeenCalledOnce();
     });
   });
 
@@ -140,7 +181,7 @@ describe("role-management", () => {
   describe("updateRole", () => {
     it("rejects built-in role modification", async () => {
       // getRoleWithPermissions lookup
-      queryMock.mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 1,
@@ -162,11 +203,57 @@ describe("role-management", () => {
     });
 
     it("rejects non-existent role", async () => {
-      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
       const result = await mod.updateRole(999, "Name", null, []);
       expect(result.valid).toBe(false);
       expect(result.errors?.[0]).toMatch(/not found/);
+    });
+
+    it("updates role inside a transaction", async () => {
+      // getRoleWithPermissions
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 10,
+            name: "Old Name",
+            description: null,
+            is_builtin: false,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: ["accounts:read"],
+            account_count: "0",
+          },
+        ],
+        rowCount: 1,
+      });
+      // Duplicate name check
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      // Inside transaction: update role, delete permissions, insert permissions
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 10,
+              name: "New Name",
+              description: null,
+              is_builtin: false,
+              created_at: "2025-01-01",
+              updated_at: "2025-01-01",
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const result = await mod.updateRole(10, "New Name", null, [
+        "accounts:write",
+      ]);
+      expect(result.valid).toBe(true);
+      expect(result.data?.name).toBe("New Name");
+      expect(result.data?.permissions).toEqual(["accounts:write"]);
+      expect(mockWithTransaction).toHaveBeenCalledOnce();
     });
   });
 
@@ -174,7 +261,7 @@ describe("role-management", () => {
 
   describe("deleteRole", () => {
     it("rejects built-in role deletion", async () => {
-      queryMock.mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 1,
@@ -196,7 +283,7 @@ describe("role-management", () => {
     });
 
     it("rejects deletion of role in use", async () => {
-      queryMock.mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 10,
@@ -219,7 +306,7 @@ describe("role-management", () => {
 
     it("deletes role successfully", async () => {
       // getRoleWithPermissions
-      queryMock.mockResolvedValueOnce({
+      mockQuery.mockResolvedValueOnce({
         rows: [
           {
             id: 10,
@@ -235,7 +322,7 @@ describe("role-management", () => {
         rowCount: 1,
       });
       // DELETE
-      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
       const result = await mod.deleteRole(10);
       expect(result.valid).toBe(true);

--- a/src/__tests__/lib/auth/role-management.test.ts
+++ b/src/__tests__/lib/auth/role-management.test.ts
@@ -29,7 +29,8 @@ describe("role-management", () => {
     mockWithTransaction.mockClear();
     // Default: withTransaction executes the callback with a fake client
     mockWithTransaction.mockImplementation(
-      async (fn: (...args: never[]) => unknown) => fn(makeFakeClient()),
+      // biome-ignore lint/suspicious/noExplicitAny: test mock accepts any callback shape
+      async (fn: (client: any) => unknown) => fn(makeFakeClient()),
     );
   });
 

--- a/src/__tests__/lib/auth/role-management.test.ts
+++ b/src/__tests__/lib/auth/role-management.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@/lib/db/client";
+
+const queryMock = vi.mocked(query);
+
+describe("role-management", () => {
+  let mod: typeof import("@/lib/auth/role-management");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mod = await import("@/lib/auth/role-management");
+    queryMock.mockClear();
+  });
+
+  // ── getRolesWithDetails ─────────────────────────────────────
+
+  describe("getRolesWithDetails", () => {
+    it("returns all roles with details", async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            name: "System Administrator",
+            description: "Full access",
+            is_builtin: true,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: ["accounts:read", "accounts:write"],
+            account_count: "3",
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.getRolesWithDetails();
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("System Administrator");
+      expect(result[0].account_count).toBe(3);
+      expect(result[0].permissions).toEqual([
+        "accounts:read",
+        "accounts:write",
+      ]);
+    });
+  });
+
+  // ── getRoleWithPermissions ──────────────────────────────────
+
+  describe("getRoleWithPermissions", () => {
+    it("returns null for non-existent role", async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const result = await mod.getRoleWithPermissions(999);
+      expect(result).toBeNull();
+    });
+
+    it("returns role with permissions", async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            name: "Test Role",
+            description: null,
+            is_builtin: false,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: ["accounts:read"],
+            account_count: "0",
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.getRoleWithPermissions(1);
+      expect(result?.name).toBe("Test Role");
+      expect(result?.account_count).toBe(0);
+    });
+  });
+
+  // ── createRole ──────────────────────────────────────────────
+
+  describe("createRole", () => {
+    it("rejects empty name", async () => {
+      const result = await mod.createRole("", null, ["accounts:read"]);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/Name/);
+    });
+
+    it("rejects unknown permissions", async () => {
+      const result = await mod.createRole("Test", null, ["unknown:perm"]);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/Unknown permission/);
+    });
+
+    it("rejects duplicate name", async () => {
+      queryMock.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+
+      const result = await mod.createRole("Existing Role", null, []);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/already exists/);
+    });
+
+    it("creates role with permissions", async () => {
+      // Check duplicate name
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      // Insert role
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 10,
+            name: "New Role",
+            description: "Test",
+            is_builtin: false,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+          },
+        ],
+        rowCount: 1,
+      });
+      // Insert permissions
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const result = await mod.createRole("New Role", "Test", [
+        "accounts:read",
+      ]);
+      expect(result.valid).toBe(true);
+      expect(result.data?.name).toBe("New Role");
+      expect(result.data?.permissions).toEqual(["accounts:read"]);
+    });
+  });
+
+  // ── updateRole ──────────────────────────────────────────────
+
+  describe("updateRole", () => {
+    it("rejects built-in role modification", async () => {
+      // getRoleWithPermissions lookup
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            name: "System Administrator",
+            description: null,
+            is_builtin: true,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: [],
+            account_count: "0",
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.updateRole(1, "Renamed", null, []);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/Built-in/);
+    });
+
+    it("rejects non-existent role", async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const result = await mod.updateRole(999, "Name", null, []);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/not found/);
+    });
+  });
+
+  // ── deleteRole ──────────────────────────────────────────────
+
+  describe("deleteRole", () => {
+    it("rejects built-in role deletion", async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 1,
+            name: "System Administrator",
+            description: null,
+            is_builtin: true,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: [],
+            account_count: "0",
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.deleteRole(1);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/Built-in/);
+    });
+
+    it("rejects deletion of role in use", async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 10,
+            name: "Custom Role",
+            description: null,
+            is_builtin: false,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: [],
+            account_count: "2",
+          },
+        ],
+        rowCount: 1,
+      });
+
+      const result = await mod.deleteRole(10);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toMatch(/assigned to accounts/);
+    });
+
+    it("deletes role successfully", async () => {
+      // getRoleWithPermissions
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 10,
+            name: "Custom Role",
+            description: null,
+            is_builtin: false,
+            created_at: "2025-01-01",
+            updated_at: "2025-01-01",
+            permissions: [],
+            account_count: "0",
+          },
+        ],
+        rowCount: 1,
+      });
+      // DELETE
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const result = await mod.deleteRole(10);
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/src/app/[locale]/(dashboard)/settings/layout.tsx
+++ b/src/app/[locale]/(dashboard)/settings/layout.tsx
@@ -12,6 +12,9 @@ export default async function SettingsLayout({
   const showAccounts = session
     ? await hasPermission(session.roles, "accounts:read")
     : false;
+  const showRoles = session
+    ? await hasPermission(session.roles, "roles:read")
+    : false;
   const showCustomers = session
     ? await hasPermission(session.roles, "customers:read")
     : false;
@@ -23,6 +26,7 @@ export default async function SettingsLayout({
     <div className="space-y-6">
       <SettingsNav
         showAccounts={showAccounts}
+        showRoles={showRoles}
         showCustomers={showCustomers}
         showSystem={showSystem}
       />

--- a/src/app/[locale]/(dashboard)/settings/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/page.tsx
@@ -10,6 +10,9 @@ export default async function SettingsPage() {
     if (await hasPermission(session.roles, "accounts:read")) {
       redirect("/settings/accounts");
     }
+    if (await hasPermission(session.roles, "roles:read")) {
+      redirect("/settings/roles");
+    }
     if (await hasPermission(session.roles, "customers:read")) {
       redirect("/settings/customers");
     }

--- a/src/app/[locale]/(dashboard)/settings/roles/page.tsx
+++ b/src/app/[locale]/(dashboard)/settings/roles/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+
+import { RoleTable } from "@/components/roles/role-table";
+import { hasPermission } from "@/lib/auth/permissions";
+import { getCurrentSession, requirePermission } from "@/lib/auth/session";
+
+export default async function RolesPage() {
+  const session = await getCurrentSession();
+  if (!session) return null;
+
+  await requirePermission(session, "roles:read");
+
+  const canWrite = await hasPermission(session.roles, "roles:write");
+  const canDelete = await hasPermission(session.roles, "roles:delete");
+
+  return (
+    <Suspense>
+      <RoleTable canWrite={canWrite} canDelete={canDelete} />
+    </Suspense>
+  );
+}

--- a/src/app/api/roles/[id]/route.ts
+++ b/src/app/api/roles/[id]/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { deleteRole, updateRole } from "@/lib/auth/role-management";
+
+/**
+ * PATCH /api/roles/[id]
+ *
+ * Update a custom role. Requires `roles:write` permission.
+ * Built-in roles cannot be modified.
+ */
+export const PATCH = withAuth(
+  async (request, context, session) => {
+    const { id: idStr } = await context.params;
+    const id = Number(idStr);
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ error: "Invalid role ID" }, { status: 400 });
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const name = body.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json(
+        { error: "Missing required field: name" },
+        { status: 400 },
+      );
+    }
+
+    const description =
+      typeof body.description === "string" ? body.description : null;
+
+    const permissions = body.permissions;
+    if (!Array.isArray(permissions)) {
+      return NextResponse.json(
+        { error: "Missing required field: permissions" },
+        { status: 400 },
+      );
+    }
+
+    const result = await updateRole(
+      id,
+      name,
+      description,
+      permissions as string[],
+    );
+
+    if (!result.valid) {
+      const status = result.errors?.some(
+        (e) =>
+          e === "Role not found" || e === "Built-in roles cannot be modified",
+      )
+        ? 403
+        : 400;
+      return NextResponse.json(
+        { error: result.errors?.[0], details: result.errors },
+        { status },
+      );
+    }
+
+    await auditLog.record({
+      actor: session.accountId,
+      action: "role.update",
+      target: "role",
+      targetId: idStr,
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { name, permissions },
+    });
+
+    return NextResponse.json({ data: result.data });
+  },
+  { requiredPermissions: ["roles:write"] },
+);
+
+/**
+ * DELETE /api/roles/[id]
+ *
+ * Delete a custom role. Requires `roles:delete` permission.
+ * Built-in roles and roles in use cannot be deleted.
+ */
+export const DELETE = withAuth(
+  async (request, context, session) => {
+    const { id: idStr } = await context.params;
+    const id = Number(idStr);
+    if (Number.isNaN(id)) {
+      return NextResponse.json({ error: "Invalid role ID" }, { status: 400 });
+    }
+
+    const result = await deleteRole(id);
+
+    if (!result.valid) {
+      const status = result.errors?.some(
+        (e) =>
+          e === "Role not found" || e === "Built-in roles cannot be deleted",
+      )
+        ? 403
+        : 400;
+      return NextResponse.json(
+        { error: result.errors?.[0], details: result.errors },
+        { status },
+      );
+    }
+
+    await auditLog.record({
+      actor: session.accountId,
+      action: "role.delete",
+      target: "role",
+      targetId: idStr,
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+    });
+
+    return NextResponse.json({ success: true });
+  },
+  { requiredPermissions: ["roles:delete"] },
+);

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -2,25 +2,75 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 
+import { auditLog } from "@/lib/audit/logger";
 import { withAuth } from "@/lib/auth/guard";
-import { query } from "@/lib/db/client";
-
-interface RoleRow {
-  id: number;
-  name: string;
-  description: string | null;
-  is_builtin: boolean;
-}
+import { extractClientIp } from "@/lib/auth/ip";
+import { createRole, getRolesWithDetails } from "@/lib/auth/role-management";
 
 /**
  * GET /api/roles
  *
- * List all roles. No special permission required beyond being
- * authenticated — needed for account creation forms.
+ * List all roles with details. No special permission required beyond
+ * being authenticated — needed for account creation forms.
  */
 export const GET = withAuth(async () => {
-  const { rows } = await query<RoleRow>(
-    "SELECT id, name, description, is_builtin FROM roles ORDER BY id",
-  );
-  return NextResponse.json({ data: rows });
+  const roles = await getRolesWithDetails();
+  return NextResponse.json({ data: roles });
 });
+
+/**
+ * POST /api/roles
+ *
+ * Create a new custom role. Requires `roles:write` permission.
+ */
+export const POST = withAuth(
+  async (request, _context, session) => {
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const name = body.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json(
+        { error: "Missing required field: name" },
+        { status: 400 },
+      );
+    }
+
+    const description =
+      typeof body.description === "string" ? body.description : null;
+
+    const permissions = body.permissions;
+    if (!Array.isArray(permissions)) {
+      return NextResponse.json(
+        { error: "Missing required field: permissions" },
+        { status: 400 },
+      );
+    }
+
+    const result = await createRole(name, description, permissions as string[]);
+
+    if (!result.valid) {
+      return NextResponse.json(
+        { error: "Validation failed", details: result.errors },
+        { status: 400 },
+      );
+    }
+
+    await auditLog.record({
+      actor: session.accountId,
+      action: "role.create",
+      target: "role",
+      targetId: String(result.data?.id),
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+      details: { name, permissions },
+    });
+
+    return NextResponse.json({ data: result.data }, { status: 201 });
+  },
+  { requiredPermissions: ["roles:write"] },
+);

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -5,16 +5,31 @@ import { NextResponse } from "next/server";
 import { auditLog } from "@/lib/audit/logger";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
-import { createRole, getRolesWithDetails } from "@/lib/auth/role-management";
+import { hasPermission } from "@/lib/auth/permissions";
+import {
+  createRole,
+  getRoles,
+  getRolesWithDetails,
+} from "@/lib/auth/role-management";
 
 /**
  * GET /api/roles
  *
- * List all roles with details. No special permission required beyond
- * being authenticated — needed for account creation forms.
+ * Without `roles:read`: returns minimal fields (id, name, description,
+ * is_builtin) — safe for any authenticated user (e.g. account forms).
+ *
+ * With `roles:read`: returns full permission arrays and account counts
+ * for the role management UI.
  */
-export const GET = withAuth(async () => {
-  const roles = await getRolesWithDetails();
+export const GET = withAuth(async (_request, _context, session) => {
+  const canReadDetails = await hasPermission(session.roles, "roles:read");
+
+  if (canReadDetails) {
+    const roles = await getRolesWithDetails();
+    return NextResponse.json({ data: roles });
+  }
+
+  const roles = await getRoles();
   return NextResponse.json({ data: roles });
 });
 

--- a/src/components/layout/settings-nav.tsx
+++ b/src/components/layout/settings-nav.tsx
@@ -6,12 +6,14 @@ import { cn } from "@/lib/utils";
 
 interface SettingsNavProps {
   showAccounts?: boolean;
+  showRoles?: boolean;
   showCustomers?: boolean;
   showSystem?: boolean;
 }
 
 export function SettingsNav({
   showAccounts,
+  showRoles,
   showCustomers,
   showSystem,
 }: SettingsNavProps) {
@@ -20,6 +22,7 @@ export function SettingsNav({
 
   const items: { key: string; href: string }[] = [];
   if (showAccounts) items.push({ key: "accounts", href: "/settings/accounts" });
+  if (showRoles) items.push({ key: "roles", href: "/settings/roles" });
   if (showCustomers)
     items.push({ key: "customers", href: "/settings/customers" });
   if (showSystem) items.push({ key: "system", href: "/settings/system" });

--- a/src/components/roles/role-form-dialog.tsx
+++ b/src/components/roles/role-form-dialog.tsx
@@ -39,8 +39,14 @@ interface RoleFormDialogProps {
 const PERMISSION_GROUPS = {
   accounts: ["accounts:read", "accounts:write", "accounts:delete"],
   roles: ["roles:read", "roles:write", "roles:delete"],
-  customers: ["customers:read", "customers:write", "customers:access-all"],
+  customers: [
+    "customers:read",
+    "customers:write",
+    "customers:delete",
+    "customers:access-all",
+  ],
   "audit-logs": ["audit-logs:read"],
+  dashboard: ["dashboard:read", "dashboard:write"],
   "system-settings": ["system-settings:read", "system-settings:write"],
 } as const;
 

--- a/src/components/roles/role-form-dialog.tsx
+++ b/src/components/roles/role-form-dialog.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface Role {
+  id: number;
+  name: string;
+  description: string | null;
+  permissions: string[];
+}
+
+interface RoleFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  role?: Role;
+  cloneSource?: Role;
+  onSuccess: () => void;
+}
+
+// ── Permission groups (mirrors ALL_PERMISSIONS from server) ────
+
+const PERMISSION_GROUPS = {
+  accounts: ["accounts:read", "accounts:write", "accounts:delete"],
+  roles: ["roles:read", "roles:write", "roles:delete"],
+  customers: ["customers:read", "customers:write", "customers:access-all"],
+  "audit-logs": ["audit-logs:read"],
+  "system-settings": ["system-settings:read", "system-settings:write"],
+} as const;
+
+// ── Component ───────────────────────────────────────────────────
+
+export function RoleFormDialog({
+  open,
+  onOpenChange,
+  role,
+  cloneSource,
+  onSuccess,
+}: RoleFormDialogProps) {
+  const t = useTranslations("roles");
+  const isEdit = !!role;
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [selectedPermissions, setSelectedPermissions] = useState<Set<string>>(
+    new Set(),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset form when dialog opens/changes
+  useEffect(() => {
+    if (open) {
+      if (role) {
+        setName(role.name);
+        setDescription(role.description ?? "");
+        setSelectedPermissions(new Set(role.permissions));
+      } else if (cloneSource) {
+        setName("");
+        setDescription(cloneSource.description ?? "");
+        setSelectedPermissions(new Set(cloneSource.permissions));
+      } else {
+        setName("");
+        setDescription("");
+        setSelectedPermissions(new Set());
+      }
+      setError(null);
+    }
+  }, [open, role, cloneSource]);
+
+  const handlePermissionToggle = (permission: string) => {
+    setSelectedPermissions((prev) => {
+      const next = new Set(prev);
+      if (next.has(permission)) {
+        next.delete(permission);
+      } else {
+        next.add(permission);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (csrfToken) {
+        headers["X-CSRF-Token"] = csrfToken;
+      }
+
+      const payload = {
+        name: name.trim(),
+        description: description.trim() || null,
+        permissions: [...selectedPermissions],
+      };
+
+      const url = isEdit ? `/api/roles/${role.id}` : "/api/roles";
+      const method = isEdit ? "PATCH" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers,
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+
+      onOpenChange(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const isValid = name.trim().length > 0;
+
+  const dialogTitle = isEdit
+    ? t("edit")
+    : cloneSource
+      ? t("clone")
+      : t("create");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{dialogTitle}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Name */}
+          <div className="space-y-2">
+            <Label htmlFor="role-name">{t("name")}</Label>
+            <Input
+              id="role-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={100}
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-2">
+            <Label htmlFor="role-description">{t("description")}</Label>
+            <Input
+              id="role-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          {/* Permission checkbox grid */}
+          <div className="space-y-3">
+            <Label>{t("permissions")}</Label>
+            <div className="space-y-4 rounded border p-3">
+              {Object.entries(PERMISSION_GROUPS).map(([group, perms]) => (
+                <div key={group}>
+                  <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wider">
+                    {t(`permissionGroups.${group}`)}
+                  </p>
+                  <div className="flex flex-wrap gap-x-6 gap-y-2">
+                    {perms.map((perm) => {
+                      const checkboxId = `perm-${perm}`;
+                      // Extract action part: "accounts:read" → "read"
+                      const action = perm.split(":")[1];
+                      return (
+                        <div
+                          key={perm}
+                          className="flex items-center gap-2 text-sm"
+                        >
+                          <Checkbox
+                            id={checkboxId}
+                            checked={selectedPermissions.has(perm)}
+                            onCheckedChange={() => handlePermissionToggle(perm)}
+                          />
+                          <label htmlFor={checkboxId}>
+                            {t(`permissionActions.${action}`)}
+                          </label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {error && <p className="text-destructive text-sm">{error}</p>}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={submitting}>
+                {t("cancel")}
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={submitting || !isValid}>
+              {submitting ? t("loading") : isEdit ? t("edit") : t("create")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/roles/role-form-dialog.tsx
+++ b/src/components/roles/role-form-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ALL_PERMISSIONS } from "@/lib/auth/permission-defs";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -34,21 +35,7 @@ interface RoleFormDialogProps {
   onSuccess: () => void;
 }
 
-// ── Permission groups (mirrors ALL_PERMISSIONS from server) ────
-
-const PERMISSION_GROUPS = {
-  accounts: ["accounts:read", "accounts:write", "accounts:delete"],
-  roles: ["roles:read", "roles:write", "roles:delete"],
-  customers: [
-    "customers:read",
-    "customers:write",
-    "customers:delete",
-    "customers:access-all",
-  ],
-  "audit-logs": ["audit-logs:read"],
-  dashboard: ["dashboard:read", "dashboard:write"],
-  "system-settings": ["system-settings:read", "system-settings:write"],
-} as const;
+// ── Permission groups ────────────────────────────────────────
 
 // ── Component ───────────────────────────────────────────────────
 
@@ -187,7 +174,7 @@ export function RoleFormDialog({
           <div className="space-y-3">
             <Label>{t("permissions")}</Label>
             <div className="space-y-4 rounded border p-3">
-              {Object.entries(PERMISSION_GROUPS).map(([group, perms]) => (
+              {Object.entries(ALL_PERMISSIONS).map(([group, perms]) => (
                 <div key={group}>
                   <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wider">
                     {t(`permissionGroups.${group}`)}

--- a/src/components/roles/role-table.tsx
+++ b/src/components/roles/role-table.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { Copy, Pencil, Plus, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+
+import { RoleFormDialog } from "@/components/roles/role-form-dialog";
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+// ── Types ───────────────────────────────────────────────────────
+
+interface Role {
+  id: number;
+  name: string;
+  description: string | null;
+  is_builtin: boolean;
+  permissions: string[];
+  account_count: number;
+}
+
+interface RoleTableProps {
+  canWrite: boolean;
+  canDelete: boolean;
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+export function RoleTable({ canWrite, canDelete }: RoleTableProps) {
+  const t = useTranslations("roles");
+
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingRole, setEditingRole] = useState<Role | undefined>();
+  const [cloneSource, setCloneSource] = useState<Role | undefined>();
+  const [deleteTarget, setDeleteTarget] = useState<Role | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // ── Fetch roles ────────────────────────────────────────────────
+
+  const fetchRoles = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/roles");
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+      const body = await res.json();
+      setRoles(body.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    fetchRoles();
+  }, [fetchRoles]);
+
+  // ── Handlers ──────────────────────────────────────────────────
+
+  const handleCreate = () => {
+    setEditingRole(undefined);
+    setCloneSource(undefined);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (role: Role) => {
+    setEditingRole(role);
+    setCloneSource(undefined);
+    setFormOpen(true);
+  };
+
+  const handleClone = (role: Role) => {
+    setEditingRole(undefined);
+    setCloneSource(role);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteError(null);
+
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {};
+      if (csrfToken) {
+        headers["X-CSRF-Token"] = csrfToken;
+      }
+
+      const res = await fetch(`/api/roles/${deleteTarget.id}`, {
+        method: "DELETE",
+        headers,
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+
+      setDeleteTarget(null);
+      fetchRoles();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : t("error"));
+    }
+  };
+
+  // ── Render ────────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-foreground text-2xl font-bold">{t("title")}</h1>
+        {canWrite && (
+          <Button onClick={handleCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t("create")}
+          </Button>
+        )}
+      </div>
+
+      {loading && (
+        <p className="text-muted-foreground text-sm">{t("loading")}</p>
+      )}
+      {error && <p className="text-destructive text-sm">{error}</p>}
+
+      {!loading && !error && roles.length === 0 && (
+        <p className="text-muted-foreground text-sm">{t("noResults")}</p>
+      )}
+
+      {!loading && roles.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t("name")}</TableHead>
+              <TableHead>{t("description")}</TableHead>
+              <TableHead className="text-center">
+                {t("permissionCount")}
+              </TableHead>
+              <TableHead className="text-center">{t("accountCount")}</TableHead>
+              {(canWrite || canDelete) && <TableHead className="w-[120px]" />}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {roles.map((role) => (
+              <TableRow key={role.id}>
+                <TableCell className="font-medium">
+                  <span className="mr-2">{role.name}</span>
+                  {role.is_builtin && (
+                    <Badge variant="secondary" className="text-xs">
+                      {t("builtin")}
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {role.description ?? "—"}
+                </TableCell>
+                <TableCell className="text-center">
+                  {role.permissions.length}
+                </TableCell>
+                <TableCell className="text-center">
+                  {role.account_count}
+                </TableCell>
+                {(canWrite || canDelete) && (
+                  <TableCell>
+                    <div className="flex gap-1">
+                      {canWrite && !role.is_builtin && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleEdit(role)}
+                          title={t("edit")}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      )}
+                      {canWrite && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleClone(role)}
+                          title={t("clone")}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
+                      )}
+                      {canDelete && !role.is_builtin && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setDeleteTarget(role)}
+                          title={t("delete")}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Create/Edit/Clone Dialog */}
+      {canWrite && (
+        <RoleFormDialog
+          open={formOpen}
+          onOpenChange={setFormOpen}
+          role={editingRole}
+          cloneSource={cloneSource}
+          onSuccess={fetchRoles}
+        />
+      )}
+
+      {/* Delete Confirmation */}
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("delete")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteConfirm")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError && (
+            <p className="text-destructive text-sm">{deleteError}</p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>
+              {t("delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -290,6 +290,7 @@
       "roles": "Roles",
       "customers": "Customers",
       "audit-logs": "Audit Logs",
+      "dashboard": "Dashboard",
       "system-settings": "System Settings"
     },
     "permissionActions": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -268,6 +268,37 @@
       "perUserWindowMinutesDescription": "Time window for per-user limit"
     }
   },
+  "roles": {
+    "title": "Roles",
+    "name": "Name",
+    "description": "Description",
+    "permissions": "Permissions",
+    "permissionCount": "Permissions",
+    "accountCount": "Accounts",
+    "builtin": "Built-in",
+    "create": "Create Role",
+    "edit": "Edit Role",
+    "clone": "Clone Role",
+    "delete": "Delete Role",
+    "cancel": "Cancel",
+    "deleteConfirm": "Are you sure you want to delete this role? This action cannot be undone.",
+    "noResults": "No roles found.",
+    "loading": "Loading...",
+    "error": "Failed to load roles",
+    "permissionGroups": {
+      "accounts": "Accounts",
+      "roles": "Roles",
+      "customers": "Customers",
+      "audit-logs": "Audit Logs",
+      "system-settings": "System Settings"
+    },
+    "permissionActions": {
+      "read": "Read",
+      "write": "Write",
+      "delete": "Delete",
+      "access-all": "Access All"
+    }
+  },
   "changePassword": {
     "heading": "Change Password",
     "currentPassword": "Current Password",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -290,6 +290,7 @@
       "roles": "역할",
       "customers": "고객",
       "audit-logs": "감사 로그",
+      "dashboard": "대시보드",
       "system-settings": "시스템 설정"
     },
     "permissionActions": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -268,6 +268,37 @@
       "perUserWindowMinutesDescription": "사용자당 제한 시간 범위"
     }
   },
+  "roles": {
+    "title": "역할",
+    "name": "이름",
+    "description": "설명",
+    "permissions": "권한",
+    "permissionCount": "권한",
+    "accountCount": "계정",
+    "builtin": "기본 제공",
+    "create": "역할 생성",
+    "edit": "역할 수정",
+    "clone": "역할 복제",
+    "delete": "역할 삭제",
+    "cancel": "취소",
+    "deleteConfirm": "이 역할을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "noResults": "역할이 없습니다.",
+    "loading": "로딩 중...",
+    "error": "역할 목록을 불러오지 못했습니다",
+    "permissionGroups": {
+      "accounts": "계정",
+      "roles": "역할",
+      "customers": "고객",
+      "audit-logs": "감사 로그",
+      "system-settings": "시스템 설정"
+    },
+    "permissionActions": {
+      "read": "읽기",
+      "write": "쓰기",
+      "delete": "삭제",
+      "access-all": "전체 접근"
+    }
+  },
   "changePassword": {
     "heading": "비밀번호 변경",
     "currentPassword": "현재 비밀번호",

--- a/src/lib/auth/permission-defs.ts
+++ b/src/lib/auth/permission-defs.ts
@@ -1,0 +1,27 @@
+/**
+ * Single source of truth for all permission strings in the system.
+ *
+ * This module is intentionally free of `server-only` so it can be
+ * imported by both server code (`permissions.ts`, `role-management.ts`)
+ * and client components (`role-form-dialog.tsx`).
+ *
+ * Grouped by resource for display purposes (permission checkbox grid).
+ */
+export const ALL_PERMISSIONS = {
+  accounts: ["accounts:read", "accounts:write", "accounts:delete"],
+  roles: ["roles:read", "roles:write", "roles:delete"],
+  customers: [
+    "customers:read",
+    "customers:write",
+    "customers:delete",
+    "customers:access-all",
+  ],
+  "audit-logs": ["audit-logs:read"],
+  dashboard: ["dashboard:read", "dashboard:write"],
+  "system-settings": ["system-settings:read", "system-settings:write"],
+} as const;
+
+/** Flat set of all valid permission strings. */
+export const VALID_PERMISSIONS: Set<string> = new Set(
+  Object.values(ALL_PERMISSIONS).flat(),
+);

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -33,6 +33,28 @@ async function loadRolePermissions(roleName: string): Promise<Set<string>> {
   return permissions;
 }
 
+// ── Constants ─────────────────────────────────────────────────
+
+/**
+ * Single source of truth for all permission strings in the system.
+ * Used for the permission checkbox grid in role management UI and
+ * for validating permission values on the server side.
+ *
+ * Grouped by resource for display purposes.
+ */
+export const ALL_PERMISSIONS = {
+  accounts: ["accounts:read", "accounts:write", "accounts:delete"],
+  roles: ["roles:read", "roles:write", "roles:delete"],
+  customers: ["customers:read", "customers:write", "customers:access-all"],
+  "audit-logs": ["audit-logs:read"],
+  "system-settings": ["system-settings:read", "system-settings:write"],
+} as const;
+
+/** Flat set of all valid permission strings. */
+export const VALID_PERMISSIONS: Set<string> = new Set(
+  Object.values(ALL_PERMISSIONS).flat(),
+);
+
 // ── Public API ─────────────────────────────────────────────────
 
 /**

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -35,31 +35,9 @@ async function loadRolePermissions(roleName: string): Promise<Set<string>> {
 
 // ── Constants ─────────────────────────────────────────────────
 
-/**
- * Single source of truth for all permission strings in the system.
- * Used for the permission checkbox grid in role management UI and
- * for validating permission values on the server side.
- *
- * Grouped by resource for display purposes.
- */
-export const ALL_PERMISSIONS = {
-  accounts: ["accounts:read", "accounts:write", "accounts:delete"],
-  roles: ["roles:read", "roles:write", "roles:delete"],
-  customers: [
-    "customers:read",
-    "customers:write",
-    "customers:delete",
-    "customers:access-all",
-  ],
-  "audit-logs": ["audit-logs:read"],
-  dashboard: ["dashboard:read", "dashboard:write"],
-  "system-settings": ["system-settings:read", "system-settings:write"],
-} as const;
-
-/** Flat set of all valid permission strings. */
-export const VALID_PERMISSIONS: Set<string> = new Set(
-  Object.values(ALL_PERMISSIONS).flat(),
-);
+// Re-export from the shared (non-server-only) module so that existing
+// server-side consumers can keep importing from this file.
+export { ALL_PERMISSIONS, VALID_PERMISSIONS } from "./permission-defs";
 
 // ── Public API ─────────────────────────────────────────────────
 

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -45,8 +45,14 @@ async function loadRolePermissions(roleName: string): Promise<Set<string>> {
 export const ALL_PERMISSIONS = {
   accounts: ["accounts:read", "accounts:write", "accounts:delete"],
   roles: ["roles:read", "roles:write", "roles:delete"],
-  customers: ["customers:read", "customers:write", "customers:access-all"],
+  customers: [
+    "customers:read",
+    "customers:write",
+    "customers:delete",
+    "customers:access-all",
+  ],
   "audit-logs": ["audit-logs:read"],
+  dashboard: ["dashboard:read", "dashboard:write"],
   "system-settings": ["system-settings:read", "system-settings:write"],
 } as const;
 

--- a/src/lib/auth/role-management.ts
+++ b/src/lib/auth/role-management.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { query } from "@/lib/db/client";
+import { query, withTransaction } from "@/lib/db/client";
 
 import { invalidatePermissionCache, VALID_PERMISSIONS } from "./permissions";
 
@@ -54,8 +54,29 @@ function validateRoleInput(
 
 // ── Public API ─────────────────────────────────────────────────
 
+export interface RoleSummary {
+  id: number;
+  name: string;
+  description: string | null;
+  is_builtin: boolean;
+}
+
 /**
- * List all roles with their permission counts and account counts.
+ * List all roles with minimal fields (id, name, description, is_builtin).
+ * Safe for any authenticated user — used by account creation forms.
+ */
+export async function getRoles(): Promise<RoleSummary[]> {
+  const { rows } = await query<RoleSummary>(
+    `SELECT id, name, description, is_builtin
+     FROM roles
+     ORDER BY is_builtin DESC, name`,
+  );
+  return rows;
+}
+
+/**
+ * List all roles with their full permissions and account counts.
+ * Should only be exposed to users with `roles:read`.
  */
 export async function getRolesWithDetails(): Promise<RoleWithPermissions[]> {
   const { rows } = await query<
@@ -129,24 +150,28 @@ export async function createRole(
     return { valid: false, errors: ["A role with this name already exists"] };
   }
 
-  // Insert role
-  const { rows } = await query<RoleRow>(
-    `INSERT INTO roles (name, description)
-     VALUES ($1, $2)
-     RETURNING id, name, description, is_builtin, created_at, updated_at`,
-    [name.trim(), description?.trim() || null],
-  );
-
-  const role = rows[0];
-
-  // Insert permissions
-  if (permissions.length > 0) {
-    const values = permissions.map((_, i) => `($1, $${i + 2})`).join(", ");
-    await query(
-      `INSERT INTO role_permissions (role_id, permission) VALUES ${values}`,
-      [role.id, ...permissions],
+  const role = await withTransaction(async (client) => {
+    // Insert role
+    const { rows } = await client.query<RoleRow>(
+      `INSERT INTO roles (name, description)
+       VALUES ($1, $2)
+       RETURNING id, name, description, is_builtin, created_at, updated_at`,
+      [name.trim(), description?.trim() || null],
     );
-  }
+
+    const created = rows[0];
+
+    // Insert permissions
+    if (permissions.length > 0) {
+      const values = permissions.map((_, i) => `($1, $${i + 2})`).join(", ");
+      await client.query(
+        `INSERT INTO role_permissions (role_id, permission) VALUES ${values}`,
+        [created.id, ...permissions],
+      );
+    }
+
+    return created;
+  });
 
   invalidatePermissionCache();
 
@@ -186,24 +211,28 @@ export async function updateRole(
     return { valid: false, errors: ["A role with this name already exists"] };
   }
 
-  // Update role
-  const { rows } = await query<RoleRow>(
-    `UPDATE roles SET name = $1, description = $2, updated_at = NOW()
-     WHERE id = $3
-     RETURNING id, name, description, is_builtin, created_at, updated_at`,
-    [name.trim(), description?.trim() || null, id],
-  );
-
-  // Replace permissions: delete all, then insert new
-  await query("DELETE FROM role_permissions WHERE role_id = $1", [id]);
-
-  if (permissions.length > 0) {
-    const values = permissions.map((_, i) => `($1, $${i + 2})`).join(", ");
-    await query(
-      `INSERT INTO role_permissions (role_id, permission) VALUES ${values}`,
-      [id, ...permissions],
+  const updated = await withTransaction(async (client) => {
+    // Update role
+    const { rows } = await client.query<RoleRow>(
+      `UPDATE roles SET name = $1, description = $2, updated_at = NOW()
+       WHERE id = $3
+       RETURNING id, name, description, is_builtin, created_at, updated_at`,
+      [name.trim(), description?.trim() || null, id],
     );
-  }
+
+    // Replace permissions: delete all, then insert new
+    await client.query("DELETE FROM role_permissions WHERE role_id = $1", [id]);
+
+    if (permissions.length > 0) {
+      const values = permissions.map((_, i) => `($1, $${i + 2})`).join(", ");
+      await client.query(
+        `INSERT INTO role_permissions (role_id, permission) VALUES ${values}`,
+        [id, ...permissions],
+      );
+    }
+
+    return rows[0];
+  });
 
   invalidatePermissionCache(existing.name);
   // Also invalidate new name in case it changed
@@ -214,7 +243,7 @@ export async function updateRole(
   return {
     valid: true,
     data: {
-      ...rows[0],
+      ...updated,
       permissions,
       account_count: existing.account_count,
     },

--- a/src/lib/auth/role-management.ts
+++ b/src/lib/auth/role-management.ts
@@ -1,0 +1,252 @@
+import "server-only";
+
+import { query } from "@/lib/db/client";
+
+import { invalidatePermissionCache, VALID_PERMISSIONS } from "./permissions";
+
+// ── Types ──────────────────────────────────────────────────────
+
+export interface RoleRow {
+  id: number;
+  name: string;
+  description: string | null;
+  is_builtin: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RoleWithPermissions extends RoleRow {
+  permissions: string[];
+  account_count: number;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function validateRoleInput(
+  name: string,
+  permissions: string[],
+): ValidationResult {
+  const errors: string[] = [];
+
+  if (!name || name.trim().length === 0) {
+    errors.push("Name is required");
+  } else if (name.trim().length > 100) {
+    errors.push("Name must be 100 characters or fewer");
+  }
+
+  if (!Array.isArray(permissions)) {
+    errors.push("Permissions must be an array");
+  } else {
+    for (const p of permissions) {
+      if (!VALID_PERMISSIONS.has(p)) {
+        errors.push(`Unknown permission: ${p}`);
+      }
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * List all roles with their permission counts and account counts.
+ */
+export async function getRolesWithDetails(): Promise<RoleWithPermissions[]> {
+  const { rows } = await query<
+    RoleRow & { permissions: string[]; account_count: string }
+  >(
+    `SELECT r.id, r.name, r.description, r.is_builtin,
+            r.created_at, r.updated_at,
+            COALESCE(
+              (SELECT array_agg(rp.permission ORDER BY rp.permission)
+               FROM role_permissions rp WHERE rp.role_id = r.id),
+              '{}'
+            ) AS permissions,
+            (SELECT COUNT(*)::TEXT FROM accounts a WHERE a.role_id = r.id) AS account_count
+     FROM roles r
+     ORDER BY r.is_builtin DESC, r.name`,
+  );
+
+  return rows.map((r) => ({
+    ...r,
+    account_count: Number(r.account_count),
+  }));
+}
+
+/**
+ * Get a single role with its permissions.
+ */
+export async function getRoleWithPermissions(
+  id: number,
+): Promise<RoleWithPermissions | null> {
+  const { rows } = await query<
+    RoleRow & { permissions: string[]; account_count: string }
+  >(
+    `SELECT r.id, r.name, r.description, r.is_builtin,
+            r.created_at, r.updated_at,
+            COALESCE(
+              (SELECT array_agg(rp.permission ORDER BY rp.permission)
+               FROM role_permissions rp WHERE rp.role_id = r.id),
+              '{}'
+            ) AS permissions,
+            (SELECT COUNT(*)::TEXT FROM accounts a WHERE a.role_id = r.id) AS account_count
+     FROM roles r
+     WHERE r.id = $1`,
+    [id],
+  );
+
+  if (rows.length === 0) return null;
+
+  return {
+    ...rows[0],
+    account_count: Number(rows[0].account_count),
+  };
+}
+
+/**
+ * Create a new custom role with the given permissions.
+ */
+export async function createRole(
+  name: string,
+  description: string | null,
+  permissions: string[],
+): Promise<{ valid: boolean; data?: RoleWithPermissions; errors?: string[] }> {
+  const validation = validateRoleInput(name, permissions);
+  if (!validation.valid) return validation;
+
+  // Check for duplicate name
+  const { rowCount: existing } = await query(
+    "SELECT 1 FROM roles WHERE name = $1",
+    [name.trim()],
+  );
+  if (existing && existing > 0) {
+    return { valid: false, errors: ["A role with this name already exists"] };
+  }
+
+  // Insert role
+  const { rows } = await query<RoleRow>(
+    `INSERT INTO roles (name, description)
+     VALUES ($1, $2)
+     RETURNING id, name, description, is_builtin, created_at, updated_at`,
+    [name.trim(), description?.trim() || null],
+  );
+
+  const role = rows[0];
+
+  // Insert permissions
+  if (permissions.length > 0) {
+    const values = permissions.map((_, i) => `($1, $${i + 2})`).join(", ");
+    await query(
+      `INSERT INTO role_permissions (role_id, permission) VALUES ${values}`,
+      [role.id, ...permissions],
+    );
+  }
+
+  invalidatePermissionCache();
+
+  return {
+    valid: true,
+    data: { ...role, permissions, account_count: 0 },
+  };
+}
+
+/**
+ * Update an existing custom role.
+ */
+export async function updateRole(
+  id: number,
+  name: string,
+  description: string | null,
+  permissions: string[],
+): Promise<{ valid: boolean; data?: RoleWithPermissions; errors?: string[] }> {
+  const validation = validateRoleInput(name, permissions);
+  if (!validation.valid) return validation;
+
+  // Check role exists and is not built-in
+  const existing = await getRoleWithPermissions(id);
+  if (!existing) {
+    return { valid: false, errors: ["Role not found"] };
+  }
+  if (existing.is_builtin) {
+    return { valid: false, errors: ["Built-in roles cannot be modified"] };
+  }
+
+  // Check for duplicate name (excluding current role)
+  const { rowCount: nameConflict } = await query(
+    "SELECT 1 FROM roles WHERE name = $1 AND id != $2",
+    [name.trim(), id],
+  );
+  if (nameConflict && nameConflict > 0) {
+    return { valid: false, errors: ["A role with this name already exists"] };
+  }
+
+  // Update role
+  const { rows } = await query<RoleRow>(
+    `UPDATE roles SET name = $1, description = $2, updated_at = NOW()
+     WHERE id = $3
+     RETURNING id, name, description, is_builtin, created_at, updated_at`,
+    [name.trim(), description?.trim() || null, id],
+  );
+
+  // Replace permissions: delete all, then insert new
+  await query("DELETE FROM role_permissions WHERE role_id = $1", [id]);
+
+  if (permissions.length > 0) {
+    const values = permissions.map((_, i) => `($1, $${i + 2})`).join(", ");
+    await query(
+      `INSERT INTO role_permissions (role_id, permission) VALUES ${values}`,
+      [id, ...permissions],
+    );
+  }
+
+  invalidatePermissionCache(existing.name);
+  // Also invalidate new name in case it changed
+  if (existing.name !== name.trim()) {
+    invalidatePermissionCache(name.trim());
+  }
+
+  return {
+    valid: true,
+    data: {
+      ...rows[0],
+      permissions,
+      account_count: existing.account_count,
+    },
+  };
+}
+
+/**
+ * Delete a custom role. Fails if the role is built-in or in use.
+ */
+export async function deleteRole(
+  id: number,
+): Promise<{ valid: boolean; errors?: string[] }> {
+  const existing = await getRoleWithPermissions(id);
+  if (!existing) {
+    return { valid: false, errors: ["Role not found"] };
+  }
+  if (existing.is_builtin) {
+    return { valid: false, errors: ["Built-in roles cannot be deleted"] };
+  }
+  if (existing.account_count > 0) {
+    return {
+      valid: false,
+      errors: [
+        "Cannot delete a role that is assigned to accounts. Reassign accounts first.",
+      ],
+    };
+  }
+
+  // role_permissions cascade-deleted via FK
+  await query("DELETE FROM roles WHERE id = $1", [id]);
+
+  invalidatePermissionCache(existing.name);
+
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary

- Add service layer (`role-management.ts`) with `createRole`, `updateRole`, `deleteRole`, and `getRolesWithDetails` — includes validation, duplicate name checks, built-in role protection, in-use deletion prevention, and permission cache invalidation
- Add `ALL_PERMISSIONS` / `VALID_PERMISSIONS` constants to `permissions.ts` as single source of truth for the permission checkbox grid and server-side validation
- Add API routes: `POST /api/roles` (`roles:write`), `PATCH /api/roles/[id]` (`roles:write`), `DELETE /api/roles/[id]` (`roles:delete`) with audit logging; enhance existing `GET /api/roles` to return permission and account counts
- Add roles page under Settings with permission-aware navigation (`roles:read` gate, `canWrite`/`canDelete` props)
- Add role table UI (name, description, built-in badge, permission count, account count) with edit, clone, and delete actions
- Add role form dialog with permission checkbox grid grouped by resource (accounts, roles, customers, audit-logs, dashboard, system-settings)
- Add i18n messages (EN/KO) for all role management strings
- Fix missing permissions (`customers:delete`, `dashboard:read`, `dashboard:write`) in `ALL_PERMISSIONS` that blocked cloning built-in roles
- Add 25 unit/API tests + 19 E2E tests (API 9, UI 7, RBAC 2, audit 1)

## Test plan

- [x] `pnpm vitest run` — 842 tests pass (25 new)
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check` — no lint/format errors
- [x] `pnpm next build` — builds successfully
- [x] Create a custom role with selected permissions → verify role appears in list
- [x] Edit a custom role (change name, add/remove permissions) → verify changes persist
- [x] Clone a built-in role → verify new role created with same permissions
- [x] Attempt to edit/delete a built-in role → verify blocked (only clone button shown for built-in roles)
- [x] Attempt to delete a role assigned to accounts → verify blocked
- [x] Delete an unused custom role → verify removed from list
- [x] Verify audit logs record `role.create`, `role.update`, `role.delete` actions
- [x] Verify Settings nav shows Roles tab only for users with `roles:read` permission
- [x] E2E: 131/131 tests pass (19 new roles + 112 existing, no regressions)

Closes #134