### PR TITLE
Add System Administrator Dashboard

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -10,7 +10,7 @@ import {
 import {
   createTestAccount,
   createTestRole,
-  deleteAuditLogsByAction,
+  deleteAuditLogById,
   deleteTestAccount,
   deleteTestRole,
   insertAuditLog,
@@ -381,7 +381,7 @@ test("Korean locale: alerts card shows Korean detail messages", async ({
   page,
 }) => {
   // Seed an account.lock audit event to trigger the "account_lockout" rule
-  await insertAuditLog({
+  const auditId = await insertAuditLog({
     actorId: "system",
     action: "account.lock",
     targetType: "account",
@@ -407,6 +407,6 @@ test("Korean locale: alerts card shows Korean detail messages", async ({
     // Severity badge should be Korean "높음" (high)
     await expect(page.getByText("높음").first()).toBeVisible();
   } finally {
-    await deleteAuditLogsByAction("account.lock");
+    await deleteAuditLogById(auditId);
   }
 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -5,6 +5,7 @@ import {
   ADMIN_USERNAME,
   resetRateLimits,
   signInAndWait,
+  signInAndWaitKo,
 } from "./helpers/auth";
 import {
   createTestAccount,
@@ -284,4 +285,109 @@ test("locked account shows in dashboard card", async ({ page }) => {
     // Restore account status to avoid leaking state
     await setAccountStatus(LOCKED_USER, "active");
   }
+});
+
+// ── Korean locale UI tests ──────────────────────────────────────
+
+test("Korean locale: dashboard renders three cards with Korean text", async ({
+  page,
+}) => {
+  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/ko/dashboard");
+
+  // Dashboard title in Korean
+  await expect(
+    page.getByRole("heading", { name: "시스템 대시보드" }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // All three card titles in Korean
+  await expect(page.getByText("활성 세션").first()).toBeVisible();
+  await expect(page.getByText("잠긴 및 정지된 계정")).toBeVisible();
+  await expect(page.getByText("의심 활동").first()).toBeVisible();
+});
+
+test("Korean locale: sessions card shows Korean column headers", async ({
+  page,
+}) => {
+  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/ko/dashboard");
+
+  // Wait for sessions card to load data
+  await expect(page.getByText("활성 세션").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Column headers should be in Korean
+  await expect(page.getByText("사용자").first()).toBeVisible();
+  await expect(page.getByText("IP 주소").first()).toBeVisible();
+  await expect(page.getByText("마지막 활동")).toBeVisible();
+});
+
+test("Korean locale: revoke button and confirm dialog use Korean", async ({
+  page,
+}) => {
+  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/ko/dashboard");
+
+  // Wait for sessions card
+  await expect(page.getByText("활성 세션").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Revoke button should be in Korean
+  const revokeBtn = page.getByRole("button", { name: "해지" }).first();
+  await expect(revokeBtn).toBeVisible({ timeout: 5_000 });
+
+  // Click to open confirm dialog
+  await revokeBtn.click();
+
+  // Confirm dialog should show Korean text
+  const dialog = page.getByRole("alertdialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("이 세션을 해지하시겠습니까?")).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "취소" })).toBeVisible();
+
+  // Dismiss
+  await dialog.getByRole("button", { name: "취소" }).click();
+});
+
+test("Korean locale: locked account card shows Korean status", async ({
+  page,
+}) => {
+  await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
+
+  try {
+    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/ko/dashboard");
+
+    // Wait for locked accounts card in Korean
+    await expect(page.getByText("잠긴 및 정지된 계정")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The locked user should appear
+    await expect(page.getByText(LOCKED_USER)).toBeVisible({ timeout: 5_000 });
+
+    // Status badge should show Korean "잠금"
+    await expect(page.getByText("잠금").first()).toBeVisible();
+  } finally {
+    await setAccountStatus(LOCKED_USER, "active");
+  }
+});
+
+test("Korean locale: alerts card shows Korean severity and description", async ({
+  page,
+}) => {
+  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/ko/dashboard");
+
+  // Scroll the alerts card description into view and verify Korean text
+  const desc = page.getByText("최근 24시간 동안 감지된 보안 알림");
+  await desc.scrollIntoViewIfNeeded();
+  await expect(desc).toBeVisible({ timeout: 10_000 });
+
+  // Either the no-alerts message or alert severity headers should be Korean
+  const noAlerts = page.getByText("의심 활동이 감지되지 않았습니다");
+  const severityHeader = page.getByText("심각도");
+  await expect(noAlerts.or(severityHeader)).toBeVisible({ timeout: 5_000 });
 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -230,9 +230,7 @@ test("dashboard page renders three cards for admin", async ({ page }) => {
 
   // All three card titles should be present
   await expect(page.getByText("Active Sessions").first()).toBeVisible();
-  await expect(
-    page.getByText("Locked & Suspended Accounts"),
-  ).toBeVisible();
+  await expect(page.getByText("Locked & Suspended Accounts")).toBeVisible();
   await expect(page.getByText("Suspicious Activity").first()).toBeVisible();
 });
 
@@ -276,9 +274,9 @@ test("locked account shows in dashboard card", async ({ page }) => {
     await page.goto("/dashboard");
 
     // Wait for locked accounts card to render
-    await expect(
-      page.getByText("Locked & Suspended Accounts"),
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Locked & Suspended Accounts")).toBeVisible({
+      timeout: 10000,
+    });
 
     // The locked user should appear
     await expect(page.getByText(LOCKED_USER)).toBeVisible({ timeout: 5000 });

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,289 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  resetRateLimits,
+  signInAndWait,
+} from "./helpers/auth";
+import {
+  createTestAccount,
+  createTestRole,
+  deleteTestAccount,
+  deleteTestRole,
+  resetAccountDefaults,
+  setAccountStatus,
+} from "./helpers/setup-db";
+
+// ── Constants ────────────────────────────────────────────────────
+
+const NOPERM_USER = "e2e-dashboard-noperm";
+const NOPERM_PASS = "Noperm1234!";
+const NOPERM_ROLE = "E2E No Dashboard";
+
+const READER_USER = "e2e-dashboard-reader";
+const READER_PASS = "Reader1234!";
+const READER_ROLE = "E2E Dashboard Reader";
+
+const LOCKED_USER = "e2e-dashboard-locked";
+const LOCKED_PASS = "Locked1234!";
+
+function csrfHeader(csrfValue: string) {
+  return {
+    "x-csrf-token": csrfValue,
+    Origin: "http://localhost:3000",
+    "Content-Type": "application/json",
+  };
+}
+
+async function getCsrf(page: import("@playwright/test").Page) {
+  const cookies = await page.context().cookies();
+  return cookies.find((c) => c.name === "csrf")?.value ?? "";
+}
+
+// ── Setup / Teardown ─────────────────────────────────────────────
+
+test.beforeAll(async () => {
+  await resetRateLimits();
+
+  // Role with no dashboard permissions
+  await createTestRole(NOPERM_ROLE, ["accounts:read"]);
+  await createTestAccount(NOPERM_USER, NOPERM_PASS, NOPERM_ROLE);
+
+  // Role with dashboard:read only (no write)
+  await createTestRole(READER_ROLE, ["dashboard:read"]);
+  await createTestAccount(READER_USER, READER_PASS, READER_ROLE);
+
+  // Account to lock for locked-accounts card test
+  await createTestAccount(LOCKED_USER, LOCKED_PASS, "Tenant Administrator");
+});
+
+test.beforeEach(async () => {
+  await resetRateLimits();
+  await resetAccountDefaults(ADMIN_USERNAME);
+});
+
+test.afterAll(async () => {
+  try {
+    await deleteTestAccount(NOPERM_USER);
+    await deleteTestAccount(READER_USER);
+    await deleteTestAccount(LOCKED_USER);
+    await deleteTestRole(NOPERM_ROLE);
+    await deleteTestRole(READER_ROLE);
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ── API tests ────────────────────────────────────────────────────
+
+test("GET /api/dashboard/sessions returns active sessions", async ({
+  page,
+}) => {
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+  const response = await page.request.get("/api/dashboard/sessions");
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  expect(body.data.length).toBeGreaterThanOrEqual(1);
+
+  // Admin's own session should be present
+  const adminSession = body.data.find(
+    (s: { username: string }) => s.username === ADMIN_USERNAME,
+  );
+  expect(adminSession).toBeDefined();
+  expect(adminSession.ip_address).toBeTruthy();
+});
+
+test("GET /api/dashboard/locked-accounts returns locked accounts", async ({
+  page,
+}) => {
+  // Lock the test account
+  await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
+
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+  const response = await page.request.get("/api/dashboard/locked-accounts");
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  const locked = body.data.find(
+    (a: { username: string }) => a.username === LOCKED_USER,
+  );
+  expect(locked).toBeDefined();
+  expect(locked.status).toBe("locked");
+
+  // Restore for subsequent tests
+  await setAccountStatus(LOCKED_USER, "active");
+});
+
+test("GET /api/dashboard/alerts returns alerts array", async ({ page }) => {
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+  const response = await page.request.get("/api/dashboard/alerts");
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  expect(Array.isArray(body.data)).toBe(true);
+});
+
+test("POST /api/dashboard/sessions/[sid]/revoke revokes a session", async ({
+  page,
+}) => {
+  // Create a session for the reader user by signing in
+  await signInAndWait(page, READER_USER, READER_PASS);
+
+  // Now sign in as admin
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const csrf = await getCsrf(page);
+
+  // Find the reader's session
+  const sessionsRes = await page.request.get("/api/dashboard/sessions");
+  const sessions = await sessionsRes.json();
+  const readerSession = sessions.data.find(
+    (s: { username: string }) => s.username === READER_USER,
+  );
+  expect(readerSession).toBeDefined();
+
+  // Revoke it
+  const revokeRes = await page.request.post(
+    `/api/dashboard/sessions/${readerSession.sid}/revoke`,
+    { headers: csrfHeader(csrf) },
+  );
+  expect(revokeRes.status()).toBe(200);
+  const revokeBody = await revokeRes.json();
+  expect(revokeBody.ok).toBe(true);
+
+  // Verify it's gone from the sessions list
+  const verifyRes = await page.request.get("/api/dashboard/sessions");
+  const verifyBody = await verifyRes.json();
+  const found = verifyBody.data.find(
+    (s: { sid: string }) => s.sid === readerSession.sid,
+  );
+  expect(found).toBeUndefined();
+});
+
+test("POST revoke returns 404 for non-existent session", async ({ page }) => {
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  const csrf = await getCsrf(page);
+
+  const response = await page.request.post(
+    "/api/dashboard/sessions/00000000-0000-0000-0000-000000000000/revoke",
+    { headers: csrfHeader(csrf) },
+  );
+  expect(response.status()).toBe(404);
+});
+
+// ── RBAC tests ───────────────────────────────────────────────────
+
+test("user without dashboard:read gets 403 on sessions endpoint", async ({
+  page,
+}) => {
+  await signInAndWait(page, NOPERM_USER, NOPERM_PASS);
+
+  const response = await page.request.get("/api/dashboard/sessions");
+  expect(response.status()).toBe(403);
+});
+
+test("user without dashboard:read gets 403 on locked-accounts endpoint", async ({
+  page,
+}) => {
+  await signInAndWait(page, NOPERM_USER, NOPERM_PASS);
+
+  const response = await page.request.get("/api/dashboard/locked-accounts");
+  expect(response.status()).toBe(403);
+});
+
+test("user without dashboard:read gets 403 on alerts endpoint", async ({
+  page,
+}) => {
+  await signInAndWait(page, NOPERM_USER, NOPERM_PASS);
+
+  const response = await page.request.get("/api/dashboard/alerts");
+  expect(response.status()).toBe(403);
+});
+
+test("dashboard:read user cannot revoke sessions (needs dashboard:write)", async ({
+  page,
+}) => {
+  await signInAndWait(page, READER_USER, READER_PASS);
+  const csrf = await getCsrf(page);
+
+  const response = await page.request.post(
+    "/api/dashboard/sessions/00000000-0000-0000-0000-000000000000/revoke",
+    { headers: csrfHeader(csrf) },
+  );
+  expect(response.status()).toBe(403);
+});
+
+// ── UI tests ─────────────────────────────────────────────────────
+
+test("dashboard page renders three cards for admin", async ({ page }) => {
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/dashboard");
+
+  // Wait for the dashboard title to appear
+  await expect(page.getByRole("heading", { name: /Dashboard/i })).toBeVisible({
+    timeout: 10000,
+  });
+
+  // All three card titles should be present
+  await expect(page.getByText("Active Sessions").first()).toBeVisible();
+  await expect(
+    page.getByText("Locked & Suspended Accounts"),
+  ).toBeVisible();
+  await expect(page.getByText("Suspicious Activity").first()).toBeVisible();
+});
+
+test("dashboard page redirects for user without dashboard:read", async ({
+  page,
+}) => {
+  await signInAndWait(page, NOPERM_USER, NOPERM_PASS);
+  await page.goto("/dashboard");
+
+  // Should redirect away from /dashboard (requirePermission redirects to /)
+  await page.waitForURL((url) => !url.pathname.includes("/dashboard"), {
+    timeout: 10000,
+  });
+});
+
+test("dashboard:read user cannot see revoke buttons", async ({ page }) => {
+  await signInAndWait(page, READER_USER, READER_PASS);
+  await page.goto("/dashboard");
+
+  // Wait for sessions card to load
+  await expect(page.getByText("Active Sessions")).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Wait for data to load (either sessions show or "No active sessions")
+  await expect(
+    page.getByText("Active Sessions").locator("..").locator(".."),
+  ).toBeVisible();
+
+  // Revoke buttons should not be present for read-only user
+  const revokeButtons = page.getByRole("button", { name: /Revoke/i });
+  await expect(revokeButtons).toHaveCount(0);
+});
+
+test("locked account shows in dashboard card", async ({ page }) => {
+  // Lock the test account
+  await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
+
+  try {
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/dashboard");
+
+    // Wait for locked accounts card to render
+    await expect(
+      page.getByText("Locked & Suspended Accounts"),
+    ).toBeVisible({ timeout: 10000 });
+
+    // The locked user should appear
+    await expect(page.getByText(LOCKED_USER)).toBeVisible({ timeout: 5000 });
+  } finally {
+    // Restore account status to avoid leaking state
+    await setAccountStatus(LOCKED_USER, "active");
+  }
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -10,8 +10,10 @@ import {
 import {
   createTestAccount,
   createTestRole,
+  deleteAuditLogsByAction,
   deleteTestAccount,
   deleteTestRole,
+  insertAuditLog,
   resetAccountDefaults,
   setAccountStatus,
 } from "./helpers/setup-db";
@@ -375,19 +377,36 @@ test("Korean locale: locked account card shows Korean status", async ({
   }
 });
 
-test("Korean locale: alerts card shows Korean severity and description", async ({
+test("Korean locale: alerts card shows Korean detail messages", async ({
   page,
 }) => {
-  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
-  await page.goto("/ko/dashboard");
+  // Seed an account.lock audit event to trigger the "account_lockout" rule
+  await insertAuditLog({
+    actorId: "system",
+    action: "account.lock",
+    targetType: "account",
+    targetId: "e2e-fake-id",
+    ipAddress: "127.0.0.1",
+  });
 
-  // Scroll the alerts card description into view and verify Korean text
-  const desc = page.getByText("최근 24시간 동안 감지된 보안 알림");
-  await desc.scrollIntoViewIfNeeded();
-  await expect(desc).toBeVisible({ timeout: 10_000 });
+  try {
+    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/ko/dashboard");
 
-  // Either the no-alerts message or alert severity headers should be Korean
-  const noAlerts = page.getByText("의심 활동이 감지되지 않았습니다");
-  const severityHeader = page.getByText("심각도");
-  await expect(noAlerts.or(severityHeader)).toBeVisible({ timeout: 5_000 });
+    // Scroll the alerts card into view
+    const desc = page.getByText("최근 24시간 동안 감지된 보안 알림");
+    await desc.scrollIntoViewIfNeeded();
+    await expect(desc).toBeVisible({ timeout: 10_000 });
+
+    // The alert detail message should be the Korean interpolated string
+    // Rule "account_lockout" → "최근 24시간 동안 {count}건의 계정 잠금"
+    await expect(
+      page.getByText(/최근 24시간 동안 \d+건의 계정 잠금/),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Severity badge should be Korean "높음" (high)
+    await expect(page.getByText("높음").first()).toBeVisible();
+  } finally {
+    await deleteAuditLogsByAction("account.lock");
+  }
 });

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -73,3 +73,21 @@ export async function signInAndWait(
     timeout: 10_000,
   });
 }
+
+/**
+ * Korean variant of signInAndWait — navigates to /ko/sign-in, fills
+ * the form, and waits for redirect.
+ */
+export async function signInAndWaitKo(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.goto("/ko/sign-in");
+  await page.getByLabel("계정 ID").fill(username);
+  await page.locator("input[name='password']").fill(password);
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.waitForURL((url) => !url.pathname.endsWith("/sign-in"), {
+    timeout: 10_000,
+  });
+}

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -622,7 +622,7 @@ const AUDIT_DATABASE_URL = getAuditDatabaseUrl();
 
 /**
  * Insert a fake audit log entry into the audit database.
- * Useful for seeding suspicious-activity detection rules in E2E tests.
+ * Returns the inserted row ID for targeted cleanup.
  */
 export async function insertAuditLog(opts: {
   actorId: string;
@@ -631,14 +631,15 @@ export async function insertAuditLog(opts: {
   targetId?: string;
   ipAddress?: string;
   details?: Record<string, unknown>;
-}): Promise<void> {
+}): Promise<string> {
   const client = new pg.Client({ connectionString: AUDIT_DATABASE_URL });
   await client.connect();
   try {
-    await client.query(
+    const { rows } = await client.query<{ id: string }>(
       `INSERT INTO audit_logs
          (actor_id, action, target_type, target_id, ip_address, details)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
       [
         opts.actorId,
         opts.action,
@@ -648,20 +649,21 @@ export async function insertAuditLog(opts: {
         opts.details ? JSON.stringify(opts.details) : null,
       ],
     );
+    return rows[0].id;
   } finally {
     await client.end();
   }
 }
 
 /**
- * Delete audit log entries matching a given action.
- * For cleanup after E2E tests that seed fake audit data.
+ * Delete a specific audit log entry by ID.
+ * Only removes the exact row that was seeded, leaving other data intact.
  */
-export async function deleteAuditLogsByAction(action: string): Promise<void> {
+export async function deleteAuditLogById(id: string): Promise<void> {
   const client = new pg.Client({ connectionString: AUDIT_DATABASE_URL });
   await client.connect();
   try {
-    await client.query("DELETE FROM audit_logs WHERE action = $1", [action]);
+    await client.query("DELETE FROM audit_logs WHERE id = $1", [id]);
   } finally {
     await client.end();
   }

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -599,6 +599,74 @@ function escapeIdentifier(str: string): string {
   return `"${str.replace(/"/g, '""')}"`;
 }
 
+// ── Audit database helpers ────────────────────────────────────────
+
+function getAuditDatabaseUrl(): string {
+  if (process.env.AUDIT_DATABASE_URL) return process.env.AUDIT_DATABASE_URL;
+
+  try {
+    const envFile = readFileSync(
+      resolve(__dirname, "../../.env.local"),
+      "utf8",
+    );
+    const match = envFile.match(/^AUDIT_DATABASE_URL=(.+)$/m);
+    if (match) return match[1].trim();
+  } catch {
+    // .env.local not found — use default
+  }
+
+  return "postgres://postgres:postgres@localhost:5432/audit_db";
+}
+
+const AUDIT_DATABASE_URL = getAuditDatabaseUrl();
+
+/**
+ * Insert a fake audit log entry into the audit database.
+ * Useful for seeding suspicious-activity detection rules in E2E tests.
+ */
+export async function insertAuditLog(opts: {
+  actorId: string;
+  action: string;
+  targetType: string;
+  targetId?: string;
+  ipAddress?: string;
+  details?: Record<string, unknown>;
+}): Promise<void> {
+  const client = new pg.Client({ connectionString: AUDIT_DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query(
+      `INSERT INTO audit_logs
+         (actor_id, action, target_type, target_id, ip_address, details)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        opts.actorId,
+        opts.action,
+        opts.targetType,
+        opts.targetId ?? null,
+        opts.ipAddress ?? "127.0.0.1",
+        opts.details ? JSON.stringify(opts.details) : null,
+      ],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Delete audit log entries matching a given action.
+ * For cleanup after E2E tests that seed fake audit data.
+ */
+export async function deleteAuditLogsByAction(action: string): Promise<void> {
+  const client = new pg.Client({ connectionString: AUDIT_DATABASE_URL });
+  await client.connect();
+  try {
+    await client.query("DELETE FROM audit_logs WHERE action = $1", [action]);
+  } finally {
+    await client.end();
+  }
+}
+
 /**
  * Get session status for diagnostic/assertion purposes.
  */

--- a/src/__tests__/app/api/dashboard/sessions/route.test.ts
+++ b/src/__tests__/app/api/dashboard/sessions/route.test.ts
@@ -1,0 +1,227 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: unknown,
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockGetActiveSessions = vi.hoisted(() => vi.fn());
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockRevokeSession = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (request: NextRequest, context: unknown) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/dashboard/queries", () => ({
+  getActiveSessions: mockGetActiveSessions,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  revokeSession: mockRevokeSession,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: mockQuery,
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: { record: mockAuditRecord },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: () => "127.0.0.1",
+}));
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-id",
+  sessionId: "admin-session",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Chrome/131",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const viewerSession: AuthSession = {
+  ...adminSession,
+  roles: ["viewer"],
+};
+
+describe("GET /api/dashboard/sessions", () => {
+  function makeRequest() {
+    return new NextRequest("http://localhost:3000/api/dashboard/sessions");
+  }
+
+  function makeContext() {
+    return { params: Promise.resolve({}) };
+  }
+
+  beforeEach(() => {
+    mockGetActiveSessions.mockReset();
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    currentSession = adminSession;
+  });
+
+  it("returns 403 when user lacks dashboard:read", async () => {
+    currentSession = viewerSession;
+    mockHasPermission.mockResolvedValue(false);
+    const { GET } = await import("@/app/api/dashboard/sessions/route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(403);
+  });
+
+  it("returns active sessions list", async () => {
+    const sessions = [
+      {
+        sid: "s1",
+        account_id: "a1",
+        username: "admin",
+        display_name: "Admin",
+        ip_address: "10.0.0.1",
+        user_agent: "Chrome",
+        created_at: "2026-03-16T00:00:00Z",
+        last_active_at: "2026-03-16T01:00:00Z",
+        needs_reauth: false,
+      },
+    ];
+    mockGetActiveSessions.mockResolvedValueOnce(sessions);
+
+    const { GET } = await import("@/app/api/dashboard/sessions/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].sid).toBe("s1");
+  });
+
+  it("returns empty array when no sessions", async () => {
+    mockGetActiveSessions.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/dashboard/sessions/route");
+    const response = await GET(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([]);
+  });
+});
+
+describe("POST /api/dashboard/sessions/[sid]/revoke", () => {
+  const validSid = "12345678-1234-1234-1234-123456789abc";
+
+  function makeRequest() {
+    return new NextRequest(
+      `http://localhost:3000/api/dashboard/sessions/${validSid}/revoke`,
+      { method: "POST" },
+    );
+  }
+
+  function makeContext(sid = validSid) {
+    return { params: Promise.resolve({ sid }) };
+  }
+
+  beforeEach(() => {
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockQuery.mockReset();
+    mockRevokeSession.mockReset().mockResolvedValue(undefined);
+    mockAuditRecord.mockReset().mockResolvedValue(undefined);
+    currentSession = adminSession;
+  });
+
+  it("returns 403 when user lacks dashboard:write", async () => {
+    currentSession = viewerSession;
+    mockHasPermission.mockResolvedValue(false);
+
+    const { POST } = await import(
+      "@/app/api/dashboard/sessions/[sid]/revoke/route"
+    );
+    const response = await POST(makeRequest(), makeContext());
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for invalid session ID format", async () => {
+    const { POST } = await import(
+      "@/app/api/dashboard/sessions/[sid]/revoke/route"
+    );
+    const response = await POST(
+      new NextRequest(
+        "http://localhost:3000/api/dashboard/sessions/not-a-uuid/revoke",
+        { method: "POST" },
+      ),
+      makeContext("not-a-uuid"),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 when session not found", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const { POST } = await import(
+      "@/app/api/dashboard/sessions/[sid]/revoke/route"
+    );
+    const response = await POST(makeRequest(), makeContext());
+    expect(response.status).toBe(404);
+  });
+
+  it("revokes session and records audit log", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ sid: validSid, account_id: "target-account" }],
+      rowCount: 1,
+    });
+
+    const { POST } = await import(
+      "@/app/api/dashboard/sessions/[sid]/revoke/route"
+    );
+    const response = await POST(makeRequest(), makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mockRevokeSession).toHaveBeenCalledWith(validSid);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "session.revoke",
+        target: "session",
+        targetId: validSid,
+        details: expect.objectContaining({
+          targetAccountId: "target-account",
+        }),
+      }),
+    );
+  });
+});

--- a/src/__tests__/lib/dashboard/queries.test.ts
+++ b/src/__tests__/lib/dashboard/queries.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db/client", () => ({
+  query: mockQuery,
+}));
+
+describe("dashboard queries", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  describe("getActiveSessions", () => {
+    it("returns active sessions with account info", async () => {
+      const fakeRows = [
+        {
+          sid: "s1",
+          account_id: "a1",
+          username: "admin",
+          display_name: "Admin",
+          ip_address: "10.0.0.1",
+          user_agent: "Chrome/131",
+          browser_fingerprint: "Chrome/131",
+          created_at: "2026-03-16T00:00:00Z",
+          last_active_at: "2026-03-16T01:00:00Z",
+          needs_reauth: false,
+        },
+      ];
+      mockQuery.mockResolvedValueOnce({ rows: fakeRows, rowCount: 1 });
+
+      const { getActiveSessions } = await import("@/lib/dashboard/queries");
+      const result = await getActiveSessions();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].sid).toBe("s1");
+      expect(result[0].username).toBe("admin");
+    });
+
+    it("returns empty array when no active sessions", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getActiveSessions } = await import("@/lib/dashboard/queries");
+      const result = await getActiveSessions();
+
+      expect(result).toEqual([]);
+    });
+
+    it("queries only non-revoked sessions ordered by last_active_at DESC", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getActiveSessions } = await import("@/lib/dashboard/queries");
+      await getActiveSessions();
+
+      expect(mockQuery).toHaveBeenCalledOnce();
+      const sql = mockQuery.mock.calls[0][0] as string;
+      expect(sql).toContain("revoked = false");
+      expect(sql).toContain("ORDER BY s.last_active_at DESC");
+    });
+  });
+
+  describe("getLockedSuspendedAccounts", () => {
+    it("returns locked and suspended accounts", async () => {
+      const fakeRows = [
+        {
+          id: "a1",
+          username: "locked-user",
+          display_name: null,
+          role_name: "Tenant Administrator",
+          status: "locked",
+          locked_until: "2026-03-16T02:00:00Z",
+          failed_sign_in_count: 5,
+          updated_at: "2026-03-16T01:00:00Z",
+        },
+        {
+          id: "a2",
+          username: "suspended-user",
+          display_name: "Suspended",
+          role_name: "Security Monitor",
+          status: "suspended",
+          locked_until: null,
+          failed_sign_in_count: 15,
+          updated_at: "2026-03-16T00:30:00Z",
+        },
+      ];
+      mockQuery.mockResolvedValueOnce({ rows: fakeRows, rowCount: 2 });
+
+      const { getLockedSuspendedAccounts } = await import(
+        "@/lib/dashboard/queries"
+      );
+      const result = await getLockedSuspendedAccounts();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].status).toBe("locked");
+      expect(result[1].status).toBe("suspended");
+    });
+
+    it("returns empty array when no locked/suspended accounts", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getLockedSuspendedAccounts } = await import(
+        "@/lib/dashboard/queries"
+      );
+      const result = await getLockedSuspendedAccounts();
+
+      expect(result).toEqual([]);
+    });
+
+    it("filters by locked and suspended status", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getLockedSuspendedAccounts } = await import(
+        "@/lib/dashboard/queries"
+      );
+      await getLockedSuspendedAccounts();
+
+      const sql = mockQuery.mock.calls[0][0] as string;
+      expect(sql).toContain("locked");
+      expect(sql).toContain("suspended");
+    });
+  });
+});

--- a/src/__tests__/lib/dashboard/suspicious-activity.test.ts
+++ b/src/__tests__/lib/dashboard/suspicious-activity.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQueryAudit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/audit/client", () => ({
+  queryAudit: mockQueryAudit,
+}));
+
+describe("suspicious activity detection", () => {
+  beforeEach(() => {
+    mockQueryAudit.mockReset();
+  });
+
+  describe("getSuspiciousAlerts", () => {
+    it("returns empty array when no suspicious activity", async () => {
+      // 6 rules, each returns 0 results
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // brute force
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        }) // lockouts
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        }) // IP/UA mismatch
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        }) // after-hours
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        }) // privilege escalation
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // mass revocations
+
+      const { getSuspiciousAlerts } = await import(
+        "@/lib/dashboard/suspicious-activity"
+      );
+      const alerts = await getSuspiciousAlerts();
+
+      expect(alerts).toEqual([]);
+    });
+
+    it("detects brute force attempts", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              group_key: "192.168.1.100",
+              count: "25",
+              latest_at: "2026-03-16T01:00:00Z",
+            },
+          ],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getSuspiciousAlerts } = await import(
+        "@/lib/dashboard/suspicious-activity"
+      );
+      const alerts = await getSuspiciousAlerts();
+
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].rule).toBe("brute_force");
+      expect(alerts[0].severity).toBe("critical");
+      expect(alerts[0].count).toBe(25);
+    });
+
+    it("detects account lockouts", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // brute force
+        .mockResolvedValueOnce({
+          rows: [{ count: "3", latest_at: "2026-03-16T01:00:00Z" }],
+          rowCount: 1,
+        }) // lockouts
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getSuspiciousAlerts } = await import(
+        "@/lib/dashboard/suspicious-activity"
+      );
+      const alerts = await getSuspiciousAlerts();
+
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].rule).toBe("account_lockout");
+      expect(alerts[0].severity).toBe("high");
+      expect(alerts[0].count).toBe(3);
+    });
+
+    it("sorts by severity (critical first)", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              group_key: "10.0.0.1",
+              count: "15",
+              latest_at: "2026-03-16T01:00:00Z",
+            },
+          ],
+          rowCount: 1,
+        }) // brute force (critical)
+        .mockResolvedValueOnce({
+          rows: [{ count: "2", latest_at: "2026-03-16T00:30:00Z" }],
+          rowCount: 1,
+        }) // lockouts (high)
+        .mockResolvedValueOnce({
+          rows: [{ count: "5", latest_at: "2026-03-16T00:45:00Z" }],
+          rowCount: 1,
+        }) // IP/UA mismatch (medium)
+        .mockResolvedValueOnce({
+          rows: [{ count: "10", latest_at: "2026-03-16T00:15:00Z" }],
+          rowCount: 1,
+        }) // after-hours (low)
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getSuspiciousAlerts } = await import(
+        "@/lib/dashboard/suspicious-activity"
+      );
+      const alerts = await getSuspiciousAlerts();
+
+      expect(alerts.length).toBeGreaterThanOrEqual(4);
+      expect(alerts[0].severity).toBe("critical");
+      expect(alerts[1].severity).toBe("high");
+      expect(alerts[2].severity).toBe("medium");
+      expect(alerts[3].severity).toBe("low");
+    });
+
+    it("aggregates alerts from multiple rules", async () => {
+      mockQueryAudit
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              group_key: "10.0.0.1",
+              count: "12",
+              latest_at: "2026-03-16T01:00:00Z",
+            },
+            {
+              group_key: "10.0.0.2",
+              count: "11",
+              latest_at: "2026-03-16T00:50:00Z",
+            },
+          ],
+          rowCount: 2,
+        }) // 2 brute force IPs
+        .mockResolvedValueOnce({
+          rows: [{ count: "1", latest_at: "2026-03-16T00:30:00Z" }],
+          rowCount: 1,
+        }) // 1 lockout
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ count: "0", latest_at: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const { getSuspiciousAlerts } = await import(
+        "@/lib/dashboard/suspicious-activity"
+      );
+      const alerts = await getSuspiciousAlerts();
+
+      // 2 brute force + 1 lockout = 3
+      expect(alerts).toHaveLength(3);
+    });
+  });
+});

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,14 @@
+import { DashboardPanel } from "@/components/dashboard/dashboard-panel";
+import { hasPermission } from "@/lib/auth/permissions";
+import { getCurrentSession, requirePermission } from "@/lib/auth/session";
+
+export default async function DashboardPage() {
+  const session = await getCurrentSession();
+  if (!session) return null;
+
+  await requirePermission(session, "dashboard:read");
+
+  const canWrite = await hasPermission(session.roles, "dashboard:write");
+
+  return <DashboardPanel canWrite={canWrite} />;
+}

