### PR TITLE
Fix sign-out-all session consistency

### DIFF
--- a/e2e/sign-out-all.spec.ts
+++ b/e2e/sign-out-all.spec.ts
@@ -12,6 +12,8 @@ import {
 } from "./helpers/setup-db";
 
 const APP_URL = process.env.BASE_URL ?? "http://localhost:3000";
+// Next.js local CSRF origin checks still expect the canonical localhost
+// origin even when Playwright targets the app over 127.0.0.1.
 const APP_ORIGIN = APP_URL.replace("127.0.0.1", "localhost");
 
 async function signInViaApi(page: Page): Promise<void> {
@@ -64,6 +66,11 @@ test.describe("Sign-out-all", () => {
       // because the server-side guard checks session existence in the DB.
       const apiResponse = await pageB.request.get("/api/audit-logs");
       expect(apiResponse.status()).toBe(401);
+
+      // Protected page navigation should also redirect through the
+      // dashboard layout guard once the DB-backed session is gone.
+      await pageB.goto("/ko/audit-logs");
+      await expect(pageB).toHaveURL(/\/ko\/sign-in$/, { timeout: 10_000 });
     } finally {
       await contextA.close();
       await contextB.close();
@@ -80,14 +87,12 @@ test.describe("Sign-out-all", () => {
 
     await signOutAllViaApi(page);
 
-    await expect
-      .poll(async () => (await getSessionStatus(ADMIN_USERNAME)) === null)
-      .toBe(true);
+    await expect.poll(async () => getSessionStatus(ADMIN_USERNAME)).toBeNull();
 
     await signInViaApi(page);
 
     await expect
-      .poll(async () => (await getSessionStatus(ADMIN_USERNAME)) !== null)
-      .toBe(true);
+      .poll(async () => getSessionStatus(ADMIN_USERNAME))
+      .not.toBeNull();
   });
 });

--- a/e2e/sign-out-all.spec.ts
+++ b/e2e/sign-out-all.spec.ts
@@ -1,20 +1,49 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import {
   ADMIN_PASSWORD,
   ADMIN_USERNAME,
   resetRateLimits,
-  signIn,
 } from "./helpers/auth";
-import { resetAccountDefaults } from "./helpers/setup-db";
+import {
+  getSessionStatus,
+  resetAccountDefaults,
+  setMaxSessions,
+} from "./helpers/setup-db";
+
+const APP_URL = process.env.BASE_URL ?? "http://localhost:3000";
+const APP_ORIGIN = APP_URL.replace("127.0.0.1", "localhost");
+
+async function signInViaApi(page: Page): Promise<void> {
+  const response = await page.request.post("/api/auth/sign-in", {
+    headers: { "Content-Type": "application/json" },
+    data: {
+      username: ADMIN_USERNAME,
+      password: ADMIN_PASSWORD,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+}
+
+async function signOutAllViaApi(page: Page): Promise<void> {
+  const cookies = await page.context().cookies();
+  const csrf = cookies.find((c) => c.name === "csrf");
+  const response = await page.request.post("/api/auth/sign-out-all", {
+    headers: {
+      "x-csrf-token": csrf?.value ?? "",
+      Origin: APP_ORIGIN,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+}
 
 test.describe("Sign-out-all", () => {
-  test.beforeAll(async () => {
+  test.beforeEach(async () => {
     await resetRateLimits();
     await resetAccountDefaults(ADMIN_USERNAME);
   });
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
     await resetAccountDefaults(ADMIN_USERNAME);
   });
 
@@ -27,43 +56,38 @@ test.describe("Sign-out-all", () => {
       const pageA = await contextA.newPage();
       const pageB = await contextB.newPage();
 
-      // Sign in on context A.
-      await pageA.goto("http://localhost:3000/sign-in");
-      await signIn(pageA, ADMIN_USERNAME, ADMIN_PASSWORD);
-      await expect(pageA).not.toHaveURL(/sign-in/, { timeout: 10_000 });
-
-      // Sign in on context B.
-      await pageB.goto("http://localhost:3000/sign-in");
-      await signIn(pageB, ADMIN_USERNAME, ADMIN_PASSWORD);
-      await expect(pageB).not.toHaveURL(/sign-in/, { timeout: 10_000 });
-
-      // From context A: call sign-out-all.
-      const cookiesA = await contextA.cookies();
-      const csrfA = cookiesA.find((c) => c.name === "csrf");
-      const response = await pageA.request.post("/api/auth/sign-out-all", {
-        headers: {
-          "x-csrf-token": csrfA?.value ?? "",
-          Origin: "http://localhost:3000",
-        },
-      });
-      expect(response.ok()).toBeTruthy();
+      await signInViaApi(pageA);
+      await signInViaApi(pageB);
+      await signOutAllViaApi(pageA);
 
       // Context B should be invalidated: API call should return 401
       // because the server-side guard checks session existence in the DB.
-      // (The proxy only does stateless JWT verification, so page navigation
-      // still succeeds – but the API guard catches revoked sessions.)
-      const apiResponse = await pageB.request.get(
-        "http://localhost:3000/api/audit-logs",
-      );
+      const apiResponse = await pageB.request.get("/api/audit-logs");
       expect(apiResponse.status()).toBe(401);
-
-      // Protected page navigation should also redirect to localized sign-in
-      // because the dashboard layout now rejects invalidated DB sessions.
-      await pageB.goto("http://localhost:3000/ko/audit-logs");
-      await expect(pageB).toHaveURL(/\/ko\/sign-in$/, { timeout: 10_000 });
     } finally {
       await contextA.close();
       await contextB.close();
     }
+  });
+
+  test("sign-out-all clears active sessions so max_sessions does not block re-login", async ({
+    page,
+  }) => {
+    await setMaxSessions(ADMIN_USERNAME, 1);
+    await signInViaApi(page);
+
+    expect(await getSessionStatus(ADMIN_USERNAME)).not.toBeNull();
+
+    await signOutAllViaApi(page);
+
+    await expect
+      .poll(async () => (await getSessionStatus(ADMIN_USERNAME)) === null)
+      .toBe(true);
+
+    await signInViaApi(page);
+
+    await expect
+      .poll(async () => (await getSessionStatus(ADMIN_USERNAME)) !== null)
+      .toBe(true);
   });
 });

--- a/src/__tests__/app/api/auth/sign-out-all/route.test.ts
+++ b/src/__tests__/app/api/auth/sign-out-all/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthSession } from "@/lib/auth/jwt";
 
@@ -9,7 +9,7 @@ type HandlerFn = (
   session: AuthSession,
 ) => Promise<Response>;
 
-const mockQuery = vi.hoisted(() => vi.fn());
+const mockWithTransaction = vi.hoisted(() => vi.fn());
 const mockDeleteAccessTokenCookie = vi.hoisted(() => vi.fn());
 const mockDeleteTokenExpCookie = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
@@ -29,7 +29,7 @@ vi.mock("@/lib/auth/guard", () => ({
 }));
 
 vi.mock("@/lib/db/client", () => ({
-  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+  withTransaction: vi.fn((...args: unknown[]) => mockWithTransaction(...args)),
 }));
 
 vi.mock("@/lib/auth/cookies", () => ({
@@ -61,6 +61,7 @@ vi.mock("next/headers", () => ({
 
 describe("POST /api/auth/sign-out-all", () => {
   const now = Math.floor(Date.now() / 1000);
+  let mockClientQuery: ReturnType<typeof vi.fn>;
 
   const validSession: AuthSession = {
     accountId: "acc-1",
@@ -88,13 +89,24 @@ describe("POST /api/auth/sign-out-all", () => {
     return { params: Promise.resolve({}) };
   }
 
-  afterEach(() => {
+  beforeEach(() => {
     vi.resetModules();
+    mockWithTransaction.mockReset();
+    mockDeleteAccessTokenCookie.mockReset();
+    mockDeleteTokenExpCookie.mockReset();
+    mockAuditRecord.mockReset();
+    mockExtractClientIp.mockReset();
+    mockCookieDelete.mockReset();
+
+    mockClientQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 1 });
+    mockWithTransaction.mockImplementation(
+      async (fn: (client: { query: ReturnType<typeof vi.fn> }) => unknown) =>
+        fn({ query: mockClientQuery }),
+    );
   });
 
   it("returns 200 with { ok: true } on success", async () => {
     currentSession = validSession;
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
     mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
     mockAuditRecord.mockResolvedValueOnce(undefined);
     mockExtractClientIp.mockReturnValue("127.0.0.1");
@@ -109,7 +121,6 @@ describe("POST /api/auth/sign-out-all", () => {
 
   it("increments token_version in DB", async () => {
     currentSession = validSession;
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
     mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
     mockAuditRecord.mockResolvedValueOnce(undefined);
     mockExtractClientIp.mockReturnValue("127.0.0.1");
@@ -117,15 +128,30 @@ describe("POST /api/auth/sign-out-all", () => {
     const { POST } = await import("@/app/api/auth/sign-out-all/route");
     await POST(makeRequest(), makeContext());
 
-    expect(mockQuery).toHaveBeenCalledWith(
+    expect(mockClientQuery).toHaveBeenCalledWith(
       "UPDATE accounts SET token_version = token_version + 1 WHERE id = $1",
+      ["acc-1"],
+    );
+  });
+
+  it("revokes all non-revoked sessions for the account", async () => {
+    currentSession = validSession;
+    mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
+    mockAuditRecord.mockResolvedValueOnce(undefined);
+    mockExtractClientIp.mockReturnValue("127.0.0.1");
+
+    const { POST } = await import("@/app/api/auth/sign-out-all/route");
+    await POST(makeRequest(), makeContext());
+
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      `UPDATE sessions SET revoked = true
+         WHERE account_id = $1 AND revoked = false`,
       ["acc-1"],
     );
   });
 
   it("deletes all session cookies", async () => {
     currentSession = validSession;
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
     mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
     mockDeleteTokenExpCookie.mockResolvedValueOnce(undefined);
     mockAuditRecord.mockResolvedValueOnce(undefined);
@@ -141,7 +167,6 @@ describe("POST /api/auth/sign-out-all", () => {
 
   it("records audit with action session.revoke and target account", async () => {
     currentSession = validSession;
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
     mockDeleteAccessTokenCookie.mockResolvedValueOnce(undefined);
     mockAuditRecord.mockResolvedValueOnce(undefined);
     mockExtractClientIp.mockReturnValue("127.0.0.1");

--- a/src/app/api/auth/sign-out-all/route.ts
+++ b/src/app/api/auth/sign-out-all/route.ts
@@ -9,15 +9,23 @@ import {
 import { CSRF_COOKIE_NAME } from "@/lib/auth/csrf";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
-import { query } from "@/lib/db/client";
+import { withTransaction } from "@/lib/db/client";
 
 export const POST = withAuth(
   async (request, _context, session) => {
-    // Increment token_version — invalidates all existing tokens
-    await query(
-      "UPDATE accounts SET token_version = token_version + 1 WHERE id = $1",
-      [session.accountId],
-    );
+    await withTransaction(async (client) => {
+      // Keep JWT invalidation and DB-backed session revocation atomic so
+      // session limits and dashboard state update immediately.
+      await client.query(
+        "UPDATE accounts SET token_version = token_version + 1 WHERE id = $1",
+        [session.accountId],
+      );
+      await client.query(
+        `UPDATE sessions SET revoked = true
+         WHERE account_id = $1 AND revoked = false`,
+        [session.accountId],
+      );
+    });
 
     // Clear current session cookies
     await deleteAccessTokenCookie();


### PR DESCRIPTION
## Summary
- revoke all non-revoked DB sessions inside `sign-out-all` while rotating `token_version`
- update the route tests to assert both account invalidation and session-row revocation
- add E2E coverage for the `max_sessions` re-login regression using API-based auth requests

## Testing
- `pnpm check`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `BASE_URL=http://127.0.0.1:3100 pnpm playwright test --config e2e/playwright.config.ts e2e/sign-out-all.spec.ts`
- dev/prod nginx config validation with `nginx:alpine`
- `docker build -t aice-web-next:issue-155 .`

## Notes
- `pnpm markdownlint` currently reports existing failures under hidden skill/worktree docs in `.agent/` and `.claude/`, which are unrelated to this change.
- The default Playwright config reuses port 3000 locally, but that port is occupied by another Next.js app in `/Users/sehkone/projects/github-dashboard`, so the `#155` regression spec was rerun against this app on port 3100 instead.

Closes #155
