### PR TITLE
Parallelize E2E tests with worker isolation

### DIFF
--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -1,11 +1,7 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import {
   clearMustChangePassword,
   createTestAccount,
@@ -15,15 +11,6 @@ import {
   resetAccountDefaults,
   revokeAllSessions,
 } from "./helpers/setup-db";
-
-const TEST_PREFIX = "e2e-acct-";
-const UI_CREATE_USERNAME = `${TEST_PREFIX}ui-create`;
-const UI_EDIT_USERNAME = `${TEST_PREFIX}ui-edit`;
-const UI_DELETE_USERNAME = `${TEST_PREFIX}ui-delete`;
-const CUSTOM_ROLE_API_USERNAME = `${TEST_PREFIX}custom-api`;
-const CUSTOM_ROLE_UI_USERNAME = `${TEST_PREFIX}custom-ui`;
-const CUSTOM_ROLE_PREFIX = `${TEST_PREFIX}role-`;
-const CUSTOM_GLOBAL_ROLE_NAME = `${CUSTOM_ROLE_PREFIX}global-access`;
 
 const SYSTEM_ADMIN_PERMISSIONS = [
   "accounts:read",
@@ -40,8 +27,6 @@ const SYSTEM_ADMIN_PERMISSIONS = [
   "system-settings:write",
 ];
 
-let customGlobalRoleId: number;
-
 async function recreateUiAccount(
   username: string,
   password: string,
@@ -57,10 +42,29 @@ function accountRow(page: Page, username: string): Locator {
 }
 
 test.describe("Account management", () => {
-  test.beforeAll(async () => {
+  let TEST_PREFIX: string;
+  let UI_CREATE_USERNAME: string;
+  let UI_EDIT_USERNAME: string;
+  let UI_DELETE_USERNAME: string;
+  let CUSTOM_ROLE_API_USERNAME: string;
+  let CUSTOM_ROLE_UI_USERNAME: string;
+  let CUSTOM_ROLE_PREFIX: string;
+  let CUSTOM_GLOBAL_ROLE_NAME: string;
+  let customGlobalRoleId: number;
+
+  test.beforeAll(async ({ workerUsername, workerPrefix: wp }) => {
     await resetRateLimits();
-    await clearMustChangePassword(ADMIN_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
+    TEST_PREFIX = wp("e2e-acct-");
+    UI_CREATE_USERNAME = `${TEST_PREFIX}ui-create`;
+    UI_EDIT_USERNAME = `${TEST_PREFIX}ui-edit`;
+    UI_DELETE_USERNAME = `${TEST_PREFIX}ui-delete`;
+    CUSTOM_ROLE_API_USERNAME = `${TEST_PREFIX}custom-api`;
+    CUSTOM_ROLE_UI_USERNAME = `${TEST_PREFIX}custom-ui`;
+    CUSTOM_ROLE_PREFIX = `${TEST_PREFIX}role-`;
+    CUSTOM_GLOBAL_ROLE_NAME = `${CUSTOM_ROLE_PREFIX}global-access`;
+
+    await clearMustChangePassword(workerUsername);
+    await resetAccountDefaults(workerUsername);
     // Clean up any leftover test accounts
     await deleteTestAccount(`${TEST_PREFIX}alpha`);
     await deleteTestAccount(UI_CREATE_USERNAME);
@@ -76,9 +80,9 @@ test.describe("Account management", () => {
     );
   });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ workerUsername }) => {
     await resetRateLimits();
-    await revokeAllSessions(ADMIN_USERNAME);
+    await revokeAllSessions(workerUsername);
   });
 
   test.afterAll(async () => {
@@ -93,8 +97,12 @@ test.describe("Account management", () => {
 
   // ── API tests ─────────────────────────────────────────────────
 
-  test("POST /api/accounts creates an account", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("POST /api/accounts creates an account", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -122,9 +130,11 @@ test.describe("Account management", () => {
 
   test("POST /api/accounts accepts a custom global-access role without customers", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     await deleteTestAccount(CUSTOM_ROLE_API_USERNAME);
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -148,8 +158,12 @@ test.describe("Account management", () => {
     expect(body.data.role_name).toBe(CUSTOM_GLOBAL_ROLE_NAME);
   });
 
-  test("GET /api/accounts lists accounts", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("GET /api/accounts lists accounts", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.request.get(
       `/api/accounts?search=${TEST_PREFIX}`,
@@ -163,8 +177,12 @@ test.describe("Account management", () => {
     expect(testAccounts.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("PATCH /api/accounts/[id] updates an account", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("PATCH /api/accounts/[id] updates an account", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Get account ID
     const listRes = await page.request.get(
@@ -194,8 +212,10 @@ test.describe("Account management", () => {
 
   test("DELETE /api/accounts/[id] soft-deletes an account", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Get account ID
     const listRes = await page.request.get(
@@ -228,8 +248,10 @@ test.describe("Account management", () => {
 
   test("POST /api/accounts returns 400 for missing fields", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -249,11 +271,13 @@ test.describe("Account management", () => {
 
   test("navigates to accounts page and creates an account via UI", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     // Clean up first
     await deleteTestAccount(UI_CREATE_USERNAME);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/accounts");
 
     // Verify page heading
@@ -283,10 +307,12 @@ test.describe("Account management", () => {
 
   test("UI create flow treats a custom global-access role like System Administrator", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     await deleteTestAccount(CUSTOM_ROLE_UI_USERNAME);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/accounts");
 
     await page.getByRole("button", { name: "Create Account" }).click();
@@ -310,10 +336,14 @@ test.describe("Account management", () => {
     );
   });
 
-  test("edits an account via UI", async ({ page }) => {
+  test("edits an account via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await recreateUiAccount(UI_EDIT_USERNAME, "UiEditPass1234!");
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/accounts");
 
     // Wait for table to load
@@ -335,10 +365,14 @@ test.describe("Account management", () => {
     await expect(row).toContainText("E2E UI Edited", { timeout: 10_000 });
   });
 
-  test("deletes an account via UI", async ({ page }) => {
+  test("deletes an account via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await recreateUiAccount(UI_DELETE_USERNAME, "UiDeletePass1234!");
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/accounts");
 
     // Wait for table to load
@@ -395,8 +429,12 @@ test.describe("Account management", () => {
 
   // ── Filter tests ────────────────────────────────────────────
 
-  test("search filter returns matching accounts", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("search filter returns matching accounts", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.request.get("/api/accounts?search=admin");
     expect(response.status()).toBe(200);
@@ -410,8 +448,12 @@ test.describe("Account management", () => {
     ).toBe(true);
   });
 
-  test("role filter returns only matching role accounts", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("role filter returns only matching role accounts", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.request.get(
       "/api/accounts?role=System+Administrator",
@@ -428,8 +470,10 @@ test.describe("Account management", () => {
 
   test("status filter returns only matching status accounts", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.request.get("/api/accounts?status=active");
     expect(response.status()).toBe(200);
@@ -441,8 +485,12 @@ test.describe("Account management", () => {
 
   // ── Audit log verification ────────────────────────────────────
 
-  test("account audit events are visible in audit logs", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("account audit events are visible in audit logs", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Check audit logs API for account.create
     const auditRes = await page.request.get(

--- a/e2e/audit-logs.spec.ts
+++ b/e2e/audit-logs.spec.ts
@@ -1,25 +1,24 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import { resetAccountDefaults } from "./helpers/setup-db";
 
 test.describe("Audit log page", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
   });
 
-  test.afterAll(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterAll(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
-  test("audit log page loads and displays entries", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("audit log page loads and displays entries", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     await page.goto("/audit-logs");
     await page.waitForURL("**/audit-logs");
@@ -34,8 +33,12 @@ test.describe("Audit log page", () => {
     await expect(rows.first()).toBeVisible({ timeout: 10_000 });
   });
 
-  test("sign-in event appears in audit log", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("sign-in event appears in audit log", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/audit-logs");
     await page.waitForURL("**/audit-logs");
 
@@ -50,8 +53,12 @@ test.describe("Audit log page", () => {
     await expect(signInBadge.first()).toBeVisible();
   });
 
-  test("filter by action returns filtered results", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("filter by action returns filtered results", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/audit-logs");
     await page.waitForURL("**/audit-logs");
 
@@ -88,8 +95,12 @@ test.describe("Audit log page", () => {
     }
   });
 
-  test("filter by date range returns results", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("filter by date range returns results", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/audit-logs");
     await page.waitForURL("**/audit-logs");
 

--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -1,23 +1,22 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import { resetAccountDefaults } from "./helpers/setup-db";
 
-test.beforeAll(async () => {
+test.beforeAll(async ({ workerUsername }) => {
   await resetRateLimits();
-  await resetAccountDefaults(ADMIN_USERNAME);
+  await resetAccountDefaults(workerUsername);
 });
 
 test.describe("Auth flow screens (#131)", () => {
   // ── Sign-out reason screen ──────────────────────────────────
 
-  test("signed-out reason screen displays after sign-out", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("signed-out reason screen displays after sign-out", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Sign out via the nav user menu
     await page.goto("/sign-in?reason=signed-out");
@@ -110,9 +109,11 @@ test.describe("Auth flow screens (#131)", () => {
 
   test("sign-out invalidates session so protected pages redirect to sign-in", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await resetAccountDefaults(ADMIN_USERNAME);
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await resetAccountDefaults(workerUsername);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrf = cookies.find((c) => c.name === "csrf")?.value ?? "";

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,16 +1,13 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 import { resetRateLimits } from "./helpers/auth";
 import { clearMustChangePassword, revokeAllSessions } from "./helpers/setup-db";
 
-const ADMIN_USERNAME = "admin";
-const ADMIN_PASSWORD = "Admin1234!";
-
 test.describe("Authentication E2E", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await clearMustChangePassword(ADMIN_USERNAME);
-    await revokeAllSessions(ADMIN_USERNAME);
+    await clearMustChangePassword(workerUsername);
+    await revokeAllSessions(workerUsername);
   });
 
   test("unauthenticated access to protected route redirects to sign-in", async ({
@@ -36,9 +33,10 @@ test.describe("Authentication E2E", () => {
 
   test("sign-in with invalid credentials shows error message", async ({
     page,
+    workerUsername,
   }) => {
     await page.goto("/sign-in");
-    await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
+    await page.getByLabel("Account ID").fill(workerUsername);
     await page.locator("input[name='password']").fill("WrongPassword123!");
     await page.getByRole("button", { name: "Sign In" }).click();
 
@@ -50,20 +48,26 @@ test.describe("Authentication E2E", () => {
 
   test("sign-in with valid credentials redirects to dashboard", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     await page.goto("/sign-in");
-    await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
-    await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+    await page.getByLabel("Account ID").fill(workerUsername);
+    await page.locator("input[name='password']").fill(workerPassword);
     await page.getByRole("button", { name: "Sign In" }).click();
 
     await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
   });
 
-  test("sign-out clears session and redirects to sign-in", async ({ page }) => {
+  test("sign-out clears session and redirects to sign-in", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     // Sign in first
     await page.goto("/sign-in");
-    await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
-    await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+    await page.getByLabel("Account ID").fill(workerUsername);
+    await page.locator("input[name='password']").fill(workerPassword);
     await page.getByRole("button", { name: "Sign In" }).click();
     await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
 

--- a/e2e/change-password.spec.ts
+++ b/e2e/change-password.spec.ts
@@ -1,11 +1,5 @@
-import { expect, test } from "@playwright/test";
-
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signIn,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signIn } from "./helpers/auth";
 import {
   addPasswordHistory,
   clearPasswordHistory,
@@ -17,40 +11,47 @@ import {
 const NEW_PASSWORD = "NewSecurePass123!";
 
 test.describe("Change password flow", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername, workerPassword }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
-    await clearPasswordHistory(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
+    await setPassword(workerUsername, workerPassword);
+    await clearPasswordHistory(workerUsername);
   });
 
   test.beforeEach(async () => {
     await resetRateLimits();
   });
 
-  test.afterAll(async () => {
+  test.afterAll(async ({ workerUsername, workerPassword }) => {
     // Restore original password and reset account
-    await setPassword(ADMIN_USERNAME, ADMIN_PASSWORD);
-    await clearPasswordHistory(ADMIN_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await setPassword(workerUsername, workerPassword);
+    await clearPasswordHistory(workerUsername);
+    await resetAccountDefaults(workerUsername);
   });
 
   test("mustChangePassword user is redirected to /change-password from dashboard", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await setMustChangePassword(ADMIN_USERNAME, true);
+    await setMustChangePassword(workerUsername, true);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await page.waitForURL("**/change-password", { timeout: 10_000 });
     await expect(page).toHaveURL(/\/change-password/);
   });
 
-  test("wrong current password shows error", async ({ page }) => {
-    await setMustChangePassword(ADMIN_USERNAME, true);
+  test("wrong current password shows error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setMustChangePassword(workerUsername, true);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await page.waitForURL("**/change-password", { timeout: 10_000 });
 
     // Fill the change-password form with wrong current password
@@ -73,17 +74,19 @@ test.describe("Change password flow", () => {
 
   test("successful password change redirects to dashboard", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await setMustChangePassword(ADMIN_USERNAME, true);
+    await setMustChangePassword(workerUsername, true);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await page.waitForURL("**/change-password", { timeout: 10_000 });
 
     // Fill the change-password form correctly
     await page
       .locator("input[autocomplete='current-password']")
-      .fill(ADMIN_PASSWORD);
+      .fill(workerPassword);
     await page
       .locator("input[autocomplete='new-password']")
       .first()
@@ -106,14 +109,16 @@ test.describe("Change password flow", () => {
     expect(meResponse.status()).toBe(200);
 
     // Restore password for subsequent tests
-    await setPassword(ADMIN_USERNAME, ADMIN_PASSWORD);
-    await clearPasswordHistory(ADMIN_USERNAME);
+    await setPassword(workerUsername, workerPassword);
+    await clearPasswordHistory(workerUsername);
   });
 
   test("password change keeps the current session and revokes others", async ({
     browser,
+    workerUsername,
+    workerPassword,
   }) => {
-    await setMustChangePassword(ADMIN_USERNAME, true);
+    await setMustChangePassword(workerUsername, true);
 
     const contextA = await browser.newContext();
     const contextB = await browser.newContext();
@@ -123,16 +128,16 @@ test.describe("Change password flow", () => {
       const pageB = await contextB.newPage();
 
       await pageA.goto("/sign-in");
-      await signIn(pageA, ADMIN_USERNAME, ADMIN_PASSWORD);
+      await signIn(pageA, workerUsername, workerPassword);
       await pageA.waitForURL("**/change-password", { timeout: 10_000 });
 
       await pageB.goto("/sign-in");
-      await signIn(pageB, ADMIN_USERNAME, ADMIN_PASSWORD);
+      await signIn(pageB, workerUsername, workerPassword);
       await pageB.waitForURL("**/change-password", { timeout: 10_000 });
 
       await pageA
         .locator("input[autocomplete='current-password']")
-        .fill(ADMIN_PASSWORD);
+        .fill(workerPassword);
       await pageA
         .locator("input[autocomplete='new-password']")
         .first()
@@ -158,24 +163,28 @@ test.describe("Change password flow", () => {
     } finally {
       await contextA.close();
       await contextB.close();
-      await setPassword(ADMIN_USERNAME, ADMIN_PASSWORD);
-      await clearPasswordHistory(ADMIN_USERNAME);
-      await resetAccountDefaults(ADMIN_USERNAME);
+      await setPassword(workerUsername, workerPassword);
+      await clearPasswordHistory(workerUsername);
+      await resetAccountDefaults(workerUsername);
     }
   });
 
-  test("blocklisted password shows error", async ({ page }) => {
-    await setMustChangePassword(ADMIN_USERNAME, true);
+  test("blocklisted password shows error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setMustChangePassword(workerUsername, true);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await page.waitForURL("**/change-password", { timeout: 10_000 });
 
     // "password" is in the blocklist (also too short, so both errors appear)
     const blocklisted = "password";
     await page
       .locator("input[autocomplete='current-password']")
-      .fill(ADMIN_PASSWORD);
+      .fill(workerPassword);
     await page
       .locator("input[autocomplete='new-password']")
       .first()
@@ -191,15 +200,19 @@ test.describe("Change password flow", () => {
     await expect(errorAlert).toContainText(/common/i);
   });
 
-  test("recently used password shows reuse error", async ({ page }) => {
+  test("recently used password shows reuse error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     // Use a password that meets minLength (12) and add it to history
     const reusedPassword = "ReusedPass123!";
-    await setPassword(ADMIN_USERNAME, reusedPassword);
-    await addPasswordHistory(ADMIN_USERNAME, reusedPassword);
-    await setMustChangePassword(ADMIN_USERNAME, true);
+    await setPassword(workerUsername, reusedPassword);
+    await addPasswordHistory(workerUsername, reusedPassword);
+    await setMustChangePassword(workerUsername, true);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, reusedPassword);
+    await signIn(page, workerUsername, reusedPassword);
     await page.waitForURL("**/change-password", { timeout: 10_000 });
 
     // Try to reuse the same password
@@ -221,7 +234,7 @@ test.describe("Change password flow", () => {
     await expect(errorAlert).toContainText(/recent/i);
 
     // Cleanup: restore original password
-    await setPassword(ADMIN_USERNAME, ADMIN_PASSWORD);
-    await clearPasswordHistory(ADMIN_USERNAME);
+    await setPassword(workerUsername, workerPassword);
+    await clearPasswordHistory(workerUsername);
   });
 });

--- a/e2e/csrf.spec.ts
+++ b/e2e/csrf.spec.ts
@@ -1,25 +1,24 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import { resetAccountDefaults } from "./helpers/setup-db";
 
 test.describe("CSRF protection", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
   });
 
-  test.afterAll(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterAll(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
-  test("POST without x-csrf-token header returns 403", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("POST without x-csrf-token header returns 403", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.request.post("/api/auth/sign-out", {
       headers: {
@@ -31,8 +30,12 @@ test.describe("CSRF protection", () => {
     expect(response.status()).toBe(403);
   });
 
-  test("POST with wrong CSRF token returns 403", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("POST with wrong CSRF token returns 403", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.request.post("/api/auth/sign-out", {
       headers: {
@@ -47,8 +50,10 @@ test.describe("CSRF protection", () => {
   test("POST without Origin header returns 403", async ({
     page,
     playwright,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Extract cookies from the authenticated context.
     const cookies = await page.context().cookies();

--- a/e2e/customers.spec.ts
+++ b/e2e/customers.spec.ts
@@ -1,11 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import {
   clearMustChangePassword,
   deleteCustomersByPrefix,
@@ -13,19 +8,20 @@ import {
   revokeAllSessions,
 } from "./helpers/setup-db";
 
-const TEST_PREFIX = "E2E-Cust-";
-
 test.describe("Customer management — UI", () => {
-  test.beforeAll(async () => {
+  let TEST_PREFIX: string;
+
+  test.beforeAll(async ({ workerUsername, workerPrefix }) => {
     await resetRateLimits();
-    await clearMustChangePassword(ADMIN_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
+    TEST_PREFIX = workerPrefix("E2E-Cust-");
+    await clearMustChangePassword(workerUsername);
+    await resetAccountDefaults(workerUsername);
     await deleteCustomersByPrefix(TEST_PREFIX);
   });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ workerUsername }) => {
     await resetRateLimits();
-    await revokeAllSessions(ADMIN_USERNAME);
+    await revokeAllSessions(workerUsername);
   });
 
   test.afterAll(async () => {
@@ -34,8 +30,10 @@ test.describe("Customer management — UI", () => {
 
   test("navigates to customers page and creates a customer via UI", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/customers");
 
     await expect(
@@ -54,8 +52,12 @@ test.describe("Customer management — UI", () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test("edits a customer via UI", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("edits a customer via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/customers");
 
     await expect(
@@ -78,8 +80,12 @@ test.describe("Customer management — UI", () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test("deletes a customer via UI", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("deletes a customer via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/customers");
 
     await expect(

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,8 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
   resetRateLimits,
   signInAndWait,
   signInAndWaitKo,
@@ -20,17 +18,9 @@ import {
 
 // ── Constants ────────────────────────────────────────────────────
 
-const NOPERM_USER = "e2e-dashboard-noperm";
 const NOPERM_PASS = "Noperm1234!";
-const NOPERM_ROLE = "E2E No Dashboard";
-
-const READER_USER = "e2e-dashboard-reader";
 const READER_PASS = "Reader1234!";
-const READER_ROLE = "E2E Dashboard Reader";
-
-const LOCKED_USER = "e2e-dashboard-locked";
 const LOCKED_PASS = "Locked1234!";
-const SUSPENDED_USER = "e2e-dashboard-suspended";
 const SUSPENDED_PASS = "Suspended1234!";
 
 function csrfHeader(csrfValue: string) {
@@ -53,10 +43,29 @@ async function getLockedAccounts(page: import("@playwright/test").Page) {
   return body.data as Array<{ username: string; status: string }>;
 }
 
+// ── Prefix-derived constants (initialized in beforeAll) ─────────
+
+let NOPERM_USER: string;
+let NOPERM_ROLE: string;
+let READER_USER: string;
+let READER_ROLE: string;
+let LOCKED_USER: string;
+let SUSPENDED_USER: string;
+
 // ── Setup / Teardown ─────────────────────────────────────────────
 
-test.beforeAll(async () => {
+test.beforeAll(async ({ workerUsername, workerPrefix }) => {
   await resetRateLimits();
+  const prefix = workerPrefix("e2e-dashboard-");
+
+  NOPERM_USER = `${prefix}noperm`;
+  NOPERM_ROLE = `${prefix}No Dashboard`;
+  READER_USER = `${prefix}reader`;
+  READER_ROLE = `${prefix}Dashboard Reader`;
+  LOCKED_USER = `${prefix}locked`;
+  SUSPENDED_USER = `${prefix}suspended`;
+
+  await resetAccountDefaults(workerUsername);
 
   // Role with no dashboard permissions
   await createTestRole(NOPERM_ROLE, ["accounts:read"]);
@@ -75,9 +84,9 @@ test.beforeAll(async () => {
   );
 });
 
-test.beforeEach(async () => {
+test.beforeEach(async ({ workerUsername }) => {
   await resetRateLimits();
-  await resetAccountDefaults(ADMIN_USERNAME);
+  await resetAccountDefaults(workerUsername);
   await resetAccountDefaults(LOCKED_USER);
   await resetAccountDefaults(SUSPENDED_USER);
 });
@@ -99,8 +108,10 @@ test.afterAll(async () => {
 
 test("GET /api/dashboard/sessions returns active sessions", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
 
   const response = await page.request.get("/api/dashboard/sessions");
   expect(response.status()).toBe(200);
@@ -110,7 +121,7 @@ test("GET /api/dashboard/sessions returns active sessions", async ({
 
   // Admin's own session should be present
   const adminSession = body.data.find(
-    (s: { username: string }) => s.username === ADMIN_USERNAME,
+    (s: { username: string }) => s.username === workerUsername,
   );
   expect(adminSession).toBeDefined();
   expect(adminSession.ip_address).toBeTruthy();
@@ -118,11 +129,13 @@ test("GET /api/dashboard/sessions returns active sessions", async ({
 
 test("GET /api/dashboard/locked-accounts returns locked accounts", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
   // Lock the test account
   await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
 
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
 
   const response = await page.request.get("/api/dashboard/locked-accounts");
   expect(response.status()).toBe(200);
@@ -138,8 +151,12 @@ test("GET /api/dashboard/locked-accounts returns locked accounts", async ({
   await setAccountStatus(LOCKED_USER, "active");
 });
 
-test("GET /api/dashboard/alerts returns alerts array", async ({ page }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+test("GET /api/dashboard/alerts returns alerts array", async ({
+  page,
+  workerUsername,
+  workerPassword,
+}) => {
+  await signInAndWait(page, workerUsername, workerPassword);
 
   const response = await page.request.get("/api/dashboard/alerts");
   expect(response.status()).toBe(200);
@@ -150,12 +167,14 @@ test("GET /api/dashboard/alerts returns alerts array", async ({ page }) => {
 
 test("POST /api/dashboard/sessions/[sid]/revoke revokes a session", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
   // Create a session for the reader user by signing in
   await signInAndWait(page, READER_USER, READER_PASS);
 
   // Now sign in as admin
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
   const csrf = await getCsrf(page);
 
   // Find the reader's session
@@ -184,8 +203,12 @@ test("POST /api/dashboard/sessions/[sid]/revoke revokes a session", async ({
   expect(found).toBeUndefined();
 });
 
-test("POST revoke returns 404 for non-existent session", async ({ page }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+test("POST revoke returns 404 for non-existent session", async ({
+  page,
+  workerUsername,
+  workerPassword,
+}) => {
+  await signInAndWait(page, workerUsername, workerPassword);
   const csrf = await getCsrf(page);
 
   const response = await page.request.post(
@@ -239,8 +262,12 @@ test("dashboard:read user cannot revoke sessions (needs dashboard:write)", async
 
 // ── Dashboard placeholder UI tests ──────────────────────────────
 
-test("dashboard page shows placeholder for admin", async ({ page }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+test("dashboard page shows placeholder for admin", async ({
+  page,
+  workerUsername,
+  workerPassword,
+}) => {
+  await signInAndWait(page, workerUsername, workerPassword);
   await page.goto("/dashboard");
 
   await expect(page.getByRole("heading", { name: /Dashboard/i })).toBeVisible({
@@ -265,8 +292,10 @@ test("dashboard page redirects for user without dashboard:read", async ({
 
 test("Korean locale: dashboard shows placeholder in Korean", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWaitKo(page, workerUsername, workerPassword);
   await page.goto("/ko/dashboard");
 
   await expect(page.getByRole("heading", { name: "대시보드" })).toBeVisible({
@@ -279,8 +308,12 @@ test("Korean locale: dashboard shows placeholder in Korean", async ({
 
 // ── Account Status UI tests (Settings → Account Status) ─────────
 
-test("account status page renders four cards for admin", async ({ page }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+test("account status page renders four cards for admin", async ({
+  page,
+  workerUsername,
+  workerPassword,
+}) => {
+  await signInAndWait(page, workerUsername, workerPassword);
   await page.goto("/settings/account-status");
 
   await expect(
@@ -317,11 +350,15 @@ test("dashboard:read user cannot see action buttons on account status page", asy
   await expect(page.getByRole("button", { name: /Restore/i })).toHaveCount(0);
 });
 
-test("locked account shows in account status card", async ({ page }) => {
+test("locked account shows in account status card", async ({
+  page,
+  workerUsername,
+  workerPassword,
+}) => {
   await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
 
   try {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/account-status");
 
     await expect(page.getByText("Locked & Suspended Accounts")).toBeVisible({
@@ -336,9 +373,11 @@ test("locked account shows in account status card", async ({ page }) => {
 
 test("admin can unlock a locked account from account status page", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
   await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
   await page.goto("/settings/account-status");
 
   const row = page.locator("tr", { hasText: LOCKED_USER });
@@ -361,9 +400,11 @@ test("admin can unlock a locked account from account status page", async ({
 
 test("admin can restore a suspended account from account status page", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
   await setAccountStatus(SUSPENDED_USER, "suspended");
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
   await page.goto("/settings/account-status");
 
   const row = page.locator("tr", { hasText: SUSPENDED_USER });
@@ -388,8 +429,10 @@ test("admin can restore a suspended account from account status page", async ({
 
 test("GET /api/dashboard/cert-status returns valid cert status shape", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
 
   const response = await page.request.get("/api/dashboard/cert-status");
   expect(response.status()).toBe(200);
@@ -436,8 +479,10 @@ test("dashboard:read user can access cert-status endpoint", async ({
 
 test("account status page renders cert expiry card with status content", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWait(page, workerUsername, workerPassword);
   await page.goto("/settings/account-status");
 
   // Scroll down to make cert card visible
@@ -458,8 +503,10 @@ test("account status page renders cert expiry card with status content", async (
 
 test("Korean locale: account status renders four cards with Korean text", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWaitKo(page, workerUsername, workerPassword);
   await page.goto("/ko/settings/account-status");
 
   await expect(page.getByRole("heading", { name: "계정 현황" })).toBeVisible({
@@ -477,8 +524,10 @@ test("Korean locale: account status renders four cards with Korean text", async 
 
 test("Korean locale: sessions card shows Korean column headers", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWaitKo(page, workerUsername, workerPassword);
   await page.goto("/ko/settings/account-status");
 
   await expect(page.getByText("활성 세션").first()).toBeVisible({
@@ -492,8 +541,10 @@ test("Korean locale: sessions card shows Korean column headers", async ({
 
 test("Korean locale: revoke button and confirm dialog use Korean", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWaitKo(page, workerUsername, workerPassword);
   await page.goto("/ko/settings/account-status");
 
   await expect(page.getByText("활성 세션").first()).toBeVisible({
@@ -515,11 +566,13 @@ test("Korean locale: revoke button and confirm dialog use Korean", async ({
 
 test("Korean locale: locked account card shows Korean status", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
   await setAccountStatus(LOCKED_USER, "locked", new Date(Date.now() + 3600000));
 
   try {
-    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWaitKo(page, workerUsername, workerPassword);
     await page.goto("/ko/settings/account-status");
 
     await expect(page.getByText("잠긴 및 정지된 계정")).toBeVisible({
@@ -535,6 +588,8 @@ test("Korean locale: locked account card shows Korean status", async ({
 
 test("Korean locale: alerts card shows Korean detail messages", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
   const auditId = await insertAuditLog({
     actorId: "system",
@@ -545,7 +600,7 @@ test("Korean locale: alerts card shows Korean detail messages", async ({
   });
 
   try {
-    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWaitKo(page, workerUsername, workerPassword);
     await page.goto("/ko/settings/account-status");
 
     const desc = page.getByText("최근 24시간 동안 감지된 보안 알림");
@@ -564,8 +619,10 @@ test("Korean locale: alerts card shows Korean detail messages", async ({
 
 test("Korean locale: cert expiry card shows Korean text and status", async ({
   page,
+  workerUsername,
+  workerPassword,
 }) => {
-  await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await signInAndWaitKo(page, workerUsername, workerPassword);
   await page.goto("/ko/settings/account-status");
 
   const certTitle = page.getByText("인증서 만료");

--- a/e2e/error-messages.spec.ts
+++ b/e2e/error-messages.spec.ts
@@ -1,11 +1,5 @@
-import { expect, test } from "@playwright/test";
-
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signIn,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signIn } from "./helpers/auth";
 import {
   createFakeSessions,
   resetAccountDefaults,
@@ -21,27 +15,35 @@ test.describe("Sign-in error messages", () => {
     await resetRateLimits();
   });
 
-  test.afterEach(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterEach(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
-  test("inactive account shows 'Account is not active'", async ({ page }) => {
-    await setAccountStatus(ADMIN_USERNAME, "disabled");
+  test("inactive account shows 'Account is not active'", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setAccountStatus(workerUsername, "disabled");
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText("Account is not active");
   });
 
-  test("max sessions exceeded shows error", async ({ page }) => {
-    await resetAccountDefaults(ADMIN_USERNAME);
-    await setMaxSessions(ADMIN_USERNAME, 1);
-    await createFakeSessions(ADMIN_USERNAME, 1);
+  test("max sessions exceeded shows error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await resetAccountDefaults(workerUsername);
+    await setMaxSessions(workerUsername, 1);
+    await createFakeSessions(workerUsername, 1);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText(

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,51 @@
+import { test as base } from "@playwright/test";
+
+import {
+  createTestAccount,
+  resetAccountDefaults,
+  setPassword,
+} from "./helpers/setup-db";
+
+const WORKER_PASSWORD = "WorkerPass1234!";
+
+type WorkerFixtures = {
+  /** Username unique to this Playwright worker, e.g. `e2e-worker-0`. */
+  workerUsername: string;
+  /** Password for the worker account. */
+  workerPassword: string;
+  /** Returns a worker-scoped prefix: `${base}w${workerIndex}-`. */
+  workerPrefix: (base: string) => string;
+};
+
+export const test = base.extend<object, WorkerFixtures>({
+  workerUsername: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture signature
+    async ({}, use, workerInfo) => {
+      const username = `e2e-worker-${workerInfo.workerIndex}`;
+      await createTestAccount(username, WORKER_PASSWORD, "E2E Test Admin");
+      await resetAccountDefaults(username);
+      await setPassword(username, WORKER_PASSWORD);
+      await use(username);
+      await resetAccountDefaults(username);
+    },
+    { scope: "worker" },
+  ],
+
+  workerPassword: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture signature
+    async ({}, use) => {
+      await use(WORKER_PASSWORD);
+    },
+    { scope: "worker" },
+  ],
+
+  workerPrefix: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture signature
+    async ({}, use, workerInfo) => {
+      await use((base: string) => `${base}w${workerInfo.workerIndex}-`);
+    },
+    { scope: "worker" },
+  ],
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -4,6 +4,12 @@ import { resolve } from "node:path";
 
 import { exportJWK, generateKeyPair } from "jose";
 
+import {
+  createTestAccount,
+  createTestRole,
+  resetAccountDefaults,
+} from "./helpers/setup-db";
+
 /**
  * Resolve DATA_DIR the same way the app does:
  * process.env → .env.local → default "./data".
@@ -64,10 +70,44 @@ async function ensureJwtSigningKey(): Promise<void> {
   );
 }
 
+const WORKER_PASSWORD = "WorkerPass1234!";
+const WORKER_ROLE = "E2E Test Admin";
+const MAX_WORKERS = 8;
+
+// All permissions — same as System Administrator, but with a different
+// role name so worker accounts don't count toward the System Admin limit.
+const ALL_PERMISSIONS = [
+  "accounts:read",
+  "accounts:write",
+  "accounts:delete",
+  "roles:read",
+  "roles:write",
+  "roles:delete",
+  "customers:read",
+  "customers:write",
+  "customers:delete",
+  "customers:access-all",
+  "audit-logs:read",
+  "system-settings:read",
+  "system-settings:write",
+  "dashboard:read",
+  "dashboard:write",
+];
+
+async function ensureWorkerAccounts(): Promise<void> {
+  await createTestRole(WORKER_ROLE, ALL_PERMISSIONS, "E2E worker role");
+  for (let i = 0; i < MAX_WORKERS; i++) {
+    const username = `e2e-worker-${i}`;
+    await createTestAccount(username, WORKER_PASSWORD, WORKER_ROLE);
+    await resetAccountDefaults(username);
+  }
+}
+
 export default async function globalSetup(): Promise<void> {
   console.log("[e2e] Running global setup…");
   try {
     await ensureJwtSigningKey();
+    await ensureWorkerAccounts();
     console.log("[e2e] Global setup complete.");
   } catch (error) {
     console.error("[e2e] Global setup failed:", error);

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,5 @@
+import { closePools } from "./helpers/setup-db";
+
+export default async function globalTeardown(): Promise<void> {
+  await closePools();
+}

--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -23,40 +23,59 @@ function getDatabaseUrl(): string {
   return "postgres://postgres:postgres@localhost:5432/auth_db";
 }
 
-const DATABASE_URL = getDatabaseUrl();
+function getAuditDatabaseUrl(): string {
+  if (process.env.AUDIT_DATABASE_URL) return process.env.AUDIT_DATABASE_URL;
+
+  try {
+    const envFile = readFileSync(
+      resolve(__dirname, "../../.env.local"),
+      "utf8",
+    );
+    const match = envFile.match(/^AUDIT_DATABASE_URL=(.+)$/m);
+    if (match) return match[1].trim();
+  } catch {
+    // .env.local not found — use default
+  }
+
+  return "postgres://postgres:postgres@localhost:5432/audit_db";
+}
+
+const pool = new pg.Pool({ connectionString: getDatabaseUrl(), max: 10 });
+const auditPool = new pg.Pool({
+  connectionString: getAuditDatabaseUrl(),
+  max: 5,
+});
+
+/**
+ * Shut down both connection pools. Call from global teardown.
+ */
+export async function closePools(): Promise<void> {
+  await pool.end();
+  await auditPool.end();
+}
+
+// ── Account helpers ───────────────────────────────────────────────
 
 /**
  * Clear `must_change_password` so the E2E admin account redirects to
  * "/" instead of the non-existent "/change-password".
  */
 export async function clearMustChangePassword(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET must_change_password = false WHERE username = $1",
-      [username],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "UPDATE accounts SET must_change_password = false WHERE username = $1",
+    [username],
+  );
 }
 
 /**
  * Revoke all sessions so subsequent sign-in tests start clean.
  */
 export async function revokeAllSessions(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      `UPDATE sessions SET revoked = true
-       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
-      [username],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    `UPDATE sessions SET revoked = true
+     WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+    [username],
+  );
 }
 
 /**
@@ -66,16 +85,10 @@ export async function setFailedSignInCount(
   username: string,
   count: number,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET failed_sign_in_count = $2 WHERE username = $1",
-      [username, count],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "UPDATE accounts SET failed_sign_in_count = $2 WHERE username = $1",
+    [username, count],
+  );
 }
 
 /**
@@ -85,16 +98,10 @@ export async function setLockoutCount(
   username: string,
   count: number,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET lockout_count = $2 WHERE username = $1",
-      [username, count],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "UPDATE accounts SET lockout_count = $2 WHERE username = $1",
+    [username, count],
+  );
 }
 
 /**
@@ -105,18 +112,12 @@ export async function setAccountStatus(
   status: string,
   lockedUntil?: Date | null,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      `UPDATE accounts
-       SET status = $2, locked_until = $3
-       WHERE username = $1`,
-      [username, status, lockedUntil ?? null],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    `UPDATE accounts
+     SET status = $2, locked_until = $3
+     WHERE username = $1`,
+    [username, status, lockedUntil ?? null],
+  );
 }
 
 /**
@@ -126,21 +127,15 @@ export async function createFakeSessions(
   username: string,
   count: number,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      `INSERT INTO sessions (sid, account_id, ip_address, user_agent)
-       SELECT gen_random_uuid(),
-              (SELECT id FROM accounts WHERE username = $1),
-              '127.0.0.1',
-              'e2e-fake-session'
-       FROM generate_series(1, $2)`,
-      [username, count],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    `INSERT INTO sessions (sid, account_id, ip_address, user_agent)
+     SELECT gen_random_uuid(),
+            (SELECT id FROM accounts WHERE username = $1),
+            '127.0.0.1',
+            'e2e-fake-session'
+     FROM generate_series(1, $2)`,
+    [username, count],
+  );
 }
 
 /**
@@ -150,16 +145,10 @@ export async function setMaxSessions(
   username: string,
   limit: number | null,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET max_sessions = $2 WHERE username = $1",
-      [username, limit],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "UPDATE accounts SET max_sessions = $2 WHERE username = $1",
+    [username, limit],
+  );
 }
 
 /**
@@ -169,25 +158,18 @@ export async function setMustChangePassword(
   username: string,
   value: boolean,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET must_change_password = $2 WHERE username = $1",
-      [username, value],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "UPDATE accounts SET must_change_password = $2 WHERE username = $1",
+    [username, value],
+  );
 }
 
 /**
  * Reset an account to clean defaults: active, no lockout, no
- * must-change-password, no max-sessions, and revoke all sessions.
+ * must-change-password, no max-sessions, and delete all sessions.
  */
 export async function resetAccountDefaults(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     await client.query(
       `UPDATE accounts
@@ -206,7 +188,7 @@ export async function resetAccountDefaults(username: string): Promise<void> {
       [username],
     );
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -218,19 +200,13 @@ export async function expireSessionIdle(
   username: string,
   minutesAgo: number,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      `UPDATE sessions
-       SET last_active_at = NOW() - INTERVAL '${minutesAgo} minutes'
-       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
-         AND revoked = false`,
-      [username],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    `UPDATE sessions
+     SET last_active_at = NOW() - INTERVAL '${minutesAgo} minutes'
+     WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
+       AND revoked = false`,
+    [username],
+  );
 }
 
 /**
@@ -238,19 +214,13 @@ export async function expireSessionIdle(
  * Only affects non-revoked sessions.
  */
 export async function flagSessionReauth(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      `UPDATE sessions
-       SET needs_reauth = true
-       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
-         AND revoked = false`,
-      [username],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    `UPDATE sessions
+     SET needs_reauth = true
+     WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
+       AND revoked = false`,
+    [username],
+  );
 }
 
 /**
@@ -261,19 +231,13 @@ export async function changeSessionFingerprint(
   username: string,
   newFingerprint: string,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      `UPDATE sessions
-       SET browser_fingerprint = $2
-       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
-         AND revoked = false`,
-      [username, newFingerprint],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    `UPDATE sessions
+     SET browser_fingerprint = $2
+     WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
+       AND revoked = false`,
+    [username, newFingerprint],
+  );
 }
 
 /**
@@ -285,8 +249,7 @@ export async function createTestAccount(
   password: string,
   roleName: string,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     const { rows: roleRows } = await client.query<{ id: number }>(
       "SELECT id FROM roles WHERE name = $1",
@@ -299,11 +262,11 @@ export async function createTestAccount(
     await client.query(
       `INSERT INTO accounts (username, display_name, password_hash, role_id, must_change_password)
        VALUES ($1, $1, $2, $3, false)
-       ON CONFLICT (username) DO NOTHING`,
+       ON CONFLICT (username) DO UPDATE SET role_id = EXCLUDED.role_id`,
       [username, passwordHash, roleRows[0].id],
     );
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -311,8 +274,7 @@ export async function createTestAccount(
  * Delete a test account and its sessions.
  */
 export async function deleteTestAccount(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     await client.query(
       `DELETE FROM sessions
@@ -329,7 +291,7 @@ export async function deleteTestAccount(username: string): Promise<void> {
     );
     await client.query("DELETE FROM accounts WHERE username = $1", [username]);
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -340,17 +302,11 @@ export async function setPassword(
   username: string,
   password: string,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
-    await client.query(
-      "UPDATE accounts SET password_hash = $2 WHERE username = $1",
-      [username, passwordHash],
-    );
-  } finally {
-    await client.end();
-  }
+  const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
+  await pool.query(
+    "UPDATE accounts SET password_hash = $2 WHERE username = $1",
+    [username, passwordHash],
+  );
 }
 
 /**
@@ -360,61 +316,44 @@ export async function addPasswordHistory(
   username: string,
   password: string,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
-    await client.query(
-      `INSERT INTO password_history (account_id, password_hash)
-       VALUES ((SELECT id FROM accounts WHERE username = $1), $2)`,
-      [username, passwordHash],
-    );
-  } finally {
-    await client.end();
-  }
+  const passwordHash = await argon2.hash(password, { type: argon2.argon2id });
+  await pool.query(
+    `INSERT INTO password_history (account_id, password_hash)
+     VALUES ((SELECT id FROM accounts WHERE username = $1), $2)`,
+    [username, passwordHash],
+  );
 }
 
 /**
  * Clear password history for an account (for test setup).
  */
 export async function clearPasswordHistory(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "DELETE FROM password_history WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
-      [username],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "DELETE FROM password_history WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
+    [username],
+  );
 }
 
 /**
  * Get the UUID of an account by username.
  */
 export async function getAccountId(username: string): Promise<string> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    const { rows } = await client.query<{ id: string }>(
-      "SELECT id FROM accounts WHERE username = $1",
-      [username],
-    );
-    if (rows.length === 0) throw new Error(`Account "${username}" not found`);
-    return rows[0].id;
-  } finally {
-    await client.end();
-  }
+  const { rows } = await pool.query<{ id: string }>(
+    "SELECT id FROM accounts WHERE username = $1",
+    [username],
+  );
+  if (rows.length === 0) throw new Error(`Account "${username}" not found`);
+  return rows[0].id;
 }
+
+// ── Customer helpers ──────────────────────────────────────────────
 
 /**
  * Delete all customers whose name starts with a given prefix.
  * Also drops the associated databases.
  */
 export async function deleteCustomersByPrefix(prefix: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     const { rows } = await client.query<{
       id: number;
@@ -438,7 +377,7 @@ export async function deleteCustomersByPrefix(prefix: string): Promise<void> {
       ]);
     }
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -449,16 +388,10 @@ export async function assignCustomerToAccount(
   accountId: string,
   customerId: number,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "INSERT INTO account_customer (account_id, customer_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-      [accountId, customerId],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "INSERT INTO account_customer (account_id, customer_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+    [accountId, customerId],
+  );
 }
 
 /**
@@ -467,15 +400,9 @@ export async function assignCustomerToAccount(
 export async function removeAccountCustomerAssignments(
   accountId: string,
 ): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query("DELETE FROM account_customer WHERE account_id = $1", [
-      accountId,
-    ]);
-  } finally {
-    await client.end();
-  }
+  await pool.query("DELETE FROM account_customer WHERE account_id = $1", [
+    accountId,
+  ]);
 }
 
 /**
@@ -484,34 +411,52 @@ export async function removeAccountCustomerAssignments(
 export async function getCustomerIdByName(
   name: string,
 ): Promise<number | null> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    const { rows } = await client.query<{ id: number }>(
-      "SELECT id FROM customers WHERE name = $1",
-      [name],
-    );
-    return rows.length > 0 ? rows[0].id : null;
-  } finally {
-    await client.end();
-  }
+  const { rows } = await pool.query<{ id: number }>(
+    "SELECT id FROM customers WHERE name = $1",
+    [name],
+  );
+  return rows.length > 0 ? rows[0].id : null;
 }
+
+// ── Preferences helpers ───────────────────────────────────────────
 
 /**
  * Reset locale and timezone preferences for an account.
  */
 export async function resetAccountPreferences(username: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET locale = NULL, timezone = NULL WHERE username = $1",
-      [username],
-    );
-  } finally {
-    await client.end();
-  }
+  await pool.query(
+    "UPDATE accounts SET locale = NULL, timezone = NULL WHERE username = $1",
+    [username],
+  );
 }
+
+/**
+ * Set locale for an account.
+ */
+export async function setAccountLocale(
+  username: string,
+  locale: string,
+): Promise<void> {
+  await pool.query("UPDATE accounts SET locale = $2 WHERE username = $1", [
+    username,
+    locale,
+  ]);
+}
+
+/**
+ * Set timezone for an account.
+ */
+export async function setAccountTimezone(
+  username: string,
+  timezone: string,
+): Promise<void> {
+  await pool.query("UPDATE accounts SET timezone = $2 WHERE username = $1", [
+    username,
+    timezone,
+  ]);
+}
+
+// ── Role helpers ──────────────────────────────────────────────────
 
 /**
  * Create a custom role with the given permissions.
@@ -523,8 +468,7 @@ export async function createTestRole(
   permissions: string[],
   description?: string,
 ): Promise<number> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     const { rows } = await client.query<{ id: number }>(
       `INSERT INTO roles (name, description, is_builtin)
@@ -548,7 +492,7 @@ export async function createTestRole(
 
     return roleId;
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -556,8 +500,7 @@ export async function createTestRole(
  * Delete a custom role by name. Silently ignores if not found.
  */
 export async function deleteTestRole(name: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     await client.query(
       "DELETE FROM role_permissions WHERE role_id = (SELECT id FROM roles WHERE name = $1)",
@@ -568,7 +511,7 @@ export async function deleteTestRole(name: string): Promise<void> {
       [name],
     );
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -576,8 +519,7 @@ export async function deleteTestRole(name: string): Promise<void> {
  * Delete all custom roles whose name starts with a given prefix.
  */
 export async function deleteRolesByPrefix(prefix: string): Promise<void> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
+  const client = await pool.connect();
   try {
     await client.query(
       `DELETE FROM role_permissions
@@ -591,7 +533,7 @@ export async function deleteRolesByPrefix(prefix: string): Promise<void> {
       [`${prefix}%`],
     );
   } finally {
-    await client.end();
+    client.release();
   }
 }
 
@@ -600,25 +542,6 @@ function escapeIdentifier(str: string): string {
 }
 
 // ── Audit database helpers ────────────────────────────────────────
-
-function getAuditDatabaseUrl(): string {
-  if (process.env.AUDIT_DATABASE_URL) return process.env.AUDIT_DATABASE_URL;
-
-  try {
-    const envFile = readFileSync(
-      resolve(__dirname, "../../.env.local"),
-      "utf8",
-    );
-    const match = envFile.match(/^AUDIT_DATABASE_URL=(.+)$/m);
-    if (match) return match[1].trim();
-  } catch {
-    // .env.local not found — use default
-  }
-
-  return "postgres://postgres:postgres@localhost:5432/audit_db";
-}
-
-const AUDIT_DATABASE_URL = getAuditDatabaseUrl();
 
 /**
  * Insert a fake audit log entry into the audit database.
@@ -632,27 +555,21 @@ export async function insertAuditLog(opts: {
   ipAddress?: string;
   details?: Record<string, unknown>;
 }): Promise<string> {
-  const client = new pg.Client({ connectionString: AUDIT_DATABASE_URL });
-  await client.connect();
-  try {
-    const { rows } = await client.query<{ id: string }>(
-      `INSERT INTO audit_logs
-         (actor_id, action, target_type, target_id, ip_address, details)
-       VALUES ($1, $2, $3, $4, $5, $6)
-       RETURNING id`,
-      [
-        opts.actorId,
-        opts.action,
-        opts.targetType,
-        opts.targetId ?? null,
-        opts.ipAddress ?? "127.0.0.1",
-        opts.details ? JSON.stringify(opts.details) : null,
-      ],
-    );
-    return rows[0].id;
-  } finally {
-    await client.end();
-  }
+  const { rows } = await auditPool.query<{ id: string }>(
+    `INSERT INTO audit_logs
+       (actor_id, action, target_type, target_id, ip_address, details)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [
+      opts.actorId,
+      opts.action,
+      opts.targetType,
+      opts.targetId ?? null,
+      opts.ipAddress ?? "127.0.0.1",
+      opts.details ? JSON.stringify(opts.details) : null,
+    ],
+  );
+  return rows[0].id;
 }
 
 /**
@@ -660,14 +577,10 @@ export async function insertAuditLog(opts: {
  * Only removes the exact row that was seeded, leaving other data intact.
  */
 export async function deleteAuditLogById(id: string): Promise<void> {
-  const client = new pg.Client({ connectionString: AUDIT_DATABASE_URL });
-  await client.connect();
-  try {
-    await client.query("DELETE FROM audit_logs WHERE id = $1", [id]);
-  } finally {
-    await client.end();
-  }
+  await auditPool.query("DELETE FROM audit_logs WHERE id = $1", [id]);
 }
+
+// ── Session status helpers ────────────────────────────────────────
 
 /**
  * Get session status for diagnostic/assertion purposes.
@@ -677,25 +590,19 @@ export async function getSessionStatus(username: string): Promise<{
   revoked: boolean;
   browserFingerprint: string;
 } | null> {
-  const client = new pg.Client({ connectionString: DATABASE_URL });
-  await client.connect();
-  try {
-    const result = await client.query(
-      `SELECT needs_reauth, revoked, browser_fingerprint
-       FROM sessions
-       WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
-         AND revoked = false
-       ORDER BY created_at DESC
-       LIMIT 1`,
-      [username],
-    );
-    if (result.rows.length === 0) return null;
-    return {
-      needsReauth: result.rows[0].needs_reauth,
-      revoked: result.rows[0].revoked,
-      browserFingerprint: result.rows[0].browser_fingerprint,
-    };
-  } finally {
-    await client.end();
-  }
+  const result = await pool.query(
+    `SELECT needs_reauth, revoked, browser_fingerprint
+     FROM sessions
+     WHERE account_id = (SELECT id FROM accounts WHERE username = $1)
+       AND revoked = false
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [username],
+  );
+  if (result.rows.length === 0) return null;
+  return {
+    needsReauth: result.rows[0].needs_reauth,
+    revoked: result.rows[0].revoked,
+    browserFingerprint: result.rows[0].browser_fingerprint,
+  };
 }

--- a/e2e/i18n-errors.spec.ts
+++ b/e2e/i18n-errors.spec.ts
@@ -1,11 +1,5 @@
-import { expect, test } from "@playwright/test";
-
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInKo,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signInKo } from "./helpers/auth";
 import {
   createFakeSessions,
   resetAccountDefaults,
@@ -21,12 +15,15 @@ test.describe("Korean error messages", () => {
     await resetRateLimits();
   });
 
-  test.afterEach(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterEach(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
-  test("/ko wrong credentials shows Korean error", async ({ page }) => {
-    await signInKo(page, ADMIN_USERNAME, "WrongPassword!");
+  test("/ko wrong credentials shows Korean error", async ({
+    page,
+    workerUsername,
+  }) => {
+    await signInKo(page, workerUsername, "WrongPassword!");
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText(
@@ -34,10 +31,14 @@ test.describe("Korean error messages", () => {
     );
   });
 
-  test("/ko locked account shows Korean error", async ({ page }) => {
-    await setAccountStatus(ADMIN_USERNAME, "locked", null);
+  test("/ko locked account shows Korean error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setAccountStatus(workerUsername, "locked", null);
 
-    await signInKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInKo(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText(
@@ -45,21 +46,29 @@ test.describe("Korean error messages", () => {
     );
   });
 
-  test("/ko inactive account shows Korean error", async ({ page }) => {
-    await setAccountStatus(ADMIN_USERNAME, "disabled");
+  test("/ko inactive account shows Korean error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setAccountStatus(workerUsername, "disabled");
 
-    await signInKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInKo(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText("계정이 활성 상태가 아닙니다");
   });
 
-  test("/ko max sessions shows Korean error", async ({ page }) => {
-    await resetAccountDefaults(ADMIN_USERNAME);
-    await setMaxSessions(ADMIN_USERNAME, 1);
-    await createFakeSessions(ADMIN_USERNAME, 1);
+  test("/ko max sessions shows Korean error", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await resetAccountDefaults(workerUsername);
+    await setMaxSessions(workerUsername, 1);
+    await createFakeSessions(workerUsername, 1);
 
-    await signInKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInKo(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText("최대 활성 세션 수에 도달했습니다");

--- a/e2e/lockout.spec.ts
+++ b/e2e/lockout.spec.ts
@@ -1,11 +1,5 @@
-import { expect, test } from "@playwright/test";
-
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signIn,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signIn } from "./helpers/auth";
 import {
   resetAccountDefaults,
   setAccountStatus,
@@ -17,22 +11,30 @@ const alert = (page: import("@playwright/test").Page) =>
   page.locator("p[role='alert']");
 
 test.describe("Account lockout", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
   });
 
-  test.afterAll(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.beforeEach(async () => {
+    await resetRateLimits();
   });
 
-  test("temp locked account shows lockout message", async ({ page }) => {
+  test.afterAll(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
+  });
+
+  test("temp locked account shows lockout message", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     // Lock the account with a future expiry via DB.
     const future = new Date(Date.now() + 30 * 60_000);
-    await setAccountStatus(ADMIN_USERNAME, "locked", future);
+    await setAccountStatus(workerUsername, "locked", future);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText(
@@ -40,11 +42,15 @@ test.describe("Account lockout", () => {
     );
   });
 
-  test("permanent lock (no locked_until)", async ({ page }) => {
-    await setAccountStatus(ADMIN_USERNAME, "locked", null);
+  test("permanent lock (no locked_until)", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setAccountStatus(workerUsername, "locked", null);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText(
@@ -52,28 +58,33 @@ test.describe("Account lockout", () => {
     );
   });
 
-  test("temp lock auto-expires and sign-in succeeds", async ({ page }) => {
+  test("temp lock auto-expires and sign-in succeeds", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     // Set locked_until to 1 minute in the past so it's already expired.
     const past = new Date(Date.now() - 60_000);
-    await setAccountStatus(ADMIN_USERNAME, "locked", past);
-    await setFailedSignInCount(ADMIN_USERNAME, 0);
+    await setAccountStatus(workerUsername, "locked", past);
+    await setFailedSignInCount(workerUsername, 0);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
   });
 
   test("wrong password at threshold triggers lockout on next attempt", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
     // Set count to 4, so the next wrong password is the 5th failure.
-    await setFailedSignInCount(ADMIN_USERNAME, 4);
+    await setFailedSignInCount(workerUsername, 4);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, "WrongPassword!");
+    await signIn(page, workerUsername, "WrongPassword!");
 
     // The 5th failure returns INVALID_CREDENTIALS (lockout happens
     // server-side but the current response is still "invalid creds").
@@ -81,17 +92,21 @@ test.describe("Account lockout", () => {
     await expect(alert(page)).toContainText("Invalid account ID or password");
 
     // The NEXT sign-in attempt should see the lockout message.
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await expect(alert(page)).toContainText(
       "Account is locked. Please try again later.",
     );
   });
 
-  test("suspended account shows inactive message", async ({ page }) => {
-    await setAccountStatus(ADMIN_USERNAME, "suspended", null);
+  test("suspended account shows inactive message", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await setAccountStatus(workerUsername, "suspended", null);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText("Account is not active");
@@ -99,39 +114,41 @@ test.describe("Account lockout", () => {
 
   test("stage2 triggers suspension when lockout_count >= 1", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
     // Simulate: previously locked once, auto-unlocked, now at threshold again
-    await setFailedSignInCount(ADMIN_USERNAME, 4);
-    await setLockoutCount(ADMIN_USERNAME, 1);
+    await setFailedSignInCount(workerUsername, 4);
+    await setLockoutCount(workerUsername, 1);
 
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, "WrongPassword!");
+    await signIn(page, workerUsername, "WrongPassword!");
 
     // The 5th failure suspends the account (lockout_count >= 1).
     await expect(alert(page)).toBeVisible();
     await expect(alert(page)).toContainText("Invalid account ID or password");
 
     // The NEXT attempt should see the inactive (suspended) message.
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await expect(alert(page)).toContainText("Account is not active");
   });
 
   test("auto-unlock after stage1 preserves lockout_count for stage2", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
     // Simulate: stage1 lock expired (past locked_until), lockout_count = 1
     const past = new Date(Date.now() - 60_000);
-    await setAccountStatus(ADMIN_USERNAME, "locked", past);
-    await setFailedSignInCount(ADMIN_USERNAME, 0);
-    await setLockoutCount(ADMIN_USERNAME, 1);
+    await setAccountStatus(workerUsername, "locked", past);
+    await setFailedSignInCount(workerUsername, 0);
+    await setLockoutCount(workerUsername, 1);
 
     // Auto-unlock should succeed (correct password)
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
   });
 });

--- a/e2e/must-change-password.spec.ts
+++ b/e2e/must-change-password.spec.ts
@@ -1,32 +1,33 @@
-import { expect, test } from "@playwright/test";
-
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signIn,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signIn } from "./helpers/auth";
 import {
   clearMustChangePassword,
   resetAccountDefaults,
   setMustChangePassword,
+  setPassword,
 } from "./helpers/setup-db";
 
 test.describe("Must-change-password flow", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername, workerPassword }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
-    await setMustChangePassword(ADMIN_USERNAME, true);
+    await resetAccountDefaults(workerUsername);
+    await setPassword(workerUsername, workerPassword);
+    await setMustChangePassword(workerUsername, true);
   });
 
-  test.afterAll(async () => {
-    await clearMustChangePassword(ADMIN_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterAll(async ({ workerUsername, workerPassword }) => {
+    await clearMustChangePassword(workerUsername);
+    await setPassword(workerUsername, workerPassword);
+    await resetAccountDefaults(workerUsername);
   });
 
-  test("sign-in redirects to /change-password", async ({ page }) => {
+  test("sign-in redirects to /change-password", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
 
     await page.waitForURL("**/change-password", { timeout: 10_000 });
     await expect(page).toHaveURL(/\/change-password/);
@@ -34,9 +35,11 @@ test.describe("Must-change-password flow", () => {
 
   test("API returns 403 while must_change_password is true", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await page.waitForURL("**/change-password", { timeout: 10_000 });
 
     // Attempt to access a protected API endpoint.
@@ -49,9 +52,11 @@ test.describe("Must-change-password flow", () => {
 
   test("sign-out still works when must_change_password is true", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     await page.goto("/sign-in");
-    await signIn(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signIn(page, workerUsername, workerPassword);
     await page.waitForURL("**/change-password", { timeout: 10_000 });
 
     // Sign out via API (should succeed despite must_change_password).

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -28,11 +28,12 @@ function buildEnv(): Record<string, string> {
 
 export default defineConfig({
   globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
   testDir: ".",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: 1,
+  workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI
     ? [["html", { open: "never" }], ["github"]]
     : [["html", { open: "on-failure" }]],
@@ -43,7 +44,14 @@ export default defineConfig({
   },
   projects: [
     {
-      name: "chromium",
+      name: "parallel",
+      testIgnore: ["rate-limit.spec.ts", "system-settings.spec.ts"],
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "serial",
+      testMatch: ["rate-limit.spec.ts", "system-settings.spec.ts"],
+      dependencies: ["parallel"],
       use: { ...devices["Desktop Chrome"] },
     },
   ],

--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -1,87 +1,39 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { expect, test } from "@playwright/test";
-import pg from "pg";
+import { expect, test } from "./fixtures";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import {
   clearMustChangePassword,
   resetAccountDefaults,
   resetAccountPreferences,
   revokeAllSessions,
+  setAccountLocale,
+  setAccountTimezone,
 } from "./helpers/setup-db";
-
-// ── DB helpers ────────────────────────────────────────────────
-
-function getDatabaseUrl(): string {
-  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
-  try {
-    const envFile = readFileSync(resolve(__dirname, "../.env.local"), "utf8");
-    const match = envFile.match(/^DATABASE_URL=(.+)$/m);
-    if (match) return match[1].trim();
-  } catch {
-    // .env.local not found
-  }
-  return "postgres://postgres:postgres@localhost:5432/auth_db";
-}
-
-async function setAccountLocale(
-  username: string,
-  locale: string,
-): Promise<void> {
-  const client = new pg.Client({ connectionString: getDatabaseUrl() });
-  await client.connect();
-  try {
-    await client.query("UPDATE accounts SET locale = $2 WHERE username = $1", [
-      username,
-      locale,
-    ]);
-  } finally {
-    await client.end();
-  }
-}
-
-async function setAccountTimezone(
-  username: string,
-  timezone: string,
-): Promise<void> {
-  const client = new pg.Client({ connectionString: getDatabaseUrl() });
-  await client.connect();
-  try {
-    await client.query(
-      "UPDATE accounts SET timezone = $2 WHERE username = $1",
-      [username, timezone],
-    );
-  } finally {
-    await client.end();
-  }
-}
 
 // ── Tests ─────────────────────────────────────────────────────
 
 test.describe("Preferences", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await clearMustChangePassword(ADMIN_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
-    await resetAccountPreferences(ADMIN_USERNAME);
+    await clearMustChangePassword(workerUsername);
+    await resetAccountDefaults(workerUsername);
+    await resetAccountPreferences(workerUsername);
   });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ workerUsername }) => {
     await resetRateLimits();
-    await revokeAllSessions(ADMIN_USERNAME);
-    await resetAccountPreferences(ADMIN_USERNAME);
+    await revokeAllSessions(workerUsername);
+    await resetAccountPreferences(workerUsername);
   });
 
   // ── API tests ─────────────────────────────────────────────────
 
-  test("GET returns null when preferences are not set", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("GET returns null when preferences are not set", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const res = await page.request.get("/api/accounts/me/preferences");
     expect(res.status()).toBe(200);
@@ -91,8 +43,12 @@ test.describe("Preferences", () => {
     expect(body.data.timezone).toBeNull();
   });
 
-  test("PATCH sets locale and NEXT_LOCALE cookie", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("PATCH sets locale and NEXT_LOCALE cookie", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -116,8 +72,12 @@ test.describe("Preferences", () => {
     expect(localeCookie?.value).toBe("ko");
   });
 
-  test("PATCH sets timezone", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("PATCH sets timezone", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -137,8 +97,10 @@ test.describe("Preferences", () => {
 
   test("PATCH sets both locale and timezone simultaneously", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -157,8 +119,12 @@ test.describe("Preferences", () => {
     expect(body.data.timezone).toBe("Asia/Seoul");
   });
 
-  test("PATCH rejects invalid locale", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("PATCH rejects invalid locale", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -174,8 +140,12 @@ test.describe("Preferences", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("PATCH rejects invalid timezone", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("PATCH rejects invalid timezone", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -191,8 +161,12 @@ test.describe("Preferences", () => {
     expect(res.status()).toBe(400);
   });
 
-  test("PATCH null locale deletes NEXT_LOCALE cookie", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("PATCH null locale deletes NEXT_LOCALE cookie", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -224,8 +198,12 @@ test.describe("Preferences", () => {
     expect(localeCookie).toBeUndefined();
   });
 
-  test("GET returns updated values after PATCH", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("GET returns updated values after PATCH", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -259,10 +237,12 @@ test.describe("Preferences", () => {
 
   test("sign-in sets NEXT_LOCALE cookie when account has stored locale", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await setAccountLocale(ADMIN_USERNAME, "ko");
+    await setAccountLocale(workerUsername, "ko");
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const localeCookie = cookies.find((c) => c.name === "NEXT_LOCALE");
@@ -272,10 +252,12 @@ test.describe("Preferences", () => {
 
   test("sign-in does not set NEXT_LOCALE cookie when locale is null", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await resetAccountPreferences(ADMIN_USERNAME);
+    await resetAccountPreferences(workerUsername);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const localeCookie = cookies.find((c) => c.name === "NEXT_LOCALE");
@@ -284,8 +266,12 @@ test.describe("Preferences", () => {
 
   // ── UI tests ──────────────────────────────────────────────────
 
-  test("profile page shows preferences form", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("profile page shows preferences form", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/profile");
 
     await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
@@ -294,12 +280,16 @@ test.describe("Preferences", () => {
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
   });
 
-  test("profile page displays stored preferences on load", async ({ page }) => {
+  test("profile page displays stored preferences on load", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     // Pre-set preferences in DB
-    await setAccountLocale(ADMIN_USERNAME, "ko");
-    await setAccountTimezone(ADMIN_USERNAME, "Asia/Seoul");
+    await setAccountLocale(workerUsername, "ko");
+    await setAccountTimezone(workerUsername, "Asia/Seoul");
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/profile");
 
     // Form should show stored values
@@ -310,8 +300,10 @@ test.describe("Preferences", () => {
 
   test("locale change via UI switches page language to Korean", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/profile");
 
     await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
@@ -337,8 +329,12 @@ test.describe("Preferences", () => {
     await expect(page.getByLabel("시간대")).toBeVisible();
   });
 
-  test("locale change persists after page reload", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("locale change persists after page reload", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -361,8 +357,12 @@ test.describe("Preferences", () => {
     });
   });
 
-  test("timezone preference persists after page reload", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("timezone preference persists after page reload", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");
@@ -385,8 +385,12 @@ test.describe("Preferences", () => {
 
   // ── Timezone display integration ────────────────────────────────
 
-  test("audit log timestamps reflect timezone preference", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("audit log timestamps reflect timezone preference", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const cookies = await page.context().cookies();
     const csrfCookie = cookies.find((c) => c.name === "csrf");

--- a/e2e/roles.spec.ts
+++ b/e2e/roles.spec.ts
@@ -1,11 +1,7 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import {
   clearMustChangePassword,
   createTestRole,
@@ -15,8 +11,6 @@ import {
   revokeAllSessions,
 } from "./helpers/setup-db";
 
-const TEST_PREFIX = "e2e-role-";
-
 function roleRow(page: Page, name: string): Locator {
   return page.locator("tbody tr").filter({
     has: page.locator("td.font-medium", { hasText: name }),
@@ -24,16 +18,19 @@ function roleRow(page: Page, name: string): Locator {
 }
 
 test.describe("Role management — UI", () => {
-  test.beforeAll(async () => {
+  let TEST_PREFIX: string;
+
+  test.beforeAll(async ({ workerUsername, workerPrefix: wp }) => {
     await resetRateLimits();
-    await clearMustChangePassword(ADMIN_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
+    TEST_PREFIX = wp("e2e-role-");
+    await clearMustChangePassword(workerUsername);
+    await resetAccountDefaults(workerUsername);
     await deleteRolesByPrefix(TEST_PREFIX);
   });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ workerUsername }) => {
     await resetRateLimits();
-    await revokeAllSessions(ADMIN_USERNAME);
+    await revokeAllSessions(workerUsername);
   });
 
   test.afterAll(async () => {
@@ -42,8 +39,10 @@ test.describe("Role management — UI", () => {
 
   test("navigates to roles page and displays built-in roles", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     await expect(page.getByRole("heading", { name: "Roles" })).toBeVisible();
@@ -59,10 +58,14 @@ test.describe("Role management — UI", () => {
     ).toBeVisible();
   });
 
-  test("creates a custom role via UI", async ({ page }) => {
+  test("creates a custom role via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await deleteTestRole(`${TEST_PREFIX}ui-create`);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     await expect(page.getByRole("heading", { name: "Roles" })).toBeVisible();
@@ -85,14 +88,18 @@ test.describe("Role management — UI", () => {
     await expect(roleRow(page, `${TEST_PREFIX}ui-create`)).toContainText("2");
   });
 
-  test("edits a custom role via UI", async ({ page }) => {
+  test("edits a custom role via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await createTestRole(
       `${TEST_PREFIX}ui-edit`,
       ["accounts:read"],
       "Before edit",
     );
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     const row = roleRow(page, `${TEST_PREFIX}ui-edit`);
@@ -118,10 +125,14 @@ test.describe("Role management — UI", () => {
     await deleteTestRole(`${TEST_PREFIX}ui-edited`);
   });
 
-  test("clones a built-in role via UI", async ({ page }) => {
+  test("clones a built-in role via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await deleteTestRole(`${TEST_PREFIX}ui-clone`);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     const adminRow = roleRow(page, "System Administrator");
@@ -157,8 +168,12 @@ test.describe("Role management — UI", () => {
     await expect(clonedRow).toContainText("15");
   });
 
-  test("built-in roles have no edit or delete buttons", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("built-in roles have no edit or delete buttons", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     const adminRow = roleRow(page, "System Administrator");
@@ -172,10 +187,12 @@ test.describe("Role management — UI", () => {
 
   test("custom roles have edit, clone, and delete buttons", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     await createTestRole(`${TEST_PREFIX}ui-buttons`, ["accounts:read"]);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     const row = roleRow(page, `${TEST_PREFIX}ui-buttons`);
@@ -189,10 +206,14 @@ test.describe("Role management — UI", () => {
     await expect(buttons.nth(2)).toHaveAttribute("title", "Delete Role");
   });
 
-  test("deletes a custom role via UI", async ({ page }) => {
+  test("deletes a custom role via UI", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     await createTestRole(`${TEST_PREFIX}ui-delete`, ["accounts:read"]);
 
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/roles");
 
     const row = roleRow(page, `${TEST_PREFIX}ui-delete`);

--- a/e2e/session-extension.spec.ts
+++ b/e2e/session-extension.spec.ts
@@ -1,19 +1,21 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 import { resetRateLimits } from "./helpers/auth";
 import { resetAccountDefaults, revokeAllSessions } from "./helpers/setup-db";
 
-const ADMIN_USERNAME = "admin";
-const ADMIN_PASSWORD = "Admin1234!";
 const APP_URL = process.env.BASE_URL ?? "http://localhost:3000";
 
 /**
  * Helper: sign in via the UI and wait until redirected away from sign-in.
  */
-async function signIn(page: import("@playwright/test").Page): Promise<void> {
+async function signIn(
+  page: import("@playwright/test").Page,
+  username: string,
+  password: string,
+): Promise<void> {
   await page.goto("/sign-in");
-  await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
-  await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+  await page.getByLabel("Account ID").fill(username);
+  await page.locator("input[name='password']").fill(password);
   await page.getByRole("button", { name: "Sign In" }).click();
   await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
 }
@@ -44,25 +46,28 @@ async function setSessionMonitorCookies(
 }
 
 test.describe("Session Extension Dialog", () => {
-  test.beforeAll(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.beforeAll(async ({ workerUsername }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(workerUsername);
   });
 
   test.beforeEach(async () => {
     await resetRateLimits();
   });
 
-  test.afterAll(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterAll(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
   // ── 1. Dialog appears when session nears expiry ───────────────
 
   test("dialog appears when JWT remaining ≤ 1/5 of lifetime", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 2 minutes from now (< 3 min threshold)
     const exp = Math.floor(Date.now() / 1000) + 120;
@@ -90,9 +95,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("dialog does not appear when JWT has plenty of time remaining", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 10 minutes from now (well above 3 min threshold)
     const exp = Math.floor(Date.now() / 1000) + 600;
@@ -110,9 +117,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("clicking Extend calls /api/auth/me and closes the dialog", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 2 minutes from now
     const exp = Math.floor(Date.now() / 1000) + 120;
@@ -147,9 +156,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("clicking Sign Out signs out and redirects to sign-in", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 2 minutes from now
     const exp = Math.floor(Date.now() / 1000) + 120;
@@ -173,9 +184,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("when countdown reaches zero, user is redirected to sign-in", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 3 seconds from now — dialog appears, then expires
     const exp = Math.floor(Date.now() / 1000) + 3;
@@ -191,9 +204,13 @@ test.describe("Session Extension Dialog", () => {
 
   // ── 6. Countdown display shows correct format ─────────────────
 
-  test("dialog displays countdown in MM:SS format", async ({ page }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+  test("dialog displays countdown in MM:SS format", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 90 seconds from now
     const exp = Math.floor(Date.now() / 1000) + 90;
@@ -211,9 +228,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("dialog stays dismissed after extend even while near-expiry", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Set token_exp to 2 minutes from now
     const exp = Math.floor(Date.now() / 1000) + 120;
@@ -238,9 +257,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("rapid double-click on Extend only triggers one /api/auth/me", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     const exp = Math.floor(Date.now() / 1000) + 120;
     await setSessionMonitorCookies(page, exp);
@@ -271,9 +292,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("sign-out succeeds even when CSRF cookie is missing", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Delete CSRF cookies before triggering dialog
     await page.context().clearCookies({ name: "csrf" });
@@ -292,13 +315,17 @@ test.describe("Session Extension Dialog", () => {
 
   // ── 10. i18n: dialog renders in Korean locale ──────────────────
 
-  test("dialog renders correctly in Korean locale", async ({ page }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
+  test("dialog renders correctly in Korean locale", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await revokeAllSessions(workerUsername);
 
     // Sign in via Korean locale
     await page.goto("/ko/sign-in");
-    await page.getByLabel("계정 ID").fill(ADMIN_USERNAME);
-    await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+    await page.getByLabel("계정 ID").fill(workerUsername);
+    await page.locator("input[name='password']").fill(workerPassword);
     await page.getByRole("button", { name: "로그인" }).click();
     await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
 
@@ -321,9 +348,11 @@ test.describe("Session Extension Dialog", () => {
 
   test("dialog threshold follows the current JWT lifetime", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     const dialog = page.getByRole("alertdialog");
 

--- a/e2e/session-policy.spec.ts
+++ b/e2e/session-policy.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 import { resetRateLimits } from "./helpers/auth";
 import {
@@ -9,16 +9,17 @@ import {
   revokeAllSessions,
 } from "./helpers/setup-db";
 
-const ADMIN_USERNAME = "admin";
-const ADMIN_PASSWORD = "Admin1234!";
-
 /**
  * Helper: sign in via the UI and wait until redirected away from sign-in.
  */
-async function signIn(page: import("@playwright/test").Page): Promise<void> {
+async function signIn(
+  page: import("@playwright/test").Page,
+  username: string,
+  password: string,
+): Promise<void> {
   await page.goto("/sign-in");
-  await page.getByLabel("Account ID").fill(ADMIN_USERNAME);
-  await page.locator("input[name='password']").fill(ADMIN_PASSWORD);
+  await page.getByLabel("Account ID").fill(username);
+  await page.locator("input[name='password']").fill(password);
   await page.getByRole("button", { name: "Sign In" }).click();
   await expect(page).not.toHaveURL(/sign-in/, { timeout: 10_000 });
 }
@@ -33,21 +34,25 @@ async function callProtectedApi(
 }
 
 test.describe("Session Policy E2E", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
   });
 
-  test.afterAll(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterAll(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
   // ── 1. Idle timeout → 401 ──────────────────────────────────────
 
-  test("idle timeout expires session and returns 401", async ({ page }) => {
+  test("idle timeout expires session and returns 401", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
     // Clean up and sign in
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Verify authenticated API works before expiring
     const beforeResponse = await callProtectedApi(page);
@@ -55,7 +60,7 @@ test.describe("Session Policy E2E", () => {
 
     // Expire the session idle timeout by setting last_active_at far in the past
     // Default idle timeout is 30 minutes, so we set 60 minutes ago
-    await expireSessionIdle(ADMIN_USERNAME, 60);
+    await expireSessionIdle(workerUsername, 60);
 
     // Next API call should return 401 with SESSION_IDLE_TIMEOUT code
     const afterResponse = await callProtectedApi(page);
@@ -69,10 +74,12 @@ test.describe("Session Policy E2E", () => {
 
   test("session flagged for re-auth blocks API calls with REAUTH_REQUIRED", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     // Clean up and sign in
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Verify authenticated API works
     const beforeResponse = await callProtectedApi(page);
@@ -81,7 +88,7 @@ test.describe("Session Policy E2E", () => {
     // Simulate IP/UA change detection by directly flagging the session
     // (In production, the guard would detect this via IP/UA comparison.
     //  Here we simulate the outcome by writing needs_reauth = true.)
-    await flagSessionReauth(ADMIN_USERNAME);
+    await flagSessionReauth(workerUsername);
 
     // Next API call should return 401 with REAUTH_REQUIRED code
     const afterResponse = await callProtectedApi(page);
@@ -95,17 +102,19 @@ test.describe("Session Policy E2E", () => {
 
   test("re-auth with correct password restores session access", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     // Clean up and sign in
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Verify authenticated API works
     const beforeResponse = await callProtectedApi(page);
     expect(beforeResponse.ok()).toBeTruthy();
 
     // Flag the session for re-auth (simulating UA major change detection)
-    await flagSessionReauth(ADMIN_USERNAME);
+    await flagSessionReauth(workerUsername);
 
     // Verify the session is blocked
     const blockedResponse = await callProtectedApi(page);
@@ -119,7 +128,7 @@ test.describe("Session Policy E2E", () => {
 
     // Call re-auth endpoint with correct password
     const reauthResponse = await page.request.post("/api/auth/reauth", {
-      data: { password: ADMIN_PASSWORD },
+      data: { password: workerPassword },
       headers: {
         "x-csrf-token": csrfCookie?.value ?? "",
         Origin: "http://localhost:3000",
@@ -131,7 +140,7 @@ test.describe("Session Policy E2E", () => {
     expect(reauthBody.ok).toBe(true);
 
     // Verify session is restored: needs_reauth should be false now
-    const sessionStatus = await getSessionStatus(ADMIN_USERNAME);
+    const sessionStatus = await getSessionStatus(workerUsername);
     expect(sessionStatus).not.toBeNull();
     expect(sessionStatus?.needsReauth).toBe(false);
 
@@ -142,13 +151,15 @@ test.describe("Session Policy E2E", () => {
 
   test("re-auth with wrong password is rejected and session stays blocked", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
     // Clean up and sign in
-    await revokeAllSessions(ADMIN_USERNAME);
-    await signIn(page);
+    await revokeAllSessions(workerUsername);
+    await signIn(page, workerUsername, workerPassword);
 
     // Flag for re-auth
-    await flagSessionReauth(ADMIN_USERNAME);
+    await flagSessionReauth(workerUsername);
 
     // Get CSRF token
     const cookies = await page.context().cookies();
@@ -168,7 +179,7 @@ test.describe("Session Policy E2E", () => {
     expect(reauthBody.error).toBe("Invalid password");
 
     // Session should still be blocked
-    const sessionStatus = await getSessionStatus(ADMIN_USERNAME);
+    const sessionStatus = await getSessionStatus(workerUsername);
     expect(sessionStatus).not.toBeNull();
     expect(sessionStatus?.needsReauth).toBe(true);
 

--- a/e2e/settings-nav.spec.ts
+++ b/e2e/settings-nav.spec.ts
@@ -1,8 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
 import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
   resetRateLimits,
   signInAndWait,
   signInAndWaitKo,
@@ -15,49 +13,58 @@ import {
   resetAccountDefaults,
 } from "./helpers/setup-db";
 
-// User with only accounts:read — no dashboard or system-settings access
-const ACCOUNTS_ONLY_USER = "e2e-settings-acct-only";
+// Passwords are not prefix-dependent
 const ACCOUNTS_ONLY_PASS = "AcctOnly1234!";
-const ACCOUNTS_ONLY_ROLE = "E2E Accounts Only";
-
-// User with dashboard:read but no system-settings — can see Account Status but not Policies
-const DASH_ONLY_USER = "e2e-settings-dash-only";
 const DASH_ONLY_PASS = "DashOnly1234!";
-const DASH_ONLY_ROLE = "E2E Dashboard Only";
-
-test.beforeAll(async () => {
-  await resetRateLimits();
-
-  await createTestRole(ACCOUNTS_ONLY_ROLE, ["accounts:read"]);
-  await createTestAccount(
-    ACCOUNTS_ONLY_USER,
-    ACCOUNTS_ONLY_PASS,
-    ACCOUNTS_ONLY_ROLE,
-  );
-
-  await createTestRole(DASH_ONLY_ROLE, ["dashboard:read"]);
-  await createTestAccount(DASH_ONLY_USER, DASH_ONLY_PASS, DASH_ONLY_ROLE);
-});
-
-test.beforeEach(async () => {
-  await resetRateLimits();
-  await resetAccountDefaults(ADMIN_USERNAME);
-});
-
-test.afterAll(async () => {
-  try {
-    await deleteTestAccount(ACCOUNTS_ONLY_USER);
-    await deleteTestAccount(DASH_ONLY_USER);
-    await deleteTestRole(ACCOUNTS_ONLY_ROLE);
-    await deleteTestRole(DASH_ONLY_ROLE);
-  } catch {
-    // best-effort cleanup
-  }
-});
 
 test.describe("Settings navigation", () => {
-  test("settings page shows all five tabs for admin", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  let TEST_PREFIX: string;
+  let ACCOUNTS_ONLY_USER: string;
+  let ACCOUNTS_ONLY_ROLE: string;
+  let DASH_ONLY_USER: string;
+  let DASH_ONLY_ROLE: string;
+
+  test.beforeAll(async ({ workerPrefix: wp }) => {
+    await resetRateLimits();
+    TEST_PREFIX = wp("e2e-settings-");
+    ACCOUNTS_ONLY_USER = `${TEST_PREFIX}acct-only`;
+    ACCOUNTS_ONLY_ROLE = `${TEST_PREFIX}Accounts Only`;
+    DASH_ONLY_USER = `${TEST_PREFIX}dash-only`;
+    DASH_ONLY_ROLE = `${TEST_PREFIX}Dashboard Only`;
+
+    await createTestRole(ACCOUNTS_ONLY_ROLE, ["accounts:read"]);
+    await createTestAccount(
+      ACCOUNTS_ONLY_USER,
+      ACCOUNTS_ONLY_PASS,
+      ACCOUNTS_ONLY_ROLE,
+    );
+
+    await createTestRole(DASH_ONLY_ROLE, ["dashboard:read"]);
+    await createTestAccount(DASH_ONLY_USER, DASH_ONLY_PASS, DASH_ONLY_ROLE);
+  });
+
+  test.beforeEach(async ({ workerUsername }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(workerUsername);
+  });
+
+  test.afterAll(async () => {
+    try {
+      await deleteTestAccount(ACCOUNTS_ONLY_USER);
+      await deleteTestAccount(DASH_ONLY_USER);
+      await deleteTestRole(ACCOUNTS_ONLY_ROLE);
+      await deleteTestRole(DASH_ONLY_ROLE);
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  test("settings page shows all five tabs for admin", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings");
 
     const nav = page.locator("nav").filter({ hasText: "Accounts" });
@@ -70,16 +77,24 @@ test.describe("Settings navigation", () => {
     ).toBeVisible();
   });
 
-  test("settings redirects to accounts tab by default", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("settings redirects to accounts tab by default", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings");
 
     await page.waitForURL(/\/settings\/accounts/, { timeout: 10_000 });
     await expect(page.getByRole("heading", { name: "Accounts" })).toBeVisible();
   });
 
-  test("policies tab renders system settings panel", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("policies tab renders system settings panel", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/policies");
 
     await expect(page.getByRole("tab", { name: /password/i })).toBeVisible();
@@ -90,8 +105,12 @@ test.describe("Settings navigation", () => {
     await expect(page.getByRole("tab", { name: /rate limits/i })).toBeVisible();
   });
 
-  test("account status tab renders monitoring cards", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("account status tab renders monitoring cards", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/account-status");
 
     await expect(
@@ -101,8 +120,12 @@ test.describe("Settings navigation", () => {
     await expect(page.getByText("Locked & Suspended Accounts")).toBeVisible();
   });
 
-  test("breadcrumb shows correct label for policies", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("breadcrumb shows correct label for policies", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/policies");
 
     const breadcrumb = page.getByLabel("Breadcrumb");
@@ -112,19 +135,23 @@ test.describe("Settings navigation", () => {
 
   test("breadcrumb shows correct label for account status", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
     await page.goto("/settings/account-status");
 
     const breadcrumb = page.getByLabel("Breadcrumb");
     await expect(breadcrumb.getByText("Settings")).toBeVisible();
     await expect(breadcrumb.getByText("Account Status")).toBeVisible();
   });
-});
 
-test.describe("Settings navigation — Korean locale", () => {
-  test("settings page shows Korean tab labels", async ({ page }) => {
-    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("settings page shows Korean tab labels", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWaitKo(page, workerUsername, workerPassword);
     await page.goto("/ko/settings");
 
     await page.waitForURL(/\/settings\/accounts/, { timeout: 10_000 });
@@ -141,8 +168,10 @@ test.describe("Settings navigation — Korean locale", () => {
 
   test("Korean breadcrumb shows correct label for policies", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWaitKo(page, workerUsername, workerPassword);
     await page.goto("/ko/settings/policies");
 
     const breadcrumb = page.getByLabel("Breadcrumb");
@@ -152,17 +181,17 @@ test.describe("Settings navigation — Korean locale", () => {
 
   test("Korean breadcrumb shows correct label for account status", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWaitKo(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWaitKo(page, workerUsername, workerPassword);
     await page.goto("/ko/settings/account-status");
 
     const breadcrumb = page.getByLabel("Breadcrumb");
     await expect(breadcrumb.getByText("설정")).toBeVisible();
     await expect(breadcrumb.getByText("계정 현황")).toBeVisible();
   });
-});
 
-test.describe("Settings navigation — RBAC", () => {
   test("user without dashboard:read does not see Account Status tab", async ({
     page,
   }) => {
@@ -232,11 +261,13 @@ test.describe("Settings navigation — RBAC", () => {
       { timeout: 10_000 },
     );
   });
-});
 
-test.describe("Settings navigation — old URL", () => {
-  test("/settings/system returns 404", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("/settings/system returns 404", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     const response = await page.goto("/settings/system");
     expect(response?.status()).toBe(404);

--- a/e2e/sign-out-all.spec.ts
+++ b/e2e/sign-out-all.spec.ts
@@ -1,10 +1,7 @@
-import { expect, type Page, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-} from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits } from "./helpers/auth";
 import {
   getSessionStatus,
   resetAccountDefaults,
@@ -16,15 +13,17 @@ const APP_URL = process.env.BASE_URL ?? "http://localhost:3000";
 // origin even when Playwright targets the app over 127.0.0.1.
 const APP_ORIGIN = APP_URL.replace("127.0.0.1", "localhost");
 
-async function signInViaApi(page: Page): Promise<void> {
-  const response = await page.request.post("/api/auth/sign-in", {
-    headers: { "Content-Type": "application/json" },
-    data: {
-      username: ADMIN_USERNAME,
-      password: ADMIN_PASSWORD,
-    },
-  });
-  expect(response.ok()).toBeTruthy();
+function makeSignInViaApi(username: string, password: string) {
+  return async (page: Page): Promise<void> => {
+    const response = await page.request.post("/api/auth/sign-in", {
+      headers: { "Content-Type": "application/json" },
+      data: {
+        username,
+        password,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+  };
 }
 
 async function signOutAllViaApi(page: Page): Promise<void> {
@@ -40,16 +39,21 @@ async function signOutAllViaApi(page: Page): Promise<void> {
 }
 
 test.describe("Sign-out-all", () => {
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ workerUsername }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
   });
 
-  test.afterEach(async () => {
-    await resetAccountDefaults(ADMIN_USERNAME);
+  test.afterEach(async ({ workerUsername }) => {
+    await resetAccountDefaults(workerUsername);
   });
 
-  test("sign-out-all invalidates other sessions", async ({ browser }) => {
+  test("sign-out-all invalidates other sessions", async ({
+    browser,
+    workerUsername,
+    workerPassword,
+  }) => {
+    const signInViaApi = makeSignInViaApi(workerUsername, workerPassword);
     // Create two independent browser contexts (separate cookie jars).
     const contextA = await browser.newContext();
     const contextB = await browser.newContext();
@@ -79,20 +83,23 @@ test.describe("Sign-out-all", () => {
 
   test("sign-out-all clears active sessions so max_sessions does not block re-login", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await setMaxSessions(ADMIN_USERNAME, 1);
+    const signInViaApi = makeSignInViaApi(workerUsername, workerPassword);
+    await setMaxSessions(workerUsername, 1);
     await signInViaApi(page);
 
-    expect(await getSessionStatus(ADMIN_USERNAME)).not.toBeNull();
+    expect(await getSessionStatus(workerUsername)).not.toBeNull();
 
     await signOutAllViaApi(page);
 
-    await expect.poll(async () => getSessionStatus(ADMIN_USERNAME)).toBeNull();
+    await expect.poll(async () => getSessionStatus(workerUsername)).toBeNull();
 
     await signInViaApi(page);
 
     await expect
-      .poll(async () => getSessionStatus(ADMIN_USERNAME))
+      .poll(async () => getSessionStatus(workerUsername))
       .not.toBeNull();
   });
 });

--- a/e2e/ui-regression.spec.ts
+++ b/e2e/ui-regression.spec.ts
@@ -1,16 +1,15 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 
-import {
-  ADMIN_PASSWORD,
-  ADMIN_USERNAME,
-  resetRateLimits,
-  signInAndWait,
-} from "./helpers/auth";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
 import { resetAccountDefaults } from "./helpers/setup-db";
 
-test.beforeAll(async () => {
+test.beforeAll(async ({ workerUsername }) => {
   await resetRateLimits();
-  await resetAccountDefaults(ADMIN_USERNAME);
+  await resetAccountDefaults(workerUsername);
+});
+
+test.beforeEach(async () => {
+  await resetRateLimits();
 });
 
 test.describe("UI regression (#129 Logo, #130 Sidebar/NavUser)", () => {
@@ -26,8 +25,12 @@ test.describe("UI regression (#129 Logo, #130 Sidebar/NavUser)", () => {
     expect(count).toBeGreaterThanOrEqual(1);
   });
 
-  test("logo renders in sidebar after sign-in", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("logo renders in sidebar after sign-in", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Sidebar should contain at least one logo image
     const logos = page.locator('img[alt="Clumit Security"]');
@@ -39,32 +42,42 @@ test.describe("UI regression (#129 Logo, #130 Sidebar/NavUser)", () => {
 
   test("nav user shows real username instead of hardcoded text", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
-    // The nav user should show "admin" (the actual username), not "Profile" or "U"
+    // The nav user should show the actual username, not "Profile" or "U"
     // The username appears in the sidebar's nav user section
     const sidebar = page.locator("aside");
-    await expect(sidebar.getByText(ADMIN_USERNAME)).toBeVisible();
+    await expect(sidebar.getByText(workerUsername)).toBeVisible();
   });
 
-  test("nav user avatar shows correct initials", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("nav user avatar shows correct initials", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // The avatar should show the first letter(s) of the username
-    // For "admin" → "A"
+    // For "e2e-worker-N" → "E"
     const avatar = page.locator(
       '[class*="bg-primary"][class*="text-primary-foreground"]',
     );
     await expect(avatar.first()).toBeVisible();
     const text = await avatar.first().textContent();
-    expect(text?.trim().charAt(0).toUpperCase()).toBe("A");
+    expect(text?.trim().charAt(0).toUpperCase()).toBe("E");
   });
 
   // ── Sidebar active indicator (#130) ─────────────────────────
 
-  test("sidebar shows active indicator on current page", async ({ page }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  test("sidebar shows active indicator on current page", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Navigate to accounts page
     await page.goto("/settings/accounts");
@@ -92,14 +105,16 @@ test.describe("UI regression (#129 Logo, #130 Sidebar/NavUser)", () => {
 
   test("nav user dropdown has profile and sign-out options", async ({
     page,
+    workerUsername,
+    workerPassword,
   }) => {
-    await signInAndWait(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await signInAndWait(page, workerUsername, workerPassword);
 
     // Click the nav user trigger to open dropdown
     const sidebar = page.locator("aside");
     const navUser = sidebar
       .locator("button")
-      .filter({ hasText: ADMIN_USERNAME });
+      .filter({ hasText: workerUsername });
     await navUser.click();
 
     // Dropdown should show Profile and Sign Out

--- a/e2e/unlock.spec.ts
+++ b/e2e/unlock.spec.ts
@@ -1,6 +1,5 @@
-import { expect, test } from "@playwright/test";
-
-import { ADMIN_USERNAME, resetRateLimits } from "./helpers/auth";
+import { expect, test } from "./fixtures";
+import { resetRateLimits } from "./helpers/auth";
 import {
   createTestAccount,
   deleteTestAccount,
@@ -11,9 +10,9 @@ const TARGET_USERNAME = "e2e-unlock-target";
 const TARGET_PASSWORD = "Target1234!";
 
 test.describe("Account unlock/restore — UI", () => {
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ workerUsername }) => {
     await resetRateLimits();
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
     await createTestAccount(
       TARGET_USERNAME,
       TARGET_PASSWORD,
@@ -21,9 +20,9 @@ test.describe("Account unlock/restore — UI", () => {
     );
   });
 
-  test.afterAll(async () => {
+  test.afterAll(async ({ workerUsername }) => {
     await deleteTestAccount(TARGET_USERNAME);
-    await resetAccountDefaults(ADMIN_USERNAME);
+    await resetAccountDefaults(workerUsername);
   });
 
   test("restored account can sign in again", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Per-worker test accounts via Playwright worker-scoped fixtures (`e2e/fixtures.ts`) so tests run in parallel without shared-state conflicts
- Migrated `pg.Client` to `pg.Pool` for concurrent DB access from multiple workers
- Split Playwright config into `parallel` and `serial` projects — rate-limit and system-settings specs run serially after parallel specs complete
- Added "E2E Test Admin" role in global setup to avoid the `MAX_SYSTEM_ADMINISTRATORS = 5` cap
- CI now runs with **4 workers** instead of 1

## Test plan
- [x] All 157 tests pass with `workers=1` (sequential baseline)
- [x] All 157 tests pass with `workers=4` (parallel execution)
- [x] Biome lint and TypeScript type check pass
- [x] CI pipeline passes

Closes #194