### PR TITLE
Wire Detection event queries to REview via BFF (#273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,23 @@ call — fails CI with a message pointing back to this section.
    `schemas/review.version`.
 4. Review `git diff schemas/` and update any code that references
    removed or renamed fields in the same PR.
-5. Commit the schema and version files together. Call out any
-   breaking-change mitigation in the PR description.
+5. Regenerate schema-derived TypeScript types:
+
+   ```sh
+   pnpm codegen:detection
+   ```
+
+   The generator at `scripts/codegen-detection-types.mjs` reads
+   `schemas/review.graphql` and rewrites
+   `src/lib/detection/types.generated.ts` (scalars, enums, the
+   `EventListFilterInput` and its transitive inputs,
+   `EventConnection`/`EventEdge`/`PageInfo`, the `eventCountsBy*`
+   counter shapes, and an `EventBase` interface covering the Event
+   interface's common fields). A Vitest spec re-runs the generator
+   in CI and fails if the checked-in file drifts, so a schema bump
+   that forgets this step is caught at PR time.
+6. Commit the schema, version file, and regenerated types together.
+   Call out any breaking-change mitigation in the PR description.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the full system overview and
 the `decisions/` directory for detailed design records.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "e2e": "playwright test --config e2e/playwright.config.ts",
-    "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json"
+    "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json",
+    "codegen:detection": "node scripts/codegen-detection-types.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/scripts/codegen-detection-types.mjs
+++ b/scripts/codegen-detection-types.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// Generate `src/lib/detection/types.generated.ts` from the vendored
+// REview SDL at `schemas/review.graphql`.
+//
+// The generator emits the subset of schema types the Detection server
+// actions consume: scalars, enums, inputs (and their transitive input
+// deps), the paging/counter output types, and the `Event` interface's
+// common fields (as `EventBase`). A companion Vitest spec runs the
+// same `generate()` function in-memory and asserts the output matches
+// the checked-in file, so a schema bump that is not reflected in the
+// generated TS fails CI.
+//
+// Run directly with `pnpm codegen:detection`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildSchema,
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isListType,
+  isNonNullType,
+  isObjectType,
+  isScalarType,
+} from "graphql";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), "..");
+const SCHEMA_PATH = path.join(ROOT, "schemas/review.graphql");
+const OUT_PATH = path.join(ROOT, "src/lib/detection/types.generated.ts");
+
+// Built-in and custom scalars mapped to TS. Any unmapped scalar
+// referenced from the walked graph makes the generator fail loudly.
+const SCALAR_MAP = {
+  String: "string",
+  Int: "number",
+  Float: "number",
+  Boolean: "boolean",
+  ID: "IDScalar",
+  DateTime: "DateTimeScalar",
+  StringNumber: "StringNumberScalar",
+};
+
+// Scalars that get a named TS alias in the generated file instead of
+// collapsing to `string` at each use site.
+const NAMED_SCALAR_ALIASES = [
+  [
+    "DateTimeScalar",
+    "string",
+    "`DateTime` scalar; REview serializes it as an ISO-8601 string.",
+  ],
+  [
+    "StringNumberScalar",
+    "string",
+    "`StringNumber` scalar; REview serializes 64-bit counts as strings to avoid JavaScript number precision loss. Never cast to `number`.",
+  ],
+  ["IDScalar", "string", "`ID` scalar."],
+];
+
+// Roots the generator walks; everything they transitively reference
+// is emitted too.
+const ROOT_TYPES = [
+  "EventListFilterInput",
+  "EventConnection",
+  "EventEdge",
+  "PageInfo",
+  "TriageScore",
+  "StringEventCounter",
+  "U8EventCounter",
+  "Event",
+];
+
+/**
+ * Render a GraphQL type as a TS type, wrapping for lists and
+ * nullability using GraphQL's semantics:
+ *   - Non-null `T!` → `T`
+ *   - Nullable `T`  → `T | null`
+ *   - `[T!]!` → `T[]`, `[T!]` → `T[] | null`,
+ *     `[T]!` → `(T | null)[]`, `[T]` → `(T | null)[] | null`.
+ */
+function renderType(type, used) {
+  if (isNonNullType(type)) return renderInner(type.ofType, used);
+  return `${renderInner(type, used)} | null`;
+}
+
+function renderInner(type, used) {
+  if (isListType(type)) {
+    const inner = renderType(type.ofType, used);
+    const needsParens = inner.includes(" ");
+    return `${needsParens ? `(${inner})` : inner}[]`;
+  }
+  if (isScalarType(type)) {
+    const mapped = SCALAR_MAP[type.name];
+    if (!mapped) {
+      throw new Error(
+        `Unmapped scalar "${type.name}" referenced by the generator. ` +
+          "Add it to SCALAR_MAP in scripts/codegen-detection-types.mjs.",
+      );
+    }
+    if (
+      mapped === "IDScalar" ||
+      mapped === "DateTimeScalar" ||
+      mapped === "StringNumberScalar"
+    ) {
+      used.add(mapped);
+    }
+    return mapped;
+  }
+  if (isInterfaceType(type)) {
+    // Interfaces are emitted as `<Name>Base` (schema-common fields
+    // plus `__typename: string`). Narrower discriminated unions over
+    // subtypes live in the hand-written `types.ts`.
+    const alias = `${type.name}Base`;
+    used.add(alias);
+    return alias;
+  }
+  if (isEnumType(type) || isInputObjectType(type) || isObjectType(type)) {
+    used.add(type.name);
+    return type.name;
+  }
+  throw new Error(`Unsupported type kind: ${type}`);
+}
+
+function collectTransitive(schema, rootNames) {
+  const seen = new Map();
+  const queue = [...rootNames];
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (seen.has(name)) continue;
+    const type = schema.getType(name);
+    if (!type) throw new Error(`Type "${name}" not found in schema.`);
+    seen.set(name, type);
+    if (
+      isInputObjectType(type) ||
+      isObjectType(type) ||
+      isInterfaceType(type)
+    ) {
+      for (const field of Object.values(type.getFields())) {
+        const innerRefs = referencedNamedTypes(field.type);
+        for (const refName of innerRefs) queue.push(refName);
+      }
+    }
+  }
+  return seen;
+}
+
+function referencedNamedTypes(type) {
+  const names = [];
+  let t = type;
+  while (isNonNullType(t) || isListType(t)) t = t.ofType;
+  if (
+    isEnumType(t) ||
+    isInputObjectType(t) ||
+    isObjectType(t) ||
+    isInterfaceType(t)
+  ) {
+    names.push(t.name);
+  }
+  return names;
+}
+
+function renderEnum(type) {
+  const values = type.getValues().map((v) => `"${v.name}"`);
+  const single = `export type ${type.name} = ${values.join(" | ")};`;
+  if (single.length <= 80) return single;
+  return `export type ${type.name} =\n${values.map((v) => `  | ${v}`).join("\n")};`;
+}
+
+function renderFields(type, used, style) {
+  const lines = [];
+  for (const field of Object.values(type.getFields())) {
+    const rendered = renderType(field.type, used);
+    if (style === "input") {
+      const optional = isNonNullType(field.type) ? "" : "?";
+      lines.push(`  ${field.name}${optional}: ${rendered};`);
+    } else {
+      lines.push(`  ${field.name}: ${rendered};`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function renderInputObject(type, used) {
+  return `export interface ${type.name} {\n${renderFields(type, used, "input")}\n}`;
+}
+
+function renderObject(type, used) {
+  return `export interface ${type.name} {\n${renderFields(type, used, "object")}\n}`;
+}
+
+function renderInterface(type, used) {
+  // Each GraphQL interface is exported as `<Name>Base`: the interface's
+  // common fields plus `__typename: string` for runtime dispatch.
+  // Hand-written discriminated unions over `<Name>Base & { __typename: "..." }`
+  // live in `src/lib/detection/types.ts` for UI use.
+  const body = renderFields(type, used, "object");
+  return `export interface ${type.name}Base {\n  __typename: string;\n${body}\n}`;
+}
+
+export function generate() {
+  const sdl = readFileSync(SCHEMA_PATH, "utf8");
+  const schema = buildSchema(sdl);
+  const types = collectTransitive(schema, ROOT_TYPES);
+  const used = new Set();
+
+  const enumSources = [];
+  const inputSources = [];
+  const objectSources = [];
+  const interfaceSources = [];
+
+  for (const [name, type] of types) {
+    used.add(name);
+    if (isEnumType(type)) enumSources.push([name, renderEnum(type)]);
+    else if (isInputObjectType(type))
+      inputSources.push([name, renderInputObject(type, used)]);
+    else if (isInterfaceType(type))
+      interfaceSources.push([name, renderInterface(type, used)]);
+    else if (isObjectType(type))
+      objectSources.push([name, renderObject(type, used)]);
+    // Scalars and others are rendered inline via renderType.
+  }
+
+  const sortByName = (a, b) => a[0].localeCompare(b[0]);
+  enumSources.sort(sortByName);
+  inputSources.sort(sortByName);
+  objectSources.sort(sortByName);
+  interfaceSources.sort(sortByName);
+
+  const header = [
+    "// AUTO-GENERATED FROM schemas/review.graphql. DO NOT EDIT.",
+    "//",
+    "// Regenerate with: pnpm codegen:detection",
+    "//",
+    "// The generator walks a curated set of roots (see",
+    "// scripts/codegen-detection-types.mjs) and emits every",
+    "// transitively-referenced type. CI re-runs generation and",
+    "// diffs the result against this file, so a schema bump that",
+    "// is not reflected here fails fast.",
+    "",
+  ].join("\n");
+
+  const scalarBlock = NAMED_SCALAR_ALIASES.filter(([name]) => used.has(name))
+    .map(
+      ([name, target, doc]) =>
+        `/** ${doc} */\nexport type ${name} = ${target};`,
+    )
+    .join("\n\n");
+
+  const sections = [];
+  if (scalarBlock) sections.push(`// ── Scalars ──\n\n${scalarBlock}`);
+  if (enumSources.length > 0)
+    sections.push(
+      `// ── Enums ──\n\n${enumSources.map(([, src]) => src).join("\n\n")}`,
+    );
+  if (inputSources.length > 0)
+    sections.push(
+      `// ── Inputs ──\n\n${inputSources.map(([, src]) => src).join("\n\n")}`,
+    );
+  if (interfaceSources.length > 0)
+    sections.push(
+      `// ── Interfaces (common fields) ──\n\n${interfaceSources.map(([, src]) => src).join("\n\n")}`,
+    );
+  if (objectSources.length > 0)
+    sections.push(
+      `// ── Object types ──\n\n${objectSources.map(([, src]) => src).join("\n\n")}`,
+    );
+
+  return `${header}\n${sections.join("\n\n")}\n`;
+}
+
+function main() {
+  const out = generate();
+  writeFileSync(OUT_PATH, out, "utf8");
+  process.stdout.write(
+    `wrote ${path.relative(ROOT, OUT_PATH)} (${out.length} bytes)\n`,
+  );
+}
+
+const isDirectInvocation =
+  process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (isDirectInvocation) {
+  main();
+}

--- a/src/__tests__/lib/auth/customer-scope.test.ts
+++ b/src/__tests__/lib/auth/customer-scope.test.ts
@@ -41,14 +41,46 @@ describe("getAccountCustomerIds", () => {
   });
 });
 
+describe("getAllCustomerIds", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("returns every registered customer ID in ascending order", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ id: 1 }, { id: 4 }, { id: 9 }],
+    });
+
+    const { getAllCustomerIds } = await import("@/lib/auth/customer-scope");
+    const result = await getAllCustomerIds();
+
+    expect(result).toEqual([1, 4, 9]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/SELECT id FROM customers ORDER BY id/i),
+    );
+  });
+
+  it("returns an empty array when no customers are registered", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const { getAllCustomerIds } = await import("@/lib/auth/customer-scope");
+    const result = await getAllCustomerIds();
+
+    expect(result).toEqual([]);
+  });
+});
+
 describe("resolveEffectiveCustomerIds", () => {
   beforeEach(() => {
     mockQuery.mockReset();
     mockHasPermission.mockReset();
   });
 
-  it("returns undefined when account has customers:access-all", async () => {
+  it("materializes every registered customer ID when account has customers:access-all", async () => {
     mockHasPermission.mockResolvedValue(true);
+    mockQuery.mockResolvedValue({
+      rows: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    });
 
     const { resolveEffectiveCustomerIds } = await import(
       "@/lib/auth/customer-scope"
@@ -57,8 +89,13 @@ describe("resolveEffectiveCustomerIds", () => {
       "System Administrator",
     ]);
 
-    expect(result).toBeUndefined();
-    expect(mockQuery).not.toHaveBeenCalled();
+    // Access-all is resolved to the explicit list of every customer —
+    // the consumer (REview) applies scope from an explicit claim set,
+    // not from an omitted claim.
+    expect(result).toEqual([1, 2, 3]);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/SELECT id FROM customers ORDER BY id/i),
+    );
   });
 
   it("returns customer IDs when account lacks customers:access-all", async () => {

--- a/src/__tests__/lib/detection/event-typenames.test.ts
+++ b/src/__tests__/lib/detection/event-typenames.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { buildSchema, GraphQLInterfaceType } from "graphql";
+import { describe, expect, it } from "vitest";
+
+import { CURATED_EVENT_TYPENAMES } from "@/lib/detection/types";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const SCHEMA_PATH = path.join(REPO_ROOT, "schemas/review.graphql");
+
+describe("detection curated Event typenames", () => {
+  it("every curated __typename implements the Event interface in the vendored schema", () => {
+    // Regression guard: the `Event` discriminated union in
+    // `src/lib/detection/types.ts` pins concrete `__typename`
+    // literals for the UI to dispatch on. If a schema-pin bump
+    // renames or drops one of those types, this test fails so the
+    // curated list is corrected in the same PR.
+    const sdl = readFileSync(SCHEMA_PATH, "utf8");
+    const schema = buildSchema(sdl);
+    const eventInterface = schema.getType("Event");
+    expect(eventInterface).toBeInstanceOf(GraphQLInterfaceType);
+    const implementors = new Set(
+      schema
+        .getImplementations(eventInterface as GraphQLInterfaceType)
+        .objects.map((o) => o.name),
+    );
+    for (const typename of CURATED_EVENT_TYPENAMES) {
+      expect(
+        implementors.has(typename),
+        `"${typename}" is listed in CURATED_EVENT_TYPENAMES but is not an implementor of the Event interface in schemas/review.graphql`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/lib/detection/filter.test.ts
+++ b/src/__tests__/lib/detection/filter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DetectionNotImplementedError,
+  type Filter,
+  toEventListFilterInput,
+} from "@/lib/detection";
+
+describe("toEventListFilterInput", () => {
+  it("returns the structured input unchanged", () => {
+    const filter: Filter = {
+      mode: "structured",
+      input: {
+        start: "2026-04-01T00:00:00Z",
+        end: "2026-04-02T00:00:00Z",
+        levels: [1, 2],
+        kinds: ["PortScan"],
+      },
+    };
+
+    expect(toEventListFilterInput(filter)).toEqual({
+      start: "2026-04-01T00:00:00Z",
+      end: "2026-04-02T00:00:00Z",
+      levels: [1, 2],
+      kinds: ["PortScan"],
+    });
+  });
+
+  it("passes caller-supplied `customers` through as a query dimension", () => {
+    // `customers` is part of the query surface — callers can narrow
+    // to a subset of their allowed scope. Authorization lives in the
+    // Context JWT attached by `graphqlRequest`, not in the filter.
+    const filter: Filter = {
+      mode: "structured",
+      input: {
+        start: "2026-04-01T00:00:00Z",
+        end: "2026-04-02T00:00:00Z",
+        customers: ["99"],
+      },
+    };
+
+    expect(toEventListFilterInput(filter)).toEqual({
+      start: "2026-04-01T00:00:00Z",
+      end: "2026-04-02T00:00:00Z",
+      customers: ["99"],
+    });
+  });
+
+  it('throws DetectionNotImplementedError for mode "query"', () => {
+    const filter: Filter = { mode: "query", text: "ip:1.1.1.1" };
+    expect(() => toEventListFilterInput(filter)).toThrow(
+      DetectionNotImplementedError,
+    );
+  });
+});

--- a/src/__tests__/lib/detection/review-integration.test.ts
+++ b/src/__tests__/lib/detection/review-integration.test.ts
@@ -1,0 +1,254 @@
+/**
+ * End-to-end wiring test for the Detection ↔ REview path.
+ *
+ * The test drives the real `searchEvents` server action through the
+ * real `graphqlRequest` helper and only mocks out:
+ *
+ *   - `@/lib/mtls` (avoids real certificate I/O)
+ *   - `undici.fetch`  (avoids a real network hop)
+ *   - `@/lib/auth/permissions` and `@/lib/auth/customer-scope`
+ *     (avoids real DB access while letting the authorization branch
+ *      still run)
+ *
+ * It asserts that a minimal `start`/`end` filter:
+ *   1. produces a POSTed GraphQL request against REview,
+ *   2. passes the caller's filter through unchanged — customer
+ *      scope is NOT injected into `filter.customers`; it travels
+ *      on the Context JWT (see `signContextJwt` mock below),
+ *   3. carries the Context JWT in the Authorization header,
+ *   4. returns the server's payload unchanged (non-error), including
+ *      `totalCount` as a string to preserve 64-bit precision.
+ *
+ * The response fixture is validated against `schemas/review.graphql`
+ * so a schema-pin bump cannot silently invalidate the test.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  buildSchema,
+  execute as gqlExecute,
+  parse as gqlParse,
+  validate as gqlValidate,
+} from "graphql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const fetchSpy = vi.fn();
+
+const signContextJwtSpy = vi.fn().mockResolvedValue("mock-jwt-token");
+
+vi.mock("@/lib/mtls", () => ({
+  signContextJwt: signContextJwtSpy,
+  getAgent: vi.fn().mockResolvedValue({ mock: "dispatcher" }),
+}));
+
+vi.mock("undici", () => ({ fetch: fetchSpy }));
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockResolveEffectiveCustomerIds = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+vi.mock("@/lib/auth/customer-scope", () => ({
+  resolveEffectiveCustomerIds: mockResolveEffectiveCustomerIds,
+}));
+
+const SCHEMA_PATH = path.resolve(
+  __dirname,
+  "../../../../schemas/review.graphql",
+);
+
+function makeSession(roles: string[]): AuthSession {
+  return {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles,
+    tokenVersion: 1,
+    mustChangePassword: false,
+    mustEnrollMfa: false,
+    iat: 0,
+    exp: 0,
+    sessionIp: "127.0.0.1",
+    sessionUserAgent: "test",
+    sessionBrowserFingerprint: "test",
+    needsReauth: false,
+    sessionCreatedAt: new Date(0),
+    sessionLastActiveAt: new Date(0),
+  } as AuthSession;
+}
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Fixture shaped like an `EventConnection` from REview's schema.
+// `totalCount` is a `StringNumber` — a string that must flow through
+// untouched to preserve 64-bit precision.
+const EVENT_LIST_FIXTURE_DATA = {
+  eventList: {
+    pageInfo: {
+      hasPreviousPage: false,
+      hasNextPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+    edges: [] as Array<{ cursor: string; node: unknown }>,
+    nodes: [] as unknown[],
+    totalCount: "18446744073709551615",
+  },
+};
+
+// Probe mirrors the response-shape subset the fixture covers. Used in
+// two places: as a sanity check that the query still validates against
+// the pinned schema, and executed against the fixture so the fixture
+// is coerced through the real schema types.
+const EVENT_LIST_PROBE = `
+  query Probe($filter: EventListFilterInput!) {
+    eventList(filter: $filter, first: 1) {
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
+      }
+      edges { cursor }
+      nodes { __typename time sensor confidence level }
+      totalCount
+    }
+  }
+`;
+
+describe("detection ↔ REview wiring (network mocked)", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    fetchSpy.mockReset();
+    signContextJwtSpy.mockClear();
+    signContextJwtSpy.mockResolvedValue("mock-jwt-token");
+    mockHasPermission.mockReset();
+    mockResolveEffectiveCustomerIds.mockReset();
+    process.env.REVIEW_GRAPHQL_ENDPOINT = "https://review.example.com/graphql";
+    const { resetClient } = await import("@/lib/graphql/client");
+    resetClient();
+  });
+
+  afterEach(() => {
+    delete process.env.REVIEW_GRAPHQL_ENDPOINT;
+  });
+
+  it("dispatches a minimal start/end filter and carries scope on the JWT, not the filter", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+
+    fetchSpy.mockResolvedValue(okJson({ data: EVENT_LIST_FIXTURE_DATA }));
+
+    const { searchEvents } = await import("@/lib/detection");
+    const result = await searchEvents(
+      makeSession(["Security Monitor"]),
+      {
+        mode: "structured",
+        input: {
+          start: "2026-04-01T00:00:00Z",
+          end: "2026-04-02T00:00:00Z",
+        },
+      },
+      { first: 25 },
+    );
+
+    // HTTP dispatch happened exactly once.
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url.toString()).toBe("https://review.example.com/graphql");
+
+    // Context JWT is attached to the request headers and was signed
+    // with the caller's resolved customer scope — this is where
+    // authorization/scoping lives, not in `filter.customers`.
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer mock-jwt-token");
+    expect(signContextJwtSpy).toHaveBeenCalledWith(
+      "Security Monitor",
+      [42, 99],
+    );
+
+    // Body carries the caller's filter *as-is* and the expected
+    // operation. Crucially, the BFF did not inject customers.
+    const body = JSON.parse(init.body);
+    expect(body.query).toContain("query EventList");
+    expect(body.variables.filter).toEqual({
+      start: "2026-04-01T00:00:00Z",
+      end: "2026-04-02T00:00:00Z",
+    });
+    expect(body.variables.filter.customers).toBeUndefined();
+    expect(body.variables.first).toBe(25);
+
+    // Non-error response flows back end-to-end, with totalCount as a
+    // string (never cast to `number`).
+    expect(result.totalCount).toBe("18446744073709551615");
+    expect(typeof result.totalCount).toBe("string");
+  });
+
+  it("fixture validates against schemas/review.graphql", async () => {
+    // Two-stage regression guard against silent drift:
+    //
+    //   1. The probe query must still validate against the pinned
+    //      schema — catches renamed/removed fields on the query side.
+    //   2. The fixture must survive `execute()` against that schema
+    //      with its shape preserved — catches fixture-side drift (a
+    //      field rename, a changed scalar, a now-non-null field the
+    //      fixture still sets to `null`, etc.). The default field
+    //      resolver walks property names on the root value, so
+    //      GraphQL type coercion is what does the real checking.
+    const schema = buildSchema(readFileSync(SCHEMA_PATH, "utf8"));
+    const probe = gqlParse(EVENT_LIST_PROBE);
+
+    const validationErrors = gqlValidate(schema, probe);
+    expect(validationErrors).toEqual([]);
+
+    const executed = await gqlExecute({
+      schema,
+      document: probe,
+      rootValue: EVENT_LIST_FIXTURE_DATA,
+      variableValues: {
+        filter: {
+          start: "2026-04-01T00:00:00Z",
+          end: "2026-04-02T00:00:00Z",
+        },
+      },
+    });
+    expect(executed.errors).toBeUndefined();
+    expect(executed.data).toEqual(EVENT_LIST_FIXTURE_DATA);
+
+    // Sanity check that execute() actually catches shape drift — set
+    // the required `hasPreviousPage` to `null` and confirm the
+    // pipeline reports a non-null violation. Keeps the positive
+    // assertion above from silently degrading into a no-op if
+    // graphql-js ever relaxes coercion.
+    const broken = {
+      eventList: {
+        ...EVENT_LIST_FIXTURE_DATA.eventList,
+        pageInfo: {
+          ...EVENT_LIST_FIXTURE_DATA.eventList.pageInfo,
+          hasPreviousPage: null as unknown as boolean,
+        },
+      },
+    };
+    const brokenResult = await gqlExecute({
+      schema,
+      document: probe,
+      rootValue: broken,
+      variableValues: {
+        filter: {
+          start: "2026-04-01T00:00:00Z",
+          end: "2026-04-02T00:00:00Z",
+        },
+      },
+    });
+    expect(brokenResult.errors).toBeDefined();
+    expect(brokenResult.errors?.[0].message).toMatch(/hasPreviousPage/);
+  });
+});

--- a/src/__tests__/lib/detection/server-actions.test.ts
+++ b/src/__tests__/lib/detection/server-actions.test.ts
@@ -1,0 +1,316 @@
+import type { DocumentNode } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockResolveEffectiveCustomerIds = vi.hoisted(() => vi.fn());
+const mockGraphqlRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/customer-scope", () => ({
+  resolveEffectiveCustomerIds: mockResolveEffectiveCustomerIds,
+}));
+
+vi.mock("@/lib/graphql/client", () => ({
+  graphqlRequest: mockGraphqlRequest,
+}));
+
+/** Build a minimally-populated AuthSession for the unit under test. */
+function makeSession(overrides: Partial<AuthSession> = {}): AuthSession {
+  return {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["Security Monitor"],
+    tokenVersion: 1,
+    mustChangePassword: false,
+    mustEnrollMfa: false,
+    iat: 0,
+    exp: 0,
+    sessionIp: "127.0.0.1",
+    sessionUserAgent: "test",
+    sessionBrowserFingerprint: "test",
+    needsReauth: false,
+    sessionCreatedAt: new Date(0),
+    sessionLastActiveAt: new Date(0),
+    ...overrides,
+  } as AuthSession;
+}
+
+describe("detection server actions", () => {
+  beforeEach(() => {
+    mockHasPermission.mockReset();
+    mockResolveEffectiveCustomerIds.mockReset();
+    mockGraphqlRequest.mockReset();
+  });
+
+  // ── Authorization ──────────────────────────────────────────────
+
+  describe("authorization", () => {
+    it("rejects a caller without detection:read before dispatching", async () => {
+      mockHasPermission.mockResolvedValue(false);
+
+      const { searchEvents, DetectionUnauthorizedError } = await import(
+        "@/lib/detection"
+      );
+
+      await expect(
+        searchEvents(makeSession(), {
+          mode: "structured",
+          input: { start: null, end: null },
+        }),
+      ).rejects.toBeInstanceOf(DetectionUnauthorizedError);
+
+      expect(mockResolveEffectiveCustomerIds).not.toHaveBeenCalled();
+      expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    });
+
+    it("rejects a caller with an empty customer scope", async () => {
+      mockHasPermission.mockResolvedValue(true);
+      mockResolveEffectiveCustomerIds.mockResolvedValue([]);
+
+      const { searchEvents, DetectionUnauthorizedError } = await import(
+        "@/lib/detection"
+      );
+
+      await expect(
+        searchEvents(makeSession(), {
+          mode: "structured",
+          input: { start: null, end: null },
+        }),
+      ).rejects.toBeInstanceOf(DetectionUnauthorizedError);
+
+      expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    });
+
+    it("carries the materialized access-all scope on the JWT context", async () => {
+      mockHasPermission.mockResolvedValue(true);
+      // Access-all callers are resolved upstream to the explicit list
+      // of every registered customer ID. The BFF forwards that list
+      // on the Context JWT verbatim — REview does not re-derive scope
+      // from role text, so the list must be present.
+      mockResolveEffectiveCustomerIds.mockResolvedValue([1, 2, 3]);
+      mockGraphqlRequest.mockResolvedValue({
+        eventList: {
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+          edges: [],
+          nodes: [],
+          totalCount: "0",
+        },
+      });
+
+      const { searchEvents } = await import("@/lib/detection");
+
+      await searchEvents(makeSession({ roles: ["System Administrator"] }), {
+        mode: "structured",
+        input: { start: null, end: null },
+      });
+
+      expect(mockGraphqlRequest).toHaveBeenCalledOnce();
+      const [, variables, context] = mockGraphqlRequest.mock.calls[0];
+      // Caller supplied no `customers` filter — the BFF must not
+      // inject one. Scope travels in the Context JWT below.
+      expect(variables.filter.customers).toBeUndefined();
+      expect(context).toEqual({
+        role: "System Administrator",
+        customerIds: [1, 2, 3],
+      });
+    });
+
+    it('rejects mode: "query" with DetectionNotImplementedError', async () => {
+      mockHasPermission.mockResolvedValue(true);
+      mockResolveEffectiveCustomerIds.mockResolvedValue([42]);
+
+      const { searchEvents, DetectionNotImplementedError } = await import(
+        "@/lib/detection"
+      );
+
+      await expect(
+        searchEvents(makeSession(), { mode: "query", text: "ip:1.1.1.1" }),
+      ).rejects.toBeInstanceOf(DetectionNotImplementedError);
+
+      expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Dispatch / scope injection ─────────────────────────────────
+
+  describe("searchEvents", () => {
+    beforeEach(() => {
+      mockHasPermission.mockResolvedValue(true);
+      mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+    });
+
+    it("passes the filter through and carries scope on the JWT context", async () => {
+      mockGraphqlRequest.mockResolvedValue({
+        eventList: {
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: true,
+            startCursor: "a",
+            endCursor: "b",
+          },
+          edges: [],
+          nodes: [],
+          totalCount: "9999999999999999",
+        },
+      });
+
+      const { searchEvents } = await import("@/lib/detection");
+      const result = await searchEvents(
+        makeSession(),
+        {
+          mode: "structured",
+          input: {
+            start: "2026-04-01T00:00:00Z",
+            end: "2026-04-02T00:00:00Z",
+            // The caller narrows to a subset of their allowed scope.
+            // The BFF must NOT broaden this to the full scope —
+            // `filter.customers` is a query dimension; authorization
+            // lives on the Context JWT (`context.customerIds`).
+            customers: ["42"],
+          },
+        },
+        { first: 50, after: "cursor-1" },
+      );
+
+      const [document, variables, context] = mockGraphqlRequest.mock.calls[0];
+      expect((document as DocumentNode).kind).toBe("Document");
+      expect(variables.filter).toEqual({
+        start: "2026-04-01T00:00:00Z",
+        end: "2026-04-02T00:00:00Z",
+        customers: ["42"],
+      });
+      expect(variables.first).toBe(50);
+      expect(variables.after).toBe("cursor-1");
+      expect(variables.last).toBeNull();
+      expect(variables.before).toBeNull();
+      expect(context).toEqual({
+        role: "Security Monitor",
+        customerIds: [42, 99],
+      });
+
+      // totalCount flows through as a string — never cast to number.
+      expect(result.totalCount).toBe("9999999999999999");
+      expect(typeof result.totalCount).toBe("string");
+    });
+
+    it("leaves filter.customers undefined when the caller did not supply one", async () => {
+      mockGraphqlRequest.mockResolvedValue({
+        eventList: {
+          pageInfo: {
+            hasPreviousPage: false,
+            hasNextPage: false,
+            startCursor: null,
+            endCursor: null,
+          },
+          edges: [],
+          nodes: [],
+          totalCount: "0",
+        },
+      });
+
+      const { searchEvents } = await import("@/lib/detection");
+      await searchEvents(makeSession(), {
+        mode: "structured",
+        input: { start: null, end: null },
+      });
+
+      const [, variables, context] = mockGraphqlRequest.mock.calls[0];
+      expect(variables.filter).toEqual({ start: null, end: null });
+      expect(variables.filter.customers).toBeUndefined();
+      // Scope still reaches REview — via the Context JWT.
+      expect(context.customerIds).toEqual([42, 99]);
+    });
+  });
+
+  // ── Per-counter wiring ─────────────────────────────────────────
+
+  describe.each([
+    ["countEventsByCategory", "eventCountsByCategory"],
+    ["countEventsByLevel", "eventCountsByLevel"],
+    ["countEventsByCountry", "eventCountsByCountry"],
+    ["countEventsByKind", "eventCountsByKind"],
+    ["countEventsByIpAddress", "eventCountsByIpAddress"],
+    ["countEventsByOriginatorIpAddress", "eventCountsByOriginatorIpAddress"],
+    ["countEventsByResponderIpAddress", "eventCountsByResponderIpAddress"],
+  ] as const)("%s", (fnName, resultKey) => {
+    beforeEach(() => {
+      mockHasPermission.mockResolvedValue(true);
+      mockResolveEffectiveCustomerIds.mockResolvedValue([7]);
+    });
+
+    it(`passes \`first\` through and unwraps \`${resultKey}\``, async () => {
+      const payload = { values: ["X"], counts: [3] };
+      mockGraphqlRequest.mockResolvedValue({ [resultKey]: payload });
+
+      const mod = await import("@/lib/detection");
+      const fn = mod[fnName] as (
+        s: AuthSession,
+        f: import("@/lib/detection").Filter,
+        first: number,
+      ) => Promise<unknown>;
+
+      const result = await fn(
+        makeSession(),
+        {
+          mode: "structured",
+          input: { start: null, end: null },
+        },
+        10,
+      );
+
+      expect(result).toBe(payload);
+      const [, variables, context] = mockGraphqlRequest.mock.calls[0];
+      // Filter is passed through — the BFF does not inject customers.
+      expect(variables.filter.customers).toBeUndefined();
+      expect(variables.first).toBe(10);
+      // Scope still reaches REview via the Context JWT.
+      expect(context.customerIds).toEqual([7]);
+    });
+  });
+
+  // ── Time series ────────────────────────────────────────────────
+
+  describe("eventFrequencySeries", () => {
+    beforeEach(() => {
+      mockHasPermission.mockResolvedValue(true);
+      mockResolveEffectiveCustomerIds.mockResolvedValue([7]);
+    });
+
+    it("passes the period through and returns the bucket array", async () => {
+      mockGraphqlRequest.mockResolvedValue({
+        eventFrequencySeries: [1, 2, 3, 4],
+      });
+
+      const { eventFrequencySeries } = await import("@/lib/detection");
+      const result = await eventFrequencySeries(
+        makeSession(),
+        {
+          mode: "structured",
+          input: {
+            start: "2026-04-01T00:00:00Z",
+            end: "2026-04-02T00:00:00Z",
+          },
+        },
+        3600,
+      );
+
+      expect(result).toEqual([1, 2, 3, 4]);
+      const [, variables, context] = mockGraphqlRequest.mock.calls[0];
+      expect(variables.period).toBe(3600);
+      expect(variables.filter.start).toBe("2026-04-01T00:00:00Z");
+      // Filter is passed through — customer scope travels on the JWT.
+      expect(variables.filter.customers).toBeUndefined();
+      expect(context.customerIds).toEqual([7]);
+    });
+  });
+});

--- a/src/__tests__/lib/detection/types-codegen.test.ts
+++ b/src/__tests__/lib/detection/types-codegen.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const GENERATED_PATH = path.join(
+  REPO_ROOT,
+  "src/lib/detection/types.generated.ts",
+);
+
+describe("detection types codegen", () => {
+  it("checked-in types.generated.ts matches the generator output", async () => {
+    // Regression guard: if `schemas/review.graphql` changes in a way
+    // that affects any of the Detection-facing types (inputs, enums,
+    // pagination, counters, the Event interface) the generator's
+    // output will drift from the committed file and this test fails.
+    //
+    // Regenerate with `pnpm codegen:detection` in the same PR that
+    // bumps `schemas/review.graphql` and `schemas/review.version`.
+    const script = await import(
+      /* @vite-ignore */ path.join(
+        REPO_ROOT,
+        "scripts/codegen-detection-types.mjs",
+      )
+    );
+    const fresh = script.generate();
+    const onDisk = readFileSync(GENERATED_PATH, "utf8");
+    expect(fresh).toBe(onDisk);
+  });
+});

--- a/src/lib/auth/customer-scope.ts
+++ b/src/lib/auth/customer-scope.ts
@@ -19,17 +19,37 @@ export async function getAccountCustomerIds(
 }
 
 /**
- * Resolve the effective customer IDs for a session.
+ * Return every customer ID registered in `customers`, in ascending
+ * order. Used to materialize the concrete scope for callers that hold
+ * `customers:access-all`, so the Context JWT always carries an
+ * explicit `customer_ids` list rather than relying on the consumer's
+ * interpretation of an omitted claim.
+ */
+export async function getAllCustomerIds(): Promise<number[]> {
+  const { rows } = await query<{ id: number }>(
+    "SELECT id FROM customers ORDER BY id",
+  );
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Resolve the effective customer IDs for a session as an explicit
+ * list.
  *
- * - If the session holds `customers:access-all`, returns `undefined`
- *   (meaning unrestricted access to all customers).
- * - Otherwise returns the array of assigned customer IDs.
+ * - If the session holds `customers:access-all`, returns every
+ *   registered customer ID from `customers`. This materializes
+ *   "unrestricted" scope into a concrete list so the Context JWT
+ *   carries `customer_ids` explicitly for every caller — REview
+ *   applies scoping from that claim set and does not re-derive it
+ *   from role text.
+ * - Otherwise returns the array of customer IDs assigned to the
+ *   account via `account_customer` (possibly empty).
  */
 export async function resolveEffectiveCustomerIds(
   accountId: string,
   roles: string[],
-): Promise<number[] | undefined> {
+): Promise<number[]> {
   const accessAll = await hasPermission(roles, "customers:access-all");
-  if (accessAll) return undefined;
+  if (accessAll) return getAllCustomerIds();
   return getAccountCustomerIds(accountId);
 }

--- a/src/lib/detection/errors.ts
+++ b/src/lib/detection/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Error thrown when a caller lacks `detection:read` or has no
+ * resolvable customer scope. Server actions throw this **before**
+ * dispatching to REview so unauthorized requests never hit the
+ * network.
+ */
+export class DetectionUnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DetectionUnauthorizedError";
+  }
+}
+
+/**
+ * Thrown by server actions when they are called in a filter mode
+ * that is not yet wired up (currently: `mode: "query"`).
+ *
+ * Kept distinct from `DetectionUnauthorizedError` so callers can
+ * distinguish a forward-compatibility stub from an authorization
+ * failure.
+ */
+export class DetectionNotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DetectionNotImplementedError";
+  }
+}

--- a/src/lib/detection/filter.ts
+++ b/src/lib/detection/filter.ts
@@ -1,0 +1,36 @@
+import { DetectionNotImplementedError } from "./errors";
+import type { EventListFilterInput } from "./types";
+
+/**
+ * Discriminated union the Detection server actions accept.
+ *
+ * `mode: "structured"` carries a concrete `EventListFilterInput`
+ * and is the only mode handled in v1. `mode: "query"` is reserved
+ * for the future search-language front-end; the shape is stable so
+ * callers that need to accept either form can be written today and
+ * will keep compiling when the second branch is wired.
+ */
+export type Filter =
+  | { mode: "structured"; input: EventListFilterInput }
+  | { mode: "query"; text: string };
+
+/**
+ * Normalize a `Filter` into an `EventListFilterInput` the BFF can
+ * forward to REview. The `customers` field is a query-surface
+ * dimension and is passed through unchanged — authorization and
+ * customer scoping travel in the Context JWT attached by
+ * `graphqlRequest`, not in the filter. REview intersects the
+ * JWT-carried scope with any `filter.customers` the caller supplies.
+ *
+ * v1: throws on `mode: "query"`. The umbrella issue calls this the
+ * "NotImplemented" branch — callers catch
+ * `DetectionNotImplementedError` if they need to fall back.
+ */
+export function toEventListFilterInput(filter: Filter): EventListFilterInput {
+  if (filter.mode === "query") {
+    throw new DetectionNotImplementedError(
+      'Filter mode "query" is not implemented yet; use mode "structured".',
+    );
+  }
+  return filter.input;
+}

--- a/src/lib/detection/index.ts
+++ b/src/lib/detection/index.ts
@@ -1,0 +1,39 @@
+export {
+  DetectionNotImplementedError,
+  DetectionUnauthorizedError,
+} from "./errors";
+export { type Filter, toEventListFilterInput } from "./filter";
+export {
+  countEventsByCategory,
+  countEventsByCountry,
+  countEventsByIpAddress,
+  countEventsByKind,
+  countEventsByLevel,
+  countEventsByOriginatorIpAddress,
+  countEventsByResponderIpAddress,
+  eventFrequencySeries,
+  type SearchEventsArgs,
+  searchEvents,
+} from "./server-actions";
+export type {
+  DateTimeScalar,
+  EndpointInput,
+  Event,
+  EventBase,
+  EventConnection,
+  EventEdge,
+  EventListFilterInput,
+  FlowKind,
+  HostNetworkGroupInput,
+  IDScalar,
+  IpRangeInput,
+  LearningMethod,
+  PageInfo,
+  StringEventCounter,
+  StringNumberScalar,
+  ThreatCategory,
+  ThreatLevel,
+  TrafficDirection,
+  TriageScore,
+  U8EventCounter,
+} from "./types";

--- a/src/lib/detection/queries.ts
+++ b/src/lib/detection/queries.ts
@@ -1,0 +1,138 @@
+import { parse } from "graphql";
+
+/**
+ * GraphQL documents for the Detection event-query family.
+ *
+ * The documents below are validated against `schemas/review.graphql`
+ * by `src/__tests__/lib/graphql/schema-validation.test.ts`, which
+ * walks every inline `parse(...)` call in the repo. Keep them as
+ * string literals so the AST walk can statically validate them.
+ */
+
+export const EVENT_LIST_QUERY = parse(`
+  query EventList(
+    $filter: EventListFilterInput!
+    $first: Int
+    $after: String
+    $last: Int
+    $before: String
+  ) {
+    eventList(
+      filter: $filter
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+    ) {
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          __typename
+          time
+          sensor
+          confidence
+          category
+          level
+          triageScores {
+            policyId
+            score
+          }
+        }
+      }
+      nodes {
+        __typename
+        time
+        sensor
+        confidence
+        category
+        level
+        triageScores {
+          policyId
+          score
+        }
+      }
+      totalCount
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_CATEGORY_QUERY = parse(`
+  query EventCountsByCategory($filter: EventListFilterInput!, $first: Int!) {
+    eventCountsByCategory(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_LEVEL_QUERY = parse(`
+  query EventCountsByLevel($filter: EventListFilterInput!, $first: Int!) {
+    eventCountsByLevel(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_COUNTRY_QUERY = parse(`
+  query EventCountsByCountry($filter: EventListFilterInput!, $first: Int!) {
+    eventCountsByCountry(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_KIND_QUERY = parse(`
+  query EventCountsByKind($filter: EventListFilterInput!, $first: Int!) {
+    eventCountsByKind(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_IP_ADDRESS_QUERY = parse(`
+  query EventCountsByIpAddress($filter: EventListFilterInput!, $first: Int!) {
+    eventCountsByIpAddress(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_ORIGINATOR_IP_ADDRESS_QUERY = parse(`
+  query EventCountsByOriginatorIpAddress(
+    $filter: EventListFilterInput!
+    $first: Int!
+  ) {
+    eventCountsByOriginatorIpAddress(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_COUNTS_BY_RESPONDER_IP_ADDRESS_QUERY = parse(`
+  query EventCountsByResponderIpAddress(
+    $filter: EventListFilterInput!
+    $first: Int!
+  ) {
+    eventCountsByResponderIpAddress(filter: $filter, first: $first) {
+      values
+      counts
+    }
+  }
+`);
+
+export const EVENT_FREQUENCY_SERIES_QUERY = parse(`
+  query EventFrequencySeries($filter: EventListFilterInput!, $period: Int!) {
+    eventFrequencySeries(filter: $filter, period: $period)
+  }
+`);

--- a/src/lib/detection/server-actions.ts
+++ b/src/lib/detection/server-actions.ts
@@ -1,0 +1,285 @@
+import "server-only";
+
+import type { DocumentNode } from "graphql";
+
+import { resolveEffectiveCustomerIds } from "@/lib/auth/customer-scope";
+import type { AuthSession } from "@/lib/auth/jwt";
+import { hasPermission } from "@/lib/auth/permissions";
+import { graphqlRequest } from "@/lib/graphql/client";
+
+import { DetectionUnauthorizedError } from "./errors";
+import { type Filter, toEventListFilterInput } from "./filter";
+import {
+  EVENT_COUNTS_BY_CATEGORY_QUERY,
+  EVENT_COUNTS_BY_COUNTRY_QUERY,
+  EVENT_COUNTS_BY_IP_ADDRESS_QUERY,
+  EVENT_COUNTS_BY_KIND_QUERY,
+  EVENT_COUNTS_BY_LEVEL_QUERY,
+  EVENT_COUNTS_BY_ORIGINATOR_IP_ADDRESS_QUERY,
+  EVENT_COUNTS_BY_RESPONDER_IP_ADDRESS_QUERY,
+  EVENT_FREQUENCY_SERIES_QUERY,
+  EVENT_LIST_QUERY,
+} from "./queries";
+import type {
+  EventConnection,
+  EventCountsByCategoryResult,
+  EventCountsByCountryResult,
+  EventCountsByIpAddressResult,
+  EventCountsByKindResult,
+  EventCountsByLevelResult,
+  EventCountsByOriginatorIpAddressResult,
+  EventCountsByResponderIpAddressResult,
+  EventFrequencySeriesResult,
+  EventListFilterInput,
+  EventListResult,
+  StringEventCounter,
+  U8EventCounter,
+} from "./types";
+
+// ── Permission / customer scope ──────────────────────────────────
+
+const DETECTION_READ = "detection:read";
+
+interface DispatchContext {
+  role: string;
+  customerIds: number[];
+  filter: EventListFilterInput;
+}
+
+/**
+ * Verify `detection:read`, resolve the caller's customer scope into
+ * an explicit list, and normalize the filter for dispatch. Runs
+ * **before** every REview request so unauthorized callers or callers
+ * with no accessible customers are rejected without any network
+ * traffic to REview.
+ *
+ * Scope is always materialized into a concrete `customer_ids` list
+ * before it reaches the Context JWT — including for callers with
+ * `customers:access-all`, who get every registered customer. REview
+ * applies customer scoping from that claim set and does not re-derive
+ * it from role text, so the BFF carries the explicit list rather than
+ * relying on the consumer's interpretation of an omitted claim.
+ *
+ * An empty resolved scope is rejected as a misconfiguration — no
+ * Detection query can succeed against it, so a silent empty result
+ * would be indistinguishable from a legitimately-empty page.
+ *
+ * The caller's customer scope travels in the Context JWT (see
+ * `graphqlRequest`), not in `filter.customers`. The filter's
+ * `customers` field stays part of the query surface so callers can
+ * narrow to a subset of their allowed scope; REview intersects the
+ * JWT-carried scope with whatever the filter asks for.
+ */
+async function buildDispatchContext(
+  session: AuthSession,
+  filter: Filter,
+): Promise<DispatchContext> {
+  if (!(await hasPermission(session.roles, DETECTION_READ))) {
+    throw new DetectionUnauthorizedError(
+      "Caller lacks the detection:read permission.",
+    );
+  }
+
+  const customerIds = await resolveEffectiveCustomerIds(
+    session.accountId,
+    session.roles,
+  );
+  if (customerIds.length === 0) {
+    throw new DetectionUnauthorizedError(
+      "Caller has no assigned customers; Detection requires a customer scope.",
+    );
+  }
+
+  return {
+    role: session.roles[0],
+    customerIds,
+    filter: toEventListFilterInput(filter),
+  };
+}
+
+// ── Variable shapes (match the `.graphql` operations one-for-one) ──
+
+interface EventListVariables extends Record<string, unknown> {
+  filter: EventListFilterInput;
+  first: number | null;
+  after: string | null;
+  last: number | null;
+  before: string | null;
+}
+
+interface CounterVariables extends Record<string, unknown> {
+  filter: EventListFilterInput;
+  first: number;
+}
+
+interface FrequencySeriesVariables extends Record<string, unknown> {
+  filter: EventListFilterInput;
+  period: number;
+}
+
+// ── Pagination / count argument types ────────────────────────────
+
+export interface SearchEventsArgs {
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+}
+
+// ── Server actions ───────────────────────────────────────────────
+
+export async function searchEvents(
+  session: AuthSession,
+  filter: Filter,
+  args: SearchEventsArgs = {},
+): Promise<EventConnection> {
+  const ctx = await buildDispatchContext(session, filter);
+  const data = await graphqlRequest<EventListResult, EventListVariables>(
+    EVENT_LIST_QUERY,
+    {
+      filter: ctx.filter,
+      first: args.first ?? null,
+      after: args.after ?? null,
+      last: args.last ?? null,
+      before: args.before ?? null,
+    },
+    { role: ctx.role, customerIds: ctx.customerIds },
+  );
+  return data.eventList;
+}
+
+async function dispatchCounter<TPayload>(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+  document: DocumentNode,
+  extract: (data: Record<string, TPayload>) => TPayload,
+): Promise<TPayload> {
+  const ctx = await buildDispatchContext(session, filter);
+  const data = await graphqlRequest<Record<string, TPayload>, CounterVariables>(
+    document,
+    { filter: ctx.filter, first },
+    { role: ctx.role, customerIds: ctx.customerIds },
+  );
+  return extract(data);
+}
+
+export async function countEventsByCategory(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<U8EventCounter> {
+  return dispatchCounter<U8EventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_CATEGORY_QUERY,
+    (d) => (d as unknown as EventCountsByCategoryResult).eventCountsByCategory,
+  );
+}
+
+export async function countEventsByLevel(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<U8EventCounter> {
+  return dispatchCounter<U8EventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_LEVEL_QUERY,
+    (d) => (d as unknown as EventCountsByLevelResult).eventCountsByLevel,
+  );
+}
+
+export async function countEventsByCountry(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<StringEventCounter> {
+  return dispatchCounter<StringEventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_COUNTRY_QUERY,
+    (d) => (d as unknown as EventCountsByCountryResult).eventCountsByCountry,
+  );
+}
+
+export async function countEventsByKind(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<StringEventCounter> {
+  return dispatchCounter<StringEventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_KIND_QUERY,
+    (d) => (d as unknown as EventCountsByKindResult).eventCountsByKind,
+  );
+}
+
+export async function countEventsByIpAddress(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<StringEventCounter> {
+  return dispatchCounter<StringEventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_IP_ADDRESS_QUERY,
+    (d) =>
+      (d as unknown as EventCountsByIpAddressResult).eventCountsByIpAddress,
+  );
+}
+
+export async function countEventsByOriginatorIpAddress(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<StringEventCounter> {
+  return dispatchCounter<StringEventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_ORIGINATOR_IP_ADDRESS_QUERY,
+    (d) =>
+      (d as unknown as EventCountsByOriginatorIpAddressResult)
+        .eventCountsByOriginatorIpAddress,
+  );
+}
+
+export async function countEventsByResponderIpAddress(
+  session: AuthSession,
+  filter: Filter,
+  first: number,
+): Promise<StringEventCounter> {
+  return dispatchCounter<StringEventCounter>(
+    session,
+    filter,
+    first,
+    EVENT_COUNTS_BY_RESPONDER_IP_ADDRESS_QUERY,
+    (d) =>
+      (d as unknown as EventCountsByResponderIpAddressResult)
+        .eventCountsByResponderIpAddress,
+  );
+}
+
+export async function eventFrequencySeries(
+  session: AuthSession,
+  filter: Filter,
+  period: number,
+): Promise<number[]> {
+  const ctx = await buildDispatchContext(session, filter);
+  const data = await graphqlRequest<
+    EventFrequencySeriesResult,
+    FrequencySeriesVariables
+  >(
+    EVENT_FREQUENCY_SERIES_QUERY,
+    { filter: ctx.filter, period },
+    { role: ctx.role, customerIds: ctx.customerIds },
+  );
+  return data.eventFrequencySeries;
+}

--- a/src/lib/detection/types.generated.ts
+++ b/src/lib/detection/types.generated.ts
@@ -1,0 +1,140 @@
+// AUTO-GENERATED FROM schemas/review.graphql. DO NOT EDIT.
+//
+// Regenerate with: pnpm codegen:detection
+//
+// The generator walks a curated set of roots (see
+// scripts/codegen-detection-types.mjs) and emits every
+// transitively-referenced type. CI re-runs generation and
+// diffs the result against this file, so a schema bump that
+// is not reflected here fails fast.
+
+// ── Scalars ──
+
+/** `DateTime` scalar; REview serializes it as an ISO-8601 string. */
+export type DateTimeScalar = string;
+
+/** `StringNumber` scalar; REview serializes 64-bit counts as strings to avoid JavaScript number precision loss. Never cast to `number`. */
+export type StringNumberScalar = string;
+
+/** `ID` scalar. */
+export type IDScalar = string;
+
+// ── Enums ──
+
+export type FlowKind = "INBOUND" | "OUTBOUND" | "INTERNAL";
+
+export type LearningMethod = "UNSUPERVISED" | "SEMI_SUPERVISED";
+
+export type ThreatCategory =
+  | "RECONNAISSANCE"
+  | "INITIAL_ACCESS"
+  | "EXECUTION"
+  | "CREDENTIAL_ACCESS"
+  | "DISCOVERY"
+  | "LATERAL_MOVEMENT"
+  | "COMMAND_AND_CONTROL"
+  | "EXFILTRATION"
+  | "IMPACT"
+  | "COLLECTION"
+  | "DEFENSE_EVASION"
+  | "PERSISTENCE"
+  | "PRIVILEGE_ESCALATION"
+  | "RESOURCE_DEVELOPMENT";
+
+export type ThreatLevel = "LOW" | "MEDIUM" | "HIGH";
+
+export type TrafficDirection = "FROM" | "TO";
+
+// ── Inputs ──
+
+export interface EndpointInput {
+  direction?: TrafficDirection | null;
+  predefined?: IDScalar | null;
+  custom?: HostNetworkGroupInput | null;
+}
+
+export interface EventListFilterInput {
+  start?: DateTimeScalar | null;
+  end?: DateTimeScalar | null;
+  customers?: IDScalar[] | null;
+  endpoints?: EndpointInput[] | null;
+  directions?: FlowKind[] | null;
+  source?: string | null;
+  destination?: string | null;
+  keywords?: string[] | null;
+  networkTags?: IDScalar[] | null;
+  sensors?: IDScalar[] | null;
+  os?: IDScalar[] | null;
+  devices?: IDScalar[] | null;
+  hostnames?: string[] | null;
+  userIds?: string[] | null;
+  userNames?: string[] | null;
+  userDepartments?: string[] | null;
+  countries?: string[] | null;
+  categories?: (number | null)[] | null;
+  levels?: number[] | null;
+  kinds?: string[] | null;
+  learningMethods?: LearningMethod[] | null;
+  confidenceMin?: number | null;
+  confidenceMax?: number | null;
+  triagePolicies?: IDScalar[] | null;
+}
+
+export interface HostNetworkGroupInput {
+  hosts: string[];
+  networks: string[];
+  ranges: IpRangeInput[];
+}
+
+export interface IpRangeInput {
+  start: string;
+  end: string;
+}
+
+// ── Interfaces (common fields) ──
+
+export interface EventBase {
+  __typename: string;
+  time: DateTimeScalar;
+  sensor: string;
+  confidence: number;
+  category: ThreatCategory | null;
+  level: ThreatLevel;
+  triageScores: TriageScore[] | null;
+}
+
+// ── Object types ──
+
+export interface EventConnection {
+  pageInfo: PageInfo;
+  edges: EventEdge[];
+  nodes: EventBase[];
+  totalCount: StringNumberScalar;
+}
+
+export interface EventEdge {
+  node: EventBase;
+  cursor: string;
+}
+
+export interface PageInfo {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  startCursor: string | null;
+  endCursor: string | null;
+}
+
+export interface StringEventCounter {
+  values: string[];
+  counts: number[];
+}
+
+export interface TriageScore {
+  policyId: IDScalar;
+  score: number;
+}
+
+export interface U8EventCounter {
+  values: number[];
+  counts: number[];
+}

--- a/src/lib/detection/types.ts
+++ b/src/lib/detection/types.ts
@@ -1,0 +1,142 @@
+/**
+ * Detection types. Schema-derived types live in
+ * `types.generated.ts` (produced by `pnpm codegen:detection` from
+ * `schemas/review.graphql`). This file re-exports them and narrows
+ * the pagination result shapes so `EventConnection.nodes` and
+ * `EventEdge.node` carry the curated discriminated union over the
+ * `Event` interface's subtypes instead of the raw `EventBase`.
+ */
+
+export type {
+  DateTimeScalar,
+  EndpointInput,
+  EventBase,
+  EventListFilterInput,
+  FlowKind,
+  HostNetworkGroupInput,
+  IDScalar,
+  IpRangeInput,
+  LearningMethod,
+  PageInfo,
+  StringEventCounter,
+  StringNumberScalar,
+  ThreatCategory,
+  ThreatLevel,
+  TrafficDirection,
+  TriageScore,
+  U8EventCounter,
+} from "./types.generated";
+
+import type {
+  EventBase,
+  EventConnection as GeneratedEventConnection,
+  EventEdge as GeneratedEventEdge,
+  StringEventCounter,
+  U8EventCounter,
+} from "./types.generated";
+
+/**
+ * Curated list of `Event` interface subtypes the Detection result
+ * list dispatches on. The list is a product choice — not every
+ * implementor of the `Event` interface needs first-class UI handling
+ * — but each entry must still be a real implementor in the vendored
+ * `schemas/review.graphql`. That contract is enforced by
+ * `src/__tests__/lib/detection/event-typenames.test.ts`, which fails
+ * CI if a schema-pin bump renames or removes one of these types.
+ *
+ * Keep this list as a `readonly` tuple of string literals so the
+ * `Event` union below inherits the literal `__typename` types.
+ */
+export const CURATED_EVENT_TYPENAMES = [
+  "BlocklistConn",
+  "DnsCovertChannel",
+  "DomainGenerationAlgorithm",
+  "ExternalDdos",
+  "FtpBruteForce",
+  "HttpThreat",
+  "LdapBruteForce",
+  "MultiHostPortScan",
+  "NetworkThreat",
+  "NonBrowser",
+  "PortScan",
+  "RdpBruteForce",
+  "RepeatedHttpSessions",
+  "SuspiciousTlsTraffic",
+  "TorConnection",
+  "TorConnectionConn",
+  "WindowsThreat",
+] as const;
+
+export type CuratedEventTypename = (typeof CURATED_EVENT_TYPENAMES)[number];
+
+/**
+ * Narrowed discriminated union over the curated subset of `Event`
+ * subtypes. Other subtypes still arrive at runtime (the `eventList`
+ * query returns `Event!`) and fall back to the base shape via the
+ * trailing `EventBase` member, so consumers always get at least the
+ * common interface fields.
+ */
+export type Event =
+  | {
+      [K in CuratedEventTypename]: EventBase & { __typename: K };
+    }[CuratedEventTypename]
+  | EventBase;
+
+/**
+ * `EventConnection` / `EventEdge` narrowed so `nodes` and `node`
+ * carry the `Event` discriminated union. The generated shapes in
+ * `types.generated.ts` type these as `EventBase` because the SDL
+ * only commits to the interface; the narrowing is a product choice
+ * about which subtypes the UI dispatches on and lives here rather
+ * than in the generated file.
+ */
+export interface EventEdge extends Omit<GeneratedEventEdge, "node"> {
+  node: Event;
+}
+
+export interface EventConnection
+  extends Omit<GeneratedEventConnection, "edges" | "nodes"> {
+  edges: EventEdge[];
+  nodes: Event[];
+}
+
+// ── Query result shapes ──────────────────────────────────────────
+//
+// These are the top-level shapes the server actions receive from
+// `graphqlRequest`. They mirror each operation's selection set.
+
+export interface EventListResult {
+  eventList: EventConnection;
+}
+
+export interface EventCountsByCategoryResult {
+  eventCountsByCategory: U8EventCounter;
+}
+
+export interface EventCountsByLevelResult {
+  eventCountsByLevel: U8EventCounter;
+}
+
+export interface EventCountsByCountryResult {
+  eventCountsByCountry: StringEventCounter;
+}
+
+export interface EventCountsByKindResult {
+  eventCountsByKind: StringEventCounter;
+}
+
+export interface EventCountsByIpAddressResult {
+  eventCountsByIpAddress: StringEventCounter;
+}
+
+export interface EventCountsByOriginatorIpAddressResult {
+  eventCountsByOriginatorIpAddress: StringEventCounter;
+}
+
+export interface EventCountsByResponderIpAddressResult {
+  eventCountsByResponderIpAddress: StringEventCounter;
+}
+
+export interface EventFrequencySeriesResult {
+  eventFrequencySeries: number[];
+}


### PR DESCRIPTION
## Summary

Adds `src/lib/detection/` with GraphQL documents and typed server actions for `eventList`, the `eventCountsBy*` top-N counters, and `eventFrequencySeries`. Queries are inline `parse()` calls so the Phase Detection-21 schema-validation harness picks them up and validates them against `schemas/review.graphql` on every CI run.

The TS types for `EventListFilterInput`, `PageInfo`, the `EventConnection`/`EventEdge` pagination shapes, the Event interface's common fields (`EventBase`), and the counter shapes are **generated** from the vendored SDL by `scripts/codegen-detection-types.mjs` into `src/lib/detection/types.generated.ts`. A companion Vitest spec re-runs the generator in CI and diffs the result against the checked-in file, so a schema-pin bump that forgets to regenerate fails CI rather than drifting silently. Regenerate with `pnpm codegen:detection`.

On top of those generated shapes, `src/lib/detection/types.ts` layers:

- A curated discriminated union `Event` over `EventBase`, covering the subset of `Event` interface subtypes the UI will dispatch on (with `EventBase` as the fallback member for unknown `__typename`s).
- Narrowed `EventConnection` / `EventEdge` whose `nodes` / `node` fields carry that `Event` union. `searchEvents()` returns this narrowed `EventConnection`, so consumers can switch on `node.__typename` and get subtype narrowing, not just `__typename: string`.

Authorization and customer scoping run in the BFF before any REview request:

- Each action checks `detection:read` via `hasPermission` and throws `DetectionUnauthorizedError` on failure (the project's `requirePermission` redirects to `/`, which is wrong for a server action that needs to surface an error).
- The caller's effective `customer_ids` are resolved into an **explicit list** and stamped onto the **Context JWT** attached to the GraphQL request (via `signContextJwt(role, customerIds)`). Callers with `customers:access-all` are materialized to every registered customer ID from the `customers` table, so the JWT always carries `customer_ids` — REview applies scope from that claim set and does not re-derive it from role text.
- Callers with no resolvable scope (empty assigned set, or `customers:access-all` with no registered customers) are rejected before the GraphQL request is made.
- `filter.customers` is **not** touched by the BFF — it is a query-surface dimension. Callers can narrow to a subset of their allowed scope; REview intersects the JWT-carried scope with whatever the filter asks for.

The public `Filter` type is a discriminated union keyed on `mode` so the future search-language entry point can be added without breaking current callers; `mode: "query"` currently throws `DetectionNotImplementedError`.

`totalCount` is typed as `StringNumberScalar` and flows through untouched, preserving 64-bit precision end to end — it is never cast to `number`. Event nodes always include `__typename` for runtime dispatch on the Event interface subtypes.

Tests cover the authorization branch, scope delivery on the Context JWT, each per-counter dispatch, the `query`-mode stub, the codegen drift check, filter pass-through (including when the caller supplies `filter.customers`), and an end-to-end wiring test that mocks `undici.fetch` to verify the Context JWT is signed with the caller's scope, the filter is forwarded as-is, and `totalCount` round-trips through the real `graphqlRequest` client. The wiring test's response fixture is executed against the vendored schema with graphql-js so a fixture-side drift (renamed field, changed scalar, now-non-null field the fixture still leaves `null`, etc.) is caught — backstopped by a negative assertion that proves `execute()` actually reports non-null violations.

No UI changes.

Closes #273
Part of #271

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check` (biome ci) passes
- [x] `pnpm vitest run` passes (1070 tests)
- [x] `pnpm build` succeeds
- [x] GraphQL documents validate against `schemas/review.graphql` in CI
- [x] `pnpm codegen:detection` regenerates `src/lib/detection/types.generated.ts` and the drift test guards against stale output
- [x] Response fixture is executed against the vendored schema, and a negative assertion verifies `execute()` catches shape drift (non-null violation)
- [x] Server actions return typed results for `eventList`, each `eventCountsBy*`, and `eventFrequencySeries`
- [x] `searchEvents()` returns an `EventConnection` whose `nodes` / `edges[].node` carry the `Event` discriminated union
- [x] Unauthorized callers (missing `detection:read`) are rejected before dispatch
- [x] Callers with no resolvable `customer_ids` are rejected before dispatch
- [x] Context JWT is signed with the caller's `customer_ids`, including access-all callers who are resolved to the explicit list of every registered customer
- [x] `filter.customers` is passed through as-is (query dimension, not scope)
- [x] `totalCount` is preserved as a string end to end (no `number` cast)
- [x] `Filter` with `mode: "query"` throws `DetectionNotImplementedError`
- [x] Integration test confirms a minimal `{ start, end }` filter returns a non-error response with the caller's customer scope applied via the Context JWT

