### PR TITLE
Add MFA TOTP challenge sign-in flow

### DIFF
--- a/e2e/helpers/setup-db.ts
+++ b/e2e/helpers/setup-db.ts
@@ -541,6 +541,81 @@ function escapeIdentifier(str: string): string {
   return `"${str.replace(/"/g, '""')}"`;
 }
 
+// ── TOTP / MFA helpers ───────────────────────────────────────────
+
+/**
+ * Enroll a verified TOTP credential directly in the DB.
+ * Returns the base32 secret for generating codes in tests.
+ */
+export async function enrollAndVerifyTotp(username: string): Promise<string> {
+  const { randomBytes } = await import("node:crypto");
+  // Manual base32 encoding of 20 random bytes
+  const raw = randomBytes(20);
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  let secret = "";
+  let bits = 0;
+  let buffer = 0;
+  for (const byte of raw) {
+    buffer = (buffer << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      secret += alphabet[(buffer >> bits) & 0x1f];
+    }
+  }
+  if (bits > 0) {
+    secret += alphabet[(buffer << (5 - bits)) & 0x1f];
+  }
+
+  await pool.query(
+    `INSERT INTO totp_credentials (account_id, secret, verified)
+     VALUES ((SELECT id FROM accounts WHERE username = $1), $2, true)
+     ON CONFLICT (account_id)
+     DO UPDATE SET secret = $2, verified = true`,
+    [username, secret],
+  );
+  return secret;
+}
+
+/**
+ * Delete all TOTP credentials for a user.
+ */
+export async function deleteTotpCredential(username: string): Promise<void> {
+  await pool.query(
+    "DELETE FROM totp_credentials WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
+    [username],
+  );
+}
+
+/**
+ * Delete all MFA challenge nonces for a user.
+ */
+export async function deleteMfaChallenges(username: string): Promise<void> {
+  await pool.query(
+    "DELETE FROM mfa_challenges WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
+    [username],
+  );
+}
+
+/**
+ * Update MFA policy allowed methods directly in DB.
+ */
+export async function setMfaPolicyAllowedMethods(
+  methods: string[],
+): Promise<void> {
+  await pool.query(
+    `UPDATE system_settings SET value = $1 WHERE key = 'mfa_policy'`,
+    [JSON.stringify({ allowed_methods: methods })],
+  );
+}
+
+/**
+ * Reset MFA policy to default (allow both webauthn and totp).
+ */
+export async function resetMfaPolicy(): Promise<void> {
+  await setMfaPolicyAllowedMethods(["webauthn", "totp"]);
+}
+
 // ── Audit database helpers ────────────────────────────────────────
 
 /**

--- a/e2e/mfa-sign-in.spec.ts
+++ b/e2e/mfa-sign-in.spec.ts
@@ -1,0 +1,154 @@
+import * as OTPAuth from "otpauth";
+
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signIn } from "./helpers/auth";
+import {
+  deleteMfaChallenges,
+  deleteTotpCredential,
+  enrollAndVerifyTotp,
+  resetAccountDefaults,
+  resetMfaPolicy,
+} from "./helpers/setup-db";
+
+/** Generate a valid TOTP code for a given base32 secret. */
+function generateCode(secret: string): string {
+  const totp = new OTPAuth.TOTP({
+    issuer: "AICE",
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secret),
+  });
+  return totp.generate();
+}
+
+test.describe("MFA sign-in flow (#207)", () => {
+  test.beforeAll(async ({ workerUsername }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(workerUsername);
+    await deleteTotpCredential(workerUsername);
+    await deleteMfaChallenges(workerUsername);
+    await resetMfaPolicy();
+  });
+
+  test.beforeEach(async ({ workerUsername }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(workerUsername);
+    await deleteTotpCredential(workerUsername);
+    await deleteMfaChallenges(workerUsername);
+    await resetMfaPolicy();
+  });
+
+  test.afterAll(async ({ workerUsername }) => {
+    await deleteTotpCredential(workerUsername);
+    await deleteMfaChallenges(workerUsername);
+    await resetAccountDefaults(workerUsername);
+    await resetMfaPolicy();
+  });
+
+  // ── Happy path: password → TOTP → dashboard ────────────────
+
+  test("sign-in with TOTP shows TOTP step then redirects to dashboard", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    const secret = await enrollAndVerifyTotp(workerUsername);
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Should show TOTP input step (not redirect yet)
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).toBeVisible({ timeout: 5_000 });
+
+    // Enter valid TOTP code
+    const code = generateCode(secret);
+    await totpInput.fill(code);
+    await page.getByRole("button", { name: /verify/i }).click();
+
+    // Should redirect to dashboard
+    await page.waitForURL((url) => !url.pathname.endsWith("/sign-in"), {
+      timeout: 10_000,
+    });
+  });
+
+  // ── Wrong code → error → retry with correct code ──────────
+
+  test("wrong TOTP code shows error, retry with correct code succeeds", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    const secret = await enrollAndVerifyTotp(workerUsername);
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Wait for TOTP step
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).toBeVisible({ timeout: 5_000 });
+
+    // Enter wrong code
+    await totpInput.fill("000000");
+    await page.getByRole("button", { name: /verify/i }).click();
+
+    // Should show error message
+    const alert = page.locator("[role='alert']");
+    await expect(alert).toBeVisible({ timeout: 5_000 });
+
+    // Clear and enter correct code
+    const code = generateCode(secret);
+    await totpInput.fill(code);
+    await page.getByRole("button", { name: /verify/i }).click();
+
+    // Should redirect to dashboard
+    await page.waitForURL((url) => !url.pathname.endsWith("/sign-in"), {
+      timeout: 10_000,
+    });
+  });
+
+  // ── Back button returns to credentials step ────────────────
+
+  test("back button returns to credentials step", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await enrollAndVerifyTotp(workerUsername);
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Wait for TOTP step
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).toBeVisible({ timeout: 5_000 });
+
+    // Click back button
+    await page.getByRole("button", { name: /back to sign in/i }).click();
+
+    // Should return to credentials form
+    await expect(page.getByLabel("Account ID")).toBeVisible();
+    await expect(page.locator("input[name='password']")).toBeVisible();
+  });
+
+  // ── No TOTP enrolled → direct sign-in (no TOTP step) ──────
+
+  test("sign-in without TOTP enrolled goes directly to dashboard", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Should go straight to dashboard without TOTP step
+    await page.waitForURL((url) => !url.pathname.endsWith("/sign-in"), {
+      timeout: 10_000,
+    });
+
+    // TOTP input should NOT have appeared
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).not.toBeVisible();
+  });
+});