--- a/src/app/api/dashboard/alerts/route.ts
+++ b/src/app/api/dashboard/alerts/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { getSuspiciousAlerts } from "@/lib/dashboard/suspicious-activity";
+
+/**
+ * GET /api/dashboard/alerts
+ *
+ * Run suspicious activity detection rules and return alerts
+ * sorted by severity.
+ * Requires `dashboard:read` permission.
+ */
+export const GET = withAuth(
+  async () => {
+    const alerts = await getSuspiciousAlerts();
+    return NextResponse.json({ data: alerts });
+  },
+  { requiredPermissions: ["dashboard:read"] },
+);

--- a/src/app/api/dashboard/locked-accounts/route.ts
+++ b/src/app/api/dashboard/locked-accounts/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { getLockedSuspendedAccounts } from "@/lib/dashboard/queries";
+
+/**
+ * GET /api/dashboard/locked-accounts
+ *
+ * List accounts with `locked` or `suspended` status.
+ * Requires `dashboard:read` permission.
+ */
+export const GET = withAuth(
+  async () => {
+    const accounts = await getLockedSuspendedAccounts();
+    return NextResponse.json({ data: accounts });
+  },
+  { requiredPermissions: ["dashboard:read"] },
+);

--- a/src/app/api/dashboard/sessions/[sid]/revoke/route.ts
+++ b/src/app/api/dashboard/sessions/[sid]/revoke/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { revokeSession } from "@/lib/auth/session";
+import { query } from "@/lib/db/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /api/dashboard/sessions/[sid]/revoke
+ *
+ * Force sign-out a session by revoking it.
+ * Requires `dashboard:write` permission.
+ */
+export const POST = withAuth(
+  async (request, context, session) => {
+    const { sid } = await context.params;
+
+    if (!UUID_RE.test(sid)) {
+      return NextResponse.json(
+        { error: "Invalid session ID format" },
+        { status: 400 },
+      );
+    }
+
+    // Verify the session exists and is not already revoked
+    const { rows } = await query<{ sid: string; account_id: string }>(
+      "SELECT sid, account_id FROM sessions WHERE sid = $1 AND revoked = false",
+      [sid],
+    );
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { error: "Session not found or already revoked" },
+        { status: 404 },
+      );
+    }
+
+    await revokeSession(sid);
+
+    const ip = extractClientIp(request);
+    await auditLog.record({
+      actor: session.accountId,
+      action: "session.revoke",
+      target: "session",
+      targetId: sid,
+      ip,
+      sid: session.sessionId,
+      details: {
+        targetAccountId: rows[0].account_id,
+        revokedBy: "admin_dashboard",
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  },
+  { requiredPermissions: ["dashboard:write"] },
+);

--- a/src/app/api/dashboard/sessions/route.ts
+++ b/src/app/api/dashboard/sessions/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { getActiveSessions } from "@/lib/dashboard/queries";
+
+/**
+ * GET /api/dashboard/sessions
+ *
+ * List all active (non-revoked) sessions with account info.
+ * Requires `dashboard:read` permission.
+ */
+export const GET = withAuth(
+  async () => {
+    const sessions = await getActiveSessions();
+    return NextResponse.json({ data: sessions });
+  },
+  { requiredPermissions: ["dashboard:read"] },
+);

--- a/src/components/dashboard/active-sessions-card.tsx
+++ b/src/components/dashboard/active-sessions-card.tsx
@@ -53,6 +53,7 @@ interface Session {
 
 export function ActiveSessionsCard({ canWrite }: { canWrite: boolean }) {
   const t = useTranslations("dashboard.activeSessions");
+  const tc = useTranslations("common");
   const tz = useTimezone();
 
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -180,7 +181,9 @@ export function ActiveSessionsCard({ canWrite }: { canWrite: boolean }) {
                               </AlertDialogDescription>
                             </AlertDialogHeader>
                             <AlertDialogFooter>
-                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogCancel>
+                                {tc("cancel")}
+                              </AlertDialogCancel>
                               <AlertDialogAction
                                 onClick={() => handleRevoke(s.sid)}
                               >

--- a/src/components/dashboard/active-sessions-card.tsx
+++ b/src/components/dashboard/active-sessions-card.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+
+import { useTimezone } from "@/components/providers/timezone-provider";
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDateTime } from "@/lib/format-date";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface Session {
+  sid: string;
+  account_id: string;
+  username: string;
+  display_name: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  created_at: string;
+  last_active_at: string;
+  needs_reauth: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function ActiveSessionsCard({ canWrite }: { canWrite: boolean }) {
+  const t = useTranslations("dashboard.activeSessions");
+  const tz = useTimezone();
+
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/dashboard/sessions");
+      if (!res.ok) throw new Error(t("error"));
+      const body = await res.json();
+      setSessions(body.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  const handleRevoke = useCallback(
+    async (sid: string) => {
+      setRevokingId(sid);
+      try {
+        const csrf = readCsrfToken();
+        const res = await fetch(`/api/dashboard/sessions/${sid}/revoke`, {
+          method: "POST",
+          headers: {
+            "x-csrf-token": csrf ?? "",
+            "Content-Type": "application/json",
+          },
+        });
+        if (!res.ok) throw new Error(t("revokeError"));
+        setSessions((prev) => prev.filter((s) => s.sid !== sid));
+      } catch {
+        setError(t("revokeError"));
+      } finally {
+        setRevokingId(null);
+      }
+    },
+    [t],
+  );
+
+  /** Truncate user agent to first meaningful part. */
+  function shortUa(ua: string | null): string {
+    if (!ua) return "-";
+    // Show first 40 chars
+    return ua.length > 40 ? `${ua.slice(0, 40)}...` : ua;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading && (
+          <p className="text-muted-foreground text-sm">{t("loading")}</p>
+        )}
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        {!loading && !error && sessions.length === 0 && (
+          <p className="text-muted-foreground text-sm">{t("noSessions")}</p>
+        )}
+        {!loading && !error && sessions.length > 0 && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("username")}</TableHead>
+                  <TableHead>{t("ipAddress")}</TableHead>
+                  <TableHead>{t("userAgent")}</TableHead>
+                  <TableHead>{t("lastActive")}</TableHead>
+                  <TableHead>{t("createdAt")}</TableHead>
+                  <TableHead>{t("needsReauth")}</TableHead>
+                  {canWrite && <TableHead />}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sessions.map((s) => (
+                  <TableRow key={s.sid}>
+                    <TableCell className="text-xs font-medium">
+                      {s.display_name ?? s.username}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {s.ip_address ?? "-"}
+                    </TableCell>
+                    <TableCell className="max-w-[200px] text-xs">
+                      {shortUa(s.user_agent)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-xs">
+                      {formatDateTime(s.last_active_at, tz)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-xs">
+                      {formatDateTime(s.created_at, tz)}
+                    </TableCell>
+                    <TableCell>
+                      {s.needs_reauth && (
+                        <Badge variant="destructive">{t("needsReauth")}</Badge>
+                      )}
+                    </TableCell>
+                    {canWrite && (
+                      <TableCell>
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={revokingId === s.sid}
+                            >
+                              {t("revoke")}
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>{t("revoke")}</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                {t("revokeConfirm")}
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleRevoke(s.sid)}
+                              >
+                                {t("revoke")}
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/dashboard-panel.tsx
+++ b/src/components/dashboard/dashboard-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { ActiveSessionsCard } from "./active-sessions-card";
+import { LockedAccountsCard } from "./locked-accounts-card";
+import { SuspiciousAlertsCard } from "./suspicious-alerts-card";
+
+interface DashboardPanelProps {
+  canWrite: boolean;
+}
+
+export function DashboardPanel({ canWrite }: DashboardPanelProps) {
+  const t = useTranslations("dashboard");
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-foreground text-2xl font-bold">{t("title")}</h1>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ActiveSessionsCard canWrite={canWrite} />
+        <LockedAccountsCard />
+      </div>
+      <SuspiciousAlertsCard />
+    </div>
+  );
+}

--- a/src/components/dashboard/locked-accounts-card.tsx
+++ b/src/components/dashboard/locked-accounts-card.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+
+import { useTimezone } from "@/components/providers/timezone-provider";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDateTime } from "@/lib/format-date";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface LockedAccount {
+  id: string;
+  username: string;
+  display_name: string | null;
+  role_name: string;
+  status: string;
+  locked_until: string | null;
+  failed_sign_in_count: number;
+  updated_at: string;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function LockedAccountsCard() {
+  const t = useTranslations("dashboard.lockedAccounts");
+  const tz = useTimezone();
+
+  const [accounts, setAccounts] = useState<LockedAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAccounts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/dashboard/locked-accounts");
+      if (!res.ok) throw new Error(t("error"));
+      const body = await res.json();
+      setAccounts(body.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    fetchAccounts();
+  }, [fetchAccounts]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading && (
+          <p className="text-muted-foreground text-sm">{t("loading")}</p>
+        )}
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        {!loading && !error && accounts.length === 0 && (
+          <p className="text-muted-foreground text-sm">{t("noAccounts")}</p>
+        )}
+        {!loading && !error && accounts.length > 0 && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("username")}</TableHead>
+                  <TableHead>{t("role")}</TableHead>
+                  <TableHead>{t("status")}</TableHead>
+                  <TableHead>{t("failedAttempts")}</TableHead>
+                  <TableHead>{t("lockedUntil")}</TableHead>
+                  <TableHead>{t("updatedAt")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {accounts.map((a) => (
+                  <TableRow key={a.id}>
+                    <TableCell className="text-xs font-medium">
+                      {a.display_name ?? a.username}
+                    </TableCell>
+                    <TableCell className="text-xs">{a.role_name}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={
+                          a.status === "locked" ? "destructive" : "secondary"
+                        }
+                      >
+                        {a.status === "locked" ? t("locked") : t("suspended")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {a.failed_sign_in_count}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-xs">
+                      {a.locked_until
+                        ? formatDateTime(a.locked_until, tz)
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-xs">
+                      {formatDateTime(a.updated_at, tz)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/suspicious-alerts-card.tsx
+++ b/src/components/dashboard/suspicious-alerts-card.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useState } from "react";
+
+import { useTimezone } from "@/components/providers/timezone-provider";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDateTime } from "@/lib/format-date";
+
+// ── Types ────────────────────────────────────────────────────────
+
+type AlertSeverity = "critical" | "high" | "medium" | "low";
+
+interface Alert {
+  id: string;
+  rule: string;
+  severity: AlertSeverity;
+  message: string;
+  count: number;
+  latest_at: string;
+}
+
+// ── Severity badge styles ────────────────────────────────────────
+
+const SEVERITY_VARIANT: Record<
+  AlertSeverity,
+  "destructive" | "default" | "secondary" | "outline"
+> = {
+  critical: "destructive",
+  high: "default",
+  medium: "secondary",
+  low: "outline",
+};
+
+// ── Component ────────────────────────────────────────────────────
+
+export function SuspiciousAlertsCard() {
+  const t = useTranslations("dashboard.alerts");
+  const tz = useTimezone();
+
+  const [alerts, setAlerts] = useState<Alert[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAlerts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/dashboard/alerts");
+      if (!res.ok) throw new Error(t("error"));
+      const body = await res.json();
+      setAlerts(body.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    fetchAlerts();
+  }, [fetchAlerts]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading && (
+          <p className="text-muted-foreground text-sm">{t("loading")}</p>
+        )}
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        {!loading && !error && alerts.length === 0 && (
+          <p className="text-muted-foreground text-sm">{t("noAlerts")}</p>
+        )}
+        {!loading && !error && alerts.length > 0 && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("severity")}</TableHead>
+                  <TableHead>{t("rule")}</TableHead>
+                  <TableHead>{t("message")}</TableHead>
+                  <TableHead>{t("count")}</TableHead>
+                  <TableHead>{t("latestAt")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {alerts.map((a) => (
+                  <TableRow key={a.id}>
+                    <TableCell>
+                      <Badge variant={SEVERITY_VARIANT[a.severity]}>
+                        {t(a.severity)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs font-medium">
+                      {t(`rules.${a.rule}` as Parameters<typeof t>[0])}
+                    </TableCell>
+                    <TableCell className="max-w-[300px] text-xs">
+                      {a.message}
+                    </TableCell>
+                    <TableCell className="text-xs">{a.count}</TableCell>
+                    <TableCell className="whitespace-nowrap text-xs">
+                      {formatDateTime(a.latest_at, tz)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/suspicious-alerts-card.tsx
+++ b/src/components/dashboard/suspicious-alerts-card.tsx
@@ -30,9 +30,9 @@ interface Alert {
   id: string;
   rule: string;
   severity: AlertSeverity;
-  message: string;
   count: number;
   latest_at: string;
+  details: Record<string, unknown>;
 }
 
 // ── Severity badge styles ────────────────────────────────────────
@@ -114,7 +114,11 @@ export function SuspiciousAlertsCard() {
                       {t(`rules.${a.rule}` as Parameters<typeof t>[0])}
                     </TableCell>
                     <TableCell className="max-w-[300px] text-xs">
-                      {a.message}
+                      {t(`messages.${a.rule}` as Parameters<typeof t>[0], {
+                        count: a.count,
+                        ip: String(a.details.ip ?? ""),
+                        actor: String(a.details.actor ?? ""),
+                      })}
                     </TableCell>
                     <TableCell className="text-xs">{a.count}</TableCell>
                     <TableCell className="whitespace-nowrap text-xs">

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -300,6 +300,68 @@
       "access-all": "Access All"
     }
   },
+  "dashboard": {
+    "title": "System Dashboard",
+    "noPermission": "You do not have permission to view the dashboard.",
+    "activeSessions": {
+      "title": "Active Sessions",
+      "description": "Currently active user sessions",
+      "username": "User",
+      "displayName": "Display Name",
+      "ipAddress": "IP Address",
+      "userAgent": "User Agent",
+      "createdAt": "Created",
+      "lastActive": "Last Active",
+      "needsReauth": "Re-auth Required",
+      "revoke": "Revoke",
+      "revokeConfirm": "Are you sure you want to revoke this session? The user will be signed out immediately.",
+      "revokeSuccess": "Session revoked successfully",
+      "revokeError": "Failed to revoke session",
+      "noSessions": "No active sessions",
+      "loading": "Loading sessions...",
+      "error": "Failed to load sessions"
+    },
+    "lockedAccounts": {
+      "title": "Locked & Suspended Accounts",
+      "description": "Accounts currently locked or suspended",
+      "username": "User",
+      "displayName": "Display Name",
+      "role": "Role",
+      "status": "Status",
+      "lockedUntil": "Locked Until",
+      "failedAttempts": "Failed Attempts",
+      "updatedAt": "Updated",
+      "locked": "Locked",
+      "suspended": "Suspended",
+      "noAccounts": "No locked or suspended accounts",
+      "loading": "Loading accounts...",
+      "error": "Failed to load accounts"
+    },
+    "alerts": {
+      "title": "Suspicious Activity",
+      "description": "Security alerts detected in the last 24 hours",
+      "severity": "Severity",
+      "rule": "Rule",
+      "message": "Details",
+      "count": "Occurrences",
+      "latestAt": "Latest",
+      "critical": "Critical",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low",
+      "noAlerts": "No suspicious activity detected",
+      "loading": "Loading alerts...",
+      "error": "Failed to load alerts",
+      "rules": {
+        "brute_force": "Brute Force",
+        "account_lockout": "Account Lockout",
+        "ip_ua_mismatch": "IP/UA Mismatch",
+        "after_hours": "After-Hours Sign-In",
+        "privilege_escalation": "Privilege Escalation",
+        "mass_revocation": "Mass Session Revocation"
+      }
+    }
+  },
   "changePassword": {
     "heading": "Change Password",
     "currentPassword": "Current Password",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -359,6 +359,14 @@
         "after_hours": "After-Hours Sign-In",
         "privilege_escalation": "Privilege Escalation",
         "mass_revocation": "Mass Session Revocation"
+      },
+      "messages": {
+        "brute_force": "{count} failed sign-in attempts from IP {ip}",
+        "account_lockout": "{count} account lockout(s) in the last 24 hours",
+        "ip_ua_mismatch": "{count} session IP/UA mismatch event(s)",
+        "after_hours": "{count} sign-in(s) during off-hours (22:00–06:00 UTC)",
+        "privilege_escalation": "{count} potential privilege escalation(s)",
+        "mass_revocation": "Actor {actor} revoked {count} sessions"
       }
     }
   },

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -300,6 +300,68 @@
       "access-all": "전체 접근"
     }
   },
+  "dashboard": {
+    "title": "시스템 대시보드",
+    "noPermission": "대시보드를 볼 수 있는 권한이 없습니다.",
+    "activeSessions": {
+      "title": "활성 세션",
+      "description": "현재 활성 상태인 사용자 세션",
+      "username": "사용자",
+      "displayName": "표시 이름",
+      "ipAddress": "IP 주소",
+      "userAgent": "사용자 에이전트",
+      "createdAt": "생성일",
+      "lastActive": "마지막 활동",
+      "needsReauth": "재인증 필요",
+      "revoke": "해지",
+      "revokeConfirm": "이 세션을 해지하시겠습니까? 해당 사용자는 즉시 로그아웃됩니다.",
+      "revokeSuccess": "세션이 해지되었습니다",
+      "revokeError": "세션 해지에 실패했습니다",
+      "noSessions": "활성 세션이 없습니다",
+      "loading": "세션 로딩 중...",
+      "error": "세션을 불러오지 못했습니다"
+    },
+    "lockedAccounts": {
+      "title": "잠긴 및 정지된 계정",
+      "description": "현재 잠금 또는 정지 상태인 계정",
+      "username": "사용자",
+      "displayName": "표시 이름",
+      "role": "역할",
+      "status": "상태",
+      "lockedUntil": "잠금 해제 시각",
+      "failedAttempts": "실패 횟수",
+      "updatedAt": "수정일",
+      "locked": "잠금",
+      "suspended": "정지",
+      "noAccounts": "잠긴 또는 정지된 계정이 없습니다",
+      "loading": "계정 로딩 중...",
+      "error": "계정을 불러오지 못했습니다"
+    },
+    "alerts": {
+      "title": "의심 활동",
+      "description": "최근 24시간 동안 감지된 보안 알림",
+      "severity": "심각도",
+      "rule": "규칙",
+      "message": "상세",
+      "count": "발생 횟수",
+      "latestAt": "최근 발생",
+      "critical": "심각",
+      "high": "높음",
+      "medium": "보통",
+      "low": "낮음",
+      "noAlerts": "의심 활동이 감지되지 않았습니다",
+      "loading": "알림 로딩 중...",
+      "error": "알림을 불러오지 못했습니다",
+      "rules": {
+        "brute_force": "무차별 대입",
+        "account_lockout": "계정 잠금",
+        "ip_ua_mismatch": "IP/UA 불일치",
+        "after_hours": "비근무시간 로그인",
+        "privilege_escalation": "권한 상승",
+        "mass_revocation": "대량 세션 해지"
+      }
+    }
+  },
   "changePassword": {
     "heading": "비밀번호 변경",
     "currentPassword": "현재 비밀번호",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -359,6 +359,14 @@
         "after_hours": "비근무시간 로그인",
         "privilege_escalation": "권한 상승",
         "mass_revocation": "대량 세션 해지"
+      },
+      "messages": {
+        "brute_force": "IP {ip}에서 {count}회 로그인 실패 시도",
+        "account_lockout": "최근 24시간 동안 {count}건의 계정 잠금",
+        "ip_ua_mismatch": "{count}건의 세션 IP/UA 불일치",
+        "after_hours": "비근무시간(22:00–06:00 UTC)에 {count}건의 로그인",
+        "privilege_escalation": "{count}건의 잠재적 권한 상승",
+        "mass_revocation": "행위자 {actor}가 {count}개 세션 해지"
       }
     }
   },

--- a/src/lib/dashboard/queries.ts
+++ b/src/lib/dashboard/queries.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import { query } from "@/lib/db/client";
+
+// ── Types ────────────────────────────────────────────────────────
+
+export interface ActiveSession {
+  sid: string;
+  account_id: string;
+  username: string;
+  display_name: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  browser_fingerprint: string | null;
+  created_at: string;
+  last_active_at: string;
+  needs_reauth: boolean;
+}
+
+export interface LockedSuspendedAccount {
+  id: string;
+  username: string;
+  display_name: string | null;
+  role_name: string;
+  status: string;
+  locked_until: string | null;
+  failed_sign_in_count: number;
+  updated_at: string;
+}
+
+// ── Queries ──────────────────────────────────────────────────────
+
+/**
+ * Fetch all active (non-revoked) sessions with account info.
+ */
+export async function getActiveSessions(): Promise<ActiveSession[]> {
+  const { rows } = await query<ActiveSession>(
+    `SELECT s.sid, s.account_id, a.username,
+            a.display_name, s.ip_address, s.user_agent,
+            s.browser_fingerprint, s.created_at, s.last_active_at,
+            s.needs_reauth
+       FROM sessions s
+       JOIN accounts a ON s.account_id = a.id
+      WHERE s.revoked = false
+      ORDER BY s.last_active_at DESC`,
+  );
+  return rows;
+}
+
+/**
+ * Fetch accounts in `locked` or `suspended` status.
+ */
+export async function getLockedSuspendedAccounts(): Promise<
+  LockedSuspendedAccount[]
+> {
+  const { rows } = await query<LockedSuspendedAccount>(
+    `SELECT a.id, a.username, a.display_name, r.name AS role_name,
+            a.status, a.locked_until, a.failed_sign_in_count, a.updated_at
+       FROM accounts a
+       JOIN roles r ON a.role_id = r.id
+      WHERE a.status IN ('locked', 'suspended')
+      ORDER BY a.updated_at DESC`,
+  );
+  return rows;
+}

--- a/src/lib/dashboard/suspicious-activity.ts
+++ b/src/lib/dashboard/suspicious-activity.ts
@@ -10,7 +10,6 @@ export interface SuspiciousAlert {
   id: string;
   rule: string;
   severity: AlertSeverity;
-  message: string;
   count: number;
   latest_at: string;
   details: Record<string, unknown>;
@@ -56,7 +55,6 @@ async function detectBruteForce(): Promise<SuspiciousAlert[]> {
     id: `brute-force-${i}`,
     rule: "brute_force",
     severity: "critical" as const,
-    message: `${r.count} failed sign-in attempts from IP ${r.group_key}`,
     count: Number.parseInt(r.count, 10),
     latest_at: r.latest_at,
     details: { ip: r.group_key },
@@ -82,7 +80,7 @@ async function detectAccountLockouts(): Promise<SuspiciousAlert[]> {
       id: "account-lockouts",
       rule: "account_lockout",
       severity: "high",
-      message: `${count} account lockout(s) in the last ${WINDOW_HOURS} hours`,
+
       count,
       latest_at: rows[0].latest_at,
       details: {},
@@ -113,7 +111,7 @@ async function detectIpUaMismatches(): Promise<SuspiciousAlert[]> {
       id: "ip-ua-mismatch",
       rule: "ip_ua_mismatch",
       severity: "medium",
-      message: `${count} session IP/UA mismatch event(s)`,
+
       count,
       latest_at: rows[0].latest_at,
       details: {},
@@ -130,8 +128,8 @@ async function detectAfterHoursSignIns(): Promise<SuspiciousAlert[]> {
        FROM audit_logs
       WHERE action = 'auth.sign_in.success'
         AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'
-        AND (EXTRACT(HOUR FROM timestamp) >= 22
-             OR EXTRACT(HOUR FROM timestamp) < 6)`,
+        AND (EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC') >= 22
+             OR EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC') < 6)`,
   );
 
   const count = Number.parseInt(rows[0].count, 10);
@@ -142,7 +140,7 @@ async function detectAfterHoursSignIns(): Promise<SuspiciousAlert[]> {
       id: "after-hours",
       rule: "after_hours",
       severity: "low",
-      message: `${count} sign-in(s) during off-hours (22:00–06:00 UTC)`,
+
       count,
       latest_at: rows[0].latest_at,
       details: {},
@@ -170,7 +168,7 @@ async function detectPrivilegeEscalation(): Promise<SuspiciousAlert[]> {
       id: "privilege-escalation",
       rule: "privilege_escalation",
       severity: "high",
-      message: `${count} potential privilege escalation(s)`,
+
       count,
       latest_at: rows[0].latest_at,
       details: {},
@@ -200,7 +198,6 @@ async function detectMassRevocations(): Promise<SuspiciousAlert[]> {
     id: `mass-revocation-${i}`,
     rule: "mass_revocation",
     severity: "medium" as const,
-    message: `Actor ${r.group_key} revoked ${r.count} sessions`,
     count: Number.parseInt(r.count, 10),
     latest_at: r.latest_at,
     details: { actor: r.group_key },

--- a/src/lib/dashboard/suspicious-activity.ts
+++ b/src/lib/dashboard/suspicious-activity.ts
@@ -1,0 +1,238 @@
+import "server-only";
+
+import { queryAudit } from "@/lib/audit/client";
+
+// ── Types ────────────────────────────────────────────────────────
+
+export type AlertSeverity = "critical" | "high" | "medium" | "low";
+
+export interface SuspiciousAlert {
+  id: string;
+  rule: string;
+  severity: AlertSeverity;
+  message: string;
+  count: number;
+  latest_at: string;
+  details: Record<string, unknown>;
+}
+
+interface CountRow {
+  count: string;
+  latest_at: string;
+}
+
+interface GroupedRow {
+  group_key: string;
+  count: string;
+  latest_at: string;
+}
+
+// ── Detection window ─────────────────────────────────────────────
+
+const WINDOW_HOURS = 24;
+
+// ── Detection rules ──────────────────────────────────────────────
+
+/**
+ * Rule 1: Brute-force attempts — multiple sign-in failures from same IP.
+ */
+async function detectBruteForce(): Promise<SuspiciousAlert[]> {
+  const threshold = 10;
+  const { rows } = await queryAudit<GroupedRow>(
+    `SELECT ip_address AS group_key, COUNT(*) AS count,
+            MAX(timestamp) AS latest_at
+       FROM audit_logs
+      WHERE action = 'auth.sign_in.failure'
+        AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'
+        AND ip_address IS NOT NULL
+      GROUP BY ip_address
+     HAVING COUNT(*) >= $1
+      ORDER BY count DESC
+      LIMIT 20`,
+    [threshold],
+  );
+
+  return rows.map((r, i) => ({
+    id: `brute-force-${i}`,
+    rule: "brute_force",
+    severity: "critical" as const,
+    message: `${r.count} failed sign-in attempts from IP ${r.group_key}`,
+    count: Number.parseInt(r.count, 10),
+    latest_at: r.latest_at,
+    details: { ip: r.group_key },
+  }));
+}
+
+/**
+ * Rule 2: Account lockouts in the detection window.
+ */
+async function detectAccountLockouts(): Promise<SuspiciousAlert[]> {
+  const { rows } = await queryAudit<CountRow>(
+    `SELECT COUNT(*) AS count, MAX(timestamp) AS latest_at
+       FROM audit_logs
+      WHERE action = 'account.lock'
+        AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'`,
+  );
+
+  const count = Number.parseInt(rows[0].count, 10);
+  if (count === 0) return [];
+
+  return [
+    {
+      id: "account-lockouts",
+      rule: "account_lockout",
+      severity: "high",
+      message: `${count} account lockout(s) in the last ${WINDOW_HOURS} hours`,
+      count,
+      latest_at: rows[0].latest_at,
+      details: {},
+    },
+  ];
+}
+
+/**
+ * Rule 3: Session IP or UA mismatch events.
+ */
+async function detectIpUaMismatches(): Promise<SuspiciousAlert[]> {
+  const { rows } = await queryAudit<CountRow>(
+    `SELECT COUNT(*) AS count, MAX(timestamp) AS latest_at
+       FROM audit_logs
+      WHERE action IN (
+              'session.ip_mismatch',
+              'session.ua_mismatch',
+              'session.ip_ua_mismatch'
+            )
+        AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'`,
+  );
+
+  const count = Number.parseInt(rows[0].count, 10);
+  if (count === 0) return [];
+
+  return [
+    {
+      id: "ip-ua-mismatch",
+      rule: "ip_ua_mismatch",
+      severity: "medium",
+      message: `${count} session IP/UA mismatch event(s)`,
+      count,
+      latest_at: rows[0].latest_at,
+      details: {},
+    },
+  ];
+}
+
+/**
+ * Rule 4: After-hours sign-ins (22:00–06:00 UTC).
+ */
+async function detectAfterHoursSignIns(): Promise<SuspiciousAlert[]> {
+  const { rows } = await queryAudit<CountRow>(
+    `SELECT COUNT(*) AS count, MAX(timestamp) AS latest_at
+       FROM audit_logs
+      WHERE action = 'auth.sign_in.success'
+        AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'
+        AND (EXTRACT(HOUR FROM timestamp) >= 22
+             OR EXTRACT(HOUR FROM timestamp) < 6)`,
+  );
+
+  const count = Number.parseInt(rows[0].count, 10);
+  if (count === 0) return [];
+
+  return [
+    {
+      id: "after-hours",
+      rule: "after_hours",
+      severity: "low",
+      message: `${count} sign-in(s) during off-hours (22:00–06:00 UTC)`,
+      count,
+      latest_at: rows[0].latest_at,
+      details: {},
+    },
+  ];
+}
+
+/**
+ * Rule 5: Privilege escalation — role changes to System Administrator.
+ */
+async function detectPrivilegeEscalation(): Promise<SuspiciousAlert[]> {
+  const { rows } = await queryAudit<CountRow>(
+    `SELECT COUNT(*) AS count, MAX(timestamp) AS latest_at
+       FROM audit_logs
+      WHERE action = 'account.update'
+        AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'
+        AND details::text LIKE '%System Administrator%'`,
+  );
+
+  const count = Number.parseInt(rows[0].count, 10);
+  if (count === 0) return [];
+
+  return [
+    {
+      id: "privilege-escalation",
+      rule: "privilege_escalation",
+      severity: "high",
+      message: `${count} potential privilege escalation(s)`,
+      count,
+      latest_at: rows[0].latest_at,
+      details: {},
+    },
+  ];
+}
+
+/**
+ * Rule 6: Mass session revocations from same actor (threshold: 5+).
+ */
+async function detectMassRevocations(): Promise<SuspiciousAlert[]> {
+  const threshold = 5;
+  const { rows } = await queryAudit<GroupedRow>(
+    `SELECT actor_id AS group_key, COUNT(*) AS count,
+            MAX(timestamp) AS latest_at
+       FROM audit_logs
+      WHERE action = 'session.revoke'
+        AND timestamp >= NOW() - INTERVAL '${WINDOW_HOURS} hours'
+      GROUP BY actor_id
+     HAVING COUNT(*) >= $1
+      ORDER BY count DESC
+      LIMIT 10`,
+    [threshold],
+  );
+
+  return rows.map((r, i) => ({
+    id: `mass-revocation-${i}`,
+    rule: "mass_revocation",
+    severity: "medium" as const,
+    message: `Actor ${r.group_key} revoked ${r.count} sessions`,
+    count: Number.parseInt(r.count, 10),
+    latest_at: r.latest_at,
+    details: { actor: r.group_key },
+  }));
+}
+
+// ── Severity ordering ────────────────────────────────────────────
+
+const SEVERITY_ORDER: Record<AlertSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+// ── Public API ───────────────────────────────────────────────────
+
+/**
+ * Run all 6 detection rules and return combined alerts sorted by
+ * severity (critical first).
+ */
+export async function getSuspiciousAlerts(): Promise<SuspiciousAlert[]> {
+  const results = await Promise.all([
+    detectBruteForce(),
+    detectAccountLockouts(),
+    detectIpUaMismatches(),
+    detectAfterHoursSignIns(),
+    detectPrivilegeEscalation(),
+    detectMassRevocations(),
+  ]);
+
+  return results
+    .flat()
+    .sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+}


### PR DESCRIPTION
## Summary

- Add data layer with `getActiveSessions()`, `getLockedSuspendedAccounts()`, and 6 suspicious activity detection rules (brute force, account lockout, IP/UA mismatch, after-hours sign-in, privilege escalation, mass session revocation)
- Add 4 permission-gated API endpoints: `GET /api/dashboard/sessions`, `GET /api/dashboard/locked-accounts`, `GET /api/dashboard/alerts` (`dashboard:read`), `POST /api/dashboard/sessions/[sid]/revoke` (`dashboard:write`)
- Add 3 card UI components (active sessions with revoke, locked/suspended accounts, suspicious alerts with severity badges) and RSC dashboard page with permission gate
- Add i18n messages (EN/KO) for all dashboard strings
- Fix review findings: move alert message composition to client-side i18n, pin after-hours detection to UTC, replace hardcoded Cancel with translated string
- Add 18 unit tests (data layer queries, suspicious activity rules, API route RBAC/validation/revocation) and 13 E2E tests (API endpoints, RBAC enforcement, UI rendering, permission gating, locked account display)

## Test plan

- [x] 863 unit tests pass (`pnpm vitest run`)
- [x] 170 E2E tests pass (`pnpm playwright test`), zero regressions
- [x] TypeScript type check passes (normal + strict)
- [x] Biome lint/format passes
- [x] `pnpm next build` succeeds, all 4 API routes registered

Closes #135