### PR TITLE
Move discussions to decisions/ and skip CI for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Change Filter
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.decide.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Filter Paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            docs:
+              - "docs/**"
+              - "decisions/**"
+              - "**/*.md"
+              - "mkdocs.yml"
+              - ".markdownlint*"
+            code:
+              - "src/**"
+              - "e2e/**"
+              - "migrations/**"
+              - "scripts/**"
+              - "infra/**"
+              - "public/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "tsconfig*.json"
+              - "next.config.*"
+              - "biome.json"
+              - "Dockerfile*"
+              - "docker-compose.yml"
+              - ".github/workflows/**"
+
+      - name: Decide Docs-Only
+        id: decide
+        run: |
+          if [ "${{ steps.filter.outputs.docs }}" = "true" ] && [ "${{ steps.filter.outputs.code }}" != "true" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
   check:
     name: Check
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -39,6 +85,8 @@ jobs:
 
   nginx-config:
     name: Nginx Config
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/decisions/account-management.md
+++ b/decisions/account-management.md
@@ -1,0 +1,770 @@
+# aice-web-next Account Management Feature Specification (v23)
+
+## Context
+
+This specification defines the account management features for aice-web-next, based on the architecture and security principles established in:
+
+- **Discussion #556**: AICE/Aimer authentication, certificate, session, and data flow design
+- **Discussion #555**: Data, authentication, secret, encryption, and audit log design principles
+
+aice-web-next is the **sole owner of account management**. REview/Giganto do not store account information or provide account-related APIs. Communication with REview/Giganto uses mTLS + Context JWT (already implemented). Account data is stored in PostgreSQL.
+
+---
+
+## 1. Role System
+
+### 1.1 Built-in Roles
+
+| Role                       | Description                                         | Deletable |
+| -------------------------- | --------------------------------------------------- | --------- |
+| **System Administrator**   | Full system, account, role, customer mgmt           | No        |
+| **Tenant Administrator**   | Tenant-scoped operations + Security Monitor account mgmt | No   |
+| **Security Monitor**       | Event/dashboard read-only                           | No        |
+
+- Built-in roles cannot be deleted, but their permissions can be modified within constraints (see below).
+- Auto-created on first system startup.
+- Each role has an `mfa_required` attribute (default: `false`) configurable by System Administrator. Determines whether accounts of that role must register MFA before accessing the system.
+
+**Immutable Permission Constraints (System Administrator)**:
+
+The following permissions cannot be removed from System Administrator role to prevent self-lockout:
+
+- `accounts:read`, `accounts:write`, `accounts:delete`
+- `roles:read`, `roles:write`, `roles:delete`
+- `customers:read`, `customers:write`, `customers:access-all`
+- `system-settings:read`, `system-settings:write`
+
+Other permissions on System Administrator may be added/removed freely. Tenant Administrator and Security Monitor have no immutable constraints (all permissions modifiable by System Administrator).
+
+### 1.2 Custom Role
+
+- Created, modified, deleted by System Administrator.
+- Defined by combining permissions.
+- Can be created by cloning a built-in role.
+- Customer assignment required (same as Tenant Administrator and Security Monitor).
+- Accounts with a Custom Role are managed (created, updated, deleted) by System Administrator only. Tenant Administrator cannot manage Custom Role accounts.
+
+### 1.3 Permission Model
+
+Resource + action combinations (account management scope):
+
+````
+accounts:read        accounts:write       accounts:delete
+roles:read           roles:write          roles:delete
+customers:read       customers:write      customers:access-all
+audit-logs:read
+system-settings:read system-settings:write
+````
+
+- Data access permissions (events, sensors, policies, dashboards, reports) are out of scope for this specification and will be defined separately.
+- Custom roles may combine any of the above permissions.
+
+### 1.4 Default Permission Sets
+
+| Permission              | System Administrator | Tenant Administrator | Security Monitor |
+| ----------------------- | :------------------: | :------------------: | :--------------: |
+| `accounts:read`         | ✅ 🔒               | ✅ ¹               | —                |
+| `accounts:write`        | ✅ 🔒               | ✅ ¹               | —                |
+| `accounts:delete`       | ✅ 🔒               | ✅ ¹               | —                |
+| `roles:read`            | ✅ 🔒               | —                    | —                |
+| `roles:write`           | ✅ 🔒               | —                    | —                |
+| `roles:delete`          | ✅ 🔒               | —                    | —                |
+| `customers:read`        | ✅ 🔒               | ✅ ²               | —                |
+| `customers:write`       | ✅ 🔒               | ✅ ²               | —                |
+| `customers:access-all`  | ✅ 🔒               | —                    | —                |
+| `audit-logs:read`       | ✅                   | —                    | —                |
+| `system-settings:read`  | ✅ 🔒               | —                    | —                |
+| `system-settings:write` | ✅ 🔒               | —                    | —                |
+
+🔒 = immutable (System Administrator only, cannot be removed)
+
+¹ Scoped: own assigned customers only, Security Monitor accounts only (role hierarchy per §4.4.1 — cannot manage equal or higher-privilege accounts).
+
+² Scoped: own assigned customers only. System Administrator sees all customers via `customers:access-all`; Tenant Administrator sees only assigned ones.
+
+**Implicit rights (all users, no permission required)**: all users can view their own profile and update `display_name`, `email`, `phone`, `password`, `locale`, `timezone` per §4.4.
+
+- Security Monitor has no account management permissions. Its primary permissions (events, dashboards, etc.) are defined in the data access specification.
+- All defaults (except 🔒) can be modified by System Administrator.
+
+---
+
+## 2. Multi-tenant Access Control
+
+### 2.1 Customer Access by Role
+
+| Role                       | Customer access                                          | Configuration                                          |
+| -------------------------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| **System Administrator**   | `customers:access-all` auto-granted; no individual mapping | Automatic on account creation                          |
+| **Tenant Administrator**   | Multiple customers allowed (1+)                          | System Administrator assigns at account creation       |
+| **Security Monitor**       | **Single customer only**                                 | System Administrator or Tenant Administrator assigns   |
+| **Custom Role**            | Multiple customers (1+)                                  | System Administrator assigns at account creation       |
+
+- `customers:access-all` can only be granted to System Administrator.
+- Tenant Administrator, Security Monitor, and Custom Role accounts cannot be created without at least one customer assignment.
+- System Administrator can add/remove customer assignments after creation.
+- Tenant Administrator can add/remove customer assignments for Security Monitor accounts, but only within their own assigned customers.
+- Context JWT includes `customer_ids` so that REview/Giganto return only data the requesting account is authorized to access.
+
+### 2.2 Customer Isolation
+
+| Item                        | Policy                                                                  |
+| --------------------------- | ----------------------------------------------------------------------- |
+| Customer data (customer_db)   | Separate database per customer                                            |
+| Account/auth (auth_db)      | Single database, `account_customer` mapping for access control            |
+| API requests                | `customer_id` required for all data queries, access rights enforced     |
+| Customer deletion           | customer_db drop + auth_db mapping removal + RocksDB key prefix range delete |
+
+### 2.3 Customer Management
+
+#### Customer Attributes (auth_db)
+
+| Field           | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `id` (SERIAL)   | Unique identifier, monotonically increasing, never reused |
+| `name`          | Customer display name                                  |
+| `description`   | Optional description                                   |
+| `created_at`    | Creation timestamp                                     |
+| `updated_at`    | Update timestamp                                       |
+
+- `id` uses a sequence (SERIAL/BIGSERIAL) and is never recycled. Deleted customer IDs are permanently retired to ensure consistency across audit logs, Context JWT history, and external system references (e.g., customer_db names, RocksDB key prefixes).
+- Additional columns will be added as requirements evolve.
+
+#### Customer CRUD
+
+| Action   | System Administrator | Tenant Administrator       | Security Monitor |
+| -------- | :------------------: | :------------------------: | :--------------: |
+| Create   | ✅                  | ❌                         | ❌              |
+| Read     | ✅ (all)            | ✅ (assigned only)         | ❌              |
+| Update   | ✅ (all)            | ✅ (assigned only)         | ❌              |
+| Delete   | ✅                  | ❌                         | ❌              |
+
+- **Create**: System Administrator only. Creates a new customer record and the corresponding `customer_db`.
+- **Read**: `customers:read` required. System Administrator sees all via `customers:access-all`; Tenant Administrator sees assigned customers only.
+- **Update**: `customers:write` required. System Administrator can update any customer; Tenant Administrator can update assigned customers only.
+- **Delete**: System Administrator only. Triggers: customer_db drop + auth_db mapping removal + RocksDB key prefix range delete (per §2.2).
+- Customer with active account assignments cannot be deleted. All account-customer mappings must be removed first.
+
+---
+
+## 3. DB Separation
+
+````
+PostgreSQL
+├── auth_db          ← Accounts, roles, sessions (aice-web-next only)
+├── audit_db         ← Audit logs (aice-web-next only, separate retention/backup)
+└── customer_db (×N) ← Per-customer input data, reports (one per customer)
+````
+
+- aice-web-next is the sole owner of auth_db, audit_db, and customer_db. It manages the full lifecycle of customer databases: creation (§2.3), schema migration, and deletion (§2.2).
+- REview/Giganto do not manage customer databases or customer metadata. They receive customer information from aice-web-next through two distinct channels:
+  - **Context JWT (`customer_ids`)** — authentication/authorization scope. When aice-web-next calls a REview/Giganto API, the JWT carries the requesting account's accessible `customer_ids` so the backend returns only authorized data.
+  - **Explicit API calls** — aice-web-next calls REview/Giganto APIs to push the full customer list or other customer attributes (e.g., after customer creation, update, or deletion) so they can keep their local state in sync. **Note:** The exact timing and trigger conditions for these sync calls are critical for data consistency across services and must be carefully designed during implementation.
+- auth_db does not store DB connection credentials.
+- DB connection credentials are injected from OpenBao.
+
+---
+
+## 4. Account
+
+### 4.1 Account Attributes (auth_db)
+
+| Field                  | Description                                   | Encryption                |
+| ---------------------- | --------------------------------------------- | ------------------------- |
+| `id` (UUID)            | Unique identifier                             | No                        |
+| `username`             | Unique sign-in name                           | No                        |
+| `display_name`         | UI display name                               | No                        |
+| `password_hash`        | PHC string format (includes algorithm + params) | Hash is self-protecting |
+| `email`                | Contact (optional)                            | **Yes** — column encryption |
+| `phone`                | Contact (optional)                            | **Yes** — column encryption |
+| `status`               | `active`, `locked`, `suspended`, `disabled`   | No                        |
+| `token_version`        | Logical session invalidation counter          | No                        |
+| `must_change_password` | Force password change on next sign-in         | No                        |
+| `mfa_required`         | MFA enforcement override: `null` = follow role default, `true` = required, `false` = exempt | No |
+| `failed_sign_in_count` | Consecutive failure count                     | No                        |
+| `locked_until`         | Lock release time (null = not locked)         | No                        |
+| `max_sessions`         | Per-account max concurrent sessions (null = use global default) | No |
+| `allowed_ips`          | Allowed IPs/CIDRs, max 5 (null = no restriction) | No                    |
+| `locale`               | Preferred language (null = browser default)    | No                        |
+| `timezone`             | Preferred timezone (null = browser default)    | No                        |
+| `last_sign_in_at`      | Last sign-in timestamp                        | No                        |
+| `password_changed_at`  | Last password change timestamp                | No                        |
+| `created_at`           | Creation timestamp                            | No                        |
+| `updated_at`           | Update timestamp                              | No                        |
+
+- SSN, passport, card numbers are never stored.
+- `email` and `phone` use Envelope Encryption (DEK wrapped by KEK (managed by OpenBao)).
+- `allowed_ips`: `null` means no restriction (access from anywhere); when set, max 5 entries. Supports individual IPs and CIDR notation (e.g., `192.168.1.0/24`). System Administrator only.
+- `max_sessions`: `null` falls back to global default in System Settings. System Administrator only.
+- `locale` and `timezone`: user can change their own. `null` means use browser defaults (`navigator.language`, `Intl.DateTimeFormat().resolvedOptions().timeZone`).
+
+### 4.2 Password Hash Format (PHC String)
+
+Industry de facto standard. A single string contains algorithm, version, parameters, salt, and hash:
+
+````
+$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$RdescudvJCsgt3ub+b+daw
+````
+
+- No separate column needed for algorithm or parameters.
+- On algorithm upgrade, existing hashes are identified by prefix and re-hashed on next successful sign-in (transparent migration).
+
+### 4.3 Column Encryption
+
+- Envelope Encryption per Discussion #555 §9.
+- DEK encrypts column value → DEK wrapped by KEK (managed by OpenBao).
+- Encryption metadata (`dek_wrapped`, `kek_key_id`, `kek_key_version`, `nonce`) stored alongside.
+- Decryption impossible without OpenBao.
+
+### 4.4 Account CRUD
+
+- **Create**: System Administrator can create all account types. Tenant Administrator can create Security Monitor accounts within their own assigned customers. Initial password + `must_change_password=true`. Customer assignment required (except System Administrator).
+- **Read**: All users can view their own profile without `accounts:read`. Self-visible fields: `username`, `display_name`, `email`, `phone`, `status`, `locale`, `timezone`, `max_sessions`, `allowed_ips`, `created_at`, `last_sign_in_at`, `password_changed_at`. Internal fields not exposed to self: `failed_sign_in_count`, `locked_until`, `token_version`, `must_change_password`. `accounts:read` enables viewing other accounts (scoped by customer assignment and role hierarchy per §4.4.1).
+- **Update**: Self can change `display_name`, `email`, `phone`, `password`, `locale`, `timezone`. All other fields require `accounts:write`. `mfa_required` override is System Administrator only (or Tenant Administrator for Security Monitor accounts within their customers). Tenant Administrator can update other Security Monitor fields within their customers.
+- **Disable**: System Administrator can disable any account. Tenant Administrator can disable Security Monitor accounts within their customers. Status → `disabled`, `token_version` incremented (immediate session invalidation).
+- **Delete**: System Administrator can delete any account. Tenant Administrator can delete Security Monitor accounts they created. Soft delete (audit trail preserved).
+
+### 4.4.1 Delegated Account Management (Tenant Administrator)
+
+| Action                           | Scope                                      |
+| -------------------------------- | ------------------------------------------ |
+| Create Security Monitor          | Own assigned customers only                  |
+| Assign customer to Security Monitor | Own assigned customers only               |
+| Update Security Monitor          | Within own assigned customers                |
+| Disable/Delete Security Monitor  | Within own assigned customers                |
+| Create Tenant Administrator      | ❌ (System Administrator only)             |
+| Create System Administrator      | ❌ (System Administrator only)             |
+
+- Tenant Administrator cannot create accounts with equal or higher privilege (privilege escalation prevention).
+- If a customer is unassigned from a Tenant Administrator, that Tenant Administrator immediately loses management rights over all Security Monitor accounts belonging to that customer — even ones they originally created.
+
+### 4.5 System Administrator Account Limits
+
+| Item    | Value                                       |
+| ------- | ------------------------------------------- |
+| Minimum | 1 (auto-created at first boot, undeletable) |
+| Maximum | 5 (hardcoded)                               |
+
+- Maximum is not configurable via UI or System Settings.
+- If override is ever needed, use environment variable at deployment time.
+
+### 4.6 Initial Administrator Account
+
+- Installer collects initial admin `username` and `password`.
+- Two injection methods (in priority order):
+  1. **Secret file**: `/run/secrets/init_admin_username`, `/run/secrets/init_admin_password` — read once, then:
+     - Attempt deletion. If successful, done.
+     - If deletion fails (e.g., RO mount like Docker Secrets), write a consumed marker to app data directory (`${DATA_DIR}/.init_admin_consumed`) and refuse to re-read the secret files while the marker exists. `DATA_DIR` defaults to `./data` (configurable via environment variable).
+  2. **Environment variable**: `INIT_ADMIN_USERNAME`, `INIT_ADMIN_PASSWORD` — fallback if secret files do not exist.
+- Secret file takes priority over environment variable if both exist.
+- On first startup, aice-web-next reads credentials from the above sources.
+- If auth_db has 0 accounts, creates System Administrator account with `must_change_password=true`.
+- If accounts already exist, ignores the credentials.
+- All account creation logic (hashing, policy validation, DB write) lives solely in aice-web-next.
+
+---
+
+## 5. Password Policy
+
+| Item                           | Default                                            | Configurable |
+| ------------------------------ | -------------------------------------------------- | ------------ |
+| Minimum length                 | 12 characters                                      | Yes          |
+| Maximum length                 | 128 characters                                     | No           |
+| Complexity rules               | **Disabled** (NIST SP 800-63B aligned)             | Yes (enable in System Settings) |
+| Unicode allowed                | Yes                                                | No           |
+| Previous password reuse ban    | Last 5                                             | Yes          |
+| Password blocklist             | Top 100K common passwords (bundled, offline)       | No           |
+| Periodic password change       | **Disabled** (NIST SP 800-63B aligned)             | Yes (90/180 days, see note below) |
+| Compromised password check     | Future: full HIBP dataset (CC0 license)            | —            |
+
+- **Argon2id** hashing with configurable memory/time parameters.
+- Password history stored as hashes (for reuse validation).
+- **Self change**: current password verification required.
+- **Admin reset**: System Administrator sets temporary password → `must_change_password=true`.
+
+### Complexity Rules Note
+
+- NIST SP 800-63B: recommends length over complexity rules.
+- ISMS-P / KISA: requires 3+ character type combination for 8+ chars, or 2+ for 10+ chars.
+- **Default: disabled** (NIST-aligned). Long passphrase + blocklist provides sufficient security without complexity burden.
+- System Settings allows **enabling** complexity rules for ISMS-P compliance (3+ of: uppercase, lowercase, digits, special chars).
+
+### Password Blocklist
+
+- Bundled top 100K common passwords (static file, no external network).
+- Checked at password creation and change time.
+- Rejection message: generic "password does not meet policy" (no hint about blocklist to avoid information leakage).
+- Phase 4: expand to full HIBP dataset (CC0 license, offline k-Anonymity).
+
+### Periodic Password Change Note
+
+- **Default: disabled** (NIST SP 800-63B aligned — periodic change increases weak-password reuse and provides minimal security benefit).
+- Current regulations (개인정보의 안전성 확보조치 기준 제5조) do **not** mandate periodic change when sufficient complexity rules are enforced.
+- Can be enabled in System Settings if an ISMS-P auditor requires it (configurable period: 90/180 days).
+
+---
+
+## 6. Authentication
+
+### 6.1 Sign-in
+
+- `POST /api/auth/sign-in`
+- Username + Password verification.
+- Success → session record created (§8.2) → JWT issued (with `sid`) → `HttpOnly + Secure + SameSite=Strict` Cookie.
+- If `must_change_password=true` → redirect to password change screen.
+- Failure → `failed_sign_in_count` incremented.
+- If `allowed_ips` is set, reject sign-in from unlisted IPs before password verification.
+
+### 6.2 Sign Out (3 variants)
+
+| Function               | Action                                               | Who              |
+| ---------------------- | ---------------------------------------------------- | ---------------- |
+| Current session        | Revoke `sid` + delete cookie                         | Self             |
+| All own sessions       | Increment `token_version` (all `sid`s revoked)       | Self             |
+| Force sign out (other) | Increment target's `token_version` (all `sid`s revoked) | System Administrator (any account), Tenant Administrator (Security Monitors within their customers) |
+
+### 6.3 Two-stage Account Lockout
+
+**Stage 1: Temporary Lock**
+
+| Item             | Default          | Configurable |
+| ---------------- | ---------------- | ------------ |
+| Failure threshold | 5 consecutive    | Yes (System Administrator) |
+| Lock duration     | 30 minutes       | Yes (System Administrator) |
+
+- Status → `locked`, `locked_until` set.
+- Auto-unlocks after duration. `failed_sign_in_count` resets.
+
+**Stage 2: Suspended**
+
+| Item             | Default          | Configurable |
+| ---------------- | ---------------- | ------------ |
+| Failure threshold after unlock | 3 consecutive | Yes (System Administrator) |
+
+- If user is temporarily locked, then unlocked by time, then fails again past this threshold → Status → `suspended`.
+- `suspended` accounts can only be restored by System Administrator.
+
+**DoS Protection — 3-tier Rate Limiting**
+
+Sign-in endpoint uses three independent rate limit buckets:
+
+| Bucket            | Default          | Purpose                               |
+| ----------------- | ---------------- | ------------------------------------- |
+| **Per-IP**        | 20 / 5 min       | Blocks brute-force from single source |
+| **Per-account+IP**| 5 / 5 min        | Limits targeted attack per source     |
+| **Global**        | 100 / 1 min      | Caps total sign-in throughput (anti-botnet) |
+
+- Exceeding any bucket → reject with `429 Too Many Requests` + `Retry-After` header.
+- Exponential backoff on response time after repeated failures from same IP.
+- Rate limits are independent of per-account lockout (§6.3 Stage 1/2) — both apply simultaneously.
+- All thresholds configurable in System Settings (§15).
+
+**General API Rate Limiting**
+
+Authenticated API endpoints are not rate-limited per-endpoint. Instead, a general per-user rate limit applies to all authenticated requests (configured in System Settings). Two categories of exceptions with tighter per-user limits:
+
+| Category                  | Reason                                            |
+| ------------------------- | ------------------------------------------------- |
+| Password change           | Prevents brute-force of current password via API  |
+| MFA verification          | Prevents TOTP code brute-force                    |
+
+- Sign-in endpoint rate limits (above) apply regardless of authentication state and are separate from the general API rate limit.
+
+**Account Recovery**
+
+- `locked` → `active`: manual unlock, `failed_sign_in_count` reset.
+- `suspended` → `active`: manual restore, `failed_sign_in_count` reset.
+- System Administrator can recover any account.
+- Tenant Administrator can recover Security Monitor accounts within their customers.
+- All recovery actions recorded in audit log.
+
+### 6.4 MFA
+
+MFA is available to all roles. Enforcement is controlled via `mfa_required` at two levels:
+
+| Level        | Who can set                                         | Scope                             |
+| ------------ | --------------------------------------------------- | --------------------------------- |
+| Role-level   | System Administrator                                | All accounts of that role         |
+| Account-level | System Administrator                               | Any account                       |
+| Account-level | Tenant Administrator                               | Security Monitor accounts within their assigned customers only |
+
+**Effective MFA Requirement**
+
+| Account `mfa_required` | Role `mfa_required` | Result   |
+| ---------------------- | ------------------- | -------- |
+| `true`                 | any                 | Required |
+| `false`                | any                 | Optional |
+| `null`                 | `true`              | Required |
+| `null`                 | `false`             | Optional |
+
+- All built-in roles default to `mfa_required = false`.
+- When required: first sign-in with ID/PW → forced MFA registration prompt → subsequent sign-ins require MFA.
+
+**MFA Methods (available to all roles)**
+
+| Method             | Description                                                      |
+| ------------------ | ---------------------------------------------------------------- |
+| **WebAuthn/FIDO2** | Hardware key or platform authenticator (Windows Hello PIN, Touch ID) |
+| **TOTP**           | Authenticator app, 30-sec cycle                                  |
+
+System Administrator can restrict which methods are available system-wide via System Settings (§15). Default: both enabled.
+
+| Setting            | Effect                                                           |
+| ------------------ | ---------------------------------------------------------------- |
+| WebAuthn + TOTP    | Both methods available (default)                                 |
+| WebAuthn only      | TOTP registration and sign-in disabled                           |
+| TOTP only          | WebAuthn registration and sign-in disabled                       |
+
+- WebAuthn recommended (phishing-resistant, no clock dependency).
+- TOTP depends on clock synchronization between the authenticator device and the server. In closed networks without a reliable internal NTP server, clock drift can exceed the ±1 step tolerance (~90 seconds), causing TOTP failures. In such environments, disabling TOTP and requiring WebAuthn only is recommended.
+- If a method is disabled after users have already registered with it, those users must register the allowed method before their next sign-in. Existing credentials of the disabled method are no longer accepted for sign-in.
+- Falls back to TOTP if WebAuthn credential not registered (only when both methods are enabled).
+
+**Once MFA is registered:**
+- **ID/PW-only sign-in is disabled** while MFA is registered.
+- MFA can be removed only by System Administrator (or Tenant Administrator for Security Monitors). Removal re-enables ID/PW-only sign-in. If enforcement remains `true`, the account will be prompted to re-register MFA on next sign-in.
+
+**TOTP Details**
+
+- QR code displayed on screen → scan with authenticator app.
+- Code validity: 30-second cycle, ±1 step tolerance (~90 seconds clock skew).
+- No external network required — works in closed networks.
+- Time skew tracking: server records per-user offset if codes consistently match at an offset.
+
+**WebAuthn/FIDO2 Details**
+
+- Register after sign-in.
+- Supports: hardware security keys (USB/NFC), platform authenticators (Windows Hello PIN, macOS Touch ID).
+- Enables fast re-authentication via biometric/PIN.
+- Works offline in closed networks (no attestation server needed).
+
+**MFA Recovery**
+
+- On MFA registration, generate **one-time recovery codes** (10 codes, single-use). Displayed once, user must store securely offline.
+- **Storage**: recovery codes stored as one-way hashes (same as passwords). Plaintext is never persisted. Used codes are immediately deleted from DB. On regeneration, all existing codes are invalidated before new ones are issued.
+- **Verification**: recovery code input is compared using constant-time comparison (`hmac.Equal` / `crypto.timingSafeEqual`) to prevent timing side-channel attacks.
+- Recovery code can substitute MFA during sign-in (each code usable once).
+- If all recovery codes exhausted and MFA device lost:
+  - **Administrator reset**: System Administrator (or Tenant Administrator for Security Monitors) resets MFA. Requires acting admin's own MFA verification (step-up) if the admin has MFA registered.
+  - **Break-glass** (when no other administrator with active MFA can help):
+    - Set environment variable `EMERGENCY_MFA_RESET=<username>` and `EMERGENCY_MFA_REASON="<mandatory reason text>"` before restart.
+    - On startup, aice-web-next processes the reset **once**: MFA cleared → `must_change_password=true` set → environment variable consumed and ignored on subsequent restarts (tracked via `${DATA_DIR}/.mfa_reset_consumed`).
+    - **Expiry**: if not consumed within 10 minutes of process start, the reset is discarded (prevents stale env vars from firing on later restarts).
+    - Audit log records (fixed fields): `system` as actor, target username, reason text, timestamp, `request_id` (auto-generated UUID per reset), `operator_id` (OS user or service account that set the env var, if determinable), `deployment_id` (container/ instance identifier), source IP of first sign-in after reset.
+    - **Reason is mandatory**: reset without `EMERGENCY_MFA_REASON` is rejected (logged as failed break-glass attempt).
+    - **Operational requirement**: remove `EMERGENCY_MFA_RESET` and `EMERGENCY_MFA_REASON` from process environment immediately after restart. Do not include in process environment dumps, debug logs, or crash reports.
+- All MFA reset actions recorded in audit log.
+
+---
+
+## 7. JWT Operation
+
+### 7.1 Access JWT Payload
+
+````
+{
+  "iss": "aice-web-next",
+  "sub": "user-uuid",
+  "aud": "aice-web-next",
+  "iat": 1730000000,
+  "exp": 1730000900,
+  "sid": "session-uuid",
+  "roles": ["Tenant Administrator"],
+  "token_version": 3
+}
+````
+
+- `sid`: per-session identifier. Each sign-in creates a new session with its own `sid`. Enables per-session revocation and tracking.
+- `roles`: used by Next.js middleware for route protection. Permission lookup (role → permission set) is performed against a server-side cache; no DB hit per request. Cache is invalidated on role permission change.
+- `permissions` claim is **not included**: derivable from `roles` via cache.
+- `customer_ids` claim is **not included**: the JWT controls only whether access is granted. Once authenticated, aice-web-next looks up the account's accessible customers from a server-side cache on demand. Included in the inter-service Context JWT (§2.1) when forwarding requests to REview/Giganto.
+- JWT header includes `kid` (Key ID) for key rotation support (§11).
+
+### 7.2 Lifetime and Storage
+
+| Item           | Value                                          |
+| -------------- | ---------------------------------------------- |
+| Expiration     | 15 minutes (configurable, 5–15 min range)      |
+| Storage        | `HttpOnly + Secure + SameSite=Strict` Cookie   |
+| Refresh Token  | Not used                                       |
+
+**Why Refresh Token is not used**
+
+A Refresh Token serves two primary purposes: (1) renewing a short-lived Access Token without re-authentication, and (2) enabling stateless AT validation in microservice environments where each service verifies the AT independently while only the central Auth server handles renewal.
+
+Neither purpose applies here:
+
+1. **UX role is covered by Sliding Rotation**: Active users never hit the expiry wall because Sliding Rotation (§7.3) automatically reissues the JWT before it expires. The UX benefit of a RT is already provided.
+
+2. **Stateless validation advantage does not apply**: This system is a single BFF — all requests pass through aice-web-next. Furthermore, `token_version` (§7.4) and `sid` validation already require a DB/cache lookup on every request. The premise of "JWT to eliminate DB lookups" does not hold; adding a RT would not reduce the number of DB queries.
+
+3. **Immediate revocation is already implemented**: `token_version` increment revokes all sessions instantly; `sid` invalidation targets a single session. The AT+RT pattern cannot achieve immediate revocation for an AT's remaining lifetime without a separate revocation infrastructure (revocation list, token introspection endpoint), which conflicts with this system's security requirement of instant session invalidation on password change, role change, and forced sign-out.
+
+4. **No third-party clients**: RT is most valuable in OAuth delegation flows where a third-party application acts on behalf of a user over an extended period. This system is internal-only with no third-party delegation.
+
+This design decision is valid under this specific combination of conditions: single BFF architecture, per-request DB lookup already required, immediate revocation mandatory, and no third-party delegation. In microservice architectures, edge/CDN token validation, OAuth/OIDC ecosystems, or extremely high-throughput systems where per-request DB hits are prohibitive, the AT+RT pattern would be the more appropriate choice.
+
+### 7.3 Sliding Rotation
+
+*Sliding Rotation* combines two concepts: **sliding expiration** (the expiry deadline shifts forward on each activity rather than being fixed at issuance) and **token rotation** (the existing JWT is replaced by a newly issued one). Together: whenever the BFF detects activity and the JWT is close to expiry, it issues a fresh JWT with a new `exp`, effectively extending the session without requiring re-authentication.
+
+- When remaining lifetime ≤ 1/3 of total, BFF auto-issues new JWT.
+- Grace Period: previous token valid for 30 seconds.
+- `iat`-based latest token priority.
+- **Active users are never forced to sign in again.**
+
+### 7.4 Revocation
+
+**Bulk revocation** (all sessions):
+- JWT `token_version` compared against DB value; mismatch → rejected.
+- `token_version` incremented on: password change, role change, customer access change, forced sign out.
+
+**Per-session revocation** (single session):
+- JWT `sid` checked against session record; `revoked=true` → rejected.
+- Used for: current session sign out, dashboard-initiated single session termination.
+
+---
+
+## 8. Session Management
+
+### 8.1 Session Policy
+
+| Item                  | Default          | Configurable |
+| --------------------- | ---------------- | ------------ |
+| Idle Timeout          | 30 minutes       | Yes          |
+| Absolute Timeout      | 8 hours          | Yes          |
+| Max concurrent sessions | No limit (global default) | Yes  |
+
+- Per-account `max_sessions` overrides global default when set.
+- Exceeding max sessions → new sign-in rejected.
+
+### 8.2 Per-session Tracking
+
+Each sign-in creates a session record in auth_db:
+
+| Field           | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `sid`           | UUID, included in JWT `sid` claim                    |
+| `account_id`    | Owner account                                        |
+| `ip_address`    | Sign-in source IP                                    |
+| `user_agent`    | Browser User-Agent string                            |
+| `created_at`    | Sign-in timestamp                                    |
+| `last_active_at`| Last Sliding Rotation timestamp                      |
+| `revoked`       | Boolean, set on sign out or force revocation         |
+
+- JWT validation checks: `sid` exists in DB, not revoked.
+- Session validation: risk-based step-up by comparing current request IP and User-Agent against stored `ip_address` and `user_agent`.
+
+  | Change                    | Risk    | Action                             |
+  | ------------------------- | ------- | ---------------------------------- |
+  | IP only (UA same)         | Low     | Log (Discussion #46 §6), proceed, **no re-auth** |
+  | UA minor version change   | Low     | Log (Discussion #46 §6), proceed, **no re-auth** |
+  | UA major change (IP same) | Medium  | Log (Discussion #46 §6), **require re-auth**     |
+  | IP + UA both              | High    | Log (Discussion #46 §6), **require re-auth**     |
+
+  - **UA comparison**: extract browser family + major version (e.g., `Chrome/131`). Minor/patch version changes (e.g., `131.0.6778` → `131.0.6779`) are ignored to tolerate browser auto-updates.
+  - Re-auth: session flagged `needs_reauth` → return 401 with re-authentication prompt → user re-enters password or MFA → `ip_address` and `user_agent` updated to current values → session continues.
+  - Session itself is not revoked (preserves user context).
+  - IP-only change without re-auth: accounts for VPN reconnect, DHCP renewal, network switch in closed network environments.
+- `token_version` increment revokes **all** sessions; `sid`-based revocation targets a **single** session.
+- Dashboard (§14) uses session records for active session display.
+
+### 8.3 Session Extension Dialog
+
+When no server requests have been made and JWT expiration approaches, display a dialog asking the user whether to extend.
+
+**Display condition:**
+- JWT remaining lifetime ≤ 1/5 of total (e.g., 3 minutes for 15-min token).
+- No Sliding Rotation has occurred (no server requests in the period).
+
+**Dialog behavior:**
+
+| User action           | Result                                                       |
+| --------------------- | ------------------------------------------------------------ |
+| **[Extend] click**    | `GET /api/auth/me` → Sliding Rotation → new JWT → dialog closes |
+| **[Sign out] click**  | Immediate sign out                                           |
+| **No response**       | Countdown expires → JWT expires → redirect to sign-in        |
+
+**Relationship with active usage:**
+
+| Situation                      | Behavior                                    |
+| ------------------------------ | ------------------------------------------- |
+| Active (server requests occur) | Sliding Rotation auto-renews, **no dialog** |
+| Reading only (no requests)     | Dialog appears near expiry → click to extend |
+| Away from desk                 | Dialog appears → no response → expires → redirect to sign-in |
+
+---
+
+## 9. CSRF (Cross-Site Request Forgery) Protection
+
+CSRF is an attack where a malicious site causes the user's browser to submit a forged request to this application while the user is already authenticated. Because the browser automatically attaches the session cookie, the server cannot distinguish the forged request from a legitimate one without an additional verification mechanism.
+
+The Double Submit Cookie pattern counters this by exploiting an asymmetry enforced by the browser's Same-Origin Policy (SOP): a malicious site can cause the browser to *send* a request (with cookies attached), but it cannot *read* cookies belonging to another origin. The server issues a token in a cookie (`HttpOnly=false`) and requires the client to echo it back in a custom request header (`X-CSRF-Token`). Client-side JavaScript reads the cookie and copies it into the header — something only code running on the legitimate origin can do. A forged request from a malicious site arrives without the header value, and is rejected.
+
+Plain Double Submit Cookie has one weakness: if an attacker can inject a cookie (e.g., via a subdomain), they can set both the cookie and the header to the same arbitrary value and pass the equality check. Adding HMAC closes this gap — the server does not merely check that cookie equals header; it verifies that the token is a valid signature produced with a server-side secret. Without that secret, a forged token fails verification regardless of how the cookie was set.
+
+**HMAC-based Double Submit Cookie** (session-bound):
+
+- Token formula: `HMAC-SHA256(sid + nonce + issued_at, server_secret)`. Transmitted as `nonce.issued_at.signature`.
+- On sign-in and each Sliding Rotation, generate new CSRF token (new nonce + issued_at).
+- Token set as cookie (`__Host-csrf`, `Secure=true`, `HttpOnly=false`, `SameSite=Strict`, `Path=/`) and sent in response header.
+- Client includes token in `X-CSRF-Token` header on state-changing requests.
+- Server parses token, recomputes HMAC from `sid` + extracted nonce + issued_at, and compares signature.
+- **Validation rules**: reject if signature mismatch, `sid` mismatch, or `issued_at` older than current JWT's `iat` (stale token).
+- **Session-bound**: token is tied to `sid`, not reusable across sessions.
+- Validated on all state-changing requests (POST/PUT/PATCH/DELETE) to **Route Handlers** (`/api/auth/*` and any future API routes).
+- **Server Actions** are exempt: Next.js enforces its own CSRF protection (Origin check, encrypted Action IDs) for Server Actions. Business mutations use Server Actions exclusively.
+- **Origin/Referer verification**: additionally check `Origin` header (or `Referer` if `Origin` absent) against the expected app origin. Reject requests from mismatched origins. This provides defense-in-depth alongside HMAC token validation.
+
+---
+
+## 10. Context Token (aimer-web Handoff)
+
+| Item       | Value                                  |
+| ---------- | -------------------------------------- |
+| Lifetime   | 30 seconds – 2 minutes                |
+| Usage      | One-time                               |
+| Payload    | `iss`, `sub`, `aice_id`, `iat`, `exp`, `jti` |
+
+- Used `jti` recorded until expiry to prevent replay.
+- Not an auth token — origin identification only.
+
+---
+
+## 11. Secret Management (Bootroot / OpenBao)
+
+**Bootroot** is the in-house PKI bootstrap and trust foundation that manages mTLS certificate issuance and rotation using step-ca and OpenBao. The same OpenBao instance managed by Bootroot will also serve as the secret store for aice-web-next application secrets. Secrets are stored in OpenBao KV v2 and rendered to local files by OpenBao Agent; the column encryption KEK is the exception and uses OpenBao Transit Engine (key never leaves OpenBao).
+
+**Development ordering**: Adding aice-web-next as a managed service in Bootroot requires coordination with the Bootroot operator (AppRole provisioning, KV v2 path policy, Transit engine configuration). aice-web-next is developed without Bootroot first; Bootroot integration is introduced in Phase 3 (see §16). Until then, secrets are supplied via environment variables or config files injected at deployment time.
+
+| Secret type                                   | Storage                              | Rotation                                                                              | Until Bootroot integration                                  |
+| --------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| PostgreSQL credentials (auth_db, audit_db, customer_db) | OpenBao KV v2 (via Bootroot)         | `bootroot rotate db`; OpenBao Agent re-renders credentials to file                   | Environment variable                                        |
+| JWT signing key (dedicated, separate from mTLS) | **Filesystem**                     | `kid`-based: two keys active during transition; old key removed after AT expiry window | Same (filesystem, manually managed)                        |
+| Column encryption KEK                         | **OpenBao Transit Engine** (via Bootroot) | `bootroot rotate kek`: rotate Transit key → rewrap all DEKs → advance `min_decryption_version`; no column data re-encryption | Column encryption deferred until Bootroot integration |
+| CSRF server secret                            | OpenBao KV v2 (via Bootroot)         | On-demand via Bootroot CLI; existing CSRF tokens invalidated on rotation              | Environment variable                                        |
+| mTLS certificates/keys                        | Filesystem (managed by Bootroot)     | Auto-rotated by Bootroot (existing impl)                                              | Already integrated                                          |
+
+- **JWT key is separate from mTLS certificate** — different lifecycle, rotation schedule, and trust scope. No key reuse across purposes. step-ca issues X.509 certificates only; it cannot issue standalone JWT signing key material. The JWT key lifecycle (generation, rotation) is managed independently of Bootroot.
+- JWT key includes `kid` (Key ID) in header for rotation support. Two keys active during rotation window (old key validates existing tokens, new key signs new tokens).
+- No credentials in code, Git, or DB.
+- OpenBao failure mitigation: application cache (TTL) + break-glass procedure.
+
+---
+
+## 12. Audit Log
+
+See **Discussion #46** — Audit Log Architecture.
+
+Account management events defined in this specification (auth, MFA, session, account, role, customer, system settings) are recorded as audit log entries in `audit_db`. Discussion #46 covers the full audit log architecture: storage (`audit_db`), search, recorded events, log attributes, and suspicious activity detection.
+
+---
+
+## 14. System Administrator Dashboard
+
+Three views for System Administrator:
+
+| View                    | Content                                        |
+| ----------------------- | ---------------------------------------------- |
+| Active sessions         | Account, IP, sign-in time, session count       |
+| Locked accounts         | Account, lock reason, unlock scheduled time    |
+| Suspended accounts      | Account, suspended time, recovery action       |
+
+Plus:
+- Suspicious activity alerts (Discussion #46 §6).
+- Quick actions: force sign out, unlock, restore.
+
+---
+
+## 15. System Settings
+
+Configurable by System Administrator:
+
+| Setting group      | Items                                                 |
+| ------------------ | ----------------------------------------------------- |
+| Password policy    | Min length, complexity toggle (default off), reuse ban count, periodic change toggle + period (§5) |
+| Session policy     | Idle Timeout, Absolute Timeout, global max sessions   |
+| Lockout policy     | Stage 1: failure threshold + duration; Stage 2: failure threshold |
+| Sign-in rate limit | Per-IP, per-account+IP, global thresholds and windows |
+| API rate limit     | General: per-user threshold for authenticated requests; Sensitive ops (password change, MFA verify): tighter per-user limits |
+| JWT policy         | Access Token expiration time                          |
+| MFA policy         | Allowed MFA methods: WebAuthn + TOTP (default) / WebAuthn only / TOTP only |
+
+- Changes recorded in audit log.
+- Stored in auth_db. Defaults hardcoded in application code.
+
+---
+
+## 16. Implementation Phases
+
+````
+Phase 1 — Core Authentication
+├── ID/PW sign-in and sign out (3 variants)
+├── JWT issuance, validation, Sliding Rotation
+├── Per-session tracking (sid + IP + User-Agent)
+├── Session extension dialog
+├── CSRF protection (HMAC Double Submit Cookie)
+├── IP rate limiting on sign-in endpoint (DoS protection)
+├── Next.js Middleware (route protection)
+├── Initial admin account (secret file / env var bootstrap)
+├── Per-account allowed IPs (CIDR support, max 5)
+├── Per-account max concurrent sessions
+└── Audit log (audit_db, PostgreSQL)
+
+Phase 2 — Account Management
+├── Account CRUD (System Administrator + Tenant Administrator delegation)
+├── Password change, reset, policy enforcement
+├── Password blocklist (top 100K, bundled offline)
+├── Two-stage lockout (temporary lock → suspended)
+├── Account recovery (unlock / restore, delegated to Tenant Administrator)
+├── RBAC (role + permission based route protection)
+├── Customer management (CRUD, System Administrator + Tenant Administrator update)
+├── Multi-tenant access control (account_customer mapping)
+└── Per-account locale and timezone
+
+Phase 3 — Operations
+├── System Administrator dashboard (sessions, locks, suspended)
+├── System Settings UI
+├── Custom Role management UI
+├── Suspicious activity detection (Discussion #46 §6)
+└── Certificate expiry detection alerts
+
+Phase 4 — MFA & Security Hardening (requires external coordination)
+├── MFA — WebAuthn/FIDO2 (available to all roles)
+├── MFA — TOTP (available to all roles)
+├── MFA enforcement (per-role `mfa_required` + per-account override)
+├── Bootroot service integration (prerequisite for column encryption and DB credential rotation)
+│   ├── Add aice-web-next as a managed service in Bootroot (AppRole, KV v2 path policy, Transit engine — coordinated with Bootroot operator)
+│   ├── Switch PostgreSQL credentials: env var → OpenBao KV v2 (via Bootroot), rendered to file by OpenBao Agent
+│   └── Switch CSRF server secret: env var → OpenBao KV v2 (via Bootroot), rendered to file by OpenBao Agent
+├── Column encryption (OpenBao Transit Engine, via Bootroot) — requires Bootroot integration
+├── Compromised password check (full HIBP dataset, CC0, offline k-Anonymity)
+└── Context Token (aimer-web handoff)
+````
+
+---
+
+## Appendix A. Roadmap Items (Non-normative)
+
+Items in this appendix are **planned enhancements**, not current requirements. They do not affect implementation of the normative sections above.
+
+### A.1 Break-glass OpenBao Token
+
+Replace environment variable `EMERGENCY_MFA_RESET` with an OpenBao-issued one-time token (`EMERGENCY_MFA_RESET_TOKEN`):
+
+- **Mechanism**: OpenBao Cubbyhole or Response-wrapping.
+- Token is cryptographically opaque, single-use, and TTL-bound by OpenBao itself.
+- Eliminates the need for app-side expiry timer and consumed marker logic.
+- Requires OpenBao availability during break-glass (trade-off vs. current env var approach which works even if OpenBao is down).
+
+### A.2 Compromised Password Check (HIBP)
+
+Full HIBP dataset integration (CC0 license, offline k-Anonymity). Scheduled for Phase 4 (see §16).
+
+### A.3 WORM Storage for Audit Log Long-term Archival
+
+See **Discussion #46** Appendix A.
+
+
+
+

--- a/decisions/audit-log.md
+++ b/decisions/audit-log.md
@@ -1,0 +1,182 @@
+# Audit Log Architecture
+
+## Context
+
+This document defines the audit log architecture for aice-web-next: what is recorded, where it is stored, and how it is queried. It was extracted from Discussion #32 (Account Management Feature Specification) because the audit log architecture applies beyond account management — any user-initiated system change captured by the BFF is an audit event.
+
+Related documents:
+
+- **Discussion #32** — Account Management Feature Specification (defines the resources and events that produce audit entries)
+- **Discussion #34** — Database Migration Strategy (`audit_db` migration runner)
+- **Discussion #45** — Backup and Restore Strategy (`audit_db` backup/restore)
+
+---
+
+## 1. Scope
+
+aice-web-next is the **sole producer of audit logs** in the system. All user-initiated changes to the system (account management, role changes, customer operations, system settings, detection rule changes via REview, etc.) pass through aice-web-next as the BFF, so the audit trail is captured at this single entry point. Other services (REview, Giganto, etc.) produce only runtime/application logs, which follow the separate file → REproduce → Giganto path.
+
+### Audit log vs. runtime/application log
+
+| | Audit log | Runtime/application log |
+| --- | --- | --- |
+| **Producer** | aice-web-next only | All services |
+| **Storage** | `audit_db` (PostgreSQL) | File → REproduce → Giganto |
+| **Purpose** | Accountability — who did what, when | Debugging, monitoring |
+| **Retention** | Long-term (years, compliance-driven) | Short-term (days to weeks, log rotation) |
+
+An event qualifies as an audit log entry if it meets **any** of these criteria:
+
+- **State change**: business data was modified (account created, role changed, setting updated)
+- **Security event**: security-relevant even without state change (sign-in failure, IP mismatch detected)
+- **Access decision**: authorization was granted or denied (customer access grant, unauthorized access attempt)
+
+The actor may be a specific user (`actor_id` = user UUID) or the system acting under policy rules (`actor_id` = `system`, e.g., automatic account lockout after failed attempts).
+
+---
+
+## 2. Source of Truth — audit_db
+
+- Audit logs are stored in `audit_db`, a **separate PostgreSQL database** dedicated to audit records.
+- `audit_db` is the source of truth (SoT).
+- Separate from `auth_db` because: (1) audit logs are append-heavy and grow over time, while `auth_db` is small and stable; (2) different retention requirements (audit logs may be preserved for years, `auth_db` backups roll over in 30 days); (3) restoring `auth_db` must not roll back audit records — the audit trail must survive `auth_db` restores.
+- Tamper resistance: the application connects to `audit_db` with a role that has INSERT and SELECT only (no UPDATE or DELETE). Additional integrity mechanisms (e.g., application-level hash chain on rows) can be layered on if needed.
+
+---
+
+## 3. Search
+
+The System Administrator can search audit logs in the UI; the BFF queries `audit_db` directly via SQL and enforces the `audit-logs:read` permission before returning results. No dependency on Giganto for audit log search.
+
+---
+
+## 4. Recorded Events
+
+| Category  | Events                                                  |
+| --------- | ------------------------------------------------------- |
+| Auth      | Sign-in success/failure, sign out, session extension, account lock/unlock, suspended/restored, IP rate limit triggered |
+| MFA       | TOTP register/remove, WebAuthn register/remove, MFA reset, recovery code used, break-glass MFA reset |
+| Session   | IP or User-Agent mismatch detected, per-session revocation |
+| Account   | Create, update, disable, delete, password change/reset  |
+| Role      | Create, update, delete, role assign/revoke              |
+| Customer  | Create, update, delete, access grant/revoke             |
+| System    | Policy changes (password, session, lockout)             |
+
+---
+
+## 5. Log Attributes
+
+| Field            | Type        | Description                                      |
+| ---------------- | ----------- | ------------------------------------------------ |
+| `timestamp`      | TIMESTAMPTZ | Event time                                       |
+| `actor_id`       | TEXT        | Actor (user UUID or `system`)                    |
+| `action`         | TEXT        | Event type                                       |
+| `target_type`    | TEXT        | Target kind (account, role, policy, etc.)        |
+| `target_id`      | TEXT        | Target identifier                                |
+| `details`        | JSONB       | Before/after values (excluding passwords/encrypted fields) |
+| `ip_address`     | TEXT        | Request source IP                                |
+| `sid`            | TEXT        | Session identifier (if applicable)               |
+| `customer_id`    | INTEGER     | Related customer (if applicable)                 |
+| `correlation_id` | UUID        | Groups related log entries from a single operation (nullable) |
+
+### 5.1 Correlation ID
+
+A single user action can produce multiple log entries — both within `audit_db` (e.g., `account.create` + `role.assign`) and across log types (audit log + runtime/application log). The `correlation_id` field enables post-hoc tracing of all entries originating from the same operation.
+
+#### Generation and propagation
+
+- Each incoming HTTP request (Route Handler or Server Action) generates a UUID v4 correlation ID at the start of processing.
+- The ID is propagated through the call stack via `AsyncLocalStorage`, making it available to all code paths within the request without explicit parameter threading.
+- System-initiated operations (e.g., bootstrap, scheduled tasks) generate their own correlation ID per operation.
+
+#### Trust policy
+
+- **Server-generated only**: `correlation_id` is always generated server-side (`crypto.randomUUID()`). External headers (`X-Request-ID`, `X-Correlation-ID`, W3C `traceparent`) are **not** accepted as `correlation_id`. This preserves audit integrity — external input could be spoofed or reused to pollute the audit trail.
+- If external request tracing is ever needed (e.g., API Gateway → BFF linkage), the external ID should be stored in `details.external_request_id`, not as the `correlation_id`.
+
+#### AsyncLocalStorage boundaries
+
+ALS propagation is reliable only within the same Node.js async context:
+
+| Scope | ALS works? | Approach |
+|---|---|---|
+| Route Handlers | ✅ Yes | Auto-read via `getCorrelationId()` |
+| Server Actions | ✅ Yes | Auto-read via `getCorrelationId()` |
+| `instrumentation.ts` hooks | ✅ Yes | Auto-read via `getCorrelationId()` |
+| Next.js Middleware (Edge Runtime) | ❌ No | Separate execution context; use `x-correlation-id` header if needed |
+| React Server Components | ❌ No | React concurrent scheduling breaks ALS; excluded |
+| Background jobs / detached promises | ❌ No | Pass `correlationId` explicitly |
+
+When ALS context is unavailable, callers **must** pass `correlationId` explicitly to `auditLog.record()`.
+
+**Middleware note**: Next.js Middleware runs in Edge Runtime (or a separate worker), so ALS context does not propagate to the subsequent Route Handler. If Middleware-level correlation is needed in the future, the Middleware should set a `x-correlation-id` request header and the Route Handler entry point should read it. Currently Middleware (#61) does not write audit logs, so this is deferred.
+
+#### Schema
+
+```sql
+ALTER TABLE audit_logs ADD COLUMN correlation_id UUID;
+CREATE INDEX idx_audit_logs_correlation_id
+  ON audit_logs (correlation_id)
+  WHERE correlation_id IS NOT NULL;
+```
+
+- PostgreSQL native `UUID` type: 16 bytes (vs 36+ for TEXT), binary comparison for efficient indexing, DB-level format validation.
+- Partial index: excludes NULL rows (pre-correlation entries, standalone system events) to reduce index size and write overhead on a table that grows indefinitely.
+
+#### Audit log integration
+
+- The audit logger (#51) reads `correlation_id` from the async context automatically.
+- Callers may also pass it explicitly when the auto-read context is not available.
+
+#### Runtime/application log integration
+
+- When structured logging is used, the `correlationId` field should be included in log output.
+- This enables joining audit log entries (in `audit_db`) with runtime log entries (in file/Giganto) by the same correlation ID.
+
+#### Example: sign-in failure leading to account lockout
+
+```
+correlation_id = "a1b2c3d4-..."
+
+audit_logs:
+  { action: "auth.sign_in_failure", correlation_id: "a1b2c3d4-..." }
+  { action: "account.lock",         correlation_id: "a1b2c3d4-..." }
+
+runtime log:
+  { level: "warn", msg: "rate limit threshold reached", correlationId: "a1b2c3d4-..." }
+```
+
+All three entries share the same `correlation_id`, making them queryable as a group.
+
+Implementation: #65
+
+---
+
+## 6. Suspicious Activity Detection
+
+Audit log-based periodic analysis (queries `audit_db`) + dashboard alerts.
+
+| Detection Indicator             | Description                                      |
+| ------------------------------- | ------------------------------------------------ |
+| Access from non-allowed IP      | Sign-in attempt from IP not in `allowed_ips` list |
+| Consecutive failures            | Linked to two-stage lockout (Discussion #32 §6.3) |
+| Off-hours sign-in               | Sign-in outside business hours (logged, not blocked) |
+| Session IP/UA mismatch          | IP or User-Agent changed mid-session (Discussion #32 §8.2) |
+| Concurrent multi-IP sessions    | Same account active from different IPs simultaneously |
+| Rapid sign-in/sign-out cycles   | Possible automation/tool abuse                   |
+
+- Displayed in System Administrator dashboard (Discussion #32 §14).
+- Severe events (non-allowed IP access, suspended trigger) show immediate dashboard alerts.
+
+---
+
+## Appendix A. WORM Storage for Long-term Archival
+
+WORM (Write Once, Read Many) storage enforces immutability at the storage layer: once written, data cannot be modified or deleted until a configured retention period expires. This is stronger than the database-level INSERT/SELECT restriction on `audit_db` (§2), which provides tamper-resistance at the application level — a database administrator with sufficient access could still alter rows, whereas WORM provides tamper-prevention even against privileged users.
+
+Two implementation approaches:
+
+- **Software WORM**: S3-compatible object storage (e.g., MinIO, Ceph) with Object Lock enabled. Runs on standard servers; no special hardware required. Retention period and legal hold are enforced by the object storage engine. Practical for most deployments.
+- **Hardware WORM**: Dedicated WORM tape drives or optical media (e.g., BD-R). Physical write-once guarantee regardless of software. Required only when regulations mandate hardware-level immutability.
+
+Consideration: if a customer deployment is subject to regulations that require tamper-proof audit log archival (e.g., financial, healthcare, government), audit logs can be periodically exported from `audit_db` and shipped to a WORM-capable object store. `audit_db` (§2) remains the operational SoT; WORM storage serves as the long-term compliance archive. This is not a current requirement and should be evaluated on a per-deployment basis.

--- a/decisions/backup-restore.md
+++ b/decisions/backup-restore.md
@@ -1,0 +1,168 @@
+# Backup and Restore Strategy
+
+## Context
+
+This document defines the backup and restore strategy for data managed by aice-web-next, based on the database architecture established in:
+
+- **Discussion #32** §3 — DB Separation (`auth_db` + `audit_db` + `customer_db` per tenant)
+- **Discussion #34** — Database Migration Strategy (migration runner, customer_db lifecycle)
+
+### Scope
+
+This strategy covers **databases owned by aice-web-next**: `auth_db`, `audit_db`, and `customer_db` instances. It does not cover:
+
+- REview/Giganto data (owned by those services)
+- Certificate and key material (managed separately through secret management)
+
+---
+
+## 1. Database Topology Recap
+
+| Database | Instances | Contents |
+| --- | --- | --- |
+| **auth_db** | 1 | Accounts, roles, permissions, customers (metadata), account–customer mappings, sessions, password history, MFA credentials, system settings |
+| **audit_db** | 1 | Audit logs (all account management and system events) |
+| **customer_db** | 1 per customer | Customer-scoped input data and reports |
+
+Key characteristics:
+
+- `auth_db` is small (accounts, roles, and settings are low-cardinality) but **highly interconnected** — foreign keys tie accounts to roles, customers, and sessions.
+- `audit_db` is append-heavy and grows over time. It references `auth_db` entities by value (not by FK constraint) and has different retention requirements. It must not be rolled back when `auth_db` is restored.
+- Each `customer_db` is **independent** of other customer databases and varies in size depending on the customer's data volume.
+
+---
+
+## 2. Backup Units
+
+### 2.1 auth_db — Whole-database backup
+
+`auth_db` is backed up as a **single consistent unit** using `pg_dump`.
+
+**Why not split by table group (settings vs. accounts vs. customers)?**
+
+- **Referential integrity**: Tables reference each other through foreign keys (`account_customer → accounts + customers`, `sessions → accounts`, etc.). Restoring subsets from different points in time breaks these relationships.
+- **Temporal consistency**: Restoring system settings to an earlier state while keeping accounts at the current state creates contradictions (e.g., an MFA policy rollback with MFA credentials registered after that point still present).
+- **No size benefit**: The entire `auth_db` is expected to remain small (< 100 MB even at scale), so splitting provides no meaningful reduction in backup time or storage.
+
+### 2.2 audit_db — Whole-database backup
+
+`audit_db` is backed up as a **single consistent unit** using `pg_dump`, independently from `auth_db`.
+
+**Why separate from `auth_db`?**
+
+- **Independent restore**: Restoring `auth_db` (e.g., to recover from a misconfiguration) must not roll back audit records. The audit trail must survive `auth_db` restores.
+- **Different retention**: Audit logs may need to be preserved for years (compliance), while `auth_db` backups roll over in 30 days.
+- **Different growth pattern**: `auth_db` is small and stable; `audit_db` grows continuously with every recorded event.
+
+### 2.3 customer_db — Per-customer backup
+
+Each `customer_db` is backed up **independently** using `pg_dump`.
+
+**Why per-customer rather than all-at-once?**
+
+- **Tenant isolation**: The reason for having separate databases in the first place. Backup boundaries should match data isolation boundaries.
+- **Independent recovery**: A corruption or accidental deletion in one customer's data should be recoverable without affecting others.
+- **Size variation**: Customer databases may vary significantly in size; independent backups allow per-customer scheduling and retention policies.
+
+---
+
+## 3. Backup Schedule
+
+| Backup unit | Method | Frequency | Retention |
+| --- | --- | --- | --- |
+| auth_db | `pg_dump --format=custom` | Daily | 30 days rolling |
+| audit_db | `pg_dump --format=custom` | Daily | Configurable (potentially longer than auth_db due to compliance requirements) |
+| Each customer_db | `pg_dump --format=custom` | Daily | Configurable per customer (default: 30 days) |
+
+**Additional considerations:**
+
+- On-demand backup before destructive operations (customer deletion, major setting changes) is recommended at the application level.
+- PostgreSQL WAL archiving can be layered on top for point-in-time recovery (PITR) if the RPO requirement becomes tighter than 24 hours. This is an infrastructure-level decision and not covered here.
+
+---
+
+## 4. Restore Scenarios
+
+### 4.1 Full disaster recovery
+
+**Trigger**: Server failure, storage corruption, or complete data loss.
+
+**Procedure**:
+1. Provision a new PostgreSQL instance.
+2. Restore `auth_db` from the latest backup.
+3. Restore `audit_db` from the latest backup.
+4. Query `auth_db` for the list of active customers.
+5. Restore each `customer_db` from its latest backup.
+6. Run the migration runner (Discussion #34) to apply any migrations newer than the backup.
+7. Start the application.
+
+**Data loss window**: Up to 24 hours (last daily backup).
+
+### 4.2 Single customer data recovery
+
+**Trigger**: Accidental data corruption or deletion within a specific customer's database.
+
+**Procedure**:
+1. Create a temporary database from the customer's backup.
+2. Verify data integrity and identify the needed data.
+3. Restore into the live `customer_db` (or replace it entirely).
+4. `auth_db` is **not** touched — the customer record and account mappings remain intact.
+
+### 4.3 System settings misconfiguration
+
+**Trigger**: An administrator changes a setting (password policy, session timeout, etc.) incorrectly.
+
+**Procedure**: Do **not** restore `auth_db` from backup. Instead:
+1. Look up the previous value in the audit log (query `audit_db`, `details.before` field).
+2. Apply the correction through the normal settings API/UI.
+
+**Rationale**: Restoring `auth_db` to undo a setting change would also roll back every account change and session created since the backup — far more destructive than the original mistake. `audit_db` must not be restored alongside `auth_db` — audit logs must be preserved to maintain a complete record of what happened.
+
+### 4.4 Accidental account deletion
+
+**Trigger**: An administrator deletes an account by mistake.
+
+**Procedure**: No backup restore needed. Account deletion is **soft delete** (Discussion #32), so the account record is retained. Reactivate the account by changing its status from `disabled` to `active`.
+
+### 4.5 Customer deletion recovery
+
+**Trigger**: A customer is deleted (Discussion #34: `DROP DATABASE` + remove from `auth_db`).
+
+**Procedure**:
+1. Restore the `customer_db` from the latest pre-deletion backup.
+2. Re-create the customer record in `auth_db` (new row; the original `id` is **never reused** per Discussion #32).
+3. Re-establish account–customer mappings as needed.
+
+**Note**: This is the most involved recovery scenario because both `auth_db` and `customer_db` state must be coordinated. An on-demand backup taken immediately before customer deletion would minimize data loss.
+
+---
+
+## 5. Implementation Considerations
+
+### 5.1 Backup execution
+
+The backup process should be an **external scheduled job** (e.g., cron, Kubernetes CronJob), not embedded in the application code. The application is responsible for:
+
+- Exposing the list of active customer database names (so the backup job knows which databases to back up).
+- Triggering an on-demand backup before destructive operations (optional, application-level safeguard).
+
+### 5.2 Backup storage
+
+- Backups should be stored **off-host** (separate storage from the database server).
+- Encryption at rest is recommended for backups containing sensitive data (encrypted email/phone fields in `auth_db` are already encrypted at the column level, but the backup file also contains password hashes and other sensitive metadata).
+
+### 5.3 Backup verification
+
+Periodically restore a backup to a temporary database and run the migration runner against it. This verifies both backup integrity and migration compatibility.
+
+---
+
+## 6. What This Strategy Does Not Cover
+
+| Topic | Reason |
+| --- | --- |
+| WAL archiving / PITR | Infrastructure-level decision; can be layered on if needed |
+| Certificate/key backup | Managed through secret management (OpenBao roadmap) |
+| REview/Giganto data | Owned by those services |
+| Automated backup tooling selection | Implementation detail; `pg_dump` is sufficient to start |
+

--- a/decisions/database-migration.md
+++ b/decisions/database-migration.md
@@ -1,0 +1,121 @@
+## Overview
+
+aice-web-next will use PostgreSQL directly for account management and related features. This document records the decisions made about schema and migration management.
+
+## Why No ORM
+
+We use **raw SQL with `pg`** instead of an ORM (Drizzle, Prisma, etc.) for the following reasons:
+
+**1. Transparency for AI-driven development**
+aice-web-next's development and debugging is primarily handled by AI. Raw SQL is fully explicit — the exact SQL being executed is always visible in the source. ORM translation layers obscure what is actually happening, making debugging harder for AI and humans alike.
+
+**2. Better AI coverage**
+SQL has decades of history and broad AI training coverage. Newer ORM APIs such as Drizzle (2022) have less coverage and more API churn, increasing the risk of AI generating outdated or incorrect code.
+
+**3. SQL injection prevention without ORM**
+SQL injection is prevented by parameterized queries, which `pg` supports natively. An ORM is not required for this.
+
+**4. Sufficient type safety without ORM overhead**
+TypeScript interfaces on query results catch type mismatches at compile time, providing adequate safety without the abstraction cost of a full ORM.
+
+## Migration Strategy
+
+We use **versioned SQL migration files** — the approach used by Flyway, Liquibase, and golang-migrate — with a custom runner instead of an external tool.
+
+### File structure
+
+Migration files are separated by database: `auth_db` (single instance for authentication and account data), `audit_db` (single instance for audit logs), and `customer_db` (one instance per customer for customer-scoped data), as defined in Discussion #32 §3.
+
+```
+migrations/
+  auth/
+    0001_init_accounts.sql          # DDL
+    0002_add_sessions.sql           # DDL
+    0003_backfill_account_status.ts # DML — same numbering, TypeScript
+  audit/
+    0001_init_audit_logs.sql        # DDL
+  customer/
+    0001_init_customer_schema.sql   # DDL
+    ...
+
+src/lib/db/
+  client.ts    # Connection pool, query<T>(), withTransaction()
+  migrate.ts   # Migration runner
+```
+
+The runner applies `migrations/auth/` to `auth_db`, `migrations/audit/` to `audit_db`, and `migrations/customer/` to every `customer_db` instance.
+
+### Multi-replica coordination
+
+In a multi-replica deployment, multiple instances start concurrently and can race the migration runner. The runner acquires a PostgreSQL advisory lock (`pg_advisory_lock`) before executing migrations and releases it on completion. Only one instance runs migrations; others wait for the lock and then skip already-applied migrations. This applies to `auth_db`, `audit_db`, and each `customer_db` independently.
+
+### customer_db lifecycle
+
+aice-web-next is the sole owner of every `customer_db` (see Discussion #32 §3). The migration runner handles three lifecycle scenarios:
+
+**1. Startup — upgrade existing databases**
+When the application starts, the runner:
+1. Runs all pending `migrations/auth/` against `auth_db`.
+2. Runs all pending `migrations/audit/` against `audit_db`.
+3. Queries `auth_db` for the list of all active customers.
+4. For each customer's database, runs any pending `migrations/customer/` migrations.
+5. The application starts only after all migrations (auth + audit + every customer) succeed.
+
+**2. Runtime — provision a new customer database**
+When a System Administrator creates a customer (Discussion #32 §2.3):
+1. `CREATE DATABASE` for the new customer. This creates an empty database with no tables.
+2. Run all `migrations/customer/` files against the new database, in order, to build the full schema from scratch (tables, indexes, constraints, etc.).
+
+Both steps run within the same request. If any migration fails, the database is dropped and the customer creation fails.
+
+**3. Runtime — delete a customer database**
+When a System Administrator deletes a customer:
+1. `DROP DATABASE` for the customer's database.
+2. Remove the customer record from `auth_db`.
+
+Both steps run within the same request.
+
+### Version tracking
+
+The runner maintains a `_migrations` table in each database:
+
+```sql
+CREATE TABLE IF NOT EXISTS _migrations (
+  version    TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  checksum   TEXT NOT NULL,
+  applied_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+On each run, the runner compares migration files on disk against the `_migrations` table and applies only unapplied migrations, in order. Each migration is executed inside a single database transaction — if any statement fails, the entire migration is rolled back and no `_migrations` row is inserted. For rare cases where a statement cannot run inside a transaction (e.g., `CREATE INDEX CONCURRENTLY`), the migration file must be isolated (one statement per file) and marked with a `-- no-transaction` comment that the runner recognizes.
+
+**Checksum validation**: The runner computes a SHA-256 hash of each migration file's contents and stores it in the `checksum` column on first apply. On subsequent runs, if an already-applied file's checksum does not match the stored value, the runner aborts with an error. This detects accidental edits to applied migrations and drift between environments (same pattern as Flyway).
+
+### DDL vs. DML
+
+- **Schema changes (DDL)**: `.sql` files, numbered sequentially.
+- **Data migrations (DML)**: `.ts` files using the `pg` client, same numbering sequence. The runner applies DDL before DML within the same version.
+
+### Migration granularity
+
+Migration files are created **per logical change**, not per release. A release may include multiple migration files, or none if the schema did not change.
+
+## Development Workflow
+
+1. **Iterate locally** — make schema changes directly against a local database while developing; no migration file is needed yet.
+2. **Write the migration file** — when a change is ready, write the next numbered file.
+3. **Include in PR** — the migration file and the code that depends on it must be in the same PR.
+4. **CI validation** — CI runs the runner against a clean database; PRs that fail cannot be merged.
+5. **Deployment** — the runner runs before the application starts, migrating `auth_db`, `audit_db`, and all existing `customer_db` instances (see *customer_db lifecycle §1* above); the application only starts after all migrations succeed.
+
+## Rollback
+
+We adopt a **forward-only** approach. Rollbacks are implemented as new migration files that undo the previous change, not by reversing migrations in place.
+
+**Rolling-deploy compatibility (expand/contract)**: In a multi-replica deployment, old and new app versions coexist during rollout. Destructive schema changes (column drop, column rename, type change) must be split across at least two releases:
+1. **Expand**: Add the new column, backfill data, update app code to read/write both old and new columns.
+2. **Contract** (next release): Remove the old column after all replicas run the new code.
+
+This prevents old replicas from breaking when they encounter a schema they do not expect. Non-destructive additions (new table, new nullable column) can be applied in a single release.
+

--- a/decisions/ui-architecture.md
+++ b/decisions/ui-architecture.md
@@ -1,0 +1,563 @@
+# UI Architecture
+
+This document establishes the frontend architecture for aice-web-next before implementation begins. It is separate from `ARCHITECTURE.md`, which covers the BFF/mTLS backend layer (see Issue #1).
+
+Designs are based on the Figma files "Ready for Development Light" and "Ready for Development Dark".
+
+---
+
+## Table of Contents
+
+1. [Tech Stack](#1-tech-stack)
+2. [Design Token System](#2-design-token-system)
+3. [Theme Strategy](#3-theme-strategy)
+4. [Responsive Strategy](#4-responsive-strategy)
+5. [Directory Structure](#5-directory-structure)
+6. [Layout Architecture](#6-layout-architecture)
+7. [shadcn/ui Setup](#7-shadcnui-setup)
+8. [Page UI Requirements](#8-page-ui-requirements)
+9. [Internationalization](#9-internationalization)
+10. [Accessibility](#10-accessibility)
+11. [Out of Scope](#11-out-of-scope)
+12. [Additional Packages](#12-additional-packages)
+
+---
+
+## 1. Tech Stack
+
+| Item | Choice | Rationale |
+|------|--------|-----------|
+| UI components | shadcn/ui (new-york style) | Official Tailwind v4 support, accessibility, customizable |
+| Styling | Tailwind CSS v4 | Already installed, CSS-first config |
+| Animation | tw-animate-css | tailwindcss-animate deprecated in v4 |
+| Forms | React Hook Form 7.x + Zod v4 + @hookform/resolvers | Decided in Issue #1 |
+| Server state | TanStack Query v5 | Decided in Issue #1 |
+| Font | Roboto (Google Fonts) | Matches Figma design; replaces current Geist |
+| Icons | lucide-react | shadcn/ui default icon set |
+| Theming | `data-theme` attribute on `<html>` | Extensible to N themes; CSS-variable-first |
+| Theme SSR | next-themes (`attribute="data-theme"`) | Prevents hydration mismatch |
+| Initial themes | `gray-light`, `gray-dark` | Current Figma palette; `gray` = palette name, `light`/`dark` = brightness |
+
+---
+
+## 2. Design Token System
+
+Tokens are extracted from the Figma "Ready for Development" files.
+
+### 2.1 Color Tokens
+
+| Token | Light | Dark | Usage |
+|-------|-------|------|-------|
+| `--bg-canvas` | `#f5f6f7` | `#1a1d20` | Page background |
+| `--card-bg` | `#ffffff` | `rgba(97, 105, 116, 0.08)` | Card background |
+| `--control-bg` | `rgba(97, 105, 116, 0.08)` | `rgba(97, 105, 116, 0.24)` | Input background |
+| `--control-placeholder` | `#616974` | `#616974` | Placeholder text |
+| `--text-primary` | `#212428` | `#fafafa` | Primary text |
+| `--text-secondary` | `#474c55` | `#b4bbc6` | Secondary text |
+| `--btn-primary-bg` | `#156ef2` | `#156ef2` | Primary button (same across themes) |
+| `--btn-primary-bg-disabled` | `#c5e4f7` | TBD | Disabled button |
+| `--btn-primary-fg` | `#ffffff` | `#ffffff` | Button text |
+| `--danger` | `#db1d03` | `#fb2c10` | Error / required indicator |
+| `--neutral-40` | `#7c8492` | `#7c8492` | Secondary icons |
+| `--neutral-30` | -- | `#8e97a5` | Dark-only neutral |
+
+### 2.2 Typography Tokens
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Font family | Roboto | All text |
+| Heading | Bold 20px / line-height 25px | Page and card titles |
+| Label | Medium 16px / line-height 24px | Form labels, buttons |
+| Body | Regular 16px / line-height 24px | General text |
+
+### 2.3 Component Dimensions
+
+| Item | Value |
+|------|-------|
+| Card border-radius | 6px |
+| Input border-radius | 8px |
+| Button border-radius | 8px |
+| Button height | 40px |
+| Input height (with label) | 68px |
+| Card shadow | `0 10px 10px rgba(0,0,0,0.04), 0 20px 25px rgba(0,0,0,0.01)` |
+| Sidebar expanded | 256px |
+| Sidebar collapsed | 64px |
+
+### 2.4 globals.css Structure
+
+**Design principle**: Components only reference CSS custom properties, never hardcoded color values. Adding a new theme requires only a new `[data-theme="name"]` block in `globals.css` -- no component changes needed.
+
+Top-level imports:
+
+```css
+@import "tailwindcss";
+@import "tw-animate-css";
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+```
+
+Base tokens shared across all themes, plus the complete shadcn/ui semantic alias set. Values marked `TBD` must be confirmed against Figma before implementation; suggested defaults are derived from the extracted palette.
+
+```css
+:root {
+  --radius: 6px;
+  --btn-primary-bg: #156ef2;
+  --btn-primary-fg: #ffffff;
+
+  /* shadcn/ui semantic aliases -- complete set */
+  --background:             var(--bg-canvas);
+  --foreground:             var(--text-primary);
+  --card:                   var(--card-bg);
+  --card-foreground:        var(--text-primary);
+  --popover:                var(--card-bg);
+  --popover-foreground:     var(--text-primary);
+  --primary:                var(--btn-primary-bg);
+  --primary-foreground:     var(--btn-primary-fg);
+  --secondary:              var(--control-bg);         /* TBD Figma */
+  --secondary-foreground:   var(--text-primary);
+  --muted:                  var(--control-bg);
+  --muted-foreground:       var(--text-secondary);
+  --accent:                 var(--control-bg);         /* TBD Figma */
+  --accent-foreground:      var(--text-primary);
+  --destructive:            var(--danger);
+  --destructive-foreground: #ffffff;
+  --border:                 rgba(97, 105, 116, 0.16);  /* TBD Figma */
+  --input:                  var(--control-bg);
+  --ring:                   var(--btn-primary-bg);
+}
+```
+
+`gray-light` theme (shipped with initial release):
+
+```css
+[data-theme="gray-light"] {
+  --bg-canvas: #f5f6f7;
+  --card-bg: #ffffff;
+  --control-bg: rgba(97, 105, 116, 0.08);
+  --control-placeholder: #616974;
+  --text-primary: #212428;
+  --text-secondary: #474c55;
+  --btn-primary-bg-disabled: #c5e4f7;
+  --danger: #db1d03;
+  --neutral-40: #7c8492;
+}
+```
+
+`gray-dark` theme (shipped with initial release):
+
+```css
+[data-theme="gray-dark"] {
+  --bg-canvas: #1a1d20;
+  --card-bg: rgba(97, 105, 116, 0.08);
+  --control-bg: rgba(97, 105, 116, 0.24);
+  --control-placeholder: #616974;
+  --text-primary: #fafafa;
+  --text-secondary: #b4bbc6;
+  --danger: #fb2c10;
+  --neutral-30: #8e97a5;
+  --neutral-40: #7c8492;
+}
+```
+
+Tailwind v4 `@theme` mapping and dark variant:
+
+```css
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-destructive: var(--destructive);
+  --font-sans: 'Roboto', sans-serif;
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 2px);
+  --breakpoint-desktop: 1280px;
+  --breakpoint-wide: 2000px;
+}
+
+/* Maps Tailwind's dark: variant to any *-dark theme */
+@custom-variant dark (&:where([data-theme$="-dark"], [data-theme$="-dark"] *));
+```
+
+**Adding a new theme**: create `[data-theme="<palette>-light"]` and `[data-theme="<palette>-dark"]` blocks in `globals.css`, then register both names in the `ThemeProvider` `themes` prop. No component changes are required.
+
+---
+
+## 3. Theme Strategy
+
+- **Mechanism**: `data-theme="<name>"` attribute on `<html>` via next-themes with `attribute="data-theme"`
+- **Initial themes**: `gray-light` (default), `gray-dark`
+- **Naming convention**: `<palette>-<brightness>` -- palette name followed by `light` or `dark` suffix; future palettes follow the same pattern (e.g., `amber-light`, `amber-dark`)
+- **Extensibility**: add a `[data-theme="<palette>-<brightness>"]` CSS block and register the name in `ThemeProvider`; no component changes needed
+- **Priority**: `localStorage` preference, fallback to system `prefers-color-scheme`
+- **Library**: next-themes (prevents SSR hydration mismatch)
+- **Utility**: `src/lib/theme.ts` (typed theme names, ThemeProvider setup)
+- **Toggle component**: `src/components/theme-toggle.tsx`
+- **Tailwind**: the `dark:` utility variant maps to any `*-dark` theme via `@custom-variant dark`; avoid using `dark:` for values that differ per theme -- prefer CSS variable references so all themes benefit automatically
+
+---
+
+## 4. Responsive Strategy
+
+The Figma design targets desktop security operations (complex dashboards, sidebar navigation). **Desktop is the primary target; mobile support is additive -- no horizontal scrolling on any viewport.**
+
+### Desktop (>= 1280px)
+
+- Minimum content width: 1280px; layout is optimized for this breakpoint
+- Maximum content width: 2000px; horizontal margins expand beyond this
+- Sidebar: 256px expanded (icon + label) / 64px collapsed (icon only + tooltip on hover); collapse state persisted in `localStorage`
+
+### Mobile (< 1280px) -- layout reflow, no horizontal scroll
+
+- Sidebar collapses into a slide-over Sheet (full-screen overlay)
+- Hamburger button in a fixed top header replaces the sidebar
+- Content area takes full width (single-column where applicable)
+- Tables use horizontal scroll within their own container, not the page
+
+---
+
+## 5. Directory Structure
+
+```
+src/
++-- app/
+|   +-- [locale]/
+|   |   +-- (auth)/                # Auth route group
+|   |   |   +-- sign-in/page.tsx
+|   |   |   +-- reset-password/page.tsx
+|   |   |   +-- layout.tsx         # Centered card layout
+|   |   +-- (dashboard)/           # Authenticated route group
+|   |   |   +-- home/page.tsx
+|   |   |   +-- dashboard/page.tsx
+|   |   |   +-- event/page.tsx
+|   |   |   +-- detection/page.tsx
+|   |   |   +-- triage/page.tsx
+|   |   |   +-- report/page.tsx
+|   |   |   +-- settings/
+|   |   |   |   +-- accounts/page.tsx
+|   |   |   |   +-- roles/page.tsx
+|   |   |   |   +-- profile/page.tsx
+|   |   |   +-- layout.tsx         # Dashboard layout with sidebar
+|   |   +-- layout.tsx             # Locale layout: renders <html lang={locale}>, <body>, and i18n provider
+|   +-- api/auth/                  # Auth Route Handlers
+|   +-- globals.css                # Design tokens + Tailwind
+|   +-- layout.tsx                 # Root layout: pass-through wrapper (returns children only, no <html>/<body>)
++-- components/
+|   +-- ui/                        # shadcn/ui (auto-generated, do not edit manually)
+|   |   +-- button.tsx, input.tsx, form.tsx, dialog.tsx
+|   |   +-- sheet.tsx, table.tsx, badge.tsx, dropdown-menu.tsx
+|   |   +-- avatar.tsx, checkbox.tsx, card.tsx, tooltip.tsx ...
+|   +-- layout/
+|   |   +-- sidebar.tsx
+|   |   +-- sidebar-item.tsx
+|   |   +-- breadcrumbs.tsx
+|   |   +-- nav-user.tsx
+|   |   +-- mobile-header.tsx
+|   +-- auth/
+|   |   +-- sign-in-form.tsx
+|   |   +-- mfa-verification.tsx
+|   |   +-- mfa-registration-wizard.tsx
+|   |   +-- reset-password-form.tsx
+|   +-- theme-toggle.tsx
++-- hooks/
+|   +-- use-sidebar.ts
++-- lib/
+    +-- theme.ts
+    +-- utils.ts                   # shadcn/ui cn() helper
+```
+
+---
+
+## 6. Layout Architecture
+
+### Auth layout `(auth)/layout.tsx`
+
+- Full-screen centered flex container
+- Background: `var(--bg-canvas)` (`#f5f6f7` light / `#1a1d20` dark)
+- Card: 432px fixed width, `var(--card-bg)` background, 6px radius, shadow
+
+### Dashboard layout `(dashboard)/layout.tsx`
+
+```
++--------------------+---------------------------+
+|  Sidebar (256px)   |  MainContent              |
+|  +---------------+ |  +---------------------+  |
+|  | Logo          | |  | Breadcrumbs (64px)  |  |
+|  |               | |  +---------------------+  |
+|  | NavList       | |  |                     |  |
+|  | (scrollable)  | |  |   Page Content      |  |
+|  +---------------+ |  |                     |  |
+|  | User Profile  | |  |                     |  |
+|  | (pinned btm)  | |  |                     |  |
+|  +---------------+ |  +---------------------+  |
++--------------------+---------------------------+
+```
+
+**Sidebar behavior**:
+
+- Expanded (256px): icon + text label
+- Collapsed (64px): icon only + tooltip on hover
+- Mobile: Sheet slide-over (full overlay)
+- Collapse state persisted in `localStorage`
+
+**Admin submenu**: 181px floating panel, 4 items x 48px each
+
+---
+
+## 7. shadcn/ui Setup
+
+### components.json
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "gray",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}
+```
+
+### Component install plan (phased)
+
+Phase 1 -- Auth UI:
+
+```bash
+pnpm dlx shadcn@latest add button input form checkbox card label
+```
+
+Phase 2 -- Dashboard layout:
+
+```bash
+pnpm dlx shadcn@latest add sheet dropdown-menu avatar tooltip badge separator
+```
+
+Phase 3 -- Account management:
+
+```bash
+pnpm dlx shadcn@latest add table dialog alert-dialog select pagination
+```
+
+---
+
+## 8. Page UI Requirements
+
+Based on GitHub Discussion #32.
+
+### Auth flow
+
+- **Sign in**: Account ID field + Password field + show/hide toggle + Sign In button
+- **MFA verification**: TOTP code input or WebAuthn prompt after ID/PW sign-in (shown when account has MFA registered)
+- **MFA registration**: step-by-step wizard — method selection → QR code display (TOTP) or authenticator prompt (WebAuthn) → verification → recovery codes display (10 single-use codes, shown once). Triggered on first sign-in when `mfa_required` is effective (Discussion #32 §6.4)
+- **Reset password**: new password + confirm password + password requirements checklist
+- **Session timeout**: warning modal with countdown timer
+- **Session ended**: signed-out screen
+
+### Account management (Settings)
+
+- **Accounts table**: name, role, status, last sign-in, row actions
+- **Create/edit account**: dialog form
+- **Role management**: permission matrix table
+- **Custom role builder**: permission checkbox grid
+
+### System settings
+
+- Password policy form (minimum length, complexity rules, expiry)
+- Session timeout configuration
+- Account lockout policy
+- MFA availability toggle
+
+---
+
+## 9. Internationalization
+
+### Current state
+
+- `src/i18n/messages/en.json` and `ko.json` exist but contain only one key
+- `[locale]` route group exists but next-intl is NOT installed
+- No `middleware.ts`, no routing config; root layout has hardcoded `lang="en"`
+
+### Setup: next-intl with Next.js 16 App Router
+
+Required files to create:
+
+```
+src/
++-- i18n/
+|   +-- routing.ts      # defineRouting({ locales, defaultLocale, localePrefix })
+|   +-- navigation.ts   # typed Link, redirect, useRouter
+|   +-- request.ts      # getRequestConfig (server-side)
+|   +-- messages/
+|       +-- en.json
+|       +-- ko.json
++-- middleware.ts        # locale detection + URL rewriting
+```
+
+`next.config.ts` must be wrapped with `createNextIntlPlugin`.
+
+### URL strategy
+
+Use `localePrefix: 'as-needed'` in `defineRouting`. The default locale gets no URL prefix; all other locales are prefixed. This must be set explicitly -- next-intl defaults to `'always'`, which would prefix every URL including the default locale.
+
+**Configurable default locale via environment variable**, supporting different deployment targets without a code rebuild:
+
+```typescript
+// src/i18n/routing.ts
+const defaultLocale = (process.env.DEFAULT_LOCALE ?? 'en') as 'en' | 'ko';
+
+export const routing = defineRouting({
+  locales: ['en', 'ko'],
+  defaultLocale,
+  localePrefix: 'as-needed',
+});
+```
+
+Deployment scenarios:
+
+| Deployment | DEFAULT_LOCALE | Result |
+|------------|----------------|--------|
+| Global | `en` (default if unset) | `/sign-in` = English, `/ko/sign-in` = Korean |
+| Korean government | `ko` | `/sign-in` = Korean, `/en/sign-in` = English |
+
+Set `DEFAULT_LOCALE` in `.env.local` (development), Docker environment variable, or Kubernetes secret. The value is read at server startup time -- changing it requires a container restart, not a code rebuild.
+
+### Translation file structure
+
+Organize by feature, not by page, to allow reuse across routes:
+
+```json
+{
+  "common": {
+    "signIn": "Sign In",
+    "signOut": "Sign Out",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "confirm": "Confirm",
+    "loading": "Loading...",
+    "error": "An error occurred"
+  },
+  "auth": {
+    "username": "Account ID",
+    "password": "Password",
+    "showPassword": "Show password",
+    "signInHeading": "Sign into your account",
+    "resetPassword": "Reset your password",
+    "sessionTimeout": "Session timeout",
+    "sessionEnded": "Session ended"
+  },
+  "nav": {
+    "home": "Home",
+    "dashboard": "Dashboard",
+    "event": "Event",
+    "detection": "Detection",
+    "triage": "Triage",
+    "report": "Report",
+    "settings": "Settings"
+  },
+  "settings": {
+    "accounts": "Accounts",
+    "roles": "Roles",
+    "profile": "Profile"
+  },
+  "validation": {
+    "required": "{field} is required",
+    "passwordMinLength": "Password must be at least {min} characters",
+    "passwordMismatch": "Passwords do not match"
+  }
+}
+```
+
+### UI considerations for en/ko
+
+- **Font**: Roboto covers Hangul in weights 400/500/700, but CJK rendering quality must be verified during implementation. If quality is insufficient, add `Noto Sans KR` as fallback: `font-family: 'Roboto', 'Noto Sans KR', sans-serif`. Make this decision after a rendering test -- do not add the fallback preemptively.
+- **Text expansion**: Korean text length differs from English; use flexible widths and avoid fixed-width text containers.
+- **Date/time**: use `next-intl`'s `useFormatter()` hook for locale-aware formatting (Korean: YYYY년 MM월 DD일).
+- **Numbers**: use `useFormatter()` for byte counts, flow counts, etc.
+- **Locale switcher**: place in the sidebar bottom section (near the user profile) or in profile settings; persist in `localStorage` and a cookie for SSR consistency.
+- **`<html lang>`**: must be dynamic -- set from the locale parameter in the root layout, not hardcoded.
+
+### shadcn/ui + i18n
+
+shadcn/ui components are unstyled primitives with no built-in text strings. All visible text must use translation keys via `useTranslations` (Client Components) or `getTranslations` (Server Components).
+
+AlertDialog, Dialog close buttons, and other interactive elements that render text must receive translated strings as props.
+
+### Type-safe translations
+
+Configure the next-intl TypeScript plugin for autocomplete and type checking of translation keys. Add to `tsconfig.json`:
+
+```json
+{
+  "plugins": [
+    { "name": "next" },
+    { "name": "next-intl/plugin", "messageDir": "./src/i18n/messages" }
+  ]
+}
+```
+
+---
+
+## 10. Accessibility
+
+These requirements are mandatory for the initial release, not aspirational. Target: WCAG 2.1 Level AA.
+
+- **Color contrast**: 4.5:1 minimum for normal text, 3:1 for large text and icons. Verify all theme token combinations (light, dark, primary button, disabled states).
+- **Focus indicators**: visible 2px `--ring` outline on all interactive elements. Never use `outline: none` without a custom visible replacement.
+- **Keyboard navigation**: all interactive elements must be reachable and operable by keyboard. Maintain logical tab order. Add a skip-to-content link on the dashboard layout.
+- **Modal focus trap**: Dialog and AlertDialog must trap focus within the overlay. Esc closes the modal. Focus returns to the trigger element on close.
+- **Tooltip accessibility**: `role="tooltip"` + `aria-describedby` on the trigger element. Tooltips must be keyboard-accessible, not hover-only.
+- **Form errors**: `aria-invalid="true"` + `aria-describedby` pointing to the error message element. Never rely on color alone to communicate errors.
+- **ARIA landmarks**: use `<main>`, `<nav>`, and `<aside>` (for the sidebar) on the dashboard layout.
+- **Semantic HTML**: use semantic elements (`<button>` for actions, `<a>` for navigation); avoid div-soup.
+
+---
+
+## 11. Out of Scope
+
+The following are explicitly excluded from this document:
+
+- API contracts, GraphQL schema, BFF endpoint design (see `ARCHITECTURE.md`)
+- Authorization and permission policy details, including permission-based conditional rendering strategy (see Discussion #32; frontend implementation will be defined alongside the data layer architecture)
+- Performance budgets and Core Web Vitals targets
+- CI/CD pipeline configuration
+- Detailed component implementation (written during feature work, not here)
+
+---
+
+## 12. Additional Packages
+
+```bash
+# i18n
+pnpm add next-intl
+
+# Theme management (SSR-safe)
+pnpm add next-themes
+
+# Animation (replaces deprecated tailwindcss-animate)
+pnpm add tw-animate-css
+
+# Icons
+pnpm add lucide-react
+
+# Forms + validation (Issue #1 confirmed)
+pnpm add react-hook-form zod @hookform/resolvers
+
+# Server state management (Issue #1 confirmed)
+pnpm add @tanstack/react-query
+```
+
+

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -127,6 +127,18 @@ When reassessing, check:
 
 See Discussion #178 for the full rationale.
 
+## CI behavior for docs-only changes
+
+The CI workflow (`.github/workflows/ci.yml`) uses `dorny/paths-filter`
+to detect docs-only changes. When a commit modifies only documentation
+files (`docs/`, `decisions/`, `**/*.md`, `mkdocs.yml`,
+`.markdownlint*`), build, test, nginx-config, and other code-related
+jobs are skipped. Only the change-filter job itself runs.
+
+This means docs-only PRs merge faster and do not consume CI resources
+for unrelated checks. If your PR includes both code and docs changes,
+all CI jobs run as usual.
+
 ## Docs PR checklist
 
 Before submitting a docs PR, verify:


### PR DESCRIPTION
## Summary
- Move 5 finalized design decisions from GitHub Discussions (#32, #33, #34, #45, #46) into `decisions/` directory for version control and PR-based updates
- Add `dorny/paths-filter` change detection to CI workflow so build, test, and nginx-config jobs are skipped when only docs/markdown files are modified (same pattern as bootroot CI)
- Reference comments added to each Discussion noting the move and that they will no longer be kept in sync

## Files
- `decisions/account-management.md` ← Discussion #32
- `decisions/ui-architecture.md` ← Discussion #33
- `decisions/database-migration.md` ← Discussion #34
- `decisions/backup-restore.md` ← Discussion #45
- `decisions/audit-log.md` ← Discussion #46
- `.github/workflows/ci.yml` — added `changes` job with docs-only filter

## Test plan
- [ ] CI passes on this PR (the PR itself contains both code and docs changes, so all jobs should still run)
- [ ] Verify a subsequent docs-only commit skips build/test jobs

Closes #181