### PR TITLE
Update commit message guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,12 @@
 
 ## Commit messages
 
-- Title: max 50 characters, start with imperative verb (e.g., `Add`, `Fix`,
-  `Remove`)
+- Title: preferably under 50 characters, start with imperative verb (e.g.,
+  `Add`, `Fix`, `Remove`)
 - Body: wrap at 72 characters, free-form, explain *why* not *what*
 - Separate title and body with a blank line
-- Reference issues with `Closes #N` or `Refs #N` in the body
+- Reference issues: use `Closes #N` to close an issue, or `Part of #N` when
+  the commit addresses part of an issue
 
 ## Language
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## Commit messages
 
-- Title: max 50 characters, start with imperative verb (e.g., `Add`, `Fix`,
-  `Remove`)
+- Title: preferably under 50 characters, start with imperative verb (e.g.,
+  `Add`, `Fix`, `Remove`)
 - Body: wrap at 72 characters, free-form, explain *why* not *what*
 - Separate title and body with a blank line
-- Reference issues with `Closes #N` or `Refs #N` in the body
+- Reference issues: use `Closes #N` to close an issue, or `Part of #N` when
+  the commit addresses part of an issue
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

- Soften title length rule from "max 50 characters" to "preferably under 50 characters"
- Clarify issue references: `Closes #N` to close an issue, `Part of #N` for partial work (replaces generic `Refs #N`)
- Applied to both `CLAUDE.md` and `AGENTS.md`

Closes #172