### PR TITLE
Add listSensors server action with endpoint-absent fallback (#301)

### DIFF
--- a/src/__tests__/lib/detection/sensors-endpoint-guard.test.ts
+++ b/src/__tests__/lib/detection/sensors-endpoint-guard.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { buildSchema } from "graphql";
+import { describe, expect, it } from "vitest";
+
+import { SENSOR_LIST_ENDPOINT_AVAILABLE } from "@/lib/detection";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const SCHEMA_PATH = path.join(REPO_ROOT, "schemas/review.graphql");
+
+// Candidate field names for the REview sensor-list query. The exact
+// identifier is TBD on the REview side — whichever name ships, the
+// guard below accepts it, so this repo only needs to flip the
+// `SENSOR_LIST_ENDPOINT_AVAILABLE` constant (and add the inline
+// `parse(...)` dispatch) to wire the query.
+const CANDIDATE_FIELDS = ["sensorList", "sensorsForCustomers"] as const;
+
+function schemaExposesAnyCandidate(): {
+  exposed: boolean;
+  matched: string | null;
+} {
+  const sdl = readFileSync(SCHEMA_PATH, "utf8");
+  const schema = buildSchema(sdl);
+  const queryType = schema.getQueryType();
+  if (!queryType) return { exposed: false, matched: null };
+  const fields = queryType.getFields();
+  for (const candidate of CANDIDATE_FIELDS) {
+    if (candidate in fields) return { exposed: true, matched: candidate };
+  }
+  return { exposed: false, matched: null };
+}
+
+describe("detection sensor-list endpoint guard", () => {
+  it("SENSOR_LIST_ENDPOINT_AVAILABLE matches the vendored schema", () => {
+    // Three-way contract: the vendored schema, the exported constant,
+    // and the dispatch wiring in `src/lib/detection/sensors.ts` must
+    // move together. This guard forces the constant side of that
+    // contract. A consumer of `listSensors()` who assumed the endpoint
+    // is always available (and therefore removed the empty-list path)
+    // would first have had to flip the constant — and would trip this
+    // test if the vendored schema had not caught up.
+    //
+    // When REview ships the query and the schema is bumped in this
+    // repo:
+    //   1. The schema check below starts returning { exposed: true }.
+    //   2. Flip `SENSOR_LIST_ENDPOINT_AVAILABLE` to `true` in
+    //      src/lib/detection/sensors.ts.
+    //   3. Add the `parse(...)` dispatch to ./queries.ts and wire it
+    //      up in listSensors() following the same pattern as
+    //      buildDispatchContext in server-actions.ts.
+    //
+    // Leaving any of those three changes out fails CI here.
+    const { exposed, matched } = schemaExposesAnyCandidate();
+    if (exposed && !SENSOR_LIST_ENDPOINT_AVAILABLE) {
+      throw new Error(
+        `schemas/review.graphql now exposes the sensor-list query ` +
+          `(as \`${matched}\`), but SENSOR_LIST_ENDPOINT_AVAILABLE is ` +
+          "still `false`. Flip the constant in " +
+          "src/lib/detection/sensors.ts and wire the inline " +
+          "`parse(...)` dispatch in the same PR.",
+      );
+    }
+    if (!exposed && SENSOR_LIST_ENDPOINT_AVAILABLE) {
+      throw new Error(
+        `SENSOR_LIST_ENDPOINT_AVAILABLE is \`true\`, but ` +
+          "schemas/review.graphql does not expose any of the " +
+          `expected sensor-list query fields (${CANDIDATE_FIELDS.join(
+            ", ",
+          )}). Either revert the constant or add the missing schema ` +
+          "field in the same PR that vendored the new schema.",
+      );
+    }
+    expect(SENSOR_LIST_ENDPOINT_AVAILABLE).toBe(exposed);
+  });
+});

--- a/src/__tests__/lib/detection/sensors.test.ts
+++ b/src/__tests__/lib/detection/sensors.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockResolveEffectiveCustomerIds = vi.hoisted(() => vi.fn());
+const mockGraphqlRequest = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/customer-scope", () => ({
+  resolveEffectiveCustomerIds: mockResolveEffectiveCustomerIds,
+}));
+
+vi.mock("@/lib/graphql/client", () => ({
+  graphqlRequest: mockGraphqlRequest,
+}));
+
+/** Build a minimally-populated AuthSession for the unit under test. */
+function makeSession(overrides: Partial<AuthSession> = {}): AuthSession {
+  return {
+    accountId: "account-1",
+    sessionId: "session-1",
+    roles: ["Security Monitor"],
+    tokenVersion: 1,
+    mustChangePassword: false,
+    mustEnrollMfa: false,
+    iat: 0,
+    exp: 0,
+    sessionIp: "127.0.0.1",
+    sessionUserAgent: "test",
+    sessionBrowserFingerprint: "test",
+    needsReauth: false,
+    sessionCreatedAt: new Date(0),
+    sessionLastActiveAt: new Date(0),
+    ...overrides,
+  } as AuthSession;
+}
+
+describe("detection sensors — listSensors()", () => {
+  beforeEach(() => {
+    mockHasPermission.mockReset();
+    mockResolveEffectiveCustomerIds.mockReset();
+    mockGraphqlRequest.mockReset();
+  });
+
+  // ── Authorization ──────────────────────────────────────────────
+
+  it("rejects a caller without detection:read before resolving scope", async () => {
+    mockHasPermission.mockResolvedValue(false);
+
+    const { listSensors, DetectionUnauthorizedError } = await import(
+      "@/lib/detection"
+    );
+
+    await expect(listSensors(makeSession())).rejects.toBeInstanceOf(
+      DetectionUnauthorizedError,
+    );
+
+    // Authorization failure short-circuits before scope resolution
+    // and before any GraphQL dispatch.
+    expect(mockResolveEffectiveCustomerIds).not.toHaveBeenCalled();
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller with an empty customer scope", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([]);
+
+    const { listSensors, DetectionUnauthorizedError } = await import(
+      "@/lib/detection"
+    );
+
+    await expect(listSensors(makeSession())).rejects.toBeInstanceOf(
+      DetectionUnauthorizedError,
+    );
+
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+  });
+
+  it("resolves customer_ids for authorized callers before the endpoint check", async () => {
+    // Forward-looking assertion for the customer-scope contract: the
+    // customer_ids list is materialized on every call, even while the
+    // endpoint is absent, so flipping `SENSOR_LIST_ENDPOINT_AVAILABLE`
+    // and wiring the dispatch does not require touching the auth path.
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+
+    const { listSensors } = await import("@/lib/detection");
+    await listSensors(makeSession());
+
+    expect(mockHasPermission).toHaveBeenCalledWith(
+      ["Security Monitor"],
+      "detection:read",
+    );
+    expect(mockResolveEffectiveCustomerIds).toHaveBeenCalledWith("account-1", [
+      "Security Monitor",
+    ]);
+  });
+
+  // ── Fallback: endpoint absent from vendored schema ─────────────
+
+  it("returns the endpoint-absent variant (and an empty list via sensorsOrEmpty) when the endpoint is missing from the vendored schema", async () => {
+    // The vendored schemas/review.graphql does not yet expose the
+    // sensor-list query (#295). While that is true, authorized callers
+    // must receive the `endpoint-absent` variant rather than an error —
+    // downstream consumers (#278 dropdown, #291 event locator) rely on
+    // this degrade-gracefully contract and choose between the
+    // discriminator (locator) or `sensorsOrEmpty()` (dropdown).
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+
+    const { listSensors, SENSOR_LIST_ENDPOINT_AVAILABLE, sensorsOrEmpty } =
+      await import("@/lib/detection");
+
+    // Precondition for this regression: the constant really is `false`
+    // in the current snapshot of the vendored schema.
+    expect(SENSOR_LIST_ENDPOINT_AVAILABLE).toBe(false);
+
+    const result = await listSensors(makeSession());
+    expect(result).toEqual({ endpointAvailable: false });
+    // The documented collapse helper still yields the flat empty list
+    // that the issue's fallback clause calls out.
+    expect(sensorsOrEmpty(result)).toEqual([]);
+    // No network traffic at all while the endpoint is absent.
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+  });
+
+  // ── Consumer-side compile-time guard ───────────────────────────
+
+  it("forces consumers to acknowledge the endpoint-availability state at the type level", async () => {
+    // This test is primarily a tsc-level assertion: the compile guard
+    // is the SensorListResult discriminated union itself (see
+    // src/lib/detection/sensors.ts). A consumer that treats the result
+    // as always having a `sensors` field — i.e. assumes the endpoint is
+    // always available — fails `tsc --noEmit` because `sensors` does
+    // not exist on the `endpoint-absent` variant. The @ts-expect-error
+    // lines below lock that guard in: if anyone widens the return
+    // shape to always expose `sensors`, the directives become dead and
+    // tsc fails the test file.
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+
+    const { listSensors } = await import("@/lib/detection");
+    const result = await listSensors(makeSession());
+
+    // @ts-expect-error — `sensors` is only present on the
+    // `endpointAvailable: true` variant; accessing it without first
+    // narrowing on the discriminator is a type error, which is
+    // exactly the consumer-side guard the issue requires.
+    void result.sensors;
+
+    // With proper narrowing, `sensors` is reachable and typed.
+    if (result.endpointAvailable) {
+      const sensors: readonly unknown[] = result.sensors;
+      expect(Array.isArray(sensors)).toBe(true);
+    } else {
+      expect(result).toEqual({ endpointAvailable: false });
+    }
+  });
+
+  // ── Wire-path guard: activates when the flag flips ─────────────
+
+  it("dispatches via graphqlRequest with { role, customerIds } once the endpoint flag is true", async () => {
+    // Behavioural counterpart to the schema-vs-constant guard in
+    // `sensors-endpoint-guard.test.ts`. Today this test is a no-op
+    // because `SENSOR_LIST_ENDPOINT_AVAILABLE` is `false`, but it
+    // activates automatically the moment someone flips the constant:
+    //
+    //   - If the dispatch body is still `return []`, `graphqlRequest`
+    //     is never called and this assertion fails — so a future PR
+    //     cannot flip the flag and leave the fallback as the live
+    //     code path.
+    //   - The assertion also locks the wire contract: the caller's
+    //     `customer_ids` travel on the Context JWT (via `graphqlRequest`
+    //     which calls `signContextJwt(role, customerIds)` internally —
+    //     see review-integration.test.ts), not on the query variables.
+    //
+    // Run against the real constant (not a mocked one) so the guard
+    // tracks the production flag, not a test-local override.
+    const { listSensors, SENSOR_LIST_ENDPOINT_AVAILABLE } = await import(
+      "@/lib/detection"
+    );
+    if (!SENSOR_LIST_ENDPOINT_AVAILABLE) {
+      // Flag is still `false`: the fallback path is exercised by the
+      // preceding test. When REview publishes the sensor-list query
+      // (#295) and the constant flips, the assertions below activate
+      // and require a wired graphqlRequest dispatch in listSensors.
+      return;
+    }
+
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+    mockGraphqlRequest.mockResolvedValue({
+      sensorList: [] as Array<{ id: string; name: string; customerId: string }>,
+    });
+
+    await listSensors(makeSession({ roles: ["Security Monitor"] }));
+
+    expect(mockGraphqlRequest).toHaveBeenCalledOnce();
+    const call = mockGraphqlRequest.mock.calls[0];
+    // graphqlRequest signature: (document, variables, context).
+    // Assert only the context — the document and variables are part
+    // of the wiring change and will be locked in by the PR that
+    // flips the flag.
+    expect(call[2]).toMatchObject({
+      role: "Security Monitor",
+      customerIds: [42, 99],
+    });
+  });
+});

