### PR TITLE
Fix undici dispatcher version mismatch (#241)

### DIFF
--- a/src/__tests__/lib/graphql/client.test.ts
+++ b/src/__tests__/lib/graphql/client.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/mtls", () => ({
-  signContextJwt: vi.fn().mockResolvedValue("mock-jwt-token"),
-  getAgent: vi.fn().mockResolvedValue({ mock: "dispatcher" }),
-}));
-
 const fetchSpy = vi.fn().mockImplementation(() =>
   Promise.resolve(
     new Response(JSON.stringify({ data: { hello: "world" } }), {
@@ -13,7 +8,15 @@ const fetchSpy = vi.fn().mockImplementation(() =>
     }),
   ),
 );
-vi.stubGlobal("fetch", fetchSpy);
+
+vi.mock("@/lib/mtls", () => ({
+  signContextJwt: vi.fn().mockResolvedValue("mock-jwt-token"),
+  getAgent: vi.fn().mockResolvedValue({ mock: "dispatcher" }),
+}));
+
+vi.mock("undici", () => ({
+  fetch: fetchSpy,
+}));
 
 describe("graphql client", () => {
   let client: typeof import("@/lib/graphql/client");

--- a/src/__tests__/lib/mtls-e2e.test.ts
+++ b/src/__tests__/lib/mtls-e2e.test.ts
@@ -17,8 +17,20 @@ import { readFileSync } from "node:fs";
 import { createServer } from "node:https";
 
 import { importPKCS8, importSPKI, jwtVerify, SignJWT } from "jose";
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+interface GraphqlResponse {
+  data: {
+    auth: {
+      role: string;
+      customerIds: number[] | null;
+      algorithm: string;
+      verified: boolean;
+    };
+  };
+  errors: { message: string }[];
+}
 
 describe("mTLS + Context JWT E2E", () => {
   // Generate a fresh CA + client cert for the test
@@ -188,18 +200,21 @@ describe("mTLS + Context JWT E2E", () => {
     const agent = await getAgent();
     const token = await signContextJwt("System Administrator", [42, 99]);
 
-    const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+    const response = await undiciFetch(
+      `https://localhost:${serverPort}/graphql`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ query: "{ auth { role customerIds } }" }),
+        dispatcher: agent,
       },
-      body: JSON.stringify({ query: "{ auth { role customerIds } }" }),
-      dispatcher: agent,
-    } as RequestInit);
+    );
 
     expect(response.status).toBe(200);
-    const body = await response.json();
+    const body = (await response.json()) as GraphqlResponse;
     expect(body.data.auth.role).toBe("System Administrator");
     expect(body.data.auth.customerIds).toEqual([42, 99]);
     expect(body.data.auth.verified).toBe(true);
@@ -211,18 +226,21 @@ describe("mTLS + Context JWT E2E", () => {
     const agent = await getAgent();
     const token = await signContextJwt("Security Administrator");
 
-    const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+    const response = await undiciFetch(
+      `https://localhost:${serverPort}/graphql`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ query: "{ auth { role customerIds } }" }),
+        dispatcher: agent,
       },
-      body: JSON.stringify({ query: "{ auth { role customerIds } }" }),
-      dispatcher: agent,
-    } as RequestInit);
+    );
 
     expect(response.status).toBe(200);
-    const body = await response.json();
+    const body = (await response.json()) as GraphqlResponse;
     expect(body.data.auth.role).toBe("Security Administrator");
     expect(body.data.auth.customerIds).toBeNull();
   });
@@ -233,18 +251,21 @@ describe("mTLS + Context JWT E2E", () => {
     const agent = await getAgent();
     const token = await signContextJwt("System Administrator", []);
 
-    const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
+    const response = await undiciFetch(
+      `https://localhost:${serverPort}/graphql`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ query: "{ auth { role customerIds } }" }),
+        dispatcher: agent,
       },
-      body: JSON.stringify({ query: "{ auth { role customerIds } }" }),
-      dispatcher: agent,
-    } as RequestInit);
+    );
 
     expect(response.status).toBe(200);
-    const body = await response.json();
+    const body = (await response.json()) as GraphqlResponse;
     expect(body.data.auth.customerIds).toEqual([]);
   });
 
@@ -252,15 +273,18 @@ describe("mTLS + Context JWT E2E", () => {
     const { getAgent } = await import("@/lib/mtls");
     const agent = await getAgent();
 
-    const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query: "{ auth { role } }" }),
-      dispatcher: agent,
-    } as RequestInit);
+    const response = await undiciFetch(
+      `https://localhost:${serverPort}/graphql`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "{ auth { role } }" }),
+        dispatcher: agent,
+      },
+    );
 
     expect(response.status).toBe(401);
