### PR TITLE
Replace pnpm/action-setup with corepack (#239)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -117,7 +118,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -147,7 +149,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Create audit_db and audit_writer role
         run: psql "postgres://postgres:postgres@localhost:5432/auth_db" -f infra/postgres/init-audit-db.sql
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -189,7 +192,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Create audit_db and audit_writer role
         run: psql "postgres://postgres:postgres@localhost:5432/auth_db" -f infra/postgres/init-audit-db.sql
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
## Summary

Replace all `pnpm/action-setup@v5` usages in CI with `corepack enable pnpm`.

`pnpm/action-setup@v6` installs pnpm via npm, which bundles a YAML parser that rejects `pnpm-lock.yaml` v9.0 format. Combined with `actions/setup-node@v6` rewriting the lockfile for npm-installed pnpm, this breaks CI. Corepack reads the `packageManager` field from `package.json` and installs the correct standalone binary, avoiding both issues.

Closes #239

## Test plan

- [x] CI passes on this branch (all jobs: lint, build, integration, e2e)
- [x] `pnpm install --frozen-lockfile` succeeds without lockfile errors
- [x] No remaining references to `pnpm/action-setup` in `.github/workflows/`