### PR TITLE
Upgrade PostgreSQL from 17 to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:17-bookworm
+        image: postgres:18-trixie
         env:
           POSTGRES_DB: auth_db
           POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17-bookworm
+    image: postgres:18-trixie
     profiles: [dev, prod]
     environment:
       POSTGRES_DB: auth_db
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/18/docker
       - ./infra/postgres/init-audit-db.sql:/docker-entrypoint-initdb.d/init-audit-db.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]


### PR DESCRIPTION
## Summary

- Upgrade Docker image from `postgres:17-bookworm` (Debian 12) to `postgres:18-trixie` (Debian 13)
- Update PGDATA volume mount path to `/var/lib/postgresql/18/docker`
- Apply changes to both `docker-compose.yml` and `.github/workflows/ci.yml`

## Test plan

- [x] CI E2E tests pass with `postgres:18-trixie`
- [x] Verify local dev environment starts correctly with the new image
- [x] Confirm existing migrations run without issues on PostgreSQL 18

Closes #174