--- a/src/lib/detection/index.ts
+++ b/src/lib/detection/index.ts
@@ -4,6 +4,13 @@ export {
 } from "./errors";
 export { type Filter, toEventListFilterInput } from "./filter";
 export {
+  listSensors,
+  SENSOR_LIST_ENDPOINT_AVAILABLE,
+  type Sensor,
+  type SensorListResult,
+  sensorsOrEmpty,
+} from "./sensors";
+export {
   countEventsByCategory,
   countEventsByCountry,
   countEventsByIpAddress,

--- a/src/lib/detection/sensors.ts
+++ b/src/lib/detection/sensors.ts
@@ -1,0 +1,174 @@
+import "server-only";
+
+import { resolveEffectiveCustomerIds } from "@/lib/auth/customer-scope";
+import type { AuthSession } from "@/lib/auth/jwt";
+import { hasPermission } from "@/lib/auth/permissions";
+
+import { DetectionUnauthorizedError } from "./errors";
+
+const DETECTION_READ = "detection:read";
+
+/**
+ * A sensor (Node) known to REview, scoped to customers the caller can
+ * access. The exact field set is a product of the REview query signature
+ * and will be finalized when the endpoint lands — see
+ * `SENSOR_LIST_ENDPOINT_AVAILABLE` below.
+ */
+export interface Sensor {
+  /** Opaque REview Node ID. Matches `EventListFilterInput.sensors` entries. */
+  id: string;
+  /** Human-readable sensor name as emitted on `Event.sensor`. */
+  name: string;
+  /** REview customer ID the sensor belongs to. */
+  customerId: string;
+}
+
+/**
+ * Whether the vendored REview schema at `schemas/review.graphql` exposes
+ * the sensor-list query consumed by this module.
+ *
+ * The REview-side endpoint is being added in a follow-up schema bump
+ * (tracked by #295). Until that bump reaches this repo's
+ * `schemas/review.graphql`, this flag stays `false` and `listSensors()`
+ * short-circuits to the `endpoint-absent` variant — see the fallback
+ * note on `listSensors()`.
+ *
+ * ## Three-way CI guard
+ *
+ * When REview ships the endpoint, flip this constant to `true` in the
+ * **same PR** that bumps the vendored schema and wires the inline
+ * `parse(...)` dispatch.
+ * `src/__tests__/lib/detection/sensors-endpoint-guard.test.ts` enforces
+ * the three-way contract at CI time — flipping the constant without a
+ * matching schema field fails, and schema drift without a constant
+ * flip fails.
+ * `src/__tests__/lib/detection/sensors.test.ts` additionally asserts
+ * that, when the constant is `true`, `listSensors()` dispatches through
+ * `graphqlRequest` with `{ role, customerIds }` — so flipping the
+ * constant while leaving the dispatch body a placeholder also fails CI.
+ * The schema bump, constant flip, and dispatch wiring therefore cannot
+ * land piecemeal.
+ */
+export const SENSOR_LIST_ENDPOINT_AVAILABLE = false as const;
+
+/**
+ * Result shape returned by `listSensors()`.
+ *
+ * Modelled as a discriminated union so consumers are forced, **at the
+ * TypeScript type level**, to acknowledge the endpoint-availability
+ * state before they can touch `sensors`. A consumer that writes
+ * `(await listSensors(session)).sensors.map(...)` fails `tsc --noEmit`
+ * because `sensors` does not exist on the `endpoint-absent` variant —
+ * which is the "clearly-named compile guard" required by #301's
+ * acceptance list.
+ *
+ * This is intentionally stricter than a shared `sensors: Sensor[]`
+ * field on both variants: the previous shape let a consumer treat an
+ * empty list returned by the fallback as indistinguishable from an
+ * empty list returned by REview (same caller with no sensors assigned
+ * to their customer scope), which is precisely the bug the guard is
+ * meant to prevent.
+ *
+ * Use `sensorsOrEmpty()` below to collapse a result into `Sensor[]`
+ * when a downstream surface only needs to iterate (e.g. #278 Sensor
+ * dropdown options). Consumers that must distinguish "endpoint absent"
+ * from "endpoint present but empty" (e.g. #291 event locator, which
+ * skips name → ID resolution when the endpoint is absent) branch on
+ * the `endpointAvailable` discriminator directly.
+ */
+export type SensorListResult =
+  | { readonly endpointAvailable: false }
+  | { readonly endpointAvailable: true; readonly sensors: readonly Sensor[] };
+
+/**
+ * Collapse a `SensorListResult` into a flat `readonly Sensor[]`. Returns
+ * the empty array when the endpoint is absent from the vendored schema,
+ * preserving the issue's "returns an empty list without throwing"
+ * fallback contract for callers that do not need the discriminator.
+ */
+export function sensorsOrEmpty(result: SensorListResult): readonly Sensor[] {
+  return result.endpointAvailable ? result.sensors : [];
+}
+
+/**
+ * Return the sensors visible to the caller.
+ *
+ * ## Authorization
+ *
+ * Mirrors `searchEvents` / counter actions (see
+ * `src/lib/detection/server-actions.ts`). Before any network traffic:
+ *
+ *   1. Caller must hold `detection:read`.
+ *   2. The caller's effective `customer_ids` must resolve to a
+ *      non-empty list — an empty scope is rejected as a
+ *      misconfiguration.
+ *
+ * When REview is reached, scope travels on the Context JWT
+ * (`signContextJwt(role, customerIds)`), not on query arguments. REview
+ * applies the scope from the JWT claim set and returns only sensors
+ * belonging to the caller's accessible customers.
+ *
+ * ## Fallback when the endpoint is absent
+ *
+ * If `SENSOR_LIST_ENDPOINT_AVAILABLE` is `false` (REview has not yet
+ * published the query in the vendored schema), this function resolves
+ * to the `{ endpointAvailable: false }` variant **instead of throwing**.
+ * Pass the result through `sensorsOrEmpty()` to recover the "empty
+ * list" iteration shape — the two consumers degrade gracefully:
+ *
+ *   - #278 Sensor dropdown: renders with no options — the multi-select
+ *     is still usable once REview ships the endpoint without any
+ *     client-side refactor.
+ *   - #291 event locator: skips name → ID resolution and omits
+ *     `sensors: [<id>]` from the tight filter (same behaviour as a
+ *     name mismatch / out-of-scope event).
+ *
+ * The fallback is **after** the authorization check, not before: an
+ * unauthorized caller is rejected even while the endpoint is missing,
+ * so the auth contract is uniform regardless of schema state.
+ */
+export async function listSensors(
+  session: AuthSession,
+): Promise<SensorListResult> {
+  if (!(await hasPermission(session.roles, DETECTION_READ))) {
+    throw new DetectionUnauthorizedError(
+      "Caller lacks the detection:read permission.",
+    );
+  }
+
+  const customerIds = await resolveEffectiveCustomerIds(
+    session.accountId,
+    session.roles,
+  );
+  if (customerIds.length === 0) {
+    throw new DetectionUnauthorizedError(
+      "Caller has no assigned customers; Detection requires a customer scope.",
+    );
+  }
+
+  if (!SENSOR_LIST_ENDPOINT_AVAILABLE) {
+    // REview has not yet published the sensor-list query in the
+    // vendored schema (#295). The `endpoint-absent` variant signals
+    // this state to consumers at the type level — see
+    // `SENSOR_LIST_ENDPOINT_AVAILABLE` for the promote-to-live
+    // procedure.
+    return { endpointAvailable: false };
+  }
+
+  // When REview ships `sensorList` (or `sensorsForCustomers` — exact
+  // identifier TBD), add the `parse(...)` document to `./queries.ts`
+  // and dispatch here via `graphqlRequest` with
+  // `{ role: session.roles[0], customerIds }`. The customer scope MUST
+  // travel on the Context JWT, not as a query argument — mirror the
+  // contract in `buildDispatchContext` (server-actions.ts). The
+  // `endpointAvailable: true` discriminator must be set on the returned
+  // object so the type-level guard in `SensorListResult` narrows the
+  // `sensors` field for consumers.
+  //
+  // Unreachable while SENSOR_LIST_ENDPOINT_AVAILABLE is the literal
+  // `false`; the narrowed type documents the intent, and the
+  // behavioural guard in `sensors.test.ts` (which imports the real
+  // constant and asserts dispatch when it is `true`) prevents this
+  // branch from staying a no-op if the constant is ever flipped.
+  return { endpointAvailable: true, sensors: [] };
+}


### PR DESCRIPTION
## Summary

Wires a `listSensors()` server action in `src/lib/detection/sensors.ts` that will dispatch the new REview sensor-list query once REview publishes it in the vendored schema. The plumbing (authorization, customer-scope resolution, typed `SensorListResult` discriminated union) ships today so downstream consumers — #278 Sensor dropdown and #291 event locator — can call the action unconditionally.

Key design points:

- **Type-level consumer guard.** `listSensors()` returns a `SensorListResult` discriminated union — `{ endpointAvailable: false } | { endpointAvailable: true; sensors }` — so a caller that assumes the endpoint is always present (e.g. `(await listSensors(session)).sensors.map(...)`) fails `tsc --noEmit`. `sensorsOrEmpty()` is exported as the convenience collapse for callers that only need to iterate. This is the "clearly-named compile guard" required by #301's acceptance list, now enforced by the type system rather than by convention.
- **Endpoint gate.** `SENSOR_LIST_ENDPOINT_AVAILABLE` is exported as the literal `false`. While the vendored `schemas/review.graphql` does not expose the query, authorized callers receive the `endpoint-absent` variant so UI consumers degrade gracefully; unauthorized callers are still rejected so the auth contract is uniform regardless of schema state.
- **Three-way CI guard.** Schema, constant, and dispatch body must move together:
  1. `src/__tests__/lib/detection/sensors-endpoint-guard.test.ts` parses `schemas/review.graphql` and fails CI if `SENSOR_LIST_ENDPOINT_AVAILABLE` disagrees with the schema.
  2. `src/__tests__/lib/detection/sensors.test.ts` asserts that, when the constant is `true`, `listSensors()` dispatches through `graphqlRequest` with `{ role, customerIds }`. Today the assertion is a no-op (flag is `false`); it activates automatically when the flag flips, and fails if the dispatch body still resolves to the placeholder. This closes the gap where someone could bump the schema and flip the constant without wiring the dispatch.
  3. A `@ts-expect-error` assertion in the same test file locks the consumer-side compile guard: widening the return type back to a shared `sensors` field makes the directive dead and fails CI.
- **Customer scope travels on the Context JWT**, not on query arguments — matches the contract established in #273 (`buildDispatchContext` in `server-actions.ts`). The wire-level JWT signing + `customer_ids` injection is already covered end-to-end for `searchEvents` in `review-integration.test.ts` (which spies `signContextJwt` and `fetch`); `listSensors()` reuses the same `graphqlRequest` helper, so the behavioural assertion above — which runs against the real constant rather than a mocked override — is sufficient to lock in the contract without duplicating the full network-mocked harness for a query that does not yet exist.

Part of #301.

## Not addressed

- **GraphQL document, types generation, and live dispatch.** Blocked on REview publishing the query in the vendored `schemas/review.graphql` (tracked by #295). The exact identifier (`sensorList` vs. `sensorsForCustomers`) is TBD on the REview side; the guard test already accepts either name. When REview ships the endpoint, the single follow-up PR must flip `SENSOR_LIST_ENDPOINT_AVAILABLE`, add the `parse(...)` document, and wire the `graphqlRequest` dispatch — otherwise the behavioural test activates and fails. The issue itself acknowledges this gating: "Until REview publishes the endpoint in the vendored schema (#295), this issue cannot land functionally."
- **End-to-end wire test against a mocked network** for `listSensors()` specifically. Deferred to the same follow-up PR: without the real query document / schema field, a network-mocked test would be validating placeholder wiring that gets replaced the moment the endpoint ships. The JWT/fetch contract is already exercised end-to-end for `searchEvents` (`review-integration.test.ts`), which shares the `graphqlRequest` code path.
- **UI changes.** Out of scope for this issue — #278 and #291 wire the consumers.

## Test plan

- [x] `pnpm vitest run` — 1138 passed (97 files)
- [x] `pnpm tsc --noEmit`
- [x] `pnpm biome check`
- [x] `pnpm build`
- [x] Unauthorized caller (no `detection:read`) is rejected with `DetectionUnauthorizedError` before scope resolution and before any GraphQL dispatch
- [x] Authorized caller with empty customer scope is rejected with `DetectionUnauthorizedError`
- [x] Authorized caller with a non-empty customer scope receives `{ endpointAvailable: false }` while `SENSOR_LIST_ENDPOINT_AVAILABLE` is `false`; `sensorsOrEmpty()` collapses that to `[]`; `graphqlRequest` is not called
- [x] Endpoint guard fails CI if `schemas/review.graphql` exposes `sensorList` / `sensorsForCustomers` while the constant is still `false` (and vice versa)
- [x] Behavioural guard locks in the dispatch contract: when `SENSOR_LIST_ENDPOINT_AVAILABLE` becomes `true`, `listSensors()` must call `graphqlRequest` with `{ role, customerIds }` or CI fails
- [x] Consumer compile guard: `@ts-expect-error` on `result.sensors` without narrowing fails `tsc` if the return type is widened to a shared-field shape