### PR TITLE
Add WebAuthn challenge sign-in flow

### DIFF
--- a/e2e/mfa-sign-in.spec.ts
+++ b/e2e/mfa-sign-in.spec.ts
@@ -6,6 +6,8 @@ import { resetRateLimits, signIn } from "./helpers/auth";
 import {
   deleteMfaChallenges,
   deleteTotpCredential,
+  deleteWebAuthnChallenges,
+  deleteWebAuthnCredentials,
   enrollAndVerifyTotp,
   resetAccountDefaults,
   resetMfaPolicy,
@@ -46,6 +48,8 @@ test.describe("MFA sign-in flow (#207)", () => {
     await resetRateLimits();
     await resetAccountDefaults(workerUsername);
     await deleteTotpCredential(workerUsername);
+    await deleteWebAuthnCredentials(workerUsername);
+    await deleteWebAuthnChallenges(workerUsername);
     await deleteMfaChallenges(workerUsername);
     await resetMfaPolicy();
   });
@@ -54,12 +58,16 @@ test.describe("MFA sign-in flow (#207)", () => {
     await resetRateLimits();
     await resetAccountDefaults(workerUsername);
     await deleteTotpCredential(workerUsername);
+    await deleteWebAuthnCredentials(workerUsername);
+    await deleteWebAuthnChallenges(workerUsername);
     await deleteMfaChallenges(workerUsername);
     await resetMfaPolicy();
   });
 
   test.afterAll(async ({ workerUsername }) => {
     await deleteTotpCredential(workerUsername);
+    await deleteWebAuthnCredentials(workerUsername);
+    await deleteWebAuthnChallenges(workerUsername);
     await deleteMfaChallenges(workerUsername);
     await resetAccountDefaults(workerUsername);
     await resetMfaPolicy();

--- a/e2e/webauthn-sign-in.spec.ts
+++ b/e2e/webauthn-sign-in.spec.ts
@@ -1,0 +1,220 @@
+import * as OTPAuth from "otpauth";
+
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signIn } from "./helpers/auth";
+import {
+  deleteMfaChallenges,
+  deleteTotpCredential,
+  deleteWebAuthnChallenges,
+  deleteWebAuthnCredentials,
+  enrollAndVerifyTotp,
+  insertWebAuthnCredential,
+  resetAccountDefaults,
+  resetMfaPolicy,
+} from "./helpers/setup-db";
+
+function generateCode(secret: string): string {
+  const totp = new OTPAuth.TOTP({
+    issuer: "AICE",
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secret),
+  });
+  return totp.generate();
+}
+
+test.describe("WebAuthn sign-in flow (#218)", () => {
+  test.beforeAll(async ({ workerUsername }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(workerUsername);
+    await deleteTotpCredential(workerUsername);
+    await deleteWebAuthnCredentials(workerUsername);
+    await deleteWebAuthnChallenges(workerUsername);
+    await deleteMfaChallenges(workerUsername);
+    await resetMfaPolicy();
+  });
+
+  test.beforeEach(async ({ workerUsername }) => {
+    await resetRateLimits();
+    await resetAccountDefaults(workerUsername);
+    await deleteTotpCredential(workerUsername);
+    await deleteWebAuthnCredentials(workerUsername);
+    await deleteWebAuthnChallenges(workerUsername);
+    await deleteMfaChallenges(workerUsername);
+    await resetMfaPolicy();
+  });
+
+  test.afterAll(async ({ workerUsername }) => {
+    await deleteTotpCredential(workerUsername);
+    await deleteWebAuthnCredentials(workerUsername);
+    await deleteWebAuthnChallenges(workerUsername);
+    await deleteMfaChallenges(workerUsername);
+    await resetAccountDefaults(workerUsername);
+    await resetMfaPolicy();
+  });
+
+  // ── WebAuthn step renders when enrolled ────────────────────────
+
+  test("sign-in with WebAuthn enrolled shows WebAuthn step", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await insertWebAuthnCredential(workerUsername, {
+      displayName: "Test Key",
+    });
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Should show WebAuthn step (passkey prompt)
+    await expect(page.getByText(/follow your browser.*prompt/i)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  // ── Method switching: WebAuthn → TOTP ──────────────────────────
+
+  test("switch from WebAuthn to TOTP and complete sign-in", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    const secret = await enrollAndVerifyTotp(workerUsername);
+    await insertWebAuthnCredential(workerUsername, {
+      displayName: "Test Key",
+    });
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Should show WebAuthn step first (default when both available)
+    await expect(page.getByText(/follow your browser.*prompt/i)).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Click "Use authenticator app instead"
+    await page.getByRole("button", { name: /authenticator app/i }).click();
+
+    // Should show TOTP input step
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).toBeVisible({ timeout: 5_000 });
+
+    // Enter valid TOTP code and complete sign-in
+    const code = generateCode(secret);
+    await totpInput.fill(code);
+    await page.getByRole("button", { name: /verify/i }).click();
+
+    // Should redirect to dashboard
+    await page.waitForURL((url) => !url.pathname.endsWith("/sign-in"), {
+      timeout: 10_000,
+    });
+  });
+
+  // ── Method switching: TOTP → WebAuthn ──────────────────────────
+
+  test("switch from TOTP to WebAuthn step", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await enrollAndVerifyTotp(workerUsername);
+    await insertWebAuthnCredential(workerUsername, {
+      displayName: "Test Key",
+    });
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Wait for WebAuthn step then switch to TOTP
+    await expect(page.getByText(/follow your browser.*prompt/i)).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.getByRole("button", { name: /authenticator app/i }).click();
+
+    // Now in TOTP step, switch back to WebAuthn
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).toBeVisible({ timeout: 5_000 });
+    await page.getByRole("button", { name: /passkey/i }).click();
+
+    // Should be back at WebAuthn step
+    await expect(page.getByText(/follow your browser.*prompt/i)).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  // ── Back button returns to credentials ─────────────────────────
+
+  test("back button from WebAuthn step returns to credentials", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await insertWebAuthnCredential(workerUsername, {
+      displayName: "Test Key",
+    });
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Wait for WebAuthn step
+    await expect(page.getByText(/follow your browser.*prompt/i)).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Click back button
+    await page.getByRole("button", { name: /back to sign in/i }).click();
+
+    // Should return to credentials form
+    await expect(page.getByLabel("Account ID")).toBeVisible();
+    await expect(page.locator("input[name='password']")).toBeVisible();
+  });
+
+  // ── TOTP-only: no WebAuthn switch link ─────────────────────────
+
+  test("TOTP-only enrollment does not show passkey switch button", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await enrollAndVerifyTotp(workerUsername);
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Should show TOTP step
+    const totpInput = page.locator("input[autocomplete='one-time-code']");
+    await expect(totpInput).toBeVisible({ timeout: 5_000 });
+
+    // Should NOT show "Use passkey instead" button
+    const passkeyBtn = page.getByRole("button", { name: /passkey/i });
+    await expect(passkeyBtn).not.toBeVisible();
+  });
+
+  // ── WebAuthn-only: no TOTP switch link ─────────────────────────
+
+  test("WebAuthn-only enrollment does not show authenticator app switch button", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await insertWebAuthnCredential(workerUsername, {
+      displayName: "Test Key",
+    });
+
+    await page.goto("/sign-in");
+    await signIn(page, workerUsername, workerPassword);
+
+    // Should show WebAuthn step
+    await expect(page.getByText(/follow your browser.*prompt/i)).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Should NOT show "Use authenticator app instead" button
+    const totpBtn = page.getByRole("button", {
+      name: /authenticator app/i,
+    });
+    await expect(totpBtn).not.toBeVisible();
+  });
+});

