### PR TITLE
Use latest Biome in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.7
+          version: latest
       - run: pnpm check
       - run: pnpm typecheck
       - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- Switch `biomejs/setup-biome@v2` from `version: 2.4.7` to `version: latest` so CI always runs the current Biome release.
- Update `biome.json` `$schema` URL from `2.4.7` to `2.4.12` (current latest) so editor tooling matches CI.
- Biome is intentionally kept out of `devDependencies` — it remains a CI-only tool installed via `biomejs/setup-biome`.

Closes #244

## Test plan

- [x] CI `check` job succeeds using the latest Biome release
- [x] Editors reading `biome.json` resolve the updated `$schema` without warnings