### PR TITLE
Remove residual role-name coupling

### DIFF
--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -9,6 +9,8 @@ import {
 import {
   clearMustChangePassword,
   createTestAccount,
+  createTestRole,
+  deleteRolesByPrefix,
   deleteTestAccount,
   resetAccountDefaults,
   revokeAllSessions,
@@ -18,6 +20,27 @@ const TEST_PREFIX = "e2e-acct-";
 const UI_CREATE_USERNAME = `${TEST_PREFIX}ui-create`;
 const UI_EDIT_USERNAME = `${TEST_PREFIX}ui-edit`;
 const UI_DELETE_USERNAME = `${TEST_PREFIX}ui-delete`;
+const CUSTOM_ROLE_API_USERNAME = `${TEST_PREFIX}custom-api`;
+const CUSTOM_ROLE_UI_USERNAME = `${TEST_PREFIX}custom-ui`;
+const CUSTOM_ROLE_PREFIX = `${TEST_PREFIX}role-`;
+const CUSTOM_GLOBAL_ROLE_NAME = `${CUSTOM_ROLE_PREFIX}global-access`;
+
+const SYSTEM_ADMIN_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "roles:read",
+  "roles:write",
+  "roles:delete",
+  "customers:read",
+  "customers:write",
+  "customers:access-all",
+  "audit-logs:read",
+  "system-settings:read",
+  "system-settings:write",
+];
+
+let customGlobalRoleId: number;
 
 async function recreateUiAccount(
   username: string,
@@ -43,6 +66,14 @@ test.describe("Account management", () => {
     await deleteTestAccount(UI_CREATE_USERNAME);
     await deleteTestAccount(UI_EDIT_USERNAME);
     await deleteTestAccount(UI_DELETE_USERNAME);
+    await deleteTestAccount(CUSTOM_ROLE_API_USERNAME);
+    await deleteTestAccount(CUSTOM_ROLE_UI_USERNAME);
+    await deleteRolesByPrefix(CUSTOM_ROLE_PREFIX);
+    customGlobalRoleId = await createTestRole(
+      CUSTOM_GLOBAL_ROLE_NAME,
+      SYSTEM_ADMIN_PERMISSIONS,
+      "E2E custom global-access role",
+    );
   });
 
   test.beforeEach(async () => {
@@ -55,6 +86,9 @@ test.describe("Account management", () => {
     await deleteTestAccount(UI_CREATE_USERNAME);
     await deleteTestAccount(UI_EDIT_USERNAME);
     await deleteTestAccount(UI_DELETE_USERNAME);
+    await deleteTestAccount(CUSTOM_ROLE_API_USERNAME);
+    await deleteTestAccount(CUSTOM_ROLE_UI_USERNAME);
+    await deleteRolesByPrefix(CUSTOM_ROLE_PREFIX);
   });
 
   // ── API tests ─────────────────────────────────────────────────
@@ -84,6 +118,34 @@ test.describe("Account management", () => {
     const body = await response.json();
     expect(body.data.username).toBe(`${TEST_PREFIX}alpha`);
     expect(body.data.status).toBe("active");
+  });
+
+  test("POST /api/accounts accepts a custom global-access role without customers", async ({
+    page,
+  }) => {
+    await deleteTestAccount(CUSTOM_ROLE_API_USERNAME);
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    const cookies = await page.context().cookies();
+    const csrfCookie = cookies.find((c) => c.name === "csrf");
+
+    const response = await page.request.post("/api/accounts", {
+      data: {
+        username: CUSTOM_ROLE_API_USERNAME,
+        displayName: "Custom Role API",
+        password: "TestPass1234!",
+        roleId: customGlobalRoleId,
+      },
+      headers: {
+        "x-csrf-token": csrfCookie?.value ?? "",
+        Origin: "http://localhost:3000",
+      },
+    });
+
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.username).toBe(CUSTOM_ROLE_API_USERNAME);
+    expect(body.data.role_name).toBe(CUSTOM_GLOBAL_ROLE_NAME);
   });
 
   test("GET /api/accounts lists accounts", async ({ page }) => {
@@ -217,6 +279,35 @@ test.describe("Account management", () => {
     await expect(accountRow(page, UI_CREATE_USERNAME)).toBeVisible({
       timeout: 15_000,
     });
+  });
+
+  test("UI create flow treats a custom global-access role like System Administrator", async ({
+    page,
+  }) => {
+    await deleteTestAccount(CUSTOM_ROLE_UI_USERNAME);
+
+    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await page.goto("/settings/accounts");
+
+    await page.getByRole("button", { name: "Create Account" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Username").fill(CUSTOM_ROLE_UI_USERNAME);
+    await dialog.getByLabel("Display Name").fill("Custom Role UI");
+    await dialog.getByLabel("Password").fill("UiTestPass1234!");
+    await dialog.getByRole("combobox").click();
+    await page.getByRole("option", { name: CUSTOM_GLOBAL_ROLE_NAME }).click();
+
+    await expect(dialog.getByText("Customers")).toHaveCount(0);
+
+    await dialog.getByRole("button", { name: "Create Account" }).click();
+
+    await expect(accountRow(page, CUSTOM_ROLE_UI_USERNAME)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(accountRow(page, CUSTOM_ROLE_UI_USERNAME)).toContainText(
+      CUSTOM_GLOBAL_ROLE_NAME,
+    );
   });
 
   test("edits an account via UI", async ({ page }) => {

--- a/src/__tests__/app/api/accounts/[id]/customers/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/customers/route.test.ts
@@ -92,6 +92,27 @@ const tenantAdminSession: AuthSession = {
   roles: ["Tenant Administrator"],
 };
 
+const TENANT_ADMIN_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "customers:read",
+  "customers:write",
+];
+
+function makeAccountRoleRow(
+  roleId: number,
+  roleName: string,
+  rolePermissions: string[],
+) {
+  return {
+    id: TARGET_UUID,
+    role_id: roleId,
+    role_name: roleName,
+    role_permissions: rolePermissions,
+  };
+}
+
 function makeContext(id = TARGET_UUID) {
   return { params: Promise.resolve({ id }) };
 }
@@ -235,7 +256,9 @@ describe("POST /api/accounts/[id]/customers", () => {
   it("assigns customers as System Administrator", async () => {
     // Account exists with role
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+      rows: [
+        makeAccountRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
+      ],
     });
     // Customers exist
     mockQuery.mockResolvedValueOnce({
@@ -286,7 +309,7 @@ describe("POST /api/accounts/[id]/customers", () => {
 
     // Account exists
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+      rows: [makeAccountRoleRow(3, "Security Monitor", [])],
     });
     // Customers exist
     mockQuery.mockResolvedValueOnce({
@@ -311,7 +334,7 @@ describe("POST /api/accounts/[id]/customers", () => {
   it("returns 400 when Security Monitor would exceed single customer", async () => {
     // Account exists as Security Monitor
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+      rows: [makeAccountRoleRow(3, "Security Monitor", [])],
     });
     // Customers exist
     mockQuery.mockResolvedValueOnce({
@@ -393,7 +416,9 @@ describe("POST /api/accounts/[id]/customers", () => {
   it("returns 400 when a customer does not exist", async () => {
     // Account exists
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+      rows: [
+        makeAccountRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
+      ],
     });
     // Only customer 1 found out of [1, 999]
     mockQuery.mockResolvedValueOnce({
@@ -470,7 +495,9 @@ describe("POST /api/accounts/[id]/customers", () => {
 
     // Account exists
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+      rows: [
+        makeAccountRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
+      ],
     });
     // Customer exists
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });
@@ -505,7 +532,9 @@ describe("POST /api/accounts/[id]/customers", () => {
   it("deduplicates customerIds", async () => {
     // Account exists
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Tenant Administrator" }],
+      rows: [
+        makeAccountRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
+      ],
     });
     // Only unique IDs should be checked — [1, 2] not [1, 2, 1, 2]
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }, { id: 2 }] });
@@ -537,7 +566,7 @@ describe("POST /api/accounts/[id]/customers", () => {
   it("returns 400 when Security Monitor already has 1 customer and adds another", async () => {
     // Account exists as Security Monitor
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+      rows: [makeAccountRoleRow(3, "Security Monitor", [])],
     });
     // Customer exists
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 2 }] });
@@ -573,7 +602,7 @@ describe("POST /api/accounts/[id]/customers", () => {
   it("allows Security Monitor to re-assign already assigned customer (idempotent)", async () => {
     // Account exists as Security Monitor
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: TARGET_UUID, role_name: "Security Monitor" }],
+      rows: [makeAccountRoleRow(3, "Security Monitor", [])],
     });
     // Customer exists
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }] });

--- a/src/__tests__/app/api/accounts/[id]/password-reset/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/password-reset/route.test.ts
@@ -77,6 +77,13 @@ vi.mock("@/lib/auth/ip", () => ({
 
 describe("POST /api/accounts/[id]/password-reset", () => {
   const now = Math.floor(Date.now() / 1000);
+  const TENANT_ADMIN_PERMISSIONS = [
+    "accounts:read",
+    "accounts:write",
+    "accounts:delete",
+    "customers:read",
+    "customers:write",
+  ];
 
   const adminSession: AuthSession = {
     accountId: "admin-1",
@@ -121,6 +128,15 @@ describe("POST /api/accounts/[id]/password-reset", () => {
     return { params: Promise.resolve({ id: currentSession.accountId }) };
   }
 
+  function makeTargetAccount(roleName: string, rolePermissions: string[]) {
+    return {
+      id: targetAccountId,
+      role_id: roleName === "Tenant Administrator" ? 2 : 3,
+      role_name: roleName,
+      role_permissions: rolePermissions,
+    };
+  }
+
   beforeEach(() => {
     currentSession = adminSession;
     mockQuery.mockReset();
@@ -146,7 +162,7 @@ describe("POST /api/accounts/[id]/password-reset", () => {
 
     // Default: account exists
     mockQuery.mockResolvedValue({
-      rows: [{ id: targetAccountId, role_name: "Security Monitor" }],
+      rows: [makeTargetAccount("Security Monitor", [])],
       rowCount: 1,
     });
     mockGetAccountCustomerIds.mockResolvedValue([1]);
@@ -222,7 +238,9 @@ describe("POST /api/accounts/[id]/password-reset", () => {
   it("returns 403 when Tenant Admin targets an in-scope Tenant Administrator", async () => {
     currentSession = tenantSession;
     mockQuery.mockResolvedValue({
-      rows: [{ id: targetAccountId, role_name: "Tenant Administrator" }],
+      rows: [
+        makeTargetAccount("Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
+      ],
       rowCount: 1,
     });
     mockGetAccountCustomerIds

--- a/src/__tests__/app/api/accounts/[id]/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/route.test.ts
@@ -94,6 +94,33 @@ const tenantSession: AuthSession = {
   roles: ["Tenant Administrator"],
 };
 
+const SYSTEM_ADMIN_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "roles:read",
+  "roles:write",
+  "roles:delete",
+  "customers:read",
+  "customers:write",
+  "customers:access-all",
+  "audit-logs:read",
+  "system-settings:read",
+  "system-settings:write",
+];
+
+const TENANT_ADMIN_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "customers:read",
+  "customers:write",
+];
+
+function makeRoleLookupRow(id: number, name: string, permissions: string[]) {
+  return { id, name, permissions };
+}
+
 function makeContext(id = TARGET_UUID) {
   return { params: Promise.resolve({ id }) };
 }
@@ -106,6 +133,7 @@ const targetRow = {
   phone: null,
   role_id: 3,
   role_name: "Security Monitor",
+  role_permissions: [] as string[],
   status: "active",
   last_sign_in_at: null,
   created_at: new Date().toISOString(),
@@ -116,7 +144,10 @@ const targetRow = {
 
 describe("GET /api/accounts/[id]", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockGetAccountCustomerIds.mockReset();
+    mockHasPermission.mockReset();
     currentSession = adminSession;
     mockHasPermission.mockImplementation(
       async (_roles: string[], perm: string) => {
@@ -232,7 +263,10 @@ describe("GET /api/accounts/[id]", () => {
 
 describe("PATCH /api/accounts/[id]", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockGetAccountCustomerIds.mockReset();
+    mockHasPermission.mockReset();
     currentSession = adminSession;
     mockHasPermission.mockImplementation(
       async (_roles: string[], perm: string) => {
@@ -411,12 +445,20 @@ describe("PATCH /api/accounts/[id]", () => {
     const { PATCH } = await import("@/app/api/accounts/[id]/route");
     const sysAdminTarget = {
       ...targetRow,
+      role_id: 1,
       role_name: "System Administrator",
+      role_permissions: SYSTEM_ADMIN_PERMISSIONS,
     };
     mockQuery
       .mockResolvedValueOnce({ rows: [sysAdminTarget], rowCount: 1 }) // fetch
       .mockResolvedValueOnce({
-        rows: [{ id: 2, name: "Tenant Administrator" }],
+        rows: [
+          makeRoleLookupRow(
+            2,
+            "Tenant Administrator",
+            TENANT_ADMIN_PERMISSIONS,
+          ),
+        ],
         rowCount: 1,
       }) // role lookup
       .mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 }); // count
@@ -438,7 +480,13 @@ describe("PATCH /api/accounts/[id]", () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [targetRow], rowCount: 1 }) // fetch
       .mockResolvedValueOnce({
-        rows: [{ id: 1, name: "System Administrator" }],
+        rows: [
+          makeRoleLookupRow(
+            1,
+            "System Administrator",
+            SYSTEM_ADMIN_PERMISSIONS,
+          ),
+        ],
         rowCount: 1,
       }) // role lookup
       .mockResolvedValueOnce({ rows: [{ count: "5" }], rowCount: 1 }); // count at max
@@ -585,7 +633,9 @@ describe("PATCH /api/accounts/[id]", () => {
     const { PATCH } = await import("@/app/api/accounts/[id]/route");
     const tenantAdminTarget = {
       ...targetRow,
+      role_id: 2,
       role_name: "Tenant Administrator",
+      role_permissions: TENANT_ADMIN_PERMISSIONS,
     };
     mockQuery.mockResolvedValueOnce({ rows: [tenantAdminTarget], rowCount: 1 });
     mockGetAccountCustomerIds
@@ -609,7 +659,9 @@ describe("PATCH /api/accounts/[id]", () => {
     const { PATCH } = await import("@/app/api/accounts/[id]/route");
     const tenantAdminTarget = {
       ...targetRow,
+      role_id: 2,
       role_name: "Tenant Administrator",
+      role_permissions: TENANT_ADMIN_PERMISSIONS,
     };
     mockQuery.mockResolvedValueOnce({ rows: [tenantAdminTarget], rowCount: 1 });
     mockGetAccountCustomerIds
@@ -676,7 +728,9 @@ describe("PATCH /api/accounts/[id]", () => {
       .mockResolvedValueOnce([1, 2]) // caller customers
       .mockResolvedValueOnce([1]); // target customers (overlap)
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 1, name: "System Administrator" }],
+      rows: [
+        makeRoleLookupRow(1, "System Administrator", SYSTEM_ADMIN_PERMISSIONS),
+      ],
       rowCount: 1,
     });
 
@@ -700,7 +754,9 @@ describe("PATCH /api/accounts/[id]", () => {
       .mockResolvedValueOnce([1, 2]) // caller customers
       .mockResolvedValueOnce([1]); // target customers (overlap)
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 2, name: "Tenant Administrator" }],
+      rows: [
+        makeRoleLookupRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
+      ],
       rowCount: 1,
     });
 
@@ -737,12 +793,25 @@ describe("PATCH /api/accounts/[id]", () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [targetRow], rowCount: 1 }) // fetch
       .mockResolvedValueOnce({
-        rows: [{ id: 2, name: "Tenant Administrator" }],
+        rows: [
+          makeRoleLookupRow(
+            2,
+            "Tenant Administrator",
+            TENANT_ADMIN_PERMISSIONS,
+          ),
+        ],
         rowCount: 1,
       }) // role lookup
       .mockResolvedValueOnce({ rows: [{ id: TARGET_UUID }], rowCount: 1 }) // update
       .mockResolvedValueOnce({
-        rows: [{ ...targetRow, role_name: "Tenant Administrator" }],
+        rows: [
+          {
+            ...targetRow,
+            role_id: 2,
+            role_name: "Tenant Administrator",
+            role_permissions: TENANT_ADMIN_PERMISSIONS,
+          },
+        ],
         rowCount: 1,
       }); // refetch
 
@@ -766,7 +835,10 @@ describe("PATCH /api/accounts/[id]", () => {
 
 describe("DELETE /api/accounts/[id]", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockGetAccountCustomerIds.mockReset();
+    mockHasPermission.mockReset();
     currentSession = adminSession;
     mockHasPermission.mockImplementation(
       async (_roles: string[], perm: string) => {
@@ -864,7 +936,9 @@ describe("DELETE /api/accounts/[id]", () => {
     const { DELETE } = await import("@/app/api/accounts/[id]/route");
     const sysAdminTarget = {
       ...targetRow,
+      role_id: 1,
       role_name: "System Administrator",
+      role_permissions: SYSTEM_ADMIN_PERMISSIONS,
     };
     mockQuery
       .mockResolvedValueOnce({ rows: [sysAdminTarget], rowCount: 1 }) // fetch
@@ -886,7 +960,9 @@ describe("DELETE /api/accounts/[id]", () => {
     const { DELETE } = await import("@/app/api/accounts/[id]/route");
     const sysAdminTarget = {
       ...targetRow,
+      role_id: 1,
       role_name: "System Administrator",
+      role_permissions: SYSTEM_ADMIN_PERMISSIONS,
     };
     mockQuery.mockResolvedValueOnce({
       rows: [sysAdminTarget],
@@ -912,7 +988,9 @@ describe("DELETE /api/accounts/[id]", () => {
     const { DELETE } = await import("@/app/api/accounts/[id]/route");
     const tenantAdminTarget = {
       ...targetRow,
+      role_id: 2,
       role_name: "Tenant Administrator",
+      role_permissions: TENANT_ADMIN_PERMISSIONS,
     };
     mockQuery.mockResolvedValueOnce({
       rows: [tenantAdminTarget],
@@ -966,7 +1044,9 @@ describe("DELETE /api/accounts/[id]", () => {
     const { DELETE } = await import("@/app/api/accounts/[id]/route");
     const sysAdminTarget = {
       ...targetRow,
+      role_id: 1,
       role_name: "System Administrator",
+      role_permissions: SYSTEM_ADMIN_PERMISSIONS,
     };
     mockQuery
       .mockResolvedValueOnce({ rows: [sysAdminTarget], rowCount: 1 }) // fetch

--- a/src/__tests__/app/api/accounts/[id]/unlock/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/unlock/route.test.ts
@@ -63,6 +63,13 @@ vi.mock("@/lib/auth/ip", () => ({
 
 describe("POST /api/accounts/[id]/unlock", () => {
   const now = Math.floor(Date.now() / 1000);
+  const TENANT_ADMIN_PERMISSIONS = [
+    "accounts:read",
+    "accounts:write",
+    "accounts:delete",
+    "customers:read",
+    "customers:write",
+  ];
 
   const adminSession: AuthSession = {
     accountId: "admin-1",
@@ -96,6 +103,17 @@ describe("POST /api/accounts/[id]/unlock", () => {
 
   function makeContext() {
     return { params: Promise.resolve({ id: targetAccountId }) };
+  }
+
+  function makeTargetAccount(roleName: string, rolePermissions: string[]) {
+    return {
+      id: targetAccountId,
+      role_id: roleName === "Tenant Administrator" ? 2 : 3,
+      role_name: roleName,
+      role_permissions: rolePermissions,
+      status: "locked",
+      lockout_count: 1,
+    };
   }
 
   beforeEach(() => {
@@ -143,14 +161,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
   it("returns 404 when Tenant Admin targets an out-of-scope account", async () => {
     currentSession = tenantSession;
     mockQuery.mockResolvedValue({
-      rows: [
-        {
-          id: targetAccountId,
-          role_name: "Security Monitor",
-          status: "locked",
-          lockout_count: 1,
-        },
-      ],
+      rows: [makeTargetAccount("Security Monitor", [])],
       rowCount: 1,
     });
     mockGetAccountCustomerIds
@@ -167,12 +178,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
     currentSession = tenantSession;
     mockQuery.mockResolvedValue({
       rows: [
-        {
-          id: targetAccountId,
-          role_name: "Tenant Administrator",
-          status: "locked",
-          lockout_count: 1,
-        },
+        makeTargetAccount("Tenant Administrator", TENANT_ADMIN_PERMISSIONS),
       ],
       rowCount: 1,
     });
@@ -192,14 +198,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
     mockQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("SELECT")) {
         return {
-          rows: [
-            {
-              id: targetAccountId,
-              role_name: "Security Monitor",
-              status: "locked",
-              lockout_count: 1,
-            },
-          ],
+          rows: [makeTargetAccount("Security Monitor", [])],
           rowCount: 1,
         };
       }
@@ -244,8 +243,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
         return {
           rows: [
             {
-              id: targetAccountId,
-              role_name: "Security Monitor",
+              ...makeTargetAccount("Security Monitor", []),
               status: "suspended",
               lockout_count: 2,
             },
@@ -287,8 +285,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
         return {
           rows: [
             {
-              id: targetAccountId,
-              role_name: "Security Monitor",
+              ...makeTargetAccount("Security Monitor", []),
               status: "locked",
               lockout_count: 0,
             },
@@ -317,14 +314,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
     mockQuery.mockImplementation(async (sql: string) => {
       if (sql.includes("SELECT")) {
         return {
-          rows: [
-            {
-              id: targetAccountId,
-              role_name: "Security Monitor",
-              status: "locked",
-              lockout_count: 1,
-            },
-          ],
+          rows: [makeTargetAccount("Security Monitor", [])],
           rowCount: 1,
         };
       }
@@ -346,8 +336,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
         return {
           rows: [
             {
-              id: targetAccountId,
-              role_name: "Security Monitor",
+              ...makeTargetAccount("Security Monitor", []),
               status: "suspended",
               lockout_count: 1,
             },
@@ -375,8 +364,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
     mockQuery.mockResolvedValue({
       rows: [
         {
-          id: targetAccountId,
-          role_name: "Security Monitor",
+          ...makeTargetAccount("Security Monitor", []),
           status: "active",
           lockout_count: 0,
         },
@@ -396,8 +384,7 @@ describe("POST /api/accounts/[id]/unlock", () => {
     mockQuery.mockResolvedValue({
       rows: [
         {
-          id: targetAccountId,
-          role_name: "Security Monitor",
+          ...makeTargetAccount("Security Monitor", []),
           status: "disabled",
           lockout_count: 0,
         },

--- a/src/__tests__/app/api/accounts/route.test.ts
+++ b/src/__tests__/app/api/accounts/route.test.ts
@@ -107,6 +107,33 @@ const tenantSession: AuthSession = {
   roles: ["Tenant Administrator"],
 };
 
+const SYSTEM_ADMIN_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "roles:read",
+  "roles:write",
+  "roles:delete",
+  "customers:read",
+  "customers:write",
+  "customers:access-all",
+  "audit-logs:read",
+  "system-settings:read",
+  "system-settings:write",
+];
+
+const TENANT_ADMIN_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "customers:read",
+  "customers:write",
+];
+
+function makeRoleRow(id: number, name: string, permissions: string[]) {
+  return { id, name, permissions };
+}
+
 function makeContext() {
   return { params: Promise.resolve({}) };
 }
@@ -115,7 +142,9 @@ function makeContext() {
 
 describe("GET /api/accounts", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockGetAccountCustomerIds.mockReset();
+    mockHasPermission.mockReset();
     currentSession = adminSession;
     mockHasPermission.mockImplementation(
       async (_roles: string[], perm: string) =>
@@ -386,7 +415,13 @@ describe("GET /api/accounts", () => {
 
 describe("POST /api/accounts", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockAuditRecord.mockReset();
+    mockHasPermission.mockReset();
+    mockGetAccountCustomerIds.mockReset();
+    mockWithTransaction.mockReset();
+    mockHashPassword.mockReset();
+    mockValidatePassword.mockReset();
     currentSession = adminSession;
     mockHasPermission.mockImplementation(
       async (_roles: string[], perm: string) =>
@@ -404,7 +439,7 @@ describe("POST /api/accounts", () => {
     const { POST } = await import("@/app/api/accounts/route");
     // Role lookup
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
     // Customer existence check
@@ -550,7 +585,7 @@ describe("POST /api/accounts", () => {
     currentSession = tenantSession;
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 2, name: "Tenant Administrator" }],
+      rows: [makeRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS)],
       rowCount: 1,
     });
 
@@ -571,7 +606,7 @@ describe("POST /api/accounts", () => {
   it("returns 400 when System Admin count limit reached", async () => {
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 1, name: "System Administrator" }],
+      rows: [makeRoleRow(1, "System Administrator", SYSTEM_ADMIN_PERMISSIONS)],
       rowCount: 1,
     });
     mockQuery.mockResolvedValueOnce({
@@ -597,7 +632,7 @@ describe("POST /api/accounts", () => {
   it("returns 400 when non-SysAdmin has no customerIds", async () => {
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
 
@@ -619,7 +654,7 @@ describe("POST /api/accounts", () => {
   it("returns 400 when Security Monitor has more than 1 customer", async () => {
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
 
@@ -642,7 +677,7 @@ describe("POST /api/accounts", () => {
   it("returns 409 when username already exists", async () => {
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
@@ -675,7 +710,7 @@ describe("POST /api/accounts", () => {
   it("returns 400 when password fails validation", async () => {
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 1, name: "System Administrator" }],
+      rows: [makeRoleRow(1, "System Administrator", SYSTEM_ADMIN_PERMISSIONS)],
       rowCount: 1,
     });
     mockQuery.mockResolvedValueOnce({ rows: [{ count: "1" }], rowCount: 1 });
@@ -702,7 +737,7 @@ describe("POST /api/accounts", () => {
   it("returns 400 when customerIds contain non-positive integers", async () => {
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
 
@@ -726,7 +761,7 @@ describe("POST /api/accounts", () => {
     const { POST } = await import("@/app/api/accounts/route");
     // Role lookup → Tenant Administrator
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 2, name: "Tenant Administrator" }],
+      rows: [makeRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS)],
       rowCount: 1,
     });
     // Customer existence check → only id=1 found, id=999 missing
@@ -756,7 +791,7 @@ describe("POST /api/accounts", () => {
     const { POST } = await import("@/app/api/accounts/route");
     const newId = "00000000-0000-0000-0000-000000000088";
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
@@ -810,7 +845,7 @@ describe("POST /api/accounts", () => {
     currentSession = tenantSession;
     const { POST } = await import("@/app/api/accounts/route");
     mockQuery.mockResolvedValueOnce({
-      rows: [{ id: 3, name: "Security Monitor" }],
+      rows: [makeRoleRow(3, "Security Monitor", [])],
       rowCount: 1,
     });
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 5 }], rowCount: 1 });

--- a/src/__tests__/lib/auth/account-role-policy.test.ts
+++ b/src/__tests__/lib/auth/account-role-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveAccountRolePolicy,
+  summarizeAccountRolePolicy,
+} from "@/lib/auth/account-role-policy";
+
+describe("account-role-policy", () => {
+  it("treats global-access roles as not requiring customer assignment", () => {
+    const policy = deriveAccountRolePolicy({
+      id: 1,
+      name: "Custom Global Admin",
+      permissions: ["accounts:read", "customers:access-all"],
+    });
+
+    expect(policy.requiresCustomerAssignment).toBe(false);
+    expect(policy.maxCustomerAssignments).toBeNull();
+    expect(policy.tenantManageable).toBe(false);
+  });
+
+  it("treats zero-permission roles as Security Monitor-equivalent", () => {
+    const policy = deriveAccountRolePolicy({
+      id: 2,
+      name: "Custom Monitor",
+      permissions: [],
+    });
+
+    expect(policy.isSecurityMonitorEquivalent).toBe(true);
+    expect(policy.requiresCustomerAssignment).toBe(true);
+    expect(policy.maxCustomerAssignments).toBe(1);
+    expect(policy.tenantManageable).toBe(true);
+  });
+
+  it("summarizes the policy for API consumers", () => {
+    const summary = summarizeAccountRolePolicy({
+      requiresCustomerAssignment: true,
+      maxCustomerAssignments: 1,
+      tenantManageable: true,
+    });
+
+    expect(summary).toEqual({
+      requires_customer_assignment: true,
+      max_customer_assignments: 1,
+      tenant_manageable: true,
+    });
+  });
+});

--- a/src/__tests__/lib/auth/account-role-policy.test.ts
+++ b/src/__tests__/lib/auth/account-role-policy.test.ts
@@ -31,6 +31,19 @@ describe("account-role-policy", () => {
     expect(policy.tenantManageable).toBe(true);
   });
 
+  it("treats customer-scoped roles with permissions as non-monitor accounts", () => {
+    const policy = deriveAccountRolePolicy({
+      id: 3,
+      name: "Custom Tenant Operator",
+      permissions: ["accounts:read", "customers:read"],
+    });
+
+    expect(policy.isSecurityMonitorEquivalent).toBe(false);
+    expect(policy.requiresCustomerAssignment).toBe(true);
+    expect(policy.maxCustomerAssignments).toBeNull();
+    expect(policy.tenantManageable).toBe(false);
+  });
+
   it("summarizes the policy for API consumers", () => {
     const summary = summarizeAccountRolePolicy({
       requiresCustomerAssignment: true,

--- a/src/__tests__/lib/auth/role-management.test.ts
+++ b/src/__tests__/lib/auth/role-management.test.ts
@@ -45,6 +45,7 @@ describe("role-management", () => {
             name: "System Administrator",
             description: "Full access",
             is_builtin: true,
+            permissions: ["accounts:read", "customers:access-all"],
           },
         ],
         rowCount: 1,
@@ -56,6 +57,7 @@ describe("role-management", () => {
       // Minimal: no permissions or account_count
       expect(result[0]).not.toHaveProperty("permissions");
       expect(result[0]).not.toHaveProperty("account_count");
+      expect(result[0].requires_customer_assignment).toBe(false);
     });
   });
 
@@ -87,6 +89,7 @@ describe("role-management", () => {
         "accounts:read",
         "accounts:write",
       ]);
+      expect(result[0].requires_customer_assignment).toBe(true);
     });
   });
 
@@ -120,6 +123,7 @@ describe("role-management", () => {
       const result = await mod.getRoleWithPermissions(1);
       expect(result?.name).toBe("Test Role");
       expect(result?.account_count).toBe(0);
+      expect(result?.tenant_manageable).toBe(false);
     });
   });
 

--- a/src/app/api/accounts/[id]/customers/route.ts
+++ b/src/app/api/accounts/[id]/customers/route.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
+import { deriveAccountRolePolicy } from "@/lib/auth/account-role-policy";
 import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
@@ -136,11 +137,19 @@ export const POST = withAuth(
     // Verify account exists and get its role
     const { rows: accountRows } = await query<{
       id: string;
+      role_id: number;
       role_name: string;
+      role_permissions: string[];
     }>(
-      `SELECT a.id, r.name AS role_name
-       FROM accounts a JOIN roles r ON a.role_id = r.id
-       WHERE a.id = $1`,
+      `SELECT a.id, a.role_id, r.name AS role_name,
+              COALESCE(
+                (SELECT array_agg(rp.permission ORDER BY rp.permission)
+                 FROM role_permissions rp WHERE rp.role_id = r.id),
+                '{}'
+              ) AS role_permissions
+       FROM accounts a
+       JOIN roles r ON a.role_id = r.id
+       WHERE id = $1`,
       [accountId],
     );
     if (accountRows.length === 0) {
@@ -178,10 +187,14 @@ export const POST = withAuth(
       }
     }
 
-    // Security Monitor: restricted to a single customer
-    const targetRole = accountRows[0].role_name;
+    const targetRole = deriveAccountRolePolicy({
+      id: accountRows[0].role_id,
+      name: accountRows[0].role_name,
+      permissions: accountRows[0].role_permissions,
+    });
+
     const assigned = await withTransaction(async (client) => {
-      if (targetRole === "Security Monitor") {
+      if (targetRole.maxCustomerAssignments === 1) {
         const { rows: countRows } = await client.query<{ count: string }>(
           "SELECT COUNT(*)::text AS count FROM account_customer WHERE account_id = $1",
           [accountId],
@@ -222,7 +235,7 @@ export const POST = withAuth(
       return NextResponse.json(
         {
           error:
-            "Security Monitor accounts can only be assigned to a single customer",
+            "Security Monitor-equivalent accounts can only be assigned to a single customer",
         },
         { status: 400 },
       );

--- a/src/app/api/accounts/[id]/customers/route.ts
+++ b/src/app/api/accounts/[id]/customers/route.ts
@@ -149,7 +149,7 @@ export const POST = withAuth(
               ) AS role_permissions
        FROM accounts a
        JOIN roles r ON a.role_id = r.id
-       WHERE id = $1`,
+       WHERE a.id = $1`,
       [accountId],
     );
     if (accountRows.length === 0) {

--- a/src/app/api/accounts/[id]/customers/route.ts
+++ b/src/app/api/accounts/[id]/customers/route.ts
@@ -3,7 +3,10 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
-import { deriveAccountRolePolicy } from "@/lib/auth/account-role-policy";
+import {
+  deriveAccountRolePolicy,
+  rolePermissionsSelectSql,
+} from "@/lib/auth/account-role-policy";
 import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
@@ -142,11 +145,7 @@ export const POST = withAuth(
       role_permissions: string[];
     }>(
       `SELECT a.id, a.role_id, r.name AS role_name,
-              COALESCE(
-                (SELECT array_agg(rp.permission ORDER BY rp.permission)
-                 FROM role_permissions rp WHERE rp.role_id = r.id),
-                '{}'
-              ) AS role_permissions
+              ${rolePermissionsSelectSql("r", "role_permissions")}
        FROM accounts a
        JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,

--- a/src/app/api/accounts/[id]/password-reset/route.ts
+++ b/src/app/api/accounts/[id]/password-reset/route.ts
@@ -49,9 +49,16 @@ export const POST = withAuth(
     // Step 2: Validate account exists
     const { rows: accountRows } = await query<{
       id: string;
+      role_id: number;
       role_name: string;
+      role_permissions: string[];
     }>(
-      `SELECT a.id, r.name AS role_name
+      `SELECT a.id, a.role_id, r.name AS role_name,
+              COALESCE(
+                (SELECT array_agg(rp.permission ORDER BY rp.permission)
+                 FROM role_permissions rp WHERE rp.role_id = r.id),
+                '{}'
+              ) AS role_permissions
        FROM accounts a
        JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,

--- a/src/app/api/accounts/[id]/password-reset/route.ts
+++ b/src/app/api/accounts/[id]/password-reset/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
 import { validateManagedAccountTarget } from "@/lib/auth/account-management";
+import { rolePermissionsSelectSql } from "@/lib/auth/account-role-policy";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { hashPassword } from "@/lib/auth/password";
@@ -54,11 +55,7 @@ export const POST = withAuth(
       role_permissions: string[];
     }>(
       `SELECT a.id, a.role_id, r.name AS role_name,
-              COALESCE(
-                (SELECT array_agg(rp.permission ORDER BY rp.permission)
-                 FROM role_permissions rp WHERE rp.role_id = r.id),
-                '{}'
-              ) AS role_permissions
+              ${rolePermissionsSelectSql("r", "role_permissions")}
        FROM accounts a
        JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -4,6 +4,10 @@ import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
 import { validateManagedAccountTarget } from "@/lib/auth/account-management";
+import {
+  loadAccountRolePolicy,
+  SYSTEM_ADMIN_ROLE_NAME,
+} from "@/lib/auth/account-role-policy";
 import { MAX_SYSTEM_ADMINISTRATORS } from "@/lib/auth/bootstrap";
 import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
 import { withAuth } from "@/lib/auth/guard";
@@ -21,6 +25,7 @@ interface AccountDetailRow {
   phone: string | null;
   role_id: number;
   role_name: string;
+  role_permissions?: string[];
   status: string;
   last_sign_in_at: string | null;
   created_at: string;
@@ -32,8 +37,6 @@ interface AccountDetailRow {
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const SYSTEM_ADMIN_ROLE = "System Administrator";
-const SECURITY_MONITOR_ROLE = "Security Monitor";
 const VALID_STATUSES = new Set(["active", "locked", "suspended", "disabled"]);
 
 // ── Route Handlers ──────────────────────────────────────────────
@@ -124,7 +127,13 @@ export const PATCH = withAuth(async (request, context, session) => {
   // Fetch target account
   const { rows: existing } = await query<AccountDetailRow>(
     `SELECT a.id, a.username, a.display_name, a.email, a.phone,
-              a.role_id, r.name AS role_name, a.status,
+              a.role_id, r.name AS role_name,
+              COALESCE(
+                (SELECT array_agg(rp.permission ORDER BY rp.permission)
+                 FROM role_permissions rp WHERE rp.role_id = r.id),
+                '{}'
+              ) AS role_permissions,
+              a.status,
               a.last_sign_in_at, a.created_at, a.updated_at
        FROM accounts a JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,
@@ -197,33 +206,33 @@ export const PATCH = withAuth(async (request, context, session) => {
       return NextResponse.json({ error: "Invalid roleId" }, { status: 400 });
     }
     // Verify role exists
-    const { rows: roleRows } = await query<{ id: number; name: string }>(
-      "SELECT id, name FROM roles WHERE id = $1",
-      [newRoleId],
-    );
-    if (roleRows.length === 0) {
+    const nextRole = await loadAccountRolePolicy(newRoleId);
+    if (!nextRole) {
       return NextResponse.json({ error: "Role not found" }, { status: 400 });
     }
     const callerAccessAll = await hasPermission(
       session.roles,
       "customers:access-all",
     );
-    if (!callerAccessAll && roleRows[0].name !== SECURITY_MONITOR_ROLE) {
+    if (!callerAccessAll && !nextRole.tenantManageable) {
       return NextResponse.json(
-        { error: "Tenant Administrator can only assign Security Monitor role" },
+        {
+          error:
+            "Tenant Administrator can only assign Security Monitor-equivalent roles",
+        },
         { status: 403 },
       );
     }
     // System Admin count check if changing away from SysAdmin
     if (
-      existing[0].role_name === SYSTEM_ADMIN_ROLE &&
-      roleRows[0].name !== SYSTEM_ADMIN_ROLE
+      existing[0].role_name === SYSTEM_ADMIN_ROLE_NAME &&
+      !nextRole.isNamedSystemAdministrator
     ) {
       const { rows: countRows } = await query<{ count: string }>(
         `SELECT COUNT(*)::text AS count FROM accounts a
            JOIN roles r ON a.role_id = r.id
            WHERE r.name = $1 AND a.status != 'disabled'`,
-        [SYSTEM_ADMIN_ROLE],
+        [SYSTEM_ADMIN_ROLE_NAME],
       );
       if (Number.parseInt(countRows[0].count, 10) <= 1) {
         return NextResponse.json(
@@ -234,14 +243,14 @@ export const PATCH = withAuth(async (request, context, session) => {
     }
     // System Admin count check if changing to SysAdmin
     if (
-      roleRows[0].name === SYSTEM_ADMIN_ROLE &&
-      existing[0].role_name !== SYSTEM_ADMIN_ROLE
+      nextRole.isNamedSystemAdministrator &&
+      existing[0].role_name !== SYSTEM_ADMIN_ROLE_NAME
     ) {
       const { rows: countRows } = await query<{ count: string }>(
         `SELECT COUNT(*)::text AS count FROM accounts a
            JOIN roles r ON a.role_id = r.id
            WHERE r.name = $1 AND a.status != 'disabled'`,
-        [SYSTEM_ADMIN_ROLE],
+        [SYSTEM_ADMIN_ROLE_NAME],
       );
       if (
         Number.parseInt(countRows[0].count, 10) >= MAX_SYSTEM_ADMINISTRATORS
@@ -257,7 +266,7 @@ export const PATCH = withAuth(async (request, context, session) => {
     updates.push(`role_id = $${idx++}`);
     params.push(newRoleId);
     changes.roleId = newRoleId;
-    changes.roleName = roleRows[0].name;
+    changes.roleName = nextRole.roleName;
   }
 
   if (body.status !== undefined) {
@@ -304,7 +313,13 @@ export const PATCH = withAuth(async (request, context, session) => {
   // Refetch with role name
   const { rows: result } = await query<AccountDetailRow>(
     `SELECT a.id, a.username, a.display_name, a.email, a.phone,
-              a.role_id, r.name AS role_name, a.status,
+              a.role_id, r.name AS role_name,
+              COALESCE(
+                (SELECT array_agg(rp.permission ORDER BY rp.permission)
+                 FROM role_permissions rp WHERE rp.role_id = r.id),
+                '{}'
+              ) AS role_permissions,
+              a.status,
               a.last_sign_in_at, a.created_at, a.updated_at
        FROM accounts a JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,
@@ -359,7 +374,13 @@ export const DELETE = withAuth(
     // Fetch target account
     const { rows } = await query<AccountDetailRow>(
       `SELECT a.id, a.username, a.display_name, a.email, a.phone,
-              a.role_id, r.name AS role_name, a.status,
+              a.role_id, r.name AS role_name,
+              COALESCE(
+                (SELECT array_agg(rp.permission ORDER BY rp.permission)
+                 FROM role_permissions rp WHERE rp.role_id = r.id),
+                '{}'
+              ) AS role_permissions,
+              a.status,
               a.last_sign_in_at, a.created_at, a.updated_at
        FROM accounts a JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,
@@ -389,12 +410,12 @@ export const DELETE = withAuth(
     }
 
     // Last System Administrator check
-    if (target.role_name === SYSTEM_ADMIN_ROLE) {
+    if (target.role_name === SYSTEM_ADMIN_ROLE_NAME) {
       const { rows: countRows } = await query<{ count: string }>(
         `SELECT COUNT(*)::text AS count FROM accounts a
          JOIN roles r ON a.role_id = r.id
          WHERE r.name = $1 AND a.status != 'disabled'`,
-        [SYSTEM_ADMIN_ROLE],
+        [SYSTEM_ADMIN_ROLE_NAME],
       );
       if (Number.parseInt(countRows[0].count, 10) <= 1) {
         return NextResponse.json(

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -6,6 +6,7 @@ import { auditLog } from "@/lib/audit/logger";
 import { validateManagedAccountTarget } from "@/lib/auth/account-management";
 import {
   loadAccountRolePolicy,
+  rolePermissionsSelectSql,
   SYSTEM_ADMIN_ROLE_NAME,
 } from "@/lib/auth/account-role-policy";
 import { MAX_SYSTEM_ADMINISTRATORS } from "@/lib/auth/bootstrap";
@@ -128,11 +129,7 @@ export const PATCH = withAuth(async (request, context, session) => {
   const { rows: existing } = await query<AccountDetailRow>(
     `SELECT a.id, a.username, a.display_name, a.email, a.phone,
               a.role_id, r.name AS role_name,
-              COALESCE(
-                (SELECT array_agg(rp.permission ORDER BY rp.permission)
-                 FROM role_permissions rp WHERE rp.role_id = r.id),
-                '{}'
-              ) AS role_permissions,
+              ${rolePermissionsSelectSql("r", "role_permissions")},
               a.status,
               a.last_sign_in_at, a.created_at, a.updated_at
        FROM accounts a JOIN roles r ON a.role_id = r.id
@@ -314,11 +311,7 @@ export const PATCH = withAuth(async (request, context, session) => {
   const { rows: result } = await query<AccountDetailRow>(
     `SELECT a.id, a.username, a.display_name, a.email, a.phone,
               a.role_id, r.name AS role_name,
-              COALESCE(
-                (SELECT array_agg(rp.permission ORDER BY rp.permission)
-                 FROM role_permissions rp WHERE rp.role_id = r.id),
-                '{}'
-              ) AS role_permissions,
+              ${rolePermissionsSelectSql("r", "role_permissions")},
               a.status,
               a.last_sign_in_at, a.created_at, a.updated_at
        FROM accounts a JOIN roles r ON a.role_id = r.id
@@ -375,11 +368,7 @@ export const DELETE = withAuth(
     const { rows } = await query<AccountDetailRow>(
       `SELECT a.id, a.username, a.display_name, a.email, a.phone,
               a.role_id, r.name AS role_name,
-              COALESCE(
-                (SELECT array_agg(rp.permission ORDER BY rp.permission)
-                 FROM role_permissions rp WHERE rp.role_id = r.id),
-                '{}'
-              ) AS role_permissions,
+              ${rolePermissionsSelectSql("r", "role_permissions")},
               a.status,
               a.last_sign_in_at, a.created_at, a.updated_at
        FROM accounts a JOIN roles r ON a.role_id = r.id

--- a/src/app/api/accounts/[id]/unlock/route.ts
+++ b/src/app/api/accounts/[id]/unlock/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
 import { validateManagedAccountTarget } from "@/lib/auth/account-management";
+import { rolePermissionsSelectSql } from "@/lib/auth/account-role-policy";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { query } from "@/lib/db/client";
@@ -36,11 +37,7 @@ export const POST = withAuth(
       lockout_count: number;
     }>(
       `SELECT a.id, a.role_id, r.name AS role_name,
-              COALESCE(
-                (SELECT array_agg(rp.permission ORDER BY rp.permission)
-                 FROM role_permissions rp WHERE rp.role_id = r.id),
-                '{}'
-              ) AS role_permissions,
+              ${rolePermissionsSelectSql("r", "role_permissions")},
               a.status, a.lockout_count
        FROM accounts a
        JOIN roles r ON a.role_id = r.id

--- a/src/app/api/accounts/[id]/unlock/route.ts
+++ b/src/app/api/accounts/[id]/unlock/route.ts
@@ -29,11 +29,19 @@ export const POST = withAuth(
     // Step 1: Fetch account status
     const { rows } = await query<{
       id: string;
+      role_id: number;
       role_name: string;
+      role_permissions: string[];
       status: string;
       lockout_count: number;
     }>(
-      `SELECT a.id, r.name AS role_name, a.status, a.lockout_count
+      `SELECT a.id, a.role_id, r.name AS role_name,
+              COALESCE(
+                (SELECT array_agg(rp.permission ORDER BY rp.permission)
+                 FROM role_permissions rp WHERE rp.role_id = r.id),
+                '{}'
+              ) AS role_permissions,
+              a.status, a.lockout_count
        FROM accounts a
        JOIN roles r ON a.role_id = r.id
        WHERE a.id = $1`,

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -3,6 +3,10 @@ import "server-only";
 import { NextResponse } from "next/server";
 
 import { auditLog } from "@/lib/audit/logger";
+import {
+  loadAccountRolePolicy,
+  SYSTEM_ADMIN_ROLE_NAME,
+} from "@/lib/auth/account-role-policy";
 import { MAX_SYSTEM_ADMINISTRATORS } from "@/lib/auth/bootstrap";
 import { getAccountCustomerIds } from "@/lib/auth/customer-scope";
 import { withAuth } from "@/lib/auth/guard";
@@ -27,9 +31,6 @@ interface AccountRow {
 }
 
 // ── Constants ───────────────────────────────────────────────────
-
-const SYSTEM_ADMIN_ROLE = "System Administrator";
-const SECURITY_MONITOR_ROLE = "Security Monitor";
 
 const VALID_STATUSES = new Set(["active", "locked", "suspended", "disabled"]);
 const DEFAULT_PAGE_SIZE = 20;
@@ -220,34 +221,33 @@ export const POST = withAuth(
     }
 
     // Step 2: Look up target role
-    const { rows: roleRows } = await query<{ id: number; name: string }>(
-      "SELECT id, name FROM roles WHERE id = $1",
-      [roleId],
-    );
-    if (roleRows.length === 0) {
+    const targetRole = await loadAccountRolePolicy(roleId);
+    if (!targetRole) {
       return NextResponse.json({ error: "Role not found" }, { status: 400 });
     }
-    const targetRoleName = roleRows[0].name;
 
-    // Step 3: Tenant Admin can only create Security Monitor
-    const callerIsSysAdmin = session.roles.includes(SYSTEM_ADMIN_ROLE);
-    if (!callerIsSysAdmin && targetRoleName !== SECURITY_MONITOR_ROLE) {
+    // Step 3: Tenant-scoped operators can only create monitor-equivalent roles
+    const callerAccessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!callerAccessAll && !targetRole.tenantManageable) {
       return NextResponse.json(
         {
           error:
-            "Tenant Administrator can only create Security Monitor accounts",
+            "Tenant Administrator can only create Security Monitor-equivalent accounts",
         },
         { status: 403 },
       );
     }
 
     // Step 4: System Admin count limit
-    if (targetRoleName === SYSTEM_ADMIN_ROLE) {
+    if (targetRole.isNamedSystemAdministrator) {
       const { rows: countRows } = await query<{ count: string }>(
         `SELECT COUNT(*)::text AS count FROM accounts a
          JOIN roles r ON a.role_id = r.id
          WHERE r.name = $1 AND a.status != 'disabled'`,
-        [SYSTEM_ADMIN_ROLE],
+        [SYSTEM_ADMIN_ROLE_NAME],
       );
       if (
         Number.parseInt(countRows[0].count, 10) >= MAX_SYSTEM_ADMINISTRATORS
@@ -262,7 +262,7 @@ export const POST = withAuth(
     }
 
     // Step 5: Customer assignment validation
-    const requiresCustomerAssignment = targetRoleName !== SYSTEM_ADMIN_ROLE;
+    const requiresCustomerAssignment = targetRole.requiresCustomerAssignment;
 
     if (requiresCustomerAssignment) {
       if (
@@ -273,7 +273,7 @@ export const POST = withAuth(
         return NextResponse.json(
           {
             error:
-              "Customer assignment is required for non-System Administrator accounts",
+              "Customer assignment is required for customer-scoped accounts",
           },
           { status: 400 },
         );
@@ -290,16 +290,15 @@ export const POST = withAuth(
       }
     }
 
-    // Security Monitor: max 1 customer
     if (
-      targetRoleName === SECURITY_MONITOR_ROLE &&
+      targetRole.maxCustomerAssignments === 1 &&
       customerIds &&
       customerIds.length > 1
     ) {
       return NextResponse.json(
         {
           error:
-            "Security Monitor accounts can only be assigned to a single customer",
+            "Security Monitor-equivalent accounts can only be assigned to a single customer",
         },
         { status: 400 },
       );
@@ -325,7 +324,7 @@ export const POST = withAuth(
     }
 
     // Tenant Admin scope: can only assign their own customers
-    if (!callerIsSysAdmin && uniqueCustomerIds.length > 0) {
+    if (!callerAccessAll && uniqueCustomerIds.length > 0) {
       const callerCustomerIds = await getAccountCustomerIds(session.accountId);
       const callerSet = new Set(callerCustomerIds);
       const outOfScope = uniqueCustomerIds.filter((id) => !callerSet.has(id));
@@ -422,7 +421,7 @@ export const POST = withAuth(
       details: {
         username,
         displayName,
-        role: targetRoleName,
+        role: targetRole.roleName,
         customerIds: uniqueCustomerIds,
       },
     });

--- a/src/components/accounts/account-form-dialog.tsx
+++ b/src/components/accounts/account-form-dialog.tsx
@@ -39,6 +39,9 @@ interface Account {
 interface Role {
   id: number;
   name: string;
+  requires_customer_assignment: boolean;
+  max_customer_assignments: number | null;
+  tenant_manageable: boolean;
 }
 
 interface Customer {
@@ -102,18 +105,17 @@ export function AccountFormDialog({
     }
   }, [open, account, roles]);
 
-  const selectedRoleName =
-    roles.find((r) => String(r.id) === roleId)?.name ?? "";
-  const isSecurityMonitor = selectedRoleName === "Security Monitor";
-  const isSysAdmin = selectedRoleName === "System Administrator";
+  const selectedRole = roles.find((r) => String(r.id) === roleId);
+  const hasSingleCustomerLimit = selectedRole?.max_customer_assignments === 1;
+  const requiresCustomerAssignment =
+    selectedRole?.requires_customer_assignment ?? false;
 
   const handleCustomerToggle = (customerId: number) => {
     setSelectedCustomerIds((prev) => {
       if (prev.includes(customerId)) {
         return prev.filter((id) => id !== customerId);
       }
-      // Security Monitor: max 1
-      if (isSecurityMonitor) {
+      if (hasSingleCustomerLimit) {
         return [customerId];
       }
       return [...prev, customerId];
@@ -185,7 +187,8 @@ export function AccountFormDialog({
     : username.trim().length > 0 &&
       displayName.trim().length > 0 &&
       password.length > 0 &&
-      roleId.length > 0;
+      roleId.length > 0 &&
+      (!requiresCustomerAssignment || selectedCustomerIds.length > 0);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -273,39 +276,41 @@ export function AccountFormDialog({
             />
           </div>
 
-          {/* Customer assignment (create only, non-SysAdmin) */}
-          {!isEdit && !isSysAdmin && customers.length > 0 && (
-            <div className="space-y-2">
-              <Label>
-                {t("customers")}
-                {isSecurityMonitor && (
-                  <span className="text-muted-foreground ml-1 text-xs">
-                    (max 1)
-                  </span>
-                )}
-              </Label>
-              <div className="max-h-40 space-y-2 overflow-y-auto rounded border p-3">
-                {customers.map((customer) => {
-                  const checkboxId = `customer-${customer.id}`;
-                  return (
-                    <div
-                      key={customer.id}
-                      className="flex items-center gap-2 text-sm"
-                    >
-                      <Checkbox
-                        id={checkboxId}
-                        checked={selectedCustomerIds.includes(customer.id)}
-                        onCheckedChange={() =>
-                          handleCustomerToggle(customer.id)
-                        }
-                      />
-                      <label htmlFor={checkboxId}>{customer.name}</label>
-                    </div>
-                  );
-                })}
+          {!isEdit &&
+            selectedRole &&
+            requiresCustomerAssignment &&
+            customers.length > 0 && (
+              <div className="space-y-2">
+                <Label>
+                  {t("customers")}
+                  {hasSingleCustomerLimit && (
+                    <span className="text-muted-foreground ml-1 text-xs">
+                      (max 1)
+                    </span>
+                  )}
+                </Label>
+                <div className="max-h-40 space-y-2 overflow-y-auto rounded border p-3">
+                  {customers.map((customer) => {
+                    const checkboxId = `customer-${customer.id}`;
+                    return (
+                      <div
+                        key={customer.id}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <Checkbox
+                          id={checkboxId}
+                          checked={selectedCustomerIds.includes(customer.id)}
+                          onCheckedChange={() =>
+                            handleCustomerToggle(customer.id)
+                          }
+                        />
+                        <label htmlFor={checkboxId}>{customer.name}</label>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
           {error && <p className="text-destructive text-sm">{error}</p>}
 

--- a/src/components/accounts/account-table.tsx
+++ b/src/components/accounts/account-table.tsx
@@ -54,6 +54,9 @@ interface Account {
 interface Role {
   id: number;
   name: string;
+  requires_customer_assignment: boolean;
+  max_customer_assignments: number | null;
+  tenant_manageable: boolean;
 }
 
 interface Customer {

--- a/src/lib/auth/account-management.ts
+++ b/src/lib/auth/account-management.ts
@@ -1,14 +1,15 @@
 import "server-only";
 
+import { deriveAccountRolePolicy } from "./account-role-policy";
 import { getAccountCustomerIds } from "./customer-scope";
 import type { AuthSession } from "./jwt";
 import { hasPermission } from "./permissions";
 
-export const SECURITY_MONITOR_ROLE = "Security Monitor";
-
 export interface ManagedAccountTarget {
   id: string;
+  role_permissions?: string[];
   role_name: string;
+  role_id: number;
 }
 
 export interface ManagedAccountPolicyError {
@@ -42,9 +43,16 @@ export async function validateManagedAccountTarget(
     return { error: "Account not found", status: 404 };
   }
 
-  if (account.role_name !== SECURITY_MONITOR_ROLE) {
+  const targetPolicy = deriveAccountRolePolicy({
+    id: account.role_id,
+    name: account.role_name,
+    permissions: account.role_permissions ?? [],
+  });
+
+  if (!targetPolicy.tenantManageable) {
     return {
-      error: "Tenant Administrator can only manage Security Monitor accounts",
+      error:
+        "Tenant Administrator can only manage Security Monitor-equivalent accounts",
       status: 403,
     };
   }

--- a/src/lib/auth/account-role-policy.ts
+++ b/src/lib/auth/account-role-policy.ts
@@ -1,0 +1,89 @@
+import "server-only";
+
+import { query } from "@/lib/db/client";
+
+export const SYSTEM_ADMIN_ROLE_NAME = "System Administrator";
+
+interface RolePolicyRow {
+  id: number;
+  name: string;
+  permissions: string[];
+}
+
+export interface AccountRolePolicy {
+  roleId: number;
+  roleName: string;
+  permissions: string[];
+  isNamedSystemAdministrator: boolean;
+  isSecurityMonitorEquivalent: boolean;
+  requiresCustomerAssignment: boolean;
+  maxCustomerAssignments: number | null;
+  tenantManageable: boolean;
+}
+
+export interface AccountRolePolicySummary {
+  requires_customer_assignment: boolean;
+  max_customer_assignments: number | null;
+  tenant_manageable: boolean;
+}
+
+function hasGlobalCustomerAccess(permissions: string[]): boolean {
+  return permissions.includes("customers:access-all");
+}
+
+export function deriveAccountRolePolicy(
+  role: RolePolicyRow,
+): AccountRolePolicy {
+  const permissions = Array.isArray(role.permissions)
+    ? [...role.permissions].sort()
+    : [];
+  const securityMonitorEquivalent = permissions.length === 0;
+  const requiresCustomerAssignment = !hasGlobalCustomerAccess(permissions);
+
+  return {
+    roleId: role.id,
+    roleName: role.name,
+    permissions,
+    isNamedSystemAdministrator: role.name === SYSTEM_ADMIN_ROLE_NAME,
+    isSecurityMonitorEquivalent: securityMonitorEquivalent,
+    requiresCustomerAssignment,
+    maxCustomerAssignments: securityMonitorEquivalent ? 1 : null,
+    tenantManageable: securityMonitorEquivalent,
+  };
+}
+
+export function summarizeAccountRolePolicy(
+  policy: Pick<
+    AccountRolePolicy,
+    "requiresCustomerAssignment" | "maxCustomerAssignments" | "tenantManageable"
+  >,
+): AccountRolePolicySummary {
+  return {
+    requires_customer_assignment: policy.requiresCustomerAssignment,
+    max_customer_assignments: policy.maxCustomerAssignments,
+    tenant_manageable: policy.tenantManageable,
+  };
+}
+
+export async function loadAccountRolePolicy(
+  roleId: number,
+): Promise<AccountRolePolicy | null> {
+  const { rows } = await query<RolePolicyRow>(
+    `SELECT r.id, r.name,
+            COALESCE(
+              (SELECT array_agg(rp.permission ORDER BY rp.permission)
+               FROM role_permissions rp
+               WHERE rp.role_id = r.id),
+              '{}'
+            ) AS permissions
+       FROM roles r
+      WHERE r.id = $1`,
+    [roleId],
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return deriveAccountRolePolicy(rows[0]);
+}

--- a/src/lib/auth/account-role-policy.ts
+++ b/src/lib/auth/account-role-policy.ts
@@ -27,6 +27,18 @@ export interface AccountRolePolicySummary {
   tenant_manageable: boolean;
 }
 
+export function rolePermissionsSelectSql(
+  roleAlias = "r",
+  columnAlias = "permissions",
+): string {
+  return `COALESCE(
+            (SELECT array_agg(rp.permission ORDER BY rp.permission)
+             FROM role_permissions rp
+             WHERE rp.role_id = ${roleAlias}.id),
+            '{}'
+          ) AS ${columnAlias}`;
+}
+
 function hasGlobalCustomerAccess(permissions: string[]): boolean {
   return permissions.includes("customers:access-all");
 }
@@ -69,13 +81,7 @@ export async function loadAccountRolePolicy(
   roleId: number,
 ): Promise<AccountRolePolicy | null> {
   const { rows } = await query<RolePolicyRow>(
-    `SELECT r.id, r.name,
-            COALESCE(
-              (SELECT array_agg(rp.permission ORDER BY rp.permission)
-               FROM role_permissions rp
-               WHERE rp.role_id = r.id),
-              '{}'
-            ) AS permissions
+    `SELECT r.id, r.name, ${rolePermissionsSelectSql("r")}
        FROM roles r
       WHERE r.id = $1`,
     [roleId],

--- a/src/lib/auth/role-management.ts
+++ b/src/lib/auth/role-management.ts
@@ -2,6 +2,10 @@ import "server-only";
 
 import { query, withTransaction } from "@/lib/db/client";
 
+import {
+  deriveAccountRolePolicy,
+  summarizeAccountRolePolicy,
+} from "./account-role-policy";
 import { invalidatePermissionCache, VALID_PERMISSIONS } from "./permissions";
 
 // ── Types ──────────────────────────────────────────────────────
@@ -18,6 +22,9 @@ export interface RoleRow {
 export interface RoleWithPermissions extends RoleRow {
   permissions: string[];
   account_count: number;
+  requires_customer_assignment: boolean;
+  max_customer_assignments: number | null;
+  tenant_manageable: boolean;
 }
 
 interface ValidationResult {
@@ -59,6 +66,9 @@ export interface RoleSummary {
   name: string;
   description: string | null;
   is_builtin: boolean;
+  requires_customer_assignment: boolean;
+  max_customer_assignments: number | null;
+  tenant_manageable: boolean;
 }
 
 /**
@@ -66,12 +76,29 @@ export interface RoleSummary {
  * Safe for any authenticated user — used by account creation forms.
  */
 export async function getRoles(): Promise<RoleSummary[]> {
-  const { rows } = await query<RoleSummary>(
-    `SELECT id, name, description, is_builtin
-     FROM roles
-     ORDER BY is_builtin DESC, name`,
+  const { rows } = await query<RoleSummary & { permissions: string[] }>(
+    `SELECT r.id, r.name, r.description, r.is_builtin,
+            COALESCE(
+              (SELECT array_agg(rp.permission ORDER BY rp.permission)
+               FROM role_permissions rp WHERE rp.role_id = r.id),
+              '{}'
+            ) AS permissions
+     FROM roles r
+     ORDER BY r.is_builtin DESC, r.name`,
   );
-  return rows;
+  return rows.map((role) => ({
+    id: role.id,
+    name: role.name,
+    description: role.description,
+    is_builtin: role.is_builtin,
+    ...summarizeAccountRolePolicy(
+      deriveAccountRolePolicy({
+        id: role.id,
+        name: role.name,
+        permissions: role.permissions,
+      }),
+    ),
+  }));
 }
 
 /**
@@ -97,6 +124,13 @@ export async function getRolesWithDetails(): Promise<RoleWithPermissions[]> {
   return rows.map((r) => ({
     ...r,
     account_count: Number(r.account_count),
+    ...summarizeAccountRolePolicy(
+      deriveAccountRolePolicy({
+        id: r.id,
+        name: r.name,
+        permissions: r.permissions,
+      }),
+    ),
   }));
 }
 
@@ -124,9 +158,17 @@ export async function getRoleWithPermissions(
 
   if (rows.length === 0) return null;
 
+  const role = rows[0];
   return {
-    ...rows[0],
-    account_count: Number(rows[0].account_count),
+    ...role,
+    account_count: Number(role.account_count),
+    ...summarizeAccountRolePolicy(
+      deriveAccountRolePolicy({
+        id: role.id,
+        name: role.name,
+        permissions: role.permissions,
+      }),
+    ),
   };
 }
 
@@ -177,7 +219,18 @@ export async function createRole(
 
   return {
     valid: true,
-    data: { ...role, permissions, account_count: 0 },
+    data: {
+      ...role,
+      permissions,
+      account_count: 0,
+      ...summarizeAccountRolePolicy(
+        deriveAccountRolePolicy({
+          id: role.id,
+          name: role.name,
+          permissions,
+        }),
+      ),
+    },
   };
 }
 
@@ -246,6 +299,13 @@ export async function updateRole(
       ...updated,
       permissions,
       account_count: existing.account_count,
+      ...summarizeAccountRolePolicy(
+        deriveAccountRolePolicy({
+          id: updated.id,
+          name: updated.name,
+          permissions,
+        }),
+      ),
     },
   };
 }

--- a/src/lib/auth/role-management.ts
+++ b/src/lib/auth/role-management.ts
@@ -4,6 +4,7 @@ import { query, withTransaction } from "@/lib/db/client";
 
 import {
   deriveAccountRolePolicy,
+  rolePermissionsSelectSql,
   summarizeAccountRolePolicy,
 } from "./account-role-policy";
 import { invalidatePermissionCache, VALID_PERMISSIONS } from "./permissions";
@@ -78,11 +79,7 @@ export interface RoleSummary {
 export async function getRoles(): Promise<RoleSummary[]> {
   const { rows } = await query<RoleSummary & { permissions: string[] }>(
     `SELECT r.id, r.name, r.description, r.is_builtin,
-            COALESCE(
-              (SELECT array_agg(rp.permission ORDER BY rp.permission)
-               FROM role_permissions rp WHERE rp.role_id = r.id),
-              '{}'
-            ) AS permissions
+            ${rolePermissionsSelectSql("r")}
      FROM roles r
      ORDER BY r.is_builtin DESC, r.name`,
   );
@@ -111,11 +108,7 @@ export async function getRolesWithDetails(): Promise<RoleWithPermissions[]> {
   >(
     `SELECT r.id, r.name, r.description, r.is_builtin,
             r.created_at, r.updated_at,
-            COALESCE(
-              (SELECT array_agg(rp.permission ORDER BY rp.permission)
-               FROM role_permissions rp WHERE rp.role_id = r.id),
-              '{}'
-            ) AS permissions,
+            ${rolePermissionsSelectSql("r")},
             (SELECT COUNT(*)::TEXT FROM accounts a WHERE a.role_id = r.id) AS account_count
      FROM roles r
      ORDER BY r.is_builtin DESC, r.name`,
@@ -145,11 +138,7 @@ export async function getRoleWithPermissions(
   >(
     `SELECT r.id, r.name, r.description, r.is_builtin,
             r.created_at, r.updated_at,
-            COALESCE(
-              (SELECT array_agg(rp.permission ORDER BY rp.permission)
-               FROM role_permissions rp WHERE rp.role_id = r.id),
-              '{}'
-            ) AS permissions,
+            ${rolePermissionsSelectSql("r")},
             (SELECT COUNT(*)::TEXT FROM accounts a WHERE a.role_id = r.id) AS account_count
      FROM roles r
      WHERE r.id = $1`,


### PR DESCRIPTION
## Summary
- add a shared account role policy helper derived from role permissions
- replace residual account and customer management role-name checks in API and UI flows with policy-based checks while preserving explicit named System Administrator constraints
- add unit and E2E coverage for custom roles that should behave like built-in global-access roles

## Testing
- pnpm check
- pnpm typecheck
- pnpm build
- pnpm vitest run src/__tests__/lib/auth/account-role-policy.test.ts src/__tests__/lib/auth/role-management.test.ts 'src/__tests__/app/api/accounts/route.test.ts' 'src/__tests__/app/api/accounts/[id]/route.test.ts' 'src/__tests__/app/api/accounts/[id]/customers/route.test.ts' 'src/__tests__/app/api/accounts/[id]/unlock/route.test.ts' 'src/__tests__/app/api/accounts/[id]/password-reset/route.test.ts'
- pnpm playwright test --config e2e/playwright.config.ts e2e/accounts.spec.ts

Closes #157