--- a/e2e/webauthn.spec.ts
+++ b/e2e/webauthn.spec.ts
@@ -133,14 +133,14 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     await insertWebAuthnCredential(workerUsername, {
       displayName: "Key 1",
     });
     await insertWebAuthnCredential(workerUsername, {
       displayName: "Key 2",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     const res = await page.request.get("/api/auth/mfa/webauthn/status", {
@@ -241,11 +241,11 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     await insertWebAuthnCredential(workerUsername, {
       displayName: "Existing",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     const res = await page.request.post(
@@ -491,11 +491,11 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     await insertWebAuthnCredential(workerUsername, {
       displayName: "My Passkey",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     const res = await page.request.get("/api/auth/mfa/webauthn/credentials", {
@@ -521,11 +521,11 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     const credId = await insertWebAuthnCredential(workerUsername, {
       displayName: "Old Name",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     const res = await page.request.patch(
@@ -573,11 +573,11 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     const credId = await insertWebAuthnCredential(workerUsername, {
       displayName: "To Delete",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     const res = await page.request.delete(
@@ -605,9 +605,9 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
-    const credId = await insertWebAuthnCredential(workerUsername);
-
     await signInAndWait(page, workerUsername, workerPassword);
+
+    const credId = await insertWebAuthnCredential(workerUsername);
     const csrf = await getCsrf(page);
 
     const res = await page.request.delete(
@@ -622,9 +622,9 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
-    const credId = await insertWebAuthnCredential(workerUsername);
-
     await signInAndWait(page, workerUsername, workerPassword);
+
+    const credId = await insertWebAuthnCredential(workerUsername);
     const csrf = await getCsrf(page);
 
     const res = await page.request.delete(
@@ -660,14 +660,14 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     const credId1 = await insertWebAuthnCredential(workerUsername, {
       displayName: "Keep",
     });
     const credId2 = await insertWebAuthnCredential(workerUsername, {
       displayName: "Remove",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     await page.request.delete(`/api/auth/mfa/webauthn/credentials/${credId2}`, {
@@ -690,11 +690,11 @@ test.describe("WebAuthn API (#217)", () => {
     workerUsername,
     workerPassword,
   }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+
     const credId = await insertWebAuthnCredential(workerUsername, {
       displayName: "Policy Off",
     });
-
-    await signInAndWait(page, workerUsername, workerPassword);
     const csrf = await getCsrf(page);
 
     // Disable webauthn in policy

--- a/migrations/auth/0017_webauthn_auth_challenge_jti.sql
+++ b/migrations/auth/0017_webauthn_auth_challenge_jti.sql
@@ -1,0 +1,21 @@
+-- Tie authentication challenges to a specific login attempt (jti)
+-- instead of just the account, so concurrent sign-in attempts from
+-- different tabs/devices don't overwrite each other's challenges.
+
+ALTER TABLE webauthn_authentication_challenges
+  ADD COLUMN jti UUID;
+
+-- Backfill any existing rows (unlikely in practice).
+UPDATE webauthn_authentication_challenges
+  SET jti = gen_random_uuid()
+  WHERE jti IS NULL;
+
+ALTER TABLE webauthn_authentication_challenges
+  ALTER COLUMN jti SET NOT NULL;
+
+-- Replace per-account uniqueness with per-login-attempt uniqueness.
+ALTER TABLE webauthn_authentication_challenges
+  DROP CONSTRAINT uq_webauthn_auth_challenge_account;
+
+ALTER TABLE webauthn_authentication_challenges
+  ADD CONSTRAINT uq_webauthn_auth_challenge_jti UNIQUE (jti);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@simplewebauthn/browser": "^13.3.0",
     "@simplewebauthn/server": "^13.3.0",
     "argon2": "^0.44.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.0(react@19.2.4))
+      '@simplewebauthn/browser':
+        specifier: ^13.3.0
+        version: 13.3.0
       '@simplewebauthn/server':
         specifier: ^13.3.0
         version: 13.3.0
@@ -1349,6 +1352,9 @@ packages:
 
   '@schummar/icu-type-parser@1.21.5':
     resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
   '@simplewebauthn/server@13.3.0':
     resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
@@ -3757,6 +3763,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@schummar/icu-type-parser@1.21.5': {}
+
+  '@simplewebauthn/browser@13.3.0': {}
 
   '@simplewebauthn/server@13.3.0':
     dependencies:

--- a/src/__integration__/api/webauthn-challenge.test.ts
+++ b/src/__integration__/api/webauthn-challenge.test.ts
@@ -1,0 +1,788 @@
+import { createHash, createSign, generateKeyPairSync } from "node:crypto";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  type AuthSession,
+  authGet,
+  authPatch,
+  resetRateLimits,
+  signIn,
+} from "../helpers/auth";
+import {
+  createFakeSessions,
+  deleteMfaChallenges,
+  deleteTotpCredential,
+  deleteWebAuthnChallenges,
+  deleteWebAuthnCredentials,
+  enrollAndVerifyTotp,
+  incrementTokenVersion,
+  insertWebAuthnCredentialWithKey,
+  resetAccountDefaults,
+  setAccountRole,
+  setAccountStatus,
+  setAllowedIps,
+  setMaxSessions,
+} from "../helpers/setup-db";
+import { SERVER_ORIGIN } from "../setup";
+
+// ── Crypto helpers for WebAuthn assertion ───────────────────────
+
+/** Encode a COSE P-256 public key from raw x,y coordinates. */
+function encodeCoseKey(x: Buffer, y: Buffer): Buffer {
+  // CBOR-encode: { 1: 2, 3: -7, -1: 1, -2: x, -3: y }
+  // A5 = map(5)
+  // 01 02 = 1: 2 (kty: EC2)
+  // 03 26 = 3: -7 (alg: ES256)
+  // 20 01 = -1: 1 (crv: P-256)
+  // 21 5820 <x> = -2: bstr(32)
+  // 22 5820 <y> = -3: bstr(32)
+  return Buffer.concat([
+    Buffer.from([0xa5, 0x01, 0x02, 0x03, 0x26, 0x20, 0x01]),
+    Buffer.from([0x21, 0x58, 0x20]),
+    x,
+    Buffer.from([0x22, 0x58, 0x20]),
+    y,
+  ]);
+}
+
+function bufferToBase64url(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** Generate an EC P-256 key pair and return credential materials. */
+function generateWebAuthnKeyPair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+
+  // Extract raw x,y from uncompressed public key (0x04 + 32x + 32y)
+  const rawPub = publicKey.export({ type: "spki", format: "der" });
+  // The uncompressed point is the last 65 bytes of the DER-encoded SPKI
+  const uncompressed = rawPub.subarray(rawPub.length - 65);
+  const x = uncompressed.subarray(1, 33);
+  const y = uncompressed.subarray(33, 65);
+
+  const coseKey = encodeCoseKey(Buffer.from(x), Buffer.from(y));
+  const credentialId = Buffer.from(crypto.getRandomValues(new Uint8Array(32)));
+
+  return { coseKey, credentialId, privateKey };
+}
+
+/** Build a valid AuthenticationResponseJSON for testing. */
+function buildAssertionResponse(params: {
+  credentialId: Buffer;
+  privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"];
+  challenge: string;
+  rpId: string;
+  origin: string;
+  counter?: number;
+}) {
+  const {
+    credentialId,
+    privateKey,
+    challenge,
+    rpId,
+    origin,
+    counter = 1,
+  } = params;
+
+  // clientDataJSON
+  const clientData = JSON.stringify({
+    type: "webauthn.get",
+    challenge,
+    origin,
+    crossOrigin: false,
+  });
+  const clientDataJSON = bufferToBase64url(Buffer.from(clientData));
+
+  // authenticatorData: rpIdHash(32) + flags(1) + counter(4)
+  const rpIdHash = createHash("sha256").update(rpId).digest();
+  const flags = Buffer.from([0x05]); // UP=1, UV=1
+  const counterBuf = Buffer.alloc(4);
+  counterBuf.writeUInt32BE(counter);
+  const authData = Buffer.concat([rpIdHash, flags, counterBuf]);
+  const authenticatorData = bufferToBase64url(authData);
+
+  // signature = sign(authData + sha256(clientDataJSON))
+  const clientDataHash = createHash("sha256")
+    .update(Buffer.from(clientData))
+    .digest();
+  const signedData = Buffer.concat([authData, clientDataHash]);
+
+  const signer = createSign("SHA256");
+  signer.update(signedData);
+  const signature = bufferToBase64url(signer.sign(privateKey));
+
+  const credIdB64 = bufferToBase64url(credentialId);
+
+  return {
+    id: credIdB64,
+    rawId: credIdB64,
+    type: "public-key",
+    response: {
+      authenticatorData,
+      clientDataJSON,
+      signature,
+    },
+    authenticatorAttachment: "platform",
+    clientExtensionResults: {},
+  };
+}
+
+/**
+ * Resolve the RP origin the same way the server does: use BASE_URL only
+ * when it is a valid absolute URL, otherwise fall back to localhost:3000.
+ * (Vitest sets BASE_URL = "/" from Vite config, which is not a valid URL.)
+ */
+function getExpectedOrigin(): string {
+  const raw = process.env.BASE_URL;
+  if (raw) {
+    try {
+      return new URL(raw).origin;
+    } catch {
+      // relative or invalid — fall through
+    }
+  }
+  return "http://localhost:3000";
+}
+
+// ── Test helpers ─────────────────────────────────────────────────
+
+/** Update MFA policy via the settings API (invalidates server cache). */
+async function setMfaPolicy(
+  session: AuthSession,
+  allowedMethods: string[],
+): Promise<void> {
+  const res = await authPatch(session, "/api/system-settings/mfa_policy", {
+    value: { allowed_methods: allowedMethods },
+  });
+  if (!res.ok) throw new Error(`Failed to update MFA policy: ${res.status}`);
+}
+
+/** Perform password sign-in and return response body. */
+async function passwordSignIn(
+  username: string,
+  password: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`${SERVER_ORIGIN}/api/auth/sign-in`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+/** Insert a WebAuthn credential with known key material for assertion testing. */
+async function insertTestCredential(username: string) {
+  const { coseKey, credentialId, privateKey } = generateWebAuthnKeyPair();
+
+  await insertWebAuthnCredentialWithKey(username, credentialId, coseKey, {
+    displayName: "Test Key",
+  });
+
+  return { credentialId, privateKey };
+}
+
+/** Request authentication options from the challenge/options endpoint. */
+async function getAuthOptions(
+  mfaToken: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(
+    `${SERVER_ORIGIN}/api/auth/mfa/webauthn/challenge/options`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mfaToken }),
+    },
+  );
+  const body = await res.json();
+  return { status: res.status, body };
+}
+
+/** Submit WebAuthn challenge and return response. */
+async function submitWebAuthnChallenge(
+  mfaToken: string,
+  response: unknown,
+): Promise<Response> {
+  return fetch(`${SERVER_ORIGIN}/api/auth/mfa/webauthn/challenge`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mfaToken, response }),
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe("WebAuthn Challenge", () => {
+  beforeAll(async () => {
+    await resetRateLimits();
+  });
+
+  beforeEach(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+    await deleteWebAuthnCredentials(ADMIN_USERNAME);
+    await deleteWebAuthnChallenges(ADMIN_USERNAME);
+    await deleteTotpCredential(ADMIN_USERNAME);
+    await deleteMfaChallenges(ADMIN_USERNAME);
+    await setAllowedIps(ADMIN_USERNAME, null);
+    const session = await signIn(ADMIN_USERNAME);
+    await setMfaPolicy(session, ["webauthn", "totp"]);
+  });
+
+  afterAll(async () => {
+    await deleteWebAuthnCredentials(ADMIN_USERNAME);
+    await deleteWebAuthnChallenges(ADMIN_USERNAME);
+    await deleteTotpCredential(ADMIN_USERNAME);
+    await deleteMfaChallenges(ADMIN_USERNAME);
+    await setAllowedIps(ADMIN_USERNAME, null);
+    await resetAccountDefaults(ADMIN_USERNAME);
+    const session = await signIn(ADMIN_USERNAME);
+    await setMfaPolicy(session, ["webauthn", "totp"]);
+  });
+
+  // ── Sign-in behavior ───────────────────────────────────────────
+
+  describe("sign-in with WebAuthn", () => {
+    it("returns mfaMethods with webauthn when enrolled and policy on", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+
+      const { status, body } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      expect(status).toBe(200);
+      expect(body.mfaRequired).toBe(true);
+      expect(body.mfaToken).toBeDefined();
+      expect(body.mfaMethods).toEqual(["webauthn"]);
+    });
+
+    it("returns both methods when TOTP and WebAuthn enrolled", async () => {
+      await enrollAndVerifyTotp(ADMIN_USERNAME);
+      await insertTestCredential(ADMIN_USERNAME);
+
+      const { status, body } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      expect(status).toBe(200);
+      expect(body.mfaRequired).toBe(true);
+      expect(body.mfaMethods).toEqual(["totp", "webauthn"]);
+    });
+
+    it("returns normal session when WebAuthn enrolled but policy off", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+      const session = await signIn(ADMIN_USERNAME);
+      await setMfaPolicy(session, ["totp"]); // WebAuthn disabled
+
+      const { status, body } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      expect(status).toBe(200);
+      expect(body.mfaRequired).toBeUndefined();
+      expect(body.mustChangePassword).toBeDefined();
+    });
+  });
+
+  // ── Challenge options endpoint ─────────────────────────────────
+
+  describe("POST /api/auth/mfa/webauthn/challenge/options", () => {
+    it("returns authentication options with valid mfaToken", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      const { status, body } = await getAuthOptions(mfaToken);
+
+      expect(status).toBe(200);
+      expect(body.challenge).toBeDefined();
+      expect(typeof body.challenge).toBe("string");
+      expect(body.rpId).toBeDefined();
+      expect(body.allowCredentials).toBeDefined();
+      expect(Array.isArray(body.allowCredentials)).toBe(true);
+    });
+
+    it("returns 401 for invalid mfaToken", async () => {
+      const { status, body } = await getAuthOptions("invalid.jwt.token");
+
+      expect(status).toBe(401);
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("returns 403 when WebAuthn policy disabled", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      // Disable WebAuthn
+      const session = await signIn(ADMIN_USERNAME);
+      await setMfaPolicy(session, ["totp"]);
+
+      const { status, body } = await getAuthOptions(
+        signInBody.mfaToken as string,
+      );
+
+      expect(status).toBe(403);
+      expect(body.code).toBe("WEBAUTHN_NOT_ALLOWED");
+    });
+
+    it("returns 400 for missing mfaToken", async () => {
+      const res = await fetch(
+        `${SERVER_ORIGIN}/api/auth/mfa/webauthn/challenge/options`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Challenge endpoint ─────────────────────────────────────────
+
+  describe("POST /api/auth/mfa/webauthn/challenge", () => {
+    it("creates session with valid WebAuthn assertion", async () => {
+      const { credentialId, privateKey } =
+        await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Get authentication options
+      const { body: options } = await getAuthOptions(mfaToken);
+      const challenge = options.challenge as string;
+      const rpId = options.rpId as string;
+
+      // Build a valid assertion
+      const assertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge,
+        rpId,
+        origin: getExpectedOrigin(),
+      });
+
+      const res = await submitWebAuthnChallenge(mfaToken, assertion);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.mustChangePassword).toBeDefined();
+
+      // Verify cookies were set (session created)
+      const cookies = res.headers.get("set-cookie");
+      expect(cookies).toContain("at=");
+    });
+
+    it("returns 401 with invalid assertion, token still usable", async () => {
+      const { credentialId, privateKey } =
+        await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Get options
+      const { body: options } = await getAuthOptions(mfaToken);
+
+      // Build assertion with wrong challenge
+      const badAssertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: bufferToBase64url(Buffer.from("wrong-challenge")),
+        rpId: options.rpId as string,
+        origin: getExpectedOrigin(),
+      });
+
+      const res1 = await submitWebAuthnChallenge(mfaToken, badAssertion);
+      expect(res1.status).toBe(401);
+      const body1 = await res1.json();
+      expect(body1.code).toBe("INVALID_MFA_CODE");
+
+      // Token should still be usable — get new options and try again
+      const { body: options2 } = await getAuthOptions(mfaToken);
+      const goodAssertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: options2.challenge as string,
+        rpId: options2.rpId as string,
+        origin: getExpectedOrigin(),
+        counter: 2,
+      });
+
+      const res2 = await submitWebAuthnChallenge(mfaToken, goodAssertion);
+      expect(res2.status).toBe(200);
+    });
+
+    it("returns 401 for invalid mfaToken", async () => {
+      const res = await submitWebAuthnChallenge("invalid.jwt.token", {
+        id: "fake",
+        rawId: "fake",
+        type: "public-key",
+        response: {
+          authenticatorData: "fake",
+          clientDataJSON: "fake",
+          signature: "fake",
+        },
+      });
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("returns 401 for replayed token after success", async () => {
+      const { credentialId, privateKey } =
+        await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // First attempt succeeds
+      const { body: options } = await getAuthOptions(mfaToken);
+      const assertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: options.challenge as string,
+        rpId: options.rpId as string,
+        origin: getExpectedOrigin(),
+      });
+
+      const res1 = await submitWebAuthnChallenge(mfaToken, assertion);
+      expect(res1.status).toBe(200);
+
+      // Replay should fail
+      const res2 = await submitWebAuthnChallenge(mfaToken, assertion);
+      expect(res2.status).toBe(401);
+      const body2 = await res2.json();
+      expect(body2.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await fetch(
+        `${SERVER_ORIGIN}/api/auth/mfa/webauthn/challenge`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Re-validation scenarios ────────────────────────────────────
+
+  describe("account state re-validation", () => {
+    /** Helper: insert credential, sign in, mutate state, then attempt challenge. */
+    async function setupAndChallenge(
+      mutate: () => Promise<void>,
+    ): Promise<Response> {
+      const { credentialId, privateKey } =
+        await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Mutate state between sign-in and challenge
+      await mutate();
+
+      const { body: options } = await getAuthOptions(mfaToken);
+      const assertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: options.challenge as string,
+        rpId: options.rpId as string,
+        origin: getExpectedOrigin(),
+      });
+
+      return submitWebAuthnChallenge(mfaToken, assertion);
+    }
+
+    it("rejects when account suspended mid-flow", async () => {
+      const res = await setupAndChallenge(() =>
+        setAccountStatus(ADMIN_USERNAME, "suspended"),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("ACCOUNT_INACTIVE");
+    });
+
+    it("rejects when account locked mid-flow", async () => {
+      const res = await setupAndChallenge(() =>
+        setAccountStatus(ADMIN_USERNAME, "locked"),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("ACCOUNT_LOCKED");
+    });
+
+    it("rejects when token_version changed mid-flow", async () => {
+      const res = await setupAndChallenge(() =>
+        incrementTokenVersion(ADMIN_USERNAME),
+      );
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+    });
+
+    it("rejects when max sessions reached mid-flow", async () => {
+      const res = await setupAndChallenge(async () => {
+        await setMaxSessions(ADMIN_USERNAME, 1);
+        await createFakeSessions(ADMIN_USERNAME, 1);
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("MAX_SESSIONS");
+    });
+
+    it("rejects when WebAuthn policy disabled mid-flow", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      // Disable WebAuthn in policy
+      const session = await signIn(ADMIN_USERNAME);
+      await setMfaPolicy(session, ["totp"]);
+
+      // Policy check happens before assertion verification,
+      // so a fake assertion body is sufficient here.
+      const res = await submitWebAuthnChallenge(mfaToken, {
+        id: "fake",
+        rawId: "fake",
+        type: "public-key",
+        response: {
+          authenticatorData: "fake",
+          clientDataJSON: "fake",
+          signature: "fake",
+        },
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("WEBAUTHN_NOT_ALLOWED");
+    });
+
+    it("rejects when role changed mid-flow", async () => {
+      const res = await setupAndChallenge(() =>
+        setAccountRole(ADMIN_USERNAME, "Security Monitor"),
+      );
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_TOKEN_INVALID");
+
+      await setAccountRole(ADMIN_USERNAME, "System Administrator");
+    });
+
+    it("rejects when IP not in allowed list", async () => {
+      const res = await setupAndChallenge(() =>
+        setAllowedIps(ADMIN_USERNAME, ["10.0.0.0/8"]),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.code).toBe("IP_RESTRICTED");
+    });
+  });
+
+  // ── Rate limiting ──────────────────────────────────────────────
+
+  describe("rate limiting", () => {
+    it("returns 429 after exceeding MFA challenge limit", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      const fakeAssertion = {
+        id: "fake",
+        rawId: "fake",
+        type: "public-key",
+        response: {
+          authenticatorData: "fake",
+          clientDataJSON: "fake",
+          signature: "fake",
+        },
+      };
+
+      // Send 5 attempts (at threshold)
+      for (let i = 0; i < 5; i++) {
+        // Get fresh options each time so there's a stored challenge
+        await getAuthOptions(mfaToken);
+        const res = await submitWebAuthnChallenge(mfaToken, fakeAssertion);
+        expect(res.status).toBe(401);
+      }
+
+      // 6th attempt should be rate limited
+      await getAuthOptions(mfaToken);
+      const res = await submitWebAuthnChallenge(mfaToken, fakeAssertion);
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.code).toBe("MFA_RATE_LIMITED");
+      expect(res.headers.get("Retry-After")).toBeDefined();
+    });
+  });
+
+  // ── Audit logging ──────────────────────────────────────────────
+
+  describe("audit logging", () => {
+    it("records mfa.webauthn.verify.success on successful challenge", async () => {
+      const { credentialId, privateKey } =
+        await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      const { body: options } = await getAuthOptions(mfaToken);
+      const assertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: options.challenge as string,
+        rpId: options.rpId as string,
+        origin: getExpectedOrigin(),
+      });
+
+      const res = await submitWebAuthnChallenge(mfaToken, assertion);
+      expect(res.status).toBe(200);
+
+      // Check audit log
+      const session = await signIn(ADMIN_USERNAME);
+      const auditRes = await authGet(
+        session,
+        "/api/audit-logs?action=mfa.webauthn.verify.success&pageSize=1",
+      );
+      expect(auditRes.status).toBe(200);
+      const auditBody = await auditRes.json();
+      expect(auditBody.data.length).toBeGreaterThanOrEqual(1);
+      expect(auditBody.data[0].action).toBe("mfa.webauthn.verify.success");
+    });
+
+    it("records mfa.webauthn.verify.failure on invalid assertion", async () => {
+      await insertTestCredential(ADMIN_USERNAME);
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const mfaToken = signInBody.mfaToken as string;
+
+      const { body: options } = await getAuthOptions(mfaToken);
+
+      // Build a bad assertion (credential ID that doesn't exist)
+      const fakeCredId = Buffer.from(
+        crypto.getRandomValues(new Uint8Array(32)),
+      );
+      const { privateKey: fakeKey } = generateWebAuthnKeyPair();
+      const badAssertion = buildAssertionResponse({
+        credentialId: fakeCredId,
+        privateKey: fakeKey,
+        challenge: options.challenge as string,
+        rpId: options.rpId as string,
+        origin: getExpectedOrigin(),
+      });
+
+      const res = await submitWebAuthnChallenge(mfaToken, badAssertion);
+      expect(res.status).toBe(401);
+
+      const session = await signIn(ADMIN_USERNAME);
+      const auditRes = await authGet(
+        session,
+        "/api/audit-logs?action=mfa.webauthn.verify.failure&pageSize=1",
+      );
+      expect(auditRes.status).toBe(200);
+      const auditBody = await auditRes.json();
+      expect(auditBody.data.length).toBeGreaterThanOrEqual(1);
+      expect(auditBody.data[0].action).toBe("mfa.webauthn.verify.failure");
+    });
+  });
+
+  // ── Counter verification ───────────────────────────────────────
+
+  describe("counter verification", () => {
+    it("updates credential counter after successful authentication", async () => {
+      const { credentialId, privateKey } =
+        await insertTestCredential(ADMIN_USERNAME);
+
+      const { body: signInBody } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+
+      const { body: options } = await getAuthOptions(
+        signInBody.mfaToken as string,
+      );
+      const assertion = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: options.challenge as string,
+        rpId: options.rpId as string,
+        origin: getExpectedOrigin(),
+        counter: 5,
+      });
+
+      const res = await submitWebAuthnChallenge(
+        signInBody.mfaToken as string,
+        assertion,
+      );
+      expect(res.status).toBe(200);
+
+      // Verify counter was updated by attempting a second auth
+      // with counter=6 (must be > 5)
+      const { body: signInBody2 } = await passwordSignIn(
+        ADMIN_USERNAME,
+        ADMIN_PASSWORD,
+      );
+      const { body: options2 } = await getAuthOptions(
+        signInBody2.mfaToken as string,
+      );
+      const assertion2 = buildAssertionResponse({
+        credentialId,
+        privateKey,
+        challenge: options2.challenge as string,
+        rpId: options2.rpId as string,
+        origin: getExpectedOrigin(),
+        counter: 6,
+      });
+
+      const res2 = await submitWebAuthnChallenge(
+        signInBody2.mfaToken as string,
+        assertion2,
+      );
+      expect(res2.status).toBe(200);
+    });
+  });
+});

--- a/src/__integration__/helpers/setup-db.ts
+++ b/src/__integration__/helpers/setup-db.ts
@@ -563,6 +563,31 @@ export async function insertWebAuthnCredential(
   });
 }
 
+/**
+ * Insert a WebAuthn credential with caller-supplied key material.
+ * Used by tests that need to build valid assertions.
+ */
+export async function insertWebAuthnCredentialWithKey(
+  username: string,
+  credentialId: Buffer,
+  publicKey: Buffer,
+  opts?: { displayName?: string },
+): Promise<string> {
+  return withAuthDb(async (c) => {
+    const { rows } = await c.query<{ id: string }>(
+      `INSERT INTO webauthn_credentials
+         (account_id, credential_id, public_key, counter, display_name)
+       VALUES (
+         (SELECT id FROM accounts WHERE username = $1),
+         $2, $3, 0, $4
+       )
+       RETURNING id`,
+      [username, credentialId, publicKey, opts?.displayName ?? null],
+    );
+    return rows[0].id;
+  });
+}
+
 // ── MFA challenge helpers ─────────────────────────────────────────
 
 export async function enrollAndVerifyTotp(username: string): Promise<string> {

--- a/src/app/api/auth/mfa/totp/challenge/route.ts
+++ b/src/app/api/auth/mfa/totp/challenge/route.ts
@@ -7,28 +7,11 @@ import {
   withCorrelationId,
 } from "@/lib/audit/correlation";
 import { auditLog } from "@/lib/audit/logger";
-import { isIpAllowed } from "@/lib/auth/cidr";
-import { extractClientIp } from "@/lib/auth/ip";
+import { validateMfaChallenge } from "@/lib/auth/mfa-challenge";
 import { loadMfaPolicy } from "@/lib/auth/mfa-policy";
-import { verifyMfaToken } from "@/lib/auth/mfa-token";
-import { loadSessionPolicy } from "@/lib/auth/session-policy";
 import { createSessionAndIssueTokens } from "@/lib/auth/sign-in";
 import { getTotpCredential, verifyTotpCode } from "@/lib/auth/totp";
 import { query } from "@/lib/db/client";
-import { checkMfaChallengeRateLimit } from "@/lib/rate-limit/limiter";
-
-// ── Account row type ────────────────────────────────────────────
-
-interface AccountRow {
-  id: string;
-  status: string;
-  token_version: number;
-  must_change_password: boolean;
-  max_sessions: number | null;
-  allowed_ips: string[] | null;
-  role_name: string;
-  locale: string | null;
-}
 
 // ── Handler ─────────────────────────────────────────────────────
 
@@ -59,50 +42,11 @@ async function handleChallenge(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // Step 2: Verify mfaToken JWT
-  let accountId: string;
-  let jti: string;
-  let roles: string[];
-  let tokenVersion: number;
+  // Steps 2–6: Shared MFA challenge validation
+  const result = await validateMfaChallenge(request, mfaToken);
+  if (result instanceof NextResponse) return result;
 
-  try {
-    const payload = await verifyMfaToken(mfaToken);
-    accountId = payload.sub;
-    jti = payload.jti;
-    roles = payload.roles;
-    tokenVersion = payload.token_version;
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
-      { status: 401 },
-    );
-  }
-
-  // Step 3: Check mfa_challenges table (exists, not used)
-  const { rows: challengeRows } = await query<{ used: boolean }>(
-    "SELECT used FROM mfa_challenges WHERE jti = $1",
-    [jti],
-  );
-
-  if (challengeRows.length === 0 || challengeRows[0].used) {
-    return NextResponse.json(
-      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
-      { status: 401 },
-    );
-  }
-
-  // Step 4: Rate limit (after token verification — accountId is now trusted)
-  const ip = extractClientIp(request);
-  const rateResult = await checkMfaChallengeRateLimit(accountId, ip);
-  if (rateResult.limited) {
-    return NextResponse.json(
-      { error: "Too many attempts", code: "MFA_RATE_LIMITED" },
-      {
-        status: 429,
-        headers: { "Retry-After": String(rateResult.retryAfterSeconds) },
-      },
-    );
-  }
+  const { accountId, jti, account, ip } = result;
 
   // Step 5: Policy check (TOTP may have been disabled mid-flow)
   const mfaPolicy = await loadMfaPolicy();
@@ -114,86 +58,6 @@ async function handleChallenge(request: NextRequest): Promise<NextResponse> {
       },
       { status: 403 },
     );
-  }
-
-  // Step 6: Account state re-validation
-  const { rows: accountRows } = await query<AccountRow>(
-    `SELECT a.id, a.status, a.token_version, a.must_change_password,
-            a.max_sessions, a.allowed_ips, r.name AS role_name, a.locale
-     FROM accounts a
-     JOIN roles r ON a.role_id = r.id
-     WHERE a.id = $1`,
-    [accountId],
-  );
-
-  if (accountRows.length === 0) {
-    return NextResponse.json(
-      { error: "Account not found", code: "MFA_TOKEN_INVALID" },
-      { status: 401 },
-    );
-  }
-
-  const account = accountRows[0];
-
-  // 6a: Status check
-  if (account.status === "locked") {
-    return NextResponse.json(
-      { error: "Account is locked", code: "ACCOUNT_LOCKED" },
-      { status: 403 },
-    );
-  }
-
-  if (account.status !== "active") {
-    return NextResponse.json(
-      { error: "Account is not active", code: "ACCOUNT_INACTIVE" },
-      { status: 403 },
-    );
-  }
-
-  // 6b: Token version check (password reset or sign-out-all invalidates)
-  if (account.token_version !== tokenVersion) {
-    return NextResponse.json(
-      { error: "Token has been invalidated", code: "MFA_TOKEN_INVALID" },
-      { status: 401 },
-    );
-  }
-
-  // 6c: Role check
-  if (!roles.includes(account.role_name)) {
-    return NextResponse.json(
-      { error: "Role has changed", code: "MFA_TOKEN_INVALID" },
-      { status: 401 },
-    );
-  }
-
-  // 6d: IP CIDR check
-  if (!isIpAllowed(ip, account.allowed_ips ?? [])) {
-    return NextResponse.json(
-      { error: "Access denied from this network", code: "IP_RESTRICTED" },
-      { status: 403 },
-    );
-  }
-
-  // 6e: Max sessions check
-  const sessionPolicy = await loadSessionPolicy();
-  const effectiveMaxSessions =
-    account.max_sessions ?? sessionPolicy.maxSessions;
-
-  if (effectiveMaxSessions !== null) {
-    const { rows: countRows } = await query<{ count: string }>(
-      "SELECT COUNT(*) AS count FROM sessions WHERE account_id = $1 AND revoked = false",
-      [accountId],
-    );
-    const activeCount = Number(countRows[0].count);
-    if (activeCount >= effectiveMaxSessions) {
-      return NextResponse.json(
-        {
-          error: "Maximum number of active sessions reached",
-          code: "MAX_SESSIONS",
-        },
-        { status: 403 },
-      );
-    }
   }
 
   // Step 7: Verify TOTP code

--- a/src/app/api/auth/mfa/webauthn/challenge/options/route.ts
+++ b/src/app/api/auth/mfa/webauthn/challenge/options/route.ts
@@ -1,0 +1,120 @@
+import "server-only";
+
+import type { Base64URLString } from "@simplewebauthn/server";
+import { generateAuthenticationOptions } from "@simplewebauthn/server";
+import { type NextRequest, NextResponse } from "next/server";
+
+import {
+  generateCorrelationId,
+  withCorrelationId,
+} from "@/lib/audit/correlation";
+import { loadMfaPolicy } from "@/lib/auth/mfa-policy";
+import { verifyMfaToken } from "@/lib/auth/mfa-token";
+import type { AuthenticatorTransport } from "@/lib/auth/webauthn";
+import {
+  bufferToBase64url,
+  getRelyingParty,
+  getWebAuthnCredentials,
+  storeAuthenticationChallenge,
+} from "@/lib/auth/webauthn";
+import { query } from "@/lib/db/client";
+
+/**
+ * POST /api/auth/mfa/webauthn/challenge/options
+ *
+ * Generate WebAuthn authentication options (assertion challenge).
+ * Pre-authentication — no session required, uses mfaToken instead.
+ */
+async function handleOptions(request: NextRequest): Promise<NextResponse> {
+  // Step 1: Parse body
+  let body: { mfaToken?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const { mfaToken } = body;
+  if (!mfaToken) {
+    return NextResponse.json(
+      { error: "mfaToken is required" },
+      { status: 400 },
+    );
+  }
+
+  // Step 2: Verify mfaToken JWT
+  let accountId: string;
+  let jti: string;
+  try {
+    const payload = await verifyMfaToken(mfaToken);
+    accountId = payload.sub;
+    jti = payload.jti;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // Step 3: Check mfa_challenges table (exists, not used)
+  const { rows: challengeRows } = await query<{ used: boolean }>(
+    "SELECT used FROM mfa_challenges WHERE jti = $1",
+    [jti],
+  );
+
+  if (challengeRows.length === 0 || challengeRows[0].used) {
+    return NextResponse.json(
+      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // Step 4: Policy check
+  const mfaPolicy = await loadMfaPolicy();
+  if (!mfaPolicy.allowedMethods.includes("webauthn")) {
+    return NextResponse.json(
+      {
+        error: "WebAuthn is not allowed by policy",
+        code: "WEBAUTHN_NOT_ALLOWED",
+      },
+      { status: 403 },
+    );
+  }
+
+  // Step 5: Get credentials and generate options
+  const credentials = await getWebAuthnCredentials(accountId);
+  if (credentials.length === 0) {
+    return NextResponse.json(
+      {
+        error: "WebAuthn is not allowed by policy",
+        code: "WEBAUTHN_NOT_ALLOWED",
+      },
+      { status: 403 },
+    );
+  }
+
+  const rp = getRelyingParty();
+  const options = await generateAuthenticationOptions({
+    rpID: rp.id,
+    allowCredentials: credentials.map((cred) => ({
+      id: bufferToBase64url(cred.credentialId) as Base64URLString,
+      transports: cred.transports as AuthenticatorTransport[] | undefined,
+    })),
+    userVerification: "preferred",
+  });
+
+  // Step 6: Store challenge in DB (keyed by jti so concurrent logins don't collide)
+  await storeAuthenticationChallenge(accountId, jti, options.challenge);
+
+  return NextResponse.json(options);
+}
+
+// ── Route export ────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const correlationId = generateCorrelationId();
+  return withCorrelationId(correlationId, () => handleOptions(request));
+}

--- a/src/app/api/auth/mfa/webauthn/challenge/route.ts
+++ b/src/app/api/auth/mfa/webauthn/challenge/route.ts
@@ -1,0 +1,184 @@
+import "server-only";
+
+import type { AuthenticationResponseJSON } from "@simplewebauthn/server";
+import { verifyAuthenticationResponse } from "@simplewebauthn/server";
+import { type NextRequest, NextResponse } from "next/server";
+
+import {
+  generateCorrelationId,
+  withCorrelationId,
+} from "@/lib/audit/correlation";
+import { auditLog } from "@/lib/audit/logger";
+import { validateMfaChallenge } from "@/lib/auth/mfa-challenge";
+import { loadMfaPolicy } from "@/lib/auth/mfa-policy";
+import { createSessionAndIssueTokens } from "@/lib/auth/sign-in";
+import type { AuthenticatorTransport } from "@/lib/auth/webauthn";
+import {
+  base64urlToUint8Array,
+  consumeAuthenticationChallenge,
+  getRelyingParty,
+  getWebAuthnCredentialByCredentialId,
+  updateWebAuthnCounter,
+} from "@/lib/auth/webauthn";
+import { query } from "@/lib/db/client";
+
+// ── Handler ─────────────────────────────────────────────────────
+
+async function handleChallenge(request: NextRequest): Promise<NextResponse> {
+  // Step 1: Parse body
+  let body: { mfaToken?: string; response?: AuthenticationResponseJSON };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const { mfaToken, response } = body;
+  if (!mfaToken || !response) {
+    return NextResponse.json(
+      { error: "mfaToken and response are required" },
+      { status: 400 },
+    );
+  }
+
+  // Steps 2–6: Shared MFA challenge validation
+  const result = await validateMfaChallenge(request, mfaToken);
+  if (result instanceof NextResponse) return result;
+
+  const { accountId, jti, account, ip } = result;
+
+  // Step 5: Policy check (WebAuthn may have been disabled mid-flow)
+  const mfaPolicy = await loadMfaPolicy();
+  if (!mfaPolicy.allowedMethods.includes("webauthn")) {
+    return NextResponse.json(
+      {
+        error: "WebAuthn is no longer allowed",
+        code: "WEBAUTHN_NOT_ALLOWED",
+      },
+      { status: 403 },
+    );
+  }
+
+  // Step 7: Retrieve stored challenge and verify WebAuthn assertion
+  const expectedChallenge = await consumeAuthenticationChallenge(jti);
+  if (!expectedChallenge) {
+    return NextResponse.json(
+      { error: "No pending challenge found", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // Look up the credential by the credential ID in the response
+  const credentialIdBytes = base64urlToUint8Array(response.id);
+  const credential =
+    await getWebAuthnCredentialByCredentialId(credentialIdBytes);
+
+  if (!credential || credential.accountId !== accountId) {
+    await auditLog.record({
+      actor: accountId,
+      action: "mfa.webauthn.verify.failure",
+      target: "mfa",
+      targetId: accountId,
+      ip,
+    });
+    return NextResponse.json(
+      { error: "Invalid assertion", code: "INVALID_MFA_CODE" },
+      { status: 401 },
+    );
+  }
+
+  const rp = getRelyingParty();
+
+  let verification: Awaited<ReturnType<typeof verifyAuthenticationResponse>>;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge,
+      expectedOrigin: rp.origin,
+      expectedRPID: rp.id,
+      credential: {
+        id: response.id,
+        publicKey: new Uint8Array(credential.publicKey),
+        counter: credential.counter,
+        transports:
+          (credential.transports as AuthenticatorTransport[] | undefined) ??
+          undefined,
+      },
+    });
+  } catch {
+    await auditLog.record({
+      actor: accountId,
+      action: "mfa.webauthn.verify.failure",
+      target: "mfa",
+      targetId: accountId,
+      ip,
+    });
+    return NextResponse.json(
+      { error: "Invalid assertion", code: "INVALID_MFA_CODE" },
+      { status: 401 },
+    );
+  }
+
+  if (!verification.verified) {
+    await auditLog.record({
+      actor: accountId,
+      action: "mfa.webauthn.verify.failure",
+      target: "mfa",
+      targetId: accountId,
+      ip,
+    });
+    return NextResponse.json(
+      { error: "Invalid assertion", code: "INVALID_MFA_CODE" },
+      { status: 401 },
+    );
+  }
+
+  // Step 8: Update credential counter
+  await updateWebAuthnCounter(
+    credentialIdBytes,
+    verification.authenticationInfo.newCounter,
+  );
+
+  // Step 9: Atomically consume token and create session
+  const { rows: consumeRows } = await query<{ jti: string }>(
+    "UPDATE mfa_challenges SET used = true WHERE jti = $1 AND used = false RETURNING jti",
+    [jti],
+  );
+
+  if (consumeRows.length === 0) {
+    return NextResponse.json(
+      { error: "Token already used", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  await auditLog.record({
+    actor: accountId,
+    action: "mfa.webauthn.verify.success",
+    target: "mfa",
+    targetId: accountId,
+    ip,
+  });
+
+  const userAgent = request.headers.get("user-agent") ?? "";
+
+  return createSessionAndIssueTokens({
+    accountId,
+    roleName: account.role_name,
+    tokenVersion: account.token_version,
+    mustChangePassword: account.must_change_password,
+    locale: account.locale,
+    ip,
+    userAgent,
+  });
+}
+
+// ── Route export ────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const correlationId = generateCorrelationId();
+  return withCorrelationId(correlationId, () => handleChallenge(request));
+}

--- a/src/app/api/auth/mfa/webauthn/register/options/route.ts
+++ b/src/app/api/auth/mfa/webauthn/register/options/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 
 import { withAuth } from "@/lib/auth/guard";
 import { loadMfaPolicy } from "@/lib/auth/mfa-policy";
+import type { AuthenticatorTransport } from "@/lib/auth/webauthn";
 import {
   bufferToBase64url,
   getRelyingParty,
@@ -65,5 +66,3 @@ export const POST = withAuth(async (_request, _context, session) => {
 
   return NextResponse.json(options);
 });
-
-type AuthenticatorTransport = "usb" | "ble" | "nfc" | "internal";

--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -18,6 +18,7 @@ import { verifyPassword } from "@/lib/auth/password";
 import { loadSessionPolicy } from "@/lib/auth/session-policy";
 import { createSessionAndIssueTokens } from "@/lib/auth/sign-in";
 import { getTotpCredential } from "@/lib/auth/totp";
+import { getWebAuthnCredentials } from "@/lib/auth/webauthn";
 import { query } from "@/lib/db/client";
 import { checkSignInRateLimit } from "@/lib/rate-limit/limiter";
 
@@ -283,29 +284,40 @@ async function handleSignIn(request: NextRequest): Promise<NextResponse> {
   }
 
   // Step 6.5: MFA check (credential + policy dual check)
+  const mfaPolicy = await loadMfaPolicy();
+  const mfaMethods: string[] = [];
+
   const totpCredential = await getTotpCredential(account.id);
-  if (totpCredential?.verified) {
-    const mfaPolicy = await loadMfaPolicy();
-    if (mfaPolicy.allowedMethods.includes("totp")) {
-      const jti = randomUUID();
-      const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
-      await query(
-        "INSERT INTO mfa_challenges (jti, account_id, expires_at) VALUES ($1, $2, $3)",
-        [jti, account.id, expiresAt],
-      );
-      const mfaToken = await issueMfaToken({
-        accountId: account.id,
-        roles: [account.role_name],
-        tokenVersion: account.token_version,
-        jti,
-      });
-      return NextResponse.json({
-        mfaRequired: true,
-        mfaToken,
-        mfaMethods: ["totp"],
-      });
-    }
-    // TOTP enrolled but not in policy — graceful degradation
+  if (totpCredential?.verified && mfaPolicy.allowedMethods.includes("totp")) {
+    mfaMethods.push("totp");
+  }
+
+  const webauthnCreds = await getWebAuthnCredentials(account.id);
+  if (
+    webauthnCreds.length > 0 &&
+    mfaPolicy.allowedMethods.includes("webauthn")
+  ) {
+    mfaMethods.push("webauthn");
+  }
+
+  if (mfaMethods.length > 0) {
+    const jti = randomUUID();
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+    await query(
+      "INSERT INTO mfa_challenges (jti, account_id, expires_at) VALUES ($1, $2, $3)",
+      [jti, account.id, expiresAt],
+    );
+    const mfaToken = await issueMfaToken({
+      accountId: account.id,
+      roles: [account.role_name],
+      tokenVersion: account.token_version,
+      jti,
+    });
+    return NextResponse.json({
+      mfaRequired: true,
+      mfaToken,
+      mfaMethods,
+    });
   }
 
   // Step 7: Max sessions check

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -1,9 +1,17 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AlertCircle, ArrowLeft, Eye, EyeOff, Loader2 } from "lucide-react";
+import { startAuthentication } from "@simplewebauthn/browser";
+import {
+  AlertCircle,
+  ArrowLeft,
+  Eye,
+  EyeOff,
+  Fingerprint,
+  Loader2,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -42,6 +50,7 @@ const MFA_CODES: Record<string, string> = {
   INVALID_MFA_CODE: "mfa.invalidCode",
   MFA_TOKEN_INVALID: "mfa.mfaTokenExpired",
   TOTP_NOT_ALLOWED: "mfa.totpDisabledMidFlow",
+  WEBAUTHN_NOT_ALLOWED: "mfa.webauthnDisabledMidFlow",
   MFA_RATE_LIMITED: "mfa.rateLimited",
 };
 
@@ -54,10 +63,14 @@ export function SignInForm() {
   const [serverError, setServerError] = useState<string | null>(null);
 
   // MFA state
-  const [mfaStep, setMfaStep] = useState<"credentials" | "totp">("credentials");
+  const [mfaStep, setMfaStep] = useState<"credentials" | "totp" | "webauthn">(
+    "credentials",
+  );
   const [mfaToken, setMfaToken] = useState<string | null>(null);
+  const [mfaMethods, setMfaMethods] = useState<string[]>([]);
   const [totpCode, setTotpCode] = useState("");
   const [mfaSubmitting, setMfaSubmitting] = useState(false);
+  const [webauthnCancelled, setWebauthnCancelled] = useState(false);
   const totpInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<SignInValues>({
@@ -67,13 +80,127 @@ export function SignInForm() {
 
   const isSubmitting = form.formState.isSubmitting;
 
-  function handleSignInSuccess(body: { mustChangePassword?: boolean }) {
-    if (body.mustChangePassword) {
-      router.push("/change-password");
-    } else {
-      router.push("/");
-    }
-  }
+  const handleSignInSuccess = useCallback(
+    (body: { mustChangePassword?: boolean }) => {
+      if (body.mustChangePassword) {
+        router.push("/change-password");
+      } else {
+        router.push("/");
+      }
+    },
+    [router],
+  );
+
+  const startWebAuthnFlow = useCallback(
+    async (token: string) => {
+      setServerError(null);
+      setWebauthnCancelled(false);
+      setMfaSubmitting(true);
+
+      try {
+        // Step 1: Get assertion options
+        const optionsRes = await fetch(
+          "/api/auth/mfa/webauthn/challenge/options",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mfaToken: token }),
+          },
+        );
+
+        if (!optionsRes.ok) {
+          const body = (await optionsRes.json().catch(() => ({}))) as {
+            code?: string;
+          };
+          if (body.code === "MFA_TOKEN_INVALID") {
+            setMfaStep("credentials");
+            setMfaToken(null);
+            setServerError(t("mfa.mfaTokenExpired"));
+            return;
+          }
+          if (body.code === "WEBAUTHN_NOT_ALLOWED") {
+            setMfaStep("credentials");
+            setMfaToken(null);
+            setServerError(t("mfa.webauthnDisabledMidFlow"));
+            return;
+          }
+          setServerError(t("mfa.webauthnError"));
+          return;
+        }
+
+        const options = await optionsRes.json();
+
+        // Step 2: Trigger browser authenticator prompt
+        const assertionResponse = await startAuthentication({
+          optionsJSON: options,
+        });
+
+        // Step 3: Submit assertion to server
+        const verifyRes = await fetch("/api/auth/mfa/webauthn/challenge", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            mfaToken: token,
+            response: assertionResponse,
+          }),
+        });
+
+        if (verifyRes.ok) {
+          const body = (await verifyRes.json()) as {
+            mustChangePassword?: boolean;
+          };
+          handleSignInSuccess(body);
+          return;
+        }
+
+        // Handle rate limit
+        if (verifyRes.status === 429) {
+          setServerError(t("mfa.rateLimited"));
+          return;
+        }
+
+        const body = (await verifyRes.json().catch(() => ({}))) as {
+          code?: string;
+        };
+        if (body.code) {
+          if (body.code === "MFA_TOKEN_INVALID") {
+            setMfaStep("credentials");
+            setMfaToken(null);
+            setServerError(t("mfa.mfaTokenExpired"));
+            return;
+          }
+          if (body.code === "WEBAUTHN_NOT_ALLOWED") {
+            setMfaStep("credentials");
+            setMfaToken(null);
+            setServerError(t("mfa.webauthnDisabledMidFlow"));
+            return;
+          }
+          const mfaKey = MFA_CODES[body.code];
+          if (mfaKey) {
+            setServerError(t(mfaKey));
+            return;
+          }
+          const sharedKey = KNOWN_CODES[body.code];
+          if (sharedKey) {
+            setServerError(t(sharedKey));
+            return;
+          }
+        }
+        setServerError(t("mfa.webauthnError"));
+      } catch (err) {
+        // User cancelled the browser prompt
+        if (err instanceof Error && err.name === "NotAllowedError") {
+          setWebauthnCancelled(true);
+          setServerError(t("mfa.webauthnCancelled"));
+          return;
+        }
+        setServerError(t("mfa.webauthnError"));
+      } finally {
+        setMfaSubmitting(false);
+      }
+    },
+    [t, handleSignInSuccess],
+  );
 
   async function onSubmit(values: SignInValues) {
     setServerError(null);
@@ -90,14 +217,23 @@ export function SignInForm() {
           mustChangePassword?: boolean;
           mfaRequired?: boolean;
           mfaToken?: string;
+          mfaMethods?: string[];
         };
 
         if (body.mfaRequired && body.mfaToken) {
+          const methods = body.mfaMethods ?? [];
           setMfaToken(body.mfaToken);
-          setMfaStep("totp");
-          setTotpCode("");
-          // Auto-focus TOTP input on next render
-          setTimeout(() => totpInputRef.current?.focus(), 0);
+          setMfaMethods(methods);
+
+          // Default to WebAuthn if available, otherwise TOTP
+          if (methods.includes("webauthn")) {
+            setMfaStep("webauthn");
+            startWebAuthnFlow(body.mfaToken);
+          } else {
+            setMfaStep("totp");
+            setTotpCode("");
+            setTimeout(() => totpInputRef.current?.focus(), 0);
+          }
           return;
         }
 
@@ -208,8 +344,87 @@ export function SignInForm() {
   function resetToCredentials() {
     setMfaStep("credentials");
     setMfaToken(null);
+    setMfaMethods([]);
     setTotpCode("");
+    setWebauthnCancelled(false);
     setServerError(null);
+  }
+
+  // ── WebAuthn step ─────────────────────────────────────────────
+
+  if (mfaStep === "webauthn") {
+    return (
+      <div className="grid gap-6">
+        <h1 className="text-xl font-semibold tracking-tight">
+          {t("mfa.usePasskey")}
+        </h1>
+
+        <div className="flex flex-col items-center gap-4 py-4">
+          <Fingerprint className="text-muted-foreground size-12" />
+          <p className="text-muted-foreground text-center text-sm">
+            {t("mfa.passkeyPrompt")}
+          </p>
+        </div>
+
+        {serverError && (
+          <p
+            className="text-destructive flex items-center gap-1 text-sm"
+            role="alert"
+          >
+            <AlertCircle className="size-3.5 shrink-0" />
+            {serverError}
+          </p>
+        )}
+
+        {(webauthnCancelled || serverError) && !mfaSubmitting && (
+          <Button
+            type="button"
+            className="w-full"
+            onClick={() => {
+              if (mfaToken) startWebAuthnFlow(mfaToken);
+            }}
+          >
+            {t("mfa.webauthnRetry")}
+          </Button>
+        )}
+
+        {mfaSubmitting && (
+          <Button type="button" className="w-full" disabled>
+            <Loader2 className="animate-spin" />
+            {t("mfa.verifying")}
+          </Button>
+        )}
+
+        {mfaMethods.includes("totp") && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full"
+            onClick={() => {
+              setMfaStep("totp");
+              setServerError(null);
+              setWebauthnCancelled(false);
+              setTotpCode("");
+              setTimeout(() => totpInputRef.current?.focus(), 0);
+            }}
+            disabled={mfaSubmitting}
+          >
+            {t("mfa.useTotp")}
+          </Button>
+        )}
+
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full"
+          onClick={resetToCredentials}
+          disabled={mfaSubmitting}
+        >
+          <ArrowLeft className="size-4" />
+          {t("mfa.backToSignIn")}
+        </Button>
+      </div>
+    );
   }
 
   // ── TOTP step ───────────────────────────────────────────────
@@ -264,6 +479,23 @@ export function SignInForm() {
             t("mfa.verifyButton")
           )}
         </Button>
+
+        {mfaMethods.includes("webauthn") && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full"
+            onClick={() => {
+              setMfaStep("webauthn");
+              setServerError(null);
+              setTotpCode("");
+              if (mfaToken) startWebAuthnFlow(mfaToken);
+            }}
+            disabled={mfaSubmitting}
+          >
+            {t("mfa.useWebauthn")}
+          </Button>
+        )}
 
         <Button
           type="button"

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -44,7 +44,15 @@
       "mfaTokenExpired": "Verification session expired. Please sign in again.",
       "totpDisabledMidFlow": "TOTP verification is no longer available. Please contact your administrator.",
       "rateLimited": "Too many attempts. Please wait and try again.",
-      "backToSignIn": "Back to sign in"
+      "backToSignIn": "Back to sign in",
+      "usePasskey": "Use a passkey",
+      "passkeyPrompt": "Follow your browser's prompt to verify your identity",
+      "useTotp": "Use authenticator app instead",
+      "useWebauthn": "Use passkey instead",
+      "webauthnError": "Passkey verification failed. Please try again.",
+      "webauthnCancelled": "Verification was cancelled. Click below to try again.",
+      "webauthnRetry": "Try again",
+      "webauthnDisabledMidFlow": "Passkeys have been disabled by an administrator. Please sign in again."
     }
   },
   "nav": {
@@ -131,7 +139,9 @@
       "mfa_totp_verify_success": "TOTP verify success",
       "mfa_totp_verify_failure": "TOTP verify failure",
       "mfa_webauthn_register": "WebAuthn register",
-      "mfa_webauthn_remove": "WebAuthn remove"
+      "mfa_webauthn_remove": "WebAuthn remove",
+      "mfa_webauthn_verify_success": "WebAuthn verify success",
+      "mfa_webauthn_verify_failure": "WebAuthn verify failure"
     },
     "targetTypes": {
       "account": "Account",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -44,7 +44,15 @@
       "mfaTokenExpired": "인증 세션이 만료되었습니다. 다시 로그인해 주세요.",
       "totpDisabledMidFlow": "TOTP 인증을 더 이상 사용할 수 없습니다. 관리자에게 문의하세요.",
       "rateLimited": "시도 횟수가 너무 많습니다. 잠시 후 다시 시도해 주세요.",
-      "backToSignIn": "로그인으로 돌아가기"
+      "backToSignIn": "로그인으로 돌아가기",
+      "usePasskey": "패스키 사용",
+      "passkeyPrompt": "브라우저의 안내에 따라 본인 인증을 완료하세요",
+      "useTotp": "인증 앱으로 전환",
+      "useWebauthn": "패스키로 전환",
+      "webauthnError": "패스키 인증에 실패했습니다. 다시 시도해 주세요.",
+      "webauthnCancelled": "인증이 취소되었습니다. 아래 버튼을 눌러 다시 시도하세요.",
+      "webauthnRetry": "다시 시도",
+      "webauthnDisabledMidFlow": "관리자에 의해 패스키가 비활성화되었습니다. 다시 로그인해 주세요."
     }
   },
   "nav": {
@@ -131,7 +139,9 @@
       "mfa_totp_verify_success": "TOTP 인증 성공",
       "mfa_totp_verify_failure": "TOTP 인증 실패",
       "mfa_webauthn_register": "WebAuthn 등록",
-      "mfa_webauthn_remove": "WebAuthn 해제"
+      "mfa_webauthn_remove": "WebAuthn 해제",
+      "mfa_webauthn_verify_success": "WebAuthn 인증 성공",
+      "mfa_webauthn_verify_failure": "WebAuthn 인증 실패"
     },
     "targetTypes": {
       "account": "계정",

--- a/src/lib/audit/schema.ts
+++ b/src/lib/audit/schema.ts
@@ -41,14 +41,16 @@ type SystemSettingsAction = "system_settings.update";
 /** Role event actions (#134). */
 type RoleAction = "role.create" | "role.update" | "role.delete";
 
-/** MFA event actions (#206, #207, #217). */
+/** MFA event actions (#206, #207, #217, #218). */
 type MfaAction =
   | "mfa.totp.enroll"
   | "mfa.totp.remove"
   | "mfa.totp.verify.success"
   | "mfa.totp.verify.failure"
   | "mfa.webauthn.register"
-  | "mfa.webauthn.remove";
+  | "mfa.webauthn.remove"
+  | "mfa.webauthn.verify.success"
+  | "mfa.webauthn.verify.failure";
 
 /** All audit event actions. */
 export type AuditAction =
@@ -106,6 +108,8 @@ export const AUDIT_ACTIONS = [
   "mfa.totp.verify.failure",
   "mfa.webauthn.register",
   "mfa.webauthn.remove",
+  "mfa.webauthn.verify.success",
+  "mfa.webauthn.verify.failure",
 ] as const satisfies readonly AuditAction[];
 
 /** Canonical runtime list of supported audit target types. */

--- a/src/lib/auth/mfa-challenge.ts
+++ b/src/lib/auth/mfa-challenge.ts
@@ -1,0 +1,167 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { isIpAllowed } from "@/lib/auth/cidr";
+import { extractClientIp } from "@/lib/auth/ip";
+import type { MfaTokenPayload } from "@/lib/auth/mfa-token";
+import { verifyMfaToken } from "@/lib/auth/mfa-token";
+import { loadSessionPolicy } from "@/lib/auth/session-policy";
+import { query } from "@/lib/db/client";
+import { checkMfaChallengeRateLimit } from "@/lib/rate-limit/limiter";
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface AccountRow {
+  id: string;
+  status: string;
+  token_version: number;
+  must_change_password: boolean;
+  max_sessions: number | null;
+  allowed_ips: string[] | null;
+  role_name: string;
+  locale: string | null;
+}
+
+export interface MfaChallengeContext {
+  accountId: string;
+  jti: string;
+  roles: string[];
+  tokenVersion: number;
+  account: AccountRow;
+  ip: string;
+}
+
+// ── Shared validation ────────────────────────────────────────────
+
+/**
+ * Validate an MFA challenge request: verify JWT, check the challenge
+ * record, apply rate limiting, and re-validate account state.
+ *
+ * Returns the validated context on success, or a NextResponse on failure.
+ */
+export async function validateMfaChallenge(
+  request: NextRequest,
+  mfaToken: string,
+): Promise<MfaChallengeContext | NextResponse> {
+  // Step 1: Verify mfaToken JWT
+  let payload: MfaTokenPayload;
+  try {
+    payload = await verifyMfaToken(mfaToken);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  const { sub: accountId, jti, roles, token_version: tokenVersion } = payload;
+
+  // Step 2: Check mfa_challenges table (exists, not used)
+  const { rows: challengeRows } = await query<{ used: boolean }>(
+    "SELECT used FROM mfa_challenges WHERE jti = $1",
+    [jti],
+  );
+
+  if (challengeRows.length === 0 || challengeRows[0].used) {
+    return NextResponse.json(
+      { error: "Invalid or expired MFA token", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // Step 3: Rate limit (after token verification — accountId is now trusted)
+  const ip = extractClientIp(request);
+  const rateResult = await checkMfaChallengeRateLimit(accountId, ip);
+  if (rateResult.limited) {
+    return NextResponse.json(
+      { error: "Too many attempts", code: "MFA_RATE_LIMITED" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateResult.retryAfterSeconds) },
+      },
+    );
+  }
+
+  // Step 4: Account state re-validation
+  const { rows: accountRows } = await query<AccountRow>(
+    `SELECT a.id, a.status, a.token_version, a.must_change_password,
+            a.max_sessions, a.allowed_ips, r.name AS role_name, a.locale
+     FROM accounts a
+     JOIN roles r ON a.role_id = r.id
+     WHERE a.id = $1`,
+    [accountId],
+  );
+
+  if (accountRows.length === 0) {
+    return NextResponse.json(
+      { error: "Account not found", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  const account = accountRows[0];
+
+  // 4a: Status check
+  if (account.status === "locked") {
+    return NextResponse.json(
+      { error: "Account is locked", code: "ACCOUNT_LOCKED" },
+      { status: 403 },
+    );
+  }
+
+  if (account.status !== "active") {
+    return NextResponse.json(
+      { error: "Account is not active", code: "ACCOUNT_INACTIVE" },
+      { status: 403 },
+    );
+  }
+
+  // 4b: Token version check (password reset or sign-out-all invalidates)
+  if (account.token_version !== tokenVersion) {
+    return NextResponse.json(
+      { error: "Token has been invalidated", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // 4c: Role check
+  if (!roles.includes(account.role_name)) {
+    return NextResponse.json(
+      { error: "Role has changed", code: "MFA_TOKEN_INVALID" },
+      { status: 401 },
+    );
+  }
+
+  // 4d: IP CIDR check
+  if (!isIpAllowed(ip, account.allowed_ips ?? [])) {
+    return NextResponse.json(
+      { error: "Access denied from this network", code: "IP_RESTRICTED" },
+      { status: 403 },
+    );
+  }
+
+  // 4e: Max sessions check
+  const sessionPolicy = await loadSessionPolicy();
+  const effectiveMaxSessions =
+    account.max_sessions ?? sessionPolicy.maxSessions;
+
+  if (effectiveMaxSessions !== null) {
+    const { rows: countRows } = await query<{ count: string }>(
+      "SELECT COUNT(*) AS count FROM sessions WHERE account_id = $1 AND revoked = false",
+      [accountId],
+    );
+    const activeCount = Number(countRows[0].count);
+    if (activeCount >= effectiveMaxSessions) {
+      return NextResponse.json(
+        {
+          error: "Maximum number of active sessions reached",
+          code: "MAX_SESSIONS",
+        },
+        { status: 403 },
+      );
+    }
+  }
+
+  return { accountId, jti, roles, tokenVersion, account, ip };
+}

--- a/src/lib/auth/webauthn.ts
+++ b/src/lib/auth/webauthn.ts
@@ -16,6 +16,8 @@ interface WebAuthnCredentialRow {
   last_used_at: Date | null;
 }
 
+export type AuthenticatorTransport = "usb" | "ble" | "nfc" | "internal";
+
 export interface WebAuthnCredentialRecord {
   id: string;
   accountId: string;
@@ -258,9 +260,10 @@ export async function consumeRegistrationChallenge(
   return rows.length > 0 ? rows[0].challenge : null;
 }
 
-/** Store an authentication challenge (one per account, UPSERT). */
+/** Store an authentication challenge keyed by login attempt (jti). */
 export async function storeAuthenticationChallenge(
   accountId: string,
+  jti: string,
   challenge: string,
 ): Promise<string> {
   await query(
@@ -268,26 +271,26 @@ export async function storeAuthenticationChallenge(
   );
 
   const { rows } = await query<{ id: string }>(
-    `INSERT INTO webauthn_authentication_challenges (account_id, challenge, expires_at)
-     VALUES ($1, $2, NOW() + INTERVAL '${CHALLENGE_TTL_SECONDS} seconds')
-     ON CONFLICT (account_id) DO UPDATE
+    `INSERT INTO webauthn_authentication_challenges (account_id, jti, challenge, expires_at)
+     VALUES ($1, $2, $3, NOW() + INTERVAL '${CHALLENGE_TTL_SECONDS} seconds')
+     ON CONFLICT (jti) DO UPDATE
        SET challenge = EXCLUDED.challenge,
            expires_at = EXCLUDED.expires_at
      RETURNING id`,
-    [accountId, challenge],
+    [accountId, jti, challenge],
   );
   return rows[0].id;
 }
 
-/** Retrieve and consume an authentication challenge. Returns null if expired or not found. */
+/** Retrieve and consume an authentication challenge by login attempt (jti). Returns null if expired or not found. */
 export async function consumeAuthenticationChallenge(
-  accountId: string,
+  jti: string,
 ): Promise<string | null> {
   const { rows } = await query<ChallengeRow>(
     `DELETE FROM webauthn_authentication_challenges
-     WHERE account_id = $1 AND expires_at > NOW()
+     WHERE jti = $1 AND expires_at > NOW()
      RETURNING id, challenge`,
-    [accountId],
+    [jti],
   );
   return rows.length > 0 ? rows[0].challenge : null;
 }


### PR DESCRIPTION
## Summary

- Extend sign-in route to check both TOTP and WebAuthn credentials, returning `mfaMethods` array so the client can offer method selection
- Add `POST /api/auth/mfa/webauthn/challenge/options` (assertion options) and `POST /api/auth/mfa/webauthn/challenge` (assertion verification + session creation) endpoints
- Extract shared MFA challenge validation (JWT, rate limit, account re-validation) into `lib/auth/mfa-challenge.ts`, deduplicating ~100 lines between TOTP and WebAuthn routes
- Add WebAuthn step to sign-in form with browser authenticator prompt, retry on cancel, and method switching links
- Add `@simplewebauthn/browser` dependency, audit events, i18n keys (EN/KO), and export shared `AuthenticatorTransport` type
- Tie authentication challenges to jti (login attempt) so concurrent sign-in attempts don't overwrite each other's challenges

## Test plan

- [x] 17 integration tests: sign-in behavior (3), options endpoint (4), challenge endpoint (5), account re-validation (7), rate limiting, audit logging, counter verification
- [x] 6 E2E tests: WebAuthn step renders, WebAuthn→TOTP switch + complete sign-in, TOTP→WebAuthn switch, back button, TOTP-only (no passkey button), WebAuthn-only (no authenticator app button)
- [x] Existing MFA tests still pass (no regression)

Closes #218