--- a/migrations/auth/0014_mfa_challenges.sql
+++ b/migrations/auth/0014_mfa_challenges.sql
@@ -1,0 +1,8 @@
+CREATE TABLE mfa_challenges (
+  jti        UUID PRIMARY KEY,
+  account_id UUID NOT NULL,
+  used       BOOLEAN NOT NULL DEFAULT false,
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_mfa_challenges_expires ON mfa_challenges (expires_at);

--- a/src/__integration__/api/mfa-challenge.test.ts
+++ b/src/__integration__/api/mfa-challenge.test.ts
@@ -1,0 +1,450 @@
+import * as OTPAuth from "otpauth";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  type AuthSession,
+  authGet,
+  authPatch,
+  resetRateLimits,
+  signIn,
+} from "../helpers/auth";
+import {
+  createFakeSessions,
+  deleteMfaChallenges,
+  deleteTotpCredential,
+  enrollAndVerifyTotp,
+  incrementTokenVersion,
+  resetAccountDefaults,
+  setAccountRole,
+  setAccountStatus,
+  setAllowedIps,
+  setMaxSessions,
+} from "../helpers/setup-db";
+import { SERVER_ORIGIN } from "../setup";
+
+/** Generate a valid TOTP code for a given base32 secret. */
+function generateCode(secret: string): string {
+  const totp = new OTPAuth.TOTP({
+    issuer: "AICE",
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secret),
+  });
+  return totp.generate();
+}
+
+/** Update MFA policy via the settings API (invalidates server cache). */
+async function setMfaPolicy(
+  session: AuthSession,
+  allowedMethods: string[],
+): Promise<void> {
+  const res = await authPatch(session, "/api/system-settings/mfa_policy", {
+    value: { allowed_methods: allowedMethods },
+  });
+  if (!res.ok) throw new Error(`Failed to update MFA policy: ${res.status}`);
+}
+
+/** Perform password sign-in and return response body. */
+async function passwordSignIn(
+  username: string,
+  password: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`${SERVER_ORIGIN}/api/auth/sign-in`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+/** Submit TOTP challenge and return response. */
+async function submitChallenge(
+  mfaToken: string,
+  code: string,
+): Promise<Response> {
+  return fetch(`${SERVER_ORIGIN}/api/auth/mfa/totp/challenge`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mfaToken, code }),
+  });
+}
+
+describe("MFA Challenge", () => {
+  beforeAll(async () => {
+    await resetRateLimits();
+  });
+
+  beforeEach(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await deleteTotpCredential(ADMIN_USERNAME);
+    await deleteMfaChallenges(ADMIN_USERNAME);
+    await setAllowedIps(ADMIN_USERNAME, null);
+    // Reset MFA policy via API
+    const session = await signIn(ADMIN_USERNAME);
+    await setMfaPolicy(session, ["webauthn", "totp"]);
+  });
+
+  afterAll(async () => {
+    await deleteTotpCredential(ADMIN_USERNAME);
+    await deleteMfaChallenges(ADMIN_USERNAME);
+    await setAllowedIps(ADMIN_USERNAME, null);
+    await resetAccountDefaults(ADMIN_USERNAME);
+    const session = await signIn(ADMIN_USERNAME);
+    await setMfaPolicy(session, ["webauthn", "totp"]);
+  });
+
+  // ── Sign-in behavior ───────────────────────────────────────────
+
+  describe("sign-in with TOTP", () => {
+    it("returns mfaRequired when TOTP enrolled and policy on", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+
+      const { status, body } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      expect(status).toBe(200);
+      expect(body.mfaRequired).toBe(true);
+      expect(body.mfaToken).toBeDefined();
+      expect(typeof body.mfaToken).toBe("string");
+      expect(body.mfaMethods).toEqual(["totp"]);
+    });
+
+    it("returns normal session when TOTP enrolled but policy off", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const session = await signIn(ADMIN_USERNAME);
+      await setMfaPolicy(session, ["webauthn"]); // TOTP disabled
+
+      const { status, body } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      expect(status).toBe(200);
+      expect(body.mfaRequired).toBeUndefined();
+      expect(body.mustChangePassword).toBeDefined();
+    });
+
+    it("returns normal session when no TOTP enrolled", async () => {
+      const { status, body } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      expect(status).toBe(200);
+      expect(body.mfaRequired).toBeUndefined();
+      expect(body.mustChangePassword).toBeDefined();
+    });
+  });
+
+  // ── Challenge endpoint ─────────────────────────────────────────
+
+  describe("POST /api/auth/mfa/totp/challenge", () => {
+    it("creates session with valid TOTP code", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(signInBody.mfaToken as string, code);
+
+      expect(res.status).toBe(200);
+      const challengeBody = await res.json();
+      expect(challengeBody.mustChangePassword).toBeDefined();
+
+      // Verify cookies were set (session created)
+      const cookies = res.headers.get("set-cookie");
+      expect(cookies).toContain("at=");
+    });
+
+    it("returns 401 INVALID_MFA_CODE with wrong code, token still usable", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Wrong code
+      const res1 = await submitChallenge(mfaToken, "000000");
+      expect(res1.status).toBe(401);
+      const body1 = await res1.json();
+      expect(body1.code).toBe("INVALID_MFA_CODE");
+
+      // Same token with correct code should still work
+      const code = generateCode(secret);
+      const res2 = await submitChallenge(mfaToken, code);
+      expect(res2.status).toBe(200);
+    });
+
+    it("returns 401 for expired/invalid mfaToken", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+
+      const res = await submitChallenge("invalid.jwt.token", "123456");
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("returns 401 for replayed token after success", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // First attempt succeeds
+      const code = generateCode(secret);
+      const res1 = await submitChallenge(mfaToken, code);
+      expect(res1.status).toBe(200);
+
+      // Replay with same token
+      const code2 = generateCode(secret);
+      const res2 = await submitChallenge(mfaToken, code2);
+      expect(res2.status).toBe(401);
+      const body2 = await res2.json();
+      expect(body2.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("returns 400 for non-6-digit code", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      const res = await submitChallenge(signInBody.mfaToken as string, "12345");
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await fetch(`${SERVER_ORIGIN}/api/auth/mfa/totp/challenge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Re-validation scenarios ────────────────────────────────────
+
+  describe("account state re-validation", () => {
+    it("rejects when account suspended mid-flow", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Suspend account between sign-in and challenge
+      await setAccountStatus(ADMIN_USERNAME, "suspended");
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("ACCOUNT_INACTIVE");
+    });
+
+    it("rejects when account locked mid-flow", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      await setAccountStatus(ADMIN_USERNAME, "locked");
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("ACCOUNT_LOCKED");
+    });
+
+    it("rejects when token_version changed mid-flow", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Increment token_version (simulates password reset or sign-out-all)
+      await incrementTokenVersion(ADMIN_USERNAME);
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("rejects when max sessions reached mid-flow", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Set max sessions to 1 and create a session
+      await setMaxSessions(ADMIN_USERNAME, 1);
+      await createFakeSessions(ADMIN_USERNAME, 1);
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("MAX_SESSIONS");
+    });
+
+    it("rejects when TOTP policy disabled mid-flow", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Disable TOTP in policy
+      const session = await signIn(ADMIN_USERNAME);
+      await setMfaPolicy(session, ["webauthn"]);
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("TOTP_NOT_ALLOWED");
+    });
+
+    it("rejects when role changed mid-flow", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Change user's role (the mfaToken has the old role)
+      await setAccountRole(ADMIN_USERNAME, "Security Monitor");
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+
+      // Restore original role
+      await setAccountRole(ADMIN_USERNAME, "System Administrator");
+    });
+
+    it("rejects when IP not in allowed list", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Set allowed IPs to exclude test IP
+      await setAllowedIps(ADMIN_USERNAME, ["10.0.0.0/8"]);
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(mfaToken, code);
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("IP_RESTRICTED");
+    });
+  });
+
+  // ── Rate limiting ──────────────────────────────────────────────
+
+  describe("rate limiting", () => {
+    it("returns 429 after exceeding MFA challenge limit", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Send 5 wrong attempts (at threshold)
+      for (let i = 0; i < 5; i++) {
+        const res = await submitChallenge(mfaToken, "000000");
+        expect(res.status).toBe(401);
+      }
+
+      // 6th attempt should be rate limited
+      const res = await submitChallenge(mfaToken, "000000");
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_RATE_LIMITED");
+      expect(res.headers.get("Retry-After")).toBeDefined();
+    });
+  });
+
+  // ── Audit logging ──────────────────────────────────────────────
+
+  describe("audit logging", () => {
+    it("records mfa.totp.verify.success on successful challenge", async () => {
+      const secret = await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      const code = generateCode(secret);
+      const res = await submitChallenge(signInBody.mfaToken as string, code);
+      expect(res.status).toBe(200);
+
+      // Check audit log
+      const session = await signIn(ADMIN_USERNAME);
+      const auditRes = await authGet(
+        session,
+        "/api/audit-logs?action=mfa.totp.verify.success&pageSize=1",
+      );
+      expect(auditRes.status).toBe(200);
+      const auditBody = await auditRes.json();
+      expect(auditBody.data.length).toBeGreaterThanOrEqual(1);
+      expect(auditBody.data[0].action).toBe("mfa.totp.verify.success");
+    });
+
+    it("records mfa.totp.verify.failure on wrong code", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      const res = await submitChallenge(
+        signInBody.mfaToken as string,
+        "000000",
+      );
+      expect(res.status).toBe(401);
+
+      // Check audit log
+      const session = await signIn(ADMIN_USERNAME);
+      const auditRes = await authGet(
+        session,
+        "/api/audit-logs?action=mfa.totp.verify.failure&pageSize=1",
+      );
+      expect(auditRes.status).toBe(200);
+      const auditBody = await auditRes.json();
+      expect(auditBody.data.length).toBeGreaterThanOrEqual(1);
+      expect(auditBody.data[0].action).toBe("mfa.totp.verify.failure");
+    });
+  });
+});

--- a/src/__integration__/helpers/setup-db.ts
+++ b/src/__integration__/helpers/setup-db.ts
@@ -512,6 +512,66 @@ export async function resetMfaPolicy(): Promise<void> {
   await setMfaPolicyAllowedMethods(["webauthn", "totp"]);
 }
 
+// ── MFA challenge helpers ─────────────────────────────────────────
+
+export async function enrollAndVerifyTotp(username: string): Promise<string> {
+  const OTPAuth = await import("otpauth");
+  const secret = new OTPAuth.Secret({ size: 20 }).base32;
+
+  return withAuthDb(async (c) => {
+    await c.query(
+      `INSERT INTO totp_credentials (account_id, secret, verified)
+       VALUES ((SELECT id FROM accounts WHERE username = $1), $2, true)
+       ON CONFLICT (account_id)
+       DO UPDATE SET secret = $2, verified = true`,
+      [username, secret],
+    );
+    return secret;
+  });
+}
+
+export async function deleteMfaChallenges(username: string): Promise<void> {
+  await withAuthDb((c) =>
+    c.query(
+      "DELETE FROM mfa_challenges WHERE account_id = (SELECT id FROM accounts WHERE username = $1)",
+      [username],
+    ),
+  );
+}
+
+export async function incrementTokenVersion(username: string): Promise<void> {
+  await withAuthDb((c) =>
+    c.query(
+      "UPDATE accounts SET token_version = token_version + 1 WHERE username = $1",
+      [username],
+    ),
+  );
+}
+
+export async function setAllowedIps(
+  username: string,
+  ips: string[] | null,
+): Promise<void> {
+  await withAuthDb((c) =>
+    c.query("UPDATE accounts SET allowed_ips = $2 WHERE username = $1", [
+      username,
+      ips,
+    ]),
+  );
+}
+
+export async function setAccountRole(
+  username: string,
+  roleName: string,
+): Promise<void> {
+  await withAuthDb((c) =>
+    c.query(
+      `UPDATE accounts SET role_id = (SELECT id FROM roles WHERE name = $1) WHERE username = $2`,
+      [roleName, username],
+    ),
+  );
+}
+
 function escapeIdentifier(str: string): string {
   return `"${str.replace(/"/g, '""')}"`;
 }

--- a/src/__tests__/lib/auth/mfa-token.test.ts
+++ b/src/__tests__/lib/auth/mfa-token.test.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { decodeJwt } from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn(),
+}));
+
+const tmpDir = path.join(__dirname, ".tmp-mfa-token");
+const dataDir = path.join(tmpDir, "data");
+
+describe("mfa-token", () => {
+  let jwtKeys: typeof import("@/lib/auth/jwt-keys");
+  let mfaToken: typeof import("@/lib/auth/mfa-token");
+
+  beforeEach(async () => {
+    mkdirSync(dataDir, { recursive: true });
+    process.env.DATA_DIR = dataDir;
+
+    jwtKeys = await import("@/lib/auth/jwt-keys");
+    jwtKeys.resetKeyState();
+
+    await jwtKeys.generateJwtSigningKey();
+    await jwtKeys.loadSigningKeys();
+
+    mfaToken = await import("@/lib/auth/mfa-token");
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── issueMfaToken ─────────────────────────────────────────────
+
+  describe("issueMfaToken", () => {
+    it("returns a valid JWT string", async () => {
+      const token = await mfaToken.issueMfaToken({
+        accountId: "account-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+        jti: "test-jti-123",
+      });
+
+      expect(typeof token).toBe("string");
+      expect(token.split(".")).toHaveLength(3);
+    });
+
+    it("includes correct claims in the payload", async () => {
+      const token = await mfaToken.issueMfaToken({
+        accountId: "account-1",
+        roles: ["admin"],
+        tokenVersion: 42,
+        jti: "jti-abc",
+      });
+
+      const payload = decodeJwt(token);
+
+      expect(payload.sub).toBe("account-1");
+      expect(payload.jti).toBe("jti-abc");
+      expect(payload.roles).toEqual(["admin"]);
+      expect(payload.token_version).toBe(42);
+      expect(payload.purpose).toBe("mfa_challenge");
+      expect(payload.iss).toBe("aice-web-next");
+      expect(payload.aud).toBe("aice-web-next");
+    });
+
+    it("sets expiration to approximately 5 minutes", async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const token = await mfaToken.issueMfaToken({
+        accountId: "account-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+        jti: "jti-exp-test",
+      });
+
+      const payload = decodeJwt(token);
+      const after = Math.floor(Date.now() / 1000);
+
+      // exp should be iat + 300 (5 minutes)
+      expect(Number(payload.exp) - Number(payload.iat)).toBe(300);
+      expect(payload.iat).toBeGreaterThanOrEqual(before);
+      expect(payload.iat).toBeLessThanOrEqual(after);
+    });
+  });
+
+  // ── verifyMfaToken ────────────────────────────────────────────
+
+  describe("verifyMfaToken", () => {
+    it("succeeds for a freshly issued token", async () => {
+      const token = await mfaToken.issueMfaToken({
+        accountId: "account-1",
+        roles: ["admin"],
+        tokenVersion: 5,
+        jti: "jti-verify-test",
+      });
+
+      const payload = await mfaToken.verifyMfaToken(token);
+
+      expect(payload.sub).toBe("account-1");
+      expect(payload.jti).toBe("jti-verify-test");
+      expect(payload.roles).toEqual(["admin"]);
+      expect(payload.token_version).toBe(5);
+      expect(payload.purpose).toBe("mfa_challenge");
+    });
+
+    it("rejects a tampered token", async () => {
+      const token = await mfaToken.issueMfaToken({
+        accountId: "account-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+        jti: "jti-tamper",
+      });
+
+      // Tamper with the payload
+      const parts = token.split(".");
+      parts[1] = `${parts[1]}x`;
+      const tampered = parts.join(".");
+
+      await expect(mfaToken.verifyMfaToken(tampered)).rejects.toThrow();
+    });
+
+    it("rejects a token after the signing key is replaced", async () => {
+      const token = await mfaToken.issueMfaToken({
+        accountId: "account-1",
+        roles: ["admin"],
+        tokenVersion: 0,
+        jti: "jti-diffkey",
+      });
+
+      // Replace the signing key entirely (no previous key preserved)
+      await jwtKeys.generateJwtSigningKey();
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      // Verification should fail because the old kid is unknown
+      await expect(mfaToken.verifyMfaToken(token)).rejects.toThrow(
+        /No verification key found/,
+      );
+    });
+  });
+});

--- a/src/app/api/auth/mfa/totp/challenge/route.ts
+++ b/src/app/api/auth/mfa/totp/challenge/route.ts
@@ -1,0 +1,263 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import {
+  generateCorrelationId,
+  withCorrelationId,
+} from "@/lib/audit/correlation";
+import { auditLog } from "@/lib/audit/logger";
+import { isIpAllowed } from "@/lib/auth/cidr";
+import { extractClientIp } from "@/lib/auth/ip";
+import { loadMfaPolicy } from "@/lib/auth/mfa-policy";
+import { verifyMfaToken } from "@/lib/auth/mfa-token";
+import { loadSessionPolicy } from "@/lib/auth/session-policy";
+import { createSessionAndIssueTokens } from "@/lib/auth/sign-in";
+import { getTotpCredential, verifyTotpCode } from "@/lib/auth/totp";
+import { query } from "@/lib/db/client";
+import { checkMfaChallengeRateLimit } from "@/lib/rate-limit/limiter";
+
+// ── Account row type ────────────────────────────────────────────
+
+interface AccountRow {
+  id: string;
+  status: string;
+  token_version: number;
+  must_change_password: boolean;
+  max_sessions: number | null;
+  allowed_ips: string[] | null;
+  role_name: string;
+  locale: string | null;
+}
+
+// ── Handler ─────────────────────────────────────────────────────
+
+async function handleChallenge(request: NextRequest): Promise<NextResponse> {
+  // Step 1: Parse body
+  let body: { mfaToken?: string; code?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const { mfaToken, code } = body;
+  if (!mfaToken || !code) {
+    return NextResponse.json(
+      { error: "mfaToken and code are required" },
+      { status: 400 },
+    );
+  }
+
+  if (!/^\d{6}$/.test(code)) {
+    return NextResponse.json(
+      { error: "Code must be a 6-digit number" },
+      { status: 400 },
+    );
+  }
+
+  // Step 2: Verify mfaToken JWT
+  let accountId: string;
+  let jti: string;
+  let roles: string[];
+  let tokenVersion: number;
+
+  try {
+    const payload = await verifyMfaToken(mfaToken);
+    accountId = payload.sub;
+    jti = payload.jti;
+    roles = payload.roles;
+    tokenVersion = payload.token_version;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // Step 3: Check mfa_challenges table (exists, not used)
+  const { rows: challengeRows } = await query<{ used: boolean }>(
+    "SELECT used FROM mfa_challenges WHERE jti = $1",
+    [jti],
+  );
+
+  if (challengeRows.length === 0 || challengeRows[0].used) {
+    return NextResponse.json(
+      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // Step 4: Rate limit (after token verification — accountId is now trusted)
+  const ip = extractClientIp(request);
+  const rateResult = await checkMfaChallengeRateLimit(accountId, ip);
+  if (rateResult.limited) {
+    return NextResponse.json(
+      { error: "Too many attempts", code: "MFA_RATE_LIMITED" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateResult.retryAfterSeconds) },
+      },
+    );
+  }
+
+  // Step 5: Policy check (TOTP may have been disabled mid-flow)
+  const mfaPolicy = await loadMfaPolicy();
+  if (!mfaPolicy.allowedMethods.includes("totp")) {
+    return NextResponse.json(
+      {
+        error: "TOTP is no longer allowed",
+        code: "TOTP_NOT_ALLOWED",
+      },
+      { status: 403 },
+    );
+  }
+
+  // Step 6: Account state re-validation
+  const { rows: accountRows } = await query<AccountRow>(
+    `SELECT a.id, a.status, a.token_version, a.must_change_password,
+            a.max_sessions, a.allowed_ips, r.name AS role_name, a.locale
+     FROM accounts a
+     JOIN roles r ON a.role_id = r.id
+     WHERE a.id = $1`,
+    [accountId],
+  );
+
+  if (accountRows.length === 0) {
+    return NextResponse.json(
+      { error: "Account not found", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  const account = accountRows[0];
+
+  // 6a: Status check
+  if (account.status === "locked") {
+    return NextResponse.json(
+      { error: "Account is locked", code: "ACCOUNT_LOCKED" },
+      { status: 403 },
+    );
+  }
+
+  if (account.status !== "active") {
+    return NextResponse.json(
+      { error: "Account is not active", code: "ACCOUNT_INACTIVE" },
+      { status: 403 },
+    );
+  }
+
+  // 6b: Token version check (password reset or sign-out-all invalidates)
+  if (account.token_version !== tokenVersion) {
+    return NextResponse.json(
+      { error: "Token has been invalidated", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // 6c: Role check
+  if (!roles.includes(account.role_name)) {
+    return NextResponse.json(
+      { error: "Role has changed", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // 6d: IP CIDR check
+  if (!isIpAllowed(ip, account.allowed_ips ?? [])) {
+    return NextResponse.json(
+      { error: "Access denied from this network", code: "IP_RESTRICTED" },
+      { status: 403 },
+    );
+  }
+
+  // 6e: Max sessions check
+  const sessionPolicy = await loadSessionPolicy();
+  const effectiveMaxSessions =
+    account.max_sessions ?? sessionPolicy.maxSessions;
+
+  if (effectiveMaxSessions !== null) {
+    const { rows: countRows } = await query<{ count: string }>(
+      "SELECT COUNT(*) AS count FROM sessions WHERE account_id = $1 AND revoked = false",
+      [accountId],
+    );
+    const activeCount = Number(countRows[0].count);
+    if (activeCount >= effectiveMaxSessions) {
+      return NextResponse.json(
+        {
+          error: "Maximum number of active sessions reached",
+          code: "MAX_SESSIONS",
+        },
+        { status: 403 },
+      );
+    }
+  }
+
+  // Step 7: Verify TOTP code
+  const credential = await getTotpCredential(accountId);
+  if (!credential?.verified) {
+    return NextResponse.json(
+      { error: "No TOTP credential found", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  const codeValid = verifyTotpCode(credential.secret, code);
+
+  if (!codeValid) {
+    await auditLog.record({
+      actor: accountId,
+      action: "mfa.totp.verify.failure",
+      target: "mfa",
+      targetId: accountId,
+      ip,
+    });
+    return NextResponse.json(
+      { error: "Invalid code", code: "INVALID_MFA_CODE" },
+      { status: 401 },
+    );
+  }
+
+  // Step 8: Atomically consume token and create session
+  const { rows: consumeRows } = await query<{ jti: string }>(
+    "UPDATE mfa_challenges SET used = true WHERE jti = $1 AND used = false RETURNING jti",
+    [jti],
+  );
+
+  if (consumeRows.length === 0) {
+    return NextResponse.json(
+      { error: "Token already used", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  await auditLog.record({
+    actor: accountId,
+    action: "mfa.totp.verify.success",
+    target: "mfa",
+    targetId: accountId,
+    ip,
+  });
+
+  const userAgent = request.headers.get("user-agent") ?? "";
+
+  return createSessionAndIssueTokens({
+    accountId,
+    roleName: account.role_name,
+    tokenVersion: account.token_version,
+    mustChangePassword: account.must_change_password,
+    locale: account.locale,
+    ip,
+    userAgent,
+  });
+}
+
+// ── Route export ────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const correlationId = generateCorrelationId();
+  return withCorrelationId(correlationId, () => handleChallenge(request));
+}

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
-import { cookies } from "next/headers";
+import { randomUUID } from "node:crypto";
+
 import { type NextRequest, NextResponse } from "next/server";
 
 import {
@@ -9,23 +10,14 @@ import {
 } from "@/lib/audit/correlation";
 import { auditLog } from "@/lib/audit/logger";
 import { isIpAllowed } from "@/lib/auth/cidr";
-import {
-  setAccessTokenCookie,
-  setTokenExpCookie,
-  setTokenTtlCookie,
-} from "@/lib/auth/cookies";
-import {
-  CSRF_COOKIE_NAME,
-  CSRF_COOKIE_OPTIONS,
-  generateCsrfToken,
-} from "@/lib/auth/csrf";
 import { extractClientIp } from "@/lib/auth/ip";
-import { issueAccessToken } from "@/lib/auth/jwt";
-import { loadJwtPolicy } from "@/lib/auth/jwt-policy";
 import { loadLockoutPolicy } from "@/lib/auth/lockout-policy";
+import { loadMfaPolicy } from "@/lib/auth/mfa-policy";
+import { issueMfaToken } from "@/lib/auth/mfa-token";
 import { verifyPassword } from "@/lib/auth/password";
 import { loadSessionPolicy } from "@/lib/auth/session-policy";
-import { extractBrowserFingerprint } from "@/lib/auth/ua-parser";
+import { createSessionAndIssueTokens } from "@/lib/auth/sign-in";
+import { getTotpCredential } from "@/lib/auth/totp";
 import { query } from "@/lib/db/client";
 import { checkSignInRateLimit } from "@/lib/rate-limit/limiter";
 
@@ -195,101 +187,6 @@ async function applyFailedLogin(
   );
 }
 
-/**
- * Create a new session, issue JWT + CSRF tokens, set cookies,
- * and log a successful sign-in.
- */
-async function createSessionAndIssueTokens(params: {
-  accountId: string;
-  roleName: string;
-  tokenVersion: number;
-  mustChangePassword: boolean;
-  locale: string | null;
-  ip: string;
-  userAgent: string;
-}): Promise<NextResponse> {
-  const {
-    accountId,
-    roleName,
-    tokenVersion,
-    mustChangePassword,
-    locale,
-    ip,
-    userAgent,
-  } = params;
-
-  // Reset failed count, lockout count, and update last_sign_in_at
-  await query(
-    `UPDATE accounts
-     SET failed_sign_in_count = 0, lockout_count = 0, last_sign_in_at = NOW()
-     WHERE id = $1`,
-    [accountId],
-  );
-
-  // Create session
-  const browserFingerprint = extractBrowserFingerprint(userAgent);
-  const { rows: sessionRows } = await query<{ sid: string }>(
-    `INSERT INTO sessions (sid, account_id, ip_address, user_agent, browser_fingerprint)
-     VALUES (gen_random_uuid(), $1, $2, $3, $4)
-     RETURNING sid`,
-    [accountId, ip, userAgent, browserFingerprint],
-  );
-  const sessionId = sessionRows[0].sid;
-
-  // Issue JWT
-  const jwt = await issueAccessToken({
-    accountId,
-    sessionId,
-    roles: [roleName],
-    tokenVersion,
-  });
-
-  // Issue CSRF token
-  const csrfSecret = process.env.CSRF_SECRET;
-  if (!csrfSecret) {
-    return NextResponse.json(
-      { error: "Server configuration error" },
-      { status: 500 },
-    );
-  }
-  const { token: csrfToken } = generateCsrfToken(sessionId, csrfSecret);
-
-  // Read JWT policy for cookie maxAge
-  const jwtPolicy = await loadJwtPolicy();
-  const maxAge = jwtPolicy.accessTokenExpirationMinutes * 60;
-
-  // Set cookies
-  const tokenExp = Math.floor(Date.now() / 1000) + maxAge;
-  await setAccessTokenCookie(jwt, maxAge);
-  await setTokenExpCookie(tokenExp, maxAge);
-  await setTokenTtlCookie(maxAge);
-  const cookieStore = await cookies();
-  cookieStore.set(CSRF_COOKIE_NAME, csrfToken, {
-    ...CSRF_COOKIE_OPTIONS,
-    maxAge,
-  });
-
-  // Set NEXT_LOCALE cookie for next-intl locale negotiation
-  if (locale) {
-    cookieStore.set("NEXT_LOCALE", locale, {
-      path: "/",
-      maxAge: 365 * 24 * 60 * 60,
-    });
-  }
-
-  // Audit success
-  await auditLog.record({
-    actor: accountId,
-    action: "auth.sign_in.success",
-    target: "session",
-    targetId: sessionId,
-    ip,
-    sid: sessionId,
-  });
-
-  return NextResponse.json({ mustChangePassword });
-}
-
 // ── Handler ─────────────────────────────────────────────────────
 
 async function handleSignIn(request: NextRequest): Promise<NextResponse> {
@@ -383,6 +280,32 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
   const passwordValid = await verifyPassword(account.password_hash, password);
   if (!passwordValid) {
     return applyFailedLogin(account, ip);
+  }
+
+  // Step 6.5: MFA check (credential + policy dual check)
+  const totpCredential = await getTotpCredential(account.id);
+  if (totpCredential?.verified) {
+    const mfaPolicy = await loadMfaPolicy();
+    if (mfaPolicy.allowedMethods.includes("totp")) {
+      const jti = randomUUID();
+      const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+      await query(
+        "INSERT INTO mfa_challenges (jti, account_id, expires_at) VALUES ($1, $2, $3)",
+        [jti, account.id, expiresAt],
+      );
+      const mfaToken = await issueMfaToken({
+        accountId: account.id,
+        roles: [account.role_name],
+        tokenVersion: account.token_version,
+        jti,
+      });
+      return NextResponse.json({
+        mfaRequired: true,
+        mfaToken,
+        mfaMethods: ["totp"],
+      });
+    }
+    // TOTP enrolled but not in policy — graceful degradation
   }
 
   // Step 7: Max sessions check

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AlertCircle, Eye, EyeOff, Loader2 } from "lucide-react";
+import { AlertCircle, ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -30,6 +30,21 @@ const ERROR_KEYS: Record<number, string> = {
   429: "rateLimited",
 };
 
+const KNOWN_CODES: Record<string, string> = {
+  INVALID_CREDENTIALS: "invalidCredentials",
+  ACCOUNT_LOCKED: "accountLocked",
+  ACCOUNT_INACTIVE: "accountInactive",
+  IP_RESTRICTED: "ipRestricted",
+  MAX_SESSIONS: "maxSessions",
+};
+
+const MFA_CODES: Record<string, string> = {
+  INVALID_MFA_CODE: "mfa.invalidCode",
+  MFA_TOKEN_INVALID: "mfa.mfaTokenExpired",
+  TOTP_NOT_ALLOWED: "mfa.totpDisabledMidFlow",
+  MFA_RATE_LIMITED: "mfa.rateLimited",
+};
+
 export function SignInForm() {
   const t = useTranslations("auth");
   const tValidation = useTranslations("validation");
@@ -38,12 +53,27 @@ export function SignInForm() {
   const [showPassword, setShowPassword] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
+  // MFA state
+  const [mfaStep, setMfaStep] = useState<"credentials" | "totp">("credentials");
+  const [mfaToken, setMfaToken] = useState<string | null>(null);
+  const [totpCode, setTotpCode] = useState("");
+  const [mfaSubmitting, setMfaSubmitting] = useState(false);
+  const totpInputRef = useRef<HTMLInputElement>(null);
+
   const form = useForm<SignInValues>({
     resolver: zodResolver(signInSchema),
     defaultValues: { username: "", password: "" },
   });
 
   const isSubmitting = form.formState.isSubmitting;
+
+  function handleSignInSuccess(body: { mustChangePassword?: boolean }) {
+    if (body.mustChangePassword) {
+      router.push("/change-password");
+    } else {
+      router.push("/");
+    }
+  }
 
   async function onSubmit(values: SignInValues) {
     setServerError(null);
@@ -56,12 +86,22 @@ export function SignInForm() {
       });
 
       if (res.ok) {
-        const body = (await res.json()) as { mustChangePassword?: boolean };
-        if (body.mustChangePassword) {
-          router.push("/change-password");
-        } else {
-          router.push("/");
+        const body = (await res.json()) as {
+          mustChangePassword?: boolean;
+          mfaRequired?: boolean;
+          mfaToken?: string;
+        };
+
+        if (body.mfaRequired && body.mfaToken) {
+          setMfaToken(body.mfaToken);
+          setMfaStep("totp");
+          setTotpCode("");
+          // Auto-focus TOTP input on next render
+          setTimeout(() => totpInputRef.current?.focus(), 0);
+          return;
         }
+
+        handleSignInSuccess(body);
         return;
       }
 
@@ -76,14 +116,7 @@ export function SignInForm() {
       try {
         const body = (await res.json()) as { code?: string };
         if (body.code) {
-          const knownCodes: Record<string, string> = {
-            INVALID_CREDENTIALS: "invalidCredentials",
-            ACCOUNT_LOCKED: "accountLocked",
-            ACCOUNT_INACTIVE: "accountInactive",
-            IP_RESTRICTED: "ipRestricted",
-            MAX_SESSIONS: "maxSessions",
-          };
-          const key = knownCodes[body.code];
+          const key = KNOWN_CODES[body.code];
           if (key) {
             setServerError(t(key));
             return;
@@ -98,6 +131,155 @@ export function SignInForm() {
       setServerError(t("serverError"));
     }
   }
+
+  async function onTotpSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setServerError(null);
+    setMfaSubmitting(true);
+
+    try {
+      const res = await fetch("/api/auth/mfa/totp/challenge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mfaToken, code: totpCode }),
+      });
+
+      if (res.ok) {
+        const body = (await res.json()) as { mustChangePassword?: boolean };
+        handleSignInSuccess(body);
+        return;
+      }
+
+      // Handle rate limit
+      if (res.status === 429) {
+        setServerError(t("mfa.rateLimited"));
+        return;
+      }
+
+      // Try to extract error code
+      try {
+        const body = (await res.json()) as { code?: string };
+        if (body.code) {
+          // MFA token expired or invalid — restart sign-in
+          if (body.code === "MFA_TOKEN_INVALID") {
+            setMfaStep("credentials");
+            setMfaToken(null);
+            setTotpCode("");
+            setServerError(t("mfa.mfaTokenExpired"));
+            return;
+          }
+
+          // TOTP disabled mid-flow — restart sign-in
+          if (body.code === "TOTP_NOT_ALLOWED") {
+            setMfaStep("credentials");
+            setMfaToken(null);
+            setTotpCode("");
+            setServerError(t("mfa.totpDisabledMidFlow"));
+            return;
+          }
+
+          // Check MFA-specific codes
+          const mfaKey = MFA_CODES[body.code];
+          if (mfaKey) {
+            setServerError(t(mfaKey));
+            setTotpCode("");
+            return;
+          }
+
+          // Check shared codes (ACCOUNT_LOCKED, etc.)
+          const sharedKey = KNOWN_CODES[body.code];
+          if (sharedKey) {
+            setServerError(t(sharedKey));
+            return;
+          }
+        }
+      } catch {
+        // Response body is not JSON
+      }
+
+      setServerError(t("serverError"));
+    } catch {
+      setServerError(t("serverError"));
+    } finally {
+      setMfaSubmitting(false);
+    }
+  }
+
+  function resetToCredentials() {
+    setMfaStep("credentials");
+    setMfaToken(null);
+    setTotpCode("");
+    setServerError(null);
+  }
+
+  // ── TOTP step ───────────────────────────────────────────────
+
+  if (mfaStep === "totp") {
+    return (
+      <form onSubmit={onTotpSubmit} className="grid gap-6">
+        <h1 className="text-xl font-semibold tracking-tight">
+          {t("mfa.enterTotpCode")}
+        </h1>
+
+        <div className="grid gap-2">
+          <Input
+            ref={totpInputRef}
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={6}
+            pattern="\d{6}"
+            value={totpCode}
+            onChange={(e) => {
+              const v = e.target.value.replace(/\D/g, "").slice(0, 6);
+              setTotpCode(v);
+            }}
+            disabled={mfaSubmitting}
+            className="text-center text-lg tracking-widest"
+            autoFocus
+          />
+        </div>
+
+        {serverError && (
+          <p
+            className="text-destructive flex items-center gap-1 text-sm"
+            role="alert"
+          >
+            <AlertCircle className="size-3.5 shrink-0" />
+            {serverError}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={mfaSubmitting || totpCode.length !== 6}
+        >
+          {mfaSubmitting ? (
+            <>
+              <Loader2 className="animate-spin" />
+              {t("mfa.verifying")}
+            </>
+          ) : (
+            t("mfa.verifyButton")
+          )}
+        </Button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full"
+          onClick={resetToCredentials}
+          disabled={mfaSubmitting}
+        >
+          <ArrowLeft className="size-4" />
+          {t("mfa.backToSignIn")}
+        </Button>
+      </form>
+    );
+  }
+
+  // ── Credentials step ────────────────────────────────────────
 
   return (
     <Form {...form}>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -35,7 +35,17 @@
     "signInAgain": "Sign in again",
     "sessionExpiring": "Your session is about to expire",
     "sessionExpiringDescription": "Your session will expire in {seconds} seconds. Would you like to stay signed in?",
-    "extendSession": "Stay Signed In"
+    "extendSession": "Stay Signed In",
+    "mfa": {
+      "enterTotpCode": "Enter the 6-digit code from your authenticator app",
+      "verifyButton": "Verify",
+      "verifying": "Verifying...",
+      "invalidCode": "Invalid verification code. Please try again.",
+      "mfaTokenExpired": "Verification session expired. Please sign in again.",
+      "totpDisabledMidFlow": "TOTP verification is no longer available. Please contact your administrator.",
+      "rateLimited": "Too many attempts. Please wait and try again.",
+      "backToSignIn": "Back to sign in"
+    }
   },
   "nav": {
     "home": "Home",
@@ -117,7 +127,9 @@
       "role_update": "Role update",
       "role_delete": "Role delete",
       "mfa_totp_enroll": "TOTP enroll",
-      "mfa_totp_remove": "TOTP remove"
+      "mfa_totp_remove": "TOTP remove",
+      "mfa_totp_verify_success": "TOTP verify success",
+      "mfa_totp_verify_failure": "TOTP verify failure"
     },
     "targetTypes": {
       "account": "Account",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -35,7 +35,17 @@
     "signInAgain": "다시 로그인",
     "sessionExpiring": "세션이 곧 만료됩니다",
     "sessionExpiringDescription": "세션이 {seconds}초 후에 만료됩니다. 로그인을 유지하시겠습니까?",
-    "extendSession": "로그인 유지"
+    "extendSession": "로그인 유지",
+    "mfa": {
+      "enterTotpCode": "인증 앱의 6자리 코드를 입력하세요",
+      "verifyButton": "확인",
+      "verifying": "확인 중...",
+      "invalidCode": "잘못된 인증 코드입니다. 다시 시도해 주세요.",
+      "mfaTokenExpired": "인증 세션이 만료되었습니다. 다시 로그인해 주세요.",
+      "totpDisabledMidFlow": "TOTP 인증을 더 이상 사용할 수 없습니다. 관리자에게 문의하세요.",
+      "rateLimited": "시도 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요.",
+      "backToSignIn": "로그인으로 돌아가기"
+    }
   },
   "nav": {
     "home": "홈",
@@ -117,7 +127,9 @@
       "role_update": "역할 수정",
       "role_delete": "역할 삭제",
       "mfa_totp_enroll": "TOTP 등록",
-      "mfa_totp_remove": "TOTP 해제"
+      "mfa_totp_remove": "TOTP 해제",
+      "mfa_totp_verify_success": "TOTP 인증 성공",
+      "mfa_totp_verify_failure": "TOTP 인증 실패"
     },
     "targetTypes": {
       "account": "계정",

--- a/src/lib/audit/schema.ts
+++ b/src/lib/audit/schema.ts
@@ -41,8 +41,12 @@ type SystemSettingsAction = "system_settings.update";
 /** Role event actions (#134). */
 type RoleAction = "role.create" | "role.update" | "role.delete";
 
-/** MFA event actions (#206). */
-type MfaAction = "mfa.totp.enroll" | "mfa.totp.remove";
+/** MFA event actions (#206, #207). */
+type MfaAction =
+  | "mfa.totp.enroll"
+  | "mfa.totp.remove"
+  | "mfa.totp.verify.success"
+  | "mfa.totp.verify.failure";
 
 /** All audit event actions. */
 export type AuditAction =
@@ -96,6 +100,8 @@ export const AUDIT_ACTIONS = [
   "role.delete",
   "mfa.totp.enroll",
   "mfa.totp.remove",
+  "mfa.totp.verify.success",
+  "mfa.totp.verify.failure",
 ] as const satisfies readonly AuditAction[];
 
 /** Canonical runtime list of supported audit target types. */

--- a/src/lib/auth/mfa-token.ts
+++ b/src/lib/auth/mfa-token.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import type { JWTPayload } from "jose";
+import { decodeProtectedHeader, jwtVerify, SignJWT } from "jose";
+
+import { getSigningKey, getVerificationKey } from "./jwt-keys";
+
+// ── Constants ───────────────────────────────────────────────────
+
+const JWT_ISSUER = "aice-web-next";
+const JWT_AUDIENCE = "aice-web-next";
+const MFA_TOKEN_EXPIRATION_MINUTES = 5;
+const MFA_TOKEN_PURPOSE = "mfa_challenge";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface MfaTokenPayload extends JWTPayload {
+  iss: string;
+  sub: string;
+  aud: string;
+  iat: number;
+  exp: number;
+  jti: string;
+  roles: string[];
+  token_version: number;
+  purpose: "mfa_challenge";
+  kid: string;
+}
+
+// ── Issuance ────────────────────────────────────────────────────
+
+export async function issueMfaToken(params: {
+  accountId: string;
+  roles: string[];
+  tokenVersion: number;
+  jti: string;
+}): Promise<string> {
+  const { accountId, roles, tokenVersion, jti } = params;
+  const key = getSigningKey();
+
+  return new SignJWT({
+    roles,
+    token_version: tokenVersion,
+    purpose: MFA_TOKEN_PURPOSE,
+    kid: key.kid,
+  })
+    .setProtectedHeader({ alg: key.algorithm, kid: key.kid })
+    .setIssuer(JWT_ISSUER)
+    .setSubject(accountId)
+    .setAudience(JWT_AUDIENCE)
+    .setJti(jti)
+    .setIssuedAt()
+    .setExpirationTime(`${MFA_TOKEN_EXPIRATION_MINUTES}m`)
+    .sign(key.privateKey);
+}
+
+// ── Verification ────────────────────────────────────────────────
+
+export async function verifyMfaToken(token: string): Promise<MfaTokenPayload> {
+  const header = decodeProtectedHeader(token);
+  const kid = header.kid;
+
+  if (!kid) {
+    throw new Error("JWT header missing kid");
+  }
+
+  const keyInfo = getVerificationKey(kid);
+  if (!keyInfo) {
+    throw new Error(`No verification key found for kid: ${kid}`);
+  }
+
+  const { payload } = await jwtVerify<MfaTokenPayload>(
+    token,
+    keyInfo.publicKey,
+    {
+      issuer: JWT_ISSUER,
+      audience: JWT_AUDIENCE,
+      algorithms: [keyInfo.algorithm],
+    },
+  );
+
+  if (payload.purpose !== MFA_TOKEN_PURPOSE) {
+    throw new Error("Invalid token purpose");
+  }
+
+  return payload;
+}

--- a/src/lib/auth/sign-in.ts
+++ b/src/lib/auth/sign-in.ts
@@ -1,0 +1,115 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import {
+  setAccessTokenCookie,
+  setTokenExpCookie,
+  setTokenTtlCookie,
+} from "@/lib/auth/cookies";
+import {
+  CSRF_COOKIE_NAME,
+  CSRF_COOKIE_OPTIONS,
+  generateCsrfToken,
+} from "@/lib/auth/csrf";
+import { issueAccessToken } from "@/lib/auth/jwt";
+import { loadJwtPolicy } from "@/lib/auth/jwt-policy";
+import { extractBrowserFingerprint } from "@/lib/auth/ua-parser";
+import { query } from "@/lib/db/client";
+
+/**
+ * Create a new session, issue JWT + CSRF tokens, set cookies,
+ * and log a successful sign-in.
+ */
+export async function createSessionAndIssueTokens(params: {
+  accountId: string;
+  roleName: string;
+  tokenVersion: number;
+  mustChangePassword: boolean;
+  locale: string | null;
+  ip: string;
+  userAgent: string;
+}): Promise<NextResponse> {
+  const {
+    accountId,
+    roleName,
+    tokenVersion,
+    mustChangePassword,
+    locale,
+    ip,
+    userAgent,
+  } = params;
+
+  // Reset failed count, lockout count, and update last_sign_in_at
+  await query(
+    `UPDATE accounts
+     SET failed_sign_in_count = 0, lockout_count = 0, last_sign_in_at = NOW()
+     WHERE id = $1`,
+    [accountId],
+  );
+
+  // Create session
+  const browserFingerprint = extractBrowserFingerprint(userAgent);
+  const { rows: sessionRows } = await query<{ sid: string }>(
+    `INSERT INTO sessions (sid, account_id, ip_address, user_agent, browser_fingerprint)
+     VALUES (gen_random_uuid(), $1, $2, $3, $4)
+     RETURNING sid`,
+    [accountId, ip, userAgent, browserFingerprint],
+  );
+  const sessionId = sessionRows[0].sid;
+
+  // Issue JWT
+  const jwt = await issueAccessToken({
+    accountId,
+    sessionId,
+    roles: [roleName],
+    tokenVersion,
+  });
+
+  // Issue CSRF token
+  const csrfSecret = process.env.CSRF_SECRET;
+  if (!csrfSecret) {
+    return NextResponse.json(
+      { error: "Server configuration error" },
+      { status: 500 },
+    );
+  }
+  const { token: csrfToken } = generateCsrfToken(sessionId, csrfSecret);
+
+  // Read JWT policy for cookie maxAge
+  const jwtPolicy = await loadJwtPolicy();
+  const maxAge = jwtPolicy.accessTokenExpirationMinutes * 60;
+
+  // Set cookies
+  const tokenExp = Math.floor(Date.now() / 1000) + maxAge;
+  await setAccessTokenCookie(jwt, maxAge);
+  await setTokenExpCookie(tokenExp, maxAge);
+  await setTokenTtlCookie(maxAge);
+  const cookieStore = await cookies();
+  cookieStore.set(CSRF_COOKIE_NAME, csrfToken, {
+    ...CSRF_COOKIE_OPTIONS,
+    maxAge,
+  });
+
+  // Set NEXT_LOCALE cookie for next-intl locale negotiation
+  if (locale) {
+    cookieStore.set("NEXT_LOCALE", locale, {
+      path: "/",
+      maxAge: 365 * 24 * 60 * 60,
+    });
+  }
+
+  // Audit success
+  await auditLog.record({
+    actor: accountId,
+    action: "auth.sign_in.success",
+    target: "session",
+    targetId: sessionId,
+    ip,
+    sid: sessionId,
+  });
+
+  return NextResponse.json({ mustChangePassword });
+}

--- a/src/lib/rate-limit/limiter.ts
+++ b/src/lib/rate-limit/limiter.ts
@@ -245,6 +245,35 @@ export async function checkSensitiveOpRateLimit(
   return { limited: false };
 }
 
+// ── MFA challenge rate limiting ──────────────────────────────────
+
+const MFA_CHALLENGE_COUNT = 5;
+const MFA_CHALLENGE_WINDOW_MINUTES = 5;
+
+/**
+ * Per-account+IP rate limit for MFA challenge attempts.
+ *
+ * @param accountId The account extracted from the mfaToken.
+ * @param ip        Client IP address.
+ */
+export async function checkMfaChallengeRateLimit(
+  accountId: string,
+  ip: string,
+): Promise<RateLimitResult> {
+  const s = getStore();
+  const windowMs = MFA_CHALLENGE_WINDOW_MINUTES * 60_000;
+  const result = s.increment(
+    `mfa-challenge:account-ip:${accountId}:${ip}`,
+    windowMs,
+  );
+
+  if (result.count > MFA_CHALLENGE_COUNT) {
+    return { limited: true, retryAfterSeconds: retryAfter(result.resetAt) };
+  }
+
+  return { limited: false };
+}
+
 // ── Cache invalidation ───────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Implements the two-step MFA TOTP challenge sign-in flow (step 2 of 3-part MFA implementation).

- After password verification, if TOTP is enrolled and policy allows it, the server issues a short-lived MFA token instead of a session
- New `POST /api/auth/mfa/totp/challenge` endpoint validates the TOTP code and completes sign-in with full account re-validation (status, token_version, role, IP CIDR, max sessions)
- Sign-in form updated with two-step UI: credentials → TOTP code input
- Single-use nonce tracking via `mfa_challenges` table, rate limiting (5 attempts/5 min), and replay prevention
- Extracted `createSessionAndIssueTokens` to shared module for reuse

## Test plan

- [x] Unit tests: `pnpm vitest run src/__tests__/lib/auth/mfa-token.test.ts` (6 cases)
- [x] Integration tests: `pnpm vitest run src/__integration__/api/mfa-challenge.test.ts` (19 cases covering sign-in behavior, challenge endpoint, account re-validation, rate limiting, audit logging)
- [x] E2E tests: `pnpm playwright test e2e/mfa-sign-in.spec.ts` (4 cases: happy path, wrong code retry, back button, no TOTP enrolled)
- [x] Verify existing tests pass with no regressions: `pnpm vitest run`

Closes #207