-    const body = await response.json();
+    const body = (await response.json()) as GraphqlResponse;
     expect(body.errors[0].message).toBe("Bearer token required");
   });
 
@@ -278,18 +302,21 @@ describe("mTLS + Context JWT E2E", () => {
     // Small delay to ensure the token is past expiration
     await new Promise((r) => setTimeout(r, 1100));
 
-    const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${expiredToken}`,
+    const response = await undiciFetch(
+      `https://localhost:${serverPort}/graphql`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${expiredToken}`,
+        },
+        body: JSON.stringify({ query: "{ auth { role } }" }),
+        dispatcher: agent,
       },
-      body: JSON.stringify({ query: "{ auth { role } }" }),
-      dispatcher: agent,
-    } as RequestInit);
+    );
 
     expect(response.status).toBe(401);
-    const body = await response.json();
+    const body = (await response.json()) as GraphqlResponse;
     expect(body.errors[0].message).toContain("exp");
   });
 
@@ -299,18 +326,21 @@ describe("mTLS + Context JWT E2E", () => {
 
     for (const role of ["System Administrator", "Security Administrator"]) {
       const token = await signContextJwt(role, [1]);
-      const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+      const response = await undiciFetch(
+        `https://localhost:${serverPort}/graphql`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ query: "{ auth { role } }" }),
+          dispatcher: agent,
         },
-        body: JSON.stringify({ query: "{ auth { role } }" }),
-        dispatcher: agent,
-      } as RequestInit);
+      );
 
       expect(response.status).toBe(200);
-      const body = await response.json();
+      const body = (await response.json()) as GraphqlResponse;
       expect(body.data.auth.role).toBe(role);
     }
   });
@@ -325,12 +355,12 @@ describe("mTLS + Context JWT E2E", () => {
     });
 
     try {
-      await fetch(`https://localhost:${serverPort}/graphql`, {
+      await undiciFetch(`https://localhost:${serverPort}/graphql`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ query: "{ auth { role } }" }),
         dispatcher: noCertAgent,
-      } as RequestInit);
+      });
       // If we get here, the TLS handshake didn't reject — check response
       expect.fail("Expected TLS handshake to fail without client cert");
     } catch (err) {
@@ -353,18 +383,21 @@ describe("mTLS + Context JWT E2E", () => {
       .setExpirationTime("5m")
       .sign(wrongKey);
 
-    const response = await fetch(`https://localhost:${serverPort}/graphql`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${forgedToken}`,
+    const response = await undiciFetch(
+      `https://localhost:${serverPort}/graphql`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${forgedToken}`,
+        },
+        body: JSON.stringify({ query: "{ auth { role } }" }),
+        dispatcher: await agent,
       },
-      body: JSON.stringify({ query: "{ auth { role } }" }),
-      dispatcher: await agent,
-    } as RequestInit);
+    );
 
     expect(response.status).toBe(401);
-    const body = await response.json();
+    const body = (await response.json()) as GraphqlResponse;
     expect(body.errors[0].message).toContain("signature");
   });
 

--- a/src/lib/graphql/client.ts
+++ b/src/lib/graphql/client.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { GraphQLClient, type RequestDocument } from "graphql-request";
+import { fetch as undiciFetch } from "undici";
 
 import { getAgent, signContextJwt } from "@/lib/mtls";
 
@@ -17,10 +18,10 @@ function getClient(): GraphQLClient {
   client = new GraphQLClient(endpoint, {
     fetch: async (input, init) => {
       const agent = await getAgent();
-      return globalThis.fetch(input, {
-        ...init,
-        dispatcher: agent,
-      } as RequestInit);
+      return undiciFetch(
+        input as string | URL,
+        { ...init, dispatcher: agent } as Parameters<typeof undiciFetch>[1],
+      ) as unknown as Response;
     },
   });
   return client;


### PR DESCRIPTION
## Summary

- Import `fetch` from the `undici` npm package instead of using `globalThis.fetch()` in `src/lib/graphql/client.ts` and `src/__tests__/lib/mtls-e2e.test.ts`, so the dispatcher and fetch share the same internal handler interface.
- Remove the now-unnecessary `as RequestInit` casts, since undici's own `fetch` natively accepts `dispatcher`.
- Update the `client.test.ts` unit test mock to stub `undici.fetch` instead of `globalThis.fetch`.
- Replace `pnpm/action-setup@v5` with `corepack enable pnpm` in the CI workflow.

Closes #241

## Test plan

- [x] All 25 unit/e2e tests pass (`pnpm vitest run`)
- [x] TypeScript compiles without errors (`pnpm tsc --noEmit`)
- [x] Biome linting passes on changed files
- [ ] CI "Unit" job passes with undici 8.0.3 (re-run on PR #237)