### PR TITLE
Add dashboard account quick actions

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -30,6 +30,8 @@ const READER_ROLE = "E2E Dashboard Reader";
 
 const LOCKED_USER = "e2e-dashboard-locked";
 const LOCKED_PASS = "Locked1234!";
+const SUSPENDED_USER = "e2e-dashboard-suspended";
+const SUSPENDED_PASS = "Suspended1234!";
 
 function csrfHeader(csrfValue: string) {
   return {
@@ -42,6 +44,13 @@ function csrfHeader(csrfValue: string) {
 async function getCsrf(page: import("@playwright/test").Page) {
   const cookies = await page.context().cookies();
   return cookies.find((c) => c.name === "csrf")?.value ?? "";
+}
+
+async function getLockedAccounts(page: import("@playwright/test").Page) {
+  const response = await page.request.get("/api/dashboard/locked-accounts");
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  return body.data as Array<{ username: string; status: string }>;
 }
 
 // ── Setup / Teardown ─────────────────────────────────────────────
@@ -59,11 +68,18 @@ test.beforeAll(async () => {
 
   // Account to lock for locked-accounts card test
   await createTestAccount(LOCKED_USER, LOCKED_PASS, "Tenant Administrator");
+  await createTestAccount(
+    SUSPENDED_USER,
+    SUSPENDED_PASS,
+    "Tenant Administrator",
+  );
 });
 
 test.beforeEach(async () => {
   await resetRateLimits();
   await resetAccountDefaults(ADMIN_USERNAME);
+  await resetAccountDefaults(LOCKED_USER);
+  await resetAccountDefaults(SUSPENDED_USER);
 });
 
 test.afterAll(async () => {
@@ -71,6 +87,7 @@ test.afterAll(async () => {
     await deleteTestAccount(NOPERM_USER);
     await deleteTestAccount(READER_USER);
     await deleteTestAccount(LOCKED_USER);
+    await deleteTestAccount(SUSPENDED_USER);
     await deleteTestRole(NOPERM_ROLE);
     await deleteTestRole(READER_ROLE);
   } catch {
@@ -252,23 +269,25 @@ test("dashboard page redirects for user without dashboard:read", async ({
   });
 });
 
-test("dashboard:read user cannot see revoke buttons", async ({ page }) => {
+test("dashboard:read user cannot see dashboard action buttons", async ({
+  page,
+}) => {
+  await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
+  await setAccountStatus(SUSPENDED_USER, "suspended");
+
   await signInAndWait(page, READER_USER, READER_PASS);
   await page.goto("/dashboard");
 
-  // Wait for sessions card to load
   await expect(page.getByText("Active Sessions")).toBeVisible({
     timeout: 10000,
   });
+  await expect(page.getByText(LOCKED_USER)).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(SUSPENDED_USER)).toBeVisible({ timeout: 5000 });
 
-  // Wait for data to load (either sessions show or "No active sessions")
-  await expect(
-    page.getByText("Active Sessions").locator("..").locator(".."),
-  ).toBeVisible();
-
-  // Revoke buttons should not be present for read-only user
   const revokeButtons = page.getByRole("button", { name: /Revoke/i });
   await expect(revokeButtons).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /Unlock/i })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /Restore/i })).toHaveCount(0);
 });
 
 test("locked account shows in dashboard card", async ({ page }) => {
@@ -290,6 +309,56 @@ test("locked account shows in dashboard card", async ({ page }) => {
     // Restore account status to avoid leaking state
     await setAccountStatus(LOCKED_USER, "active");
   }
+});
+
+test("admin can unlock a locked account from the dashboard", async ({
+  page,
+}) => {
+  await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/dashboard");
+
+  const row = page.locator("tr", { hasText: LOCKED_USER });
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.getByRole("button", { name: "Unlock" }).click();
+
+  const dialog = page.getByRole("alertdialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Unlock" }).click();
+
+  await expect(row).toHaveCount(0);
+
+  await expect
+    .poll(async () => {
+      const accounts = await getLockedAccounts(page);
+      return accounts.some((account) => account.username === LOCKED_USER);
+    })
+    .toBe(false);
+});
+
+test("admin can restore a suspended account from the dashboard", async ({
+  page,
+}) => {
+  await setAccountStatus(SUSPENDED_USER, "suspended");
+  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await page.goto("/dashboard");
+
+  const row = page.locator("tr", { hasText: SUSPENDED_USER });
+  await expect(row).toBeVisible({ timeout: 10000 });
+  await row.getByRole("button", { name: "Restore" }).click();
+
+  const dialog = page.getByRole("alertdialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Restore" }).click();
+
+  await expect(row).toHaveCount(0);
+
+  await expect
+    .poll(async () => {
+      const accounts = await getLockedAccounts(page);
+      return accounts.some((account) => account.username === SUSPENDED_USER);
+    })
+    .toBe(false);
 });
 
 // ── Certificate Expiry API tests ─────────────────────────────────

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -8,7 +8,16 @@ export default async function DashboardPage() {
 
   await requirePermission(session, "dashboard:read");
 
-  const canWrite = await hasPermission(session.roles, "dashboard:write");
+  const canWriteSessions = await hasPermission(
+    session.roles,
+    "dashboard:write",
+  );
+  const canWriteAccounts = await hasPermission(session.roles, "accounts:write");
 
-  return <DashboardPanel canWrite={canWrite} />;
+  return (
+    <DashboardPanel
+      canWriteSessions={canWriteSessions}
+      canWriteAccounts={canWriteAccounts}
+    />
+  );
 }

--- a/src/components/dashboard/dashboard-panel.tsx
+++ b/src/components/dashboard/dashboard-panel.tsx
@@ -8,18 +8,22 @@ import { LockedAccountsCard } from "./locked-accounts-card";
 import { SuspiciousAlertsCard } from "./suspicious-alerts-card";
 
 interface DashboardPanelProps {
-  canWrite: boolean;
+  canWriteSessions: boolean;
+  canWriteAccounts: boolean;
 }
 
-export function DashboardPanel({ canWrite }: DashboardPanelProps) {
+export function DashboardPanel({
+  canWriteSessions,
+  canWriteAccounts,
+}: DashboardPanelProps) {
   const t = useTranslations("dashboard");
 
   return (
     <div className="space-y-6">
       <h1 className="text-foreground text-2xl font-bold">{t("title")}</h1>
       <div className="grid gap-6 lg:grid-cols-2">
-        <ActiveSessionsCard canWrite={canWrite} />
-        <LockedAccountsCard />
+        <ActiveSessionsCard canWrite={canWriteSessions} />
+        <LockedAccountsCard canWrite={canWriteAccounts} />
       </div>
       <div className="grid gap-6 lg:grid-cols-2">
         <SuspiciousAlertsCard />

--- a/src/components/dashboard/locked-accounts-card.tsx
+++ b/src/components/dashboard/locked-accounts-card.tsx
@@ -4,7 +4,20 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 
 import { useTimezone } from "@/components/providers/timezone-provider";
+import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -37,13 +50,14 @@ interface LockedAccount {
 
 // ── Component ────────────────────────────────────────────────────
 
-export function LockedAccountsCard() {
+export function LockedAccountsCard({ canWrite }: { canWrite: boolean }) {
   const t = useTranslations("dashboard.lockedAccounts");
   const tz = useTimezone();
 
   const [accounts, setAccounts] = useState<LockedAccount[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
 
   const fetchAccounts = useCallback(async () => {
     setLoading(true);
@@ -63,6 +77,42 @@ export function LockedAccountsCard() {
   useEffect(() => {
     fetchAccounts();
   }, [fetchAccounts]);
+
+  const handleResolve = useCallback(
+    async (account: LockedAccount) => {
+      setPendingId(account.id);
+      setError(null);
+      try {
+        const csrf = readCsrfToken();
+        const res = await fetch(`/api/accounts/${account.id}/unlock`, {
+          method: "POST",
+          headers: {
+            "x-csrf-token": csrf ?? "",
+            "Content-Type": "application/json",
+          },
+        });
+
+        if (!res.ok) {
+          throw new Error(t("actionError"));
+        }
+
+        setAccounts((prev) => prev.filter((item) => item.id !== account.id));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("actionError"));
+      } finally {
+        setPendingId(null);
+      }
+    },
+    [t],
+  );
+
+  function actionLabel(status: string) {
+    return status === "locked" ? t("unlock") : t("restore");
+  }
+
+  function actionConfirm(status: string) {
+    return status === "locked" ? t("unlockConfirm") : t("restoreConfirm");
+  }
 
   return (
     <Card>
@@ -89,6 +139,7 @@ export function LockedAccountsCard() {
                   <TableHead>{t("failedAttempts")}</TableHead>
                   <TableHead>{t("lockedUntil")}</TableHead>
                   <TableHead>{t("updatedAt")}</TableHead>
+                  {canWrite && <TableHead />}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -118,6 +169,41 @@ export function LockedAccountsCard() {
                     <TableCell className="whitespace-nowrap text-xs">
                       {formatDateTime(a.updated_at, tz)}
                     </TableCell>
+                    {canWrite && (
+                      <TableCell>
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={pendingId === a.id}
+                            >
+                              {actionLabel(a.status)}
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                {actionLabel(a.status)}
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                {actionConfirm(a.status)}
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>
+                                {t("cancel")}
+                              </AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleResolve(a)}
+                              >
+                                {actionLabel(a.status)}
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </TableCell>
+                    )}
                   </TableRow>
                 ))}
               </TableBody>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -333,6 +333,12 @@
       "updatedAt": "Updated",
       "locked": "Locked",
       "suspended": "Suspended",
+      "unlock": "Unlock",
+      "unlockConfirm": "Are you sure you want to unlock this account? The account will become active immediately.",
+      "restore": "Restore",
+      "restoreConfirm": "Are you sure you want to restore this suspended account? The account will become active immediately.",
+      "cancel": "Cancel",
+      "actionError": "Failed to update account status",
       "noAccounts": "No locked or suspended accounts",
       "loading": "Loading accounts...",
       "error": "Failed to load accounts"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -333,6 +333,12 @@
       "updatedAt": "수정일",
       "locked": "잠금",
       "suspended": "정지",
+      "unlock": "잠금 해제",
+      "unlockConfirm": "이 계정을 잠금 해제하시겠습니까? 계정은 즉시 활성 상태로 돌아갑니다.",
+      "restore": "복구",
+      "restoreConfirm": "정지된 이 계정을 복구하시겠습니까? 계정은 즉시 활성 상태로 돌아갑니다.",
+      "cancel": "취소",
+      "actionError": "계정 상태 변경에 실패했습니다",
       "noAccounts": "잠긴 또는 정지된 계정이 없습니다",
       "loading": "계정 로딩 중...",
       "error": "계정을 불러오지 못했습니다"


### PR DESCRIPTION
## Summary
- add unlock and restore quick actions to the locked and suspended accounts dashboard card
- gate session actions behind `dashboard:write` and account actions behind `accounts:write` so the UI matches the existing APIs
- remove resolved accounts from the card immediately after success and extend E2E coverage for dashboard quick actions and the related hardening regressions

## Validation
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm playwright test --config e2e/playwright.config.ts e2e/dashboard.spec.ts e2e/sign-out-all.spec.ts e2e/session-extension.spec.ts`
- nginx dev/prod config validation with Docker
- `docker build -t aice-web-next:issue-158 .`

Closes #158