### PR TITLE
Scope /api/audit-logs to caller's customer set (#386)

### DIFF
--- a/src/__integration__/api/audit-logs.test.ts
+++ b/src/__integration__/api/audit-logs.test.ts
@@ -7,6 +7,7 @@ import {
   signIn,
 } from "../helpers/auth";
 import {
+  assignAllExistingCustomersToAccount,
   assignCustomerToAccount,
   createCustomerRow,
   createTestAccount,
@@ -95,12 +96,14 @@ describe("Audit logs viewer scoping", () => {
     await assignCustomerToAccount(accountAId, customerAId);
     await assignCustomerToAccount(accountBId, customerBId);
 
-    // The "all-assigned" account is linked to every test customer but
-    // does not hold customers:access-all — proves the predicate is
-    // applied even when the assignment list happens to cover every
-    // customer.
-    await assignCustomerToAccount(allAssignedId, customerAId);
-    await assignCustomerToAccount(allAssignedId, customerBId);
+    // The "all-assigned" account is linked to every customer row in
+    // the database (not just the two created here) but does not hold
+    // customers:access-all. This defends against a regression where
+    // admin status is inferred from
+    // `assignedIds.length === SELECT COUNT(*) FROM customers`: such an
+    // implementation would treat this account as admin and surface
+    // `customer_id IS NULL` rows.
+    await assignAllExistingCustomersToAccount(allAssignedId);
 
     // Seed three audit rows: one per customer plus one customer-agnostic.
     seeded = {

--- a/src/__integration__/api/audit-logs.test.ts
+++ b/src/__integration__/api/audit-logs.test.ts
@@ -1,0 +1,247 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ADMIN_USERNAME,
+  authGet,
+  resetRateLimits,
+  signIn,
+} from "../helpers/auth";
+import {
+  assignCustomerToAccount,
+  createCustomerRow,
+  createTestAccount,
+  createTestRole,
+  deleteAuditLogById,
+  deleteCustomersByPrefix,
+  deleteRolesByPrefix,
+  deleteTestAccount,
+  deleteTestRole,
+  getAccountId,
+  insertAuditLog,
+  removeAccountCustomerAssignments,
+  resetAccountDefaults,
+  revokeAllSessions,
+} from "../helpers/setup-db";
+
+// ── Fixtures ───────────────────────────────────────────────────
+
+const TEST_PREFIX = "Integ-AL-";
+const ROLE_NAME = "integ-al-auditor";
+
+const ACCOUNT_A_USERNAME = "integ-al-account-a";
+const ACCOUNT_B_USERNAME = "integ-al-account-b";
+const EMPTY_USERNAME = "integ-al-empty";
+const ALL_ASSIGNED_USERNAME = "integ-al-all-assigned";
+
+const COMMON_PASSWORD = "AuditViewer1234!";
+
+interface AuditLogResponse {
+  data: Array<{
+    id: string;
+    actor_id: string;
+    customer_id: number | null;
+    action: string;
+  }>;
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+interface SeededIds {
+  customerARowId: string;
+  customerBRowId: string;
+  nullCustomerRowId: string;
+}
+
+describe("Audit logs viewer scoping", () => {
+  let customerAId: number;
+  let customerBId: number;
+  let seeded: SeededIds;
+
+  beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+
+    // Clean up any leftover state from prior runs.
+    await deleteTestAccount(ACCOUNT_A_USERNAME);
+    await deleteTestAccount(ACCOUNT_B_USERNAME);
+    await deleteTestAccount(EMPTY_USERNAME);
+    await deleteTestAccount(ALL_ASSIGNED_USERNAME);
+    await deleteTestRole(ROLE_NAME);
+    await deleteRolesByPrefix("integ-al-");
+    await deleteCustomersByPrefix(TEST_PREFIX);
+
+    // Custom role: audit-logs:read but NOT customers:access-all.
+    await createTestRole(
+      ROLE_NAME,
+      ["audit-logs:read"],
+      "Integration test auditor (scoped)",
+    );
+
+    // Test customers (rows only, no provisioned database).
+    customerAId = await createCustomerRow(`${TEST_PREFIX}CustomerA`);
+    customerBId = await createCustomerRow(`${TEST_PREFIX}CustomerB`);
+
+    // Test accounts.
+    await createTestAccount(ACCOUNT_A_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+    await createTestAccount(ACCOUNT_B_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+    await createTestAccount(EMPTY_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+    await createTestAccount(ALL_ASSIGNED_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+
+    const accountAId = await getAccountId(ACCOUNT_A_USERNAME);
+    const accountBId = await getAccountId(ACCOUNT_B_USERNAME);
+    const allAssignedId = await getAccountId(ALL_ASSIGNED_USERNAME);
+
+    await assignCustomerToAccount(accountAId, customerAId);
+    await assignCustomerToAccount(accountBId, customerBId);
+
+    // The "all-assigned" account is linked to every test customer but
+    // does not hold customers:access-all — proves the predicate is
+    // applied even when the assignment list happens to cover every
+    // customer.
+    await assignCustomerToAccount(allAssignedId, customerAId);
+    await assignCustomerToAccount(allAssignedId, customerBId);
+
+    // Seed three audit rows: one per customer plus one customer-agnostic.
+    seeded = {
+      customerARowId: await insertAuditLog({
+        actorId: accountAId,
+        action: "customer.assign",
+        targetType: "account",
+        targetId: accountAId,
+        customerId: customerAId,
+      }),
+      customerBRowId: await insertAuditLog({
+        actorId: accountBId,
+        action: "customer.assign",
+        targetType: "account",
+        targetId: accountBId,
+        customerId: customerBId,
+      }),
+      nullCustomerRowId: await insertAuditLog({
+        actorId: "system",
+        action: "account.login",
+        targetType: "account",
+        targetId: accountAId,
+        customerId: null,
+      }),
+    };
+  });
+
+  beforeEach(async () => {
+    await resetRateLimits();
+    await revokeAllSessions(ADMIN_USERNAME);
+    await revokeAllSessions(ACCOUNT_A_USERNAME);
+    await revokeAllSessions(ACCOUNT_B_USERNAME);
+    await revokeAllSessions(EMPTY_USERNAME);
+    await revokeAllSessions(ALL_ASSIGNED_USERNAME);
+  });
+
+  afterAll(async () => {
+    await deleteAuditLogById(seeded.customerARowId);
+    await deleteAuditLogById(seeded.customerBRowId);
+    await deleteAuditLogById(seeded.nullCustomerRowId);
+
+    const accounts = [
+      ACCOUNT_A_USERNAME,
+      ACCOUNT_B_USERNAME,
+      EMPTY_USERNAME,
+      ALL_ASSIGNED_USERNAME,
+    ];
+    for (const username of accounts) {
+      const id = await getAccountId(username).catch(() => null);
+      if (id) await removeAccountCustomerAssignments(id);
+      await deleteTestAccount(username);
+    }
+    await deleteTestRole(ROLE_NAME);
+    await deleteCustomersByPrefix(TEST_PREFIX);
+  });
+
+  // ── Restricted scope: only own customer's rows ───────────────
+
+  it("account-A sees only customer-A rows (NULL and B excluded)", async () => {
+    const session = await signIn(ACCOUNT_A_USERNAME);
+
+    const response = await authGet(session, "/api/audit-logs?pageSize=100");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as AuditLogResponse;
+    const ids = body.data.map((r) => r.id);
+    const customerIds = new Set(body.data.map((r) => r.customer_id));
+
+    expect(ids).toContain(seeded.customerARowId);
+    expect(ids).not.toContain(seeded.customerBRowId);
+    expect(ids).not.toContain(seeded.nullCustomerRowId);
+    expect(customerIds).toEqual(new Set([customerAId]));
+    expect(body.total).toBe(body.data.length);
+  });
+
+  it("account-B sees only customer-B rows", async () => {
+    const session = await signIn(ACCOUNT_B_USERNAME);
+
+    const response = await authGet(session, "/api/audit-logs?pageSize=100");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as AuditLogResponse;
+    const ids = body.data.map((r) => r.id);
+    const customerIds = new Set(body.data.map((r) => r.customer_id));
+
+    expect(ids).toContain(seeded.customerBRowId);
+    expect(ids).not.toContain(seeded.customerARowId);
+    expect(ids).not.toContain(seeded.nullCustomerRowId);
+    expect(customerIds).toEqual(new Set([customerBId]));
+    expect(body.total).toBe(body.data.length);
+  });
+
+  // ── Admin: sees everything ───────────────────────────────────
+
+  it("admin sees all rows including the customer-agnostic NULL row", async () => {
+    const session = await signIn(ADMIN_USERNAME);
+
+    const response = await authGet(session, "/api/audit-logs?pageSize=100");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as AuditLogResponse;
+    const ids = body.data.map((r) => r.id);
+
+    expect(ids).toContain(seeded.customerARowId);
+    expect(ids).toContain(seeded.customerBRowId);
+    expect(ids).toContain(seeded.nullCustomerRowId);
+  });
+
+  // ── Empty scope: empty result, not admin fallback ─────────────
+
+  it("empty-scope account gets an empty result set", async () => {
+    const session = await signIn(EMPTY_USERNAME);
+
+    const response = await authGet(session, "/api/audit-logs?pageSize=100");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as AuditLogResponse;
+    expect(body.data).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  // ── All-assigned but not admin: predicate still applied ───────
+
+  it("all-customers-assigned non-admin still excludes NULL customer rows", async () => {
+    const session = await signIn(ALL_ASSIGNED_USERNAME);
+
+    const response = await authGet(session, "/api/audit-logs?pageSize=100");
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as AuditLogResponse;
+    const ids = body.data.map((r) => r.id);
+
+    // Sees both A and B rows because assigned to both.
+    expect(ids).toContain(seeded.customerARowId);
+    expect(ids).toContain(seeded.customerBRowId);
+
+    // Critically — NULL-customer rows must NOT leak via "all assigned
+    // ⇒ admin-like" inference.
+    expect(ids).not.toContain(seeded.nullCustomerRowId);
+    for (const row of body.data) {
+      expect(row.customer_id).not.toBeNull();
+    }
+  });
+});

--- a/src/__integration__/helpers/setup-db.ts
+++ b/src/__integration__/helpers/setup-db.ts
@@ -352,6 +352,22 @@ export async function removeAccountCustomerAssignments(
   );
 }
 
+export async function createCustomerRow(name: string): Promise<number> {
+  return withAuthDb(async (c) => {
+    const dbName = `customer_test_${name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .slice(0, 30)}_${Math.random().toString(16).slice(2, 8)}`;
+    const { rows } = await c.query<{ id: number }>(
+      `INSERT INTO customers (name, database_name, status)
+       VALUES ($1, $2, 'active')
+       RETURNING id`,
+      [name, dbName],
+    );
+    return rows[0].id;
+  });
+}
+
 export async function getCustomerIdByName(
   name: string,
 ): Promise<number | null> {
@@ -437,12 +453,13 @@ export async function insertAuditLog(opts: {
   targetId?: string;
   ipAddress?: string;
   details?: Record<string, unknown>;
+  customerId?: number | null;
 }): Promise<string> {
   return withAuditDb(async (c) => {
     const { rows } = await c.query<{ id: string }>(
       `INSERT INTO audit_logs
-         (actor_id, action, target_type, target_id, ip_address, details)
-       VALUES ($1, $2, $3, $4, $5, $6)
+         (actor_id, action, target_type, target_id, ip_address, details, customer_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING id`,
       [
         opts.actorId,
@@ -451,6 +468,7 @@ export async function insertAuditLog(opts: {
         opts.targetId ?? null,
         opts.ipAddress ?? "127.0.0.1",
         opts.details ? JSON.stringify(opts.details) : null,
+        opts.customerId ?? null,
       ],
     );
     return rows[0].id;
@@ -460,6 +478,12 @@ export async function insertAuditLog(opts: {
 export async function deleteAuditLogById(id: string): Promise<void> {
   await withAuditDb((c) =>
     c.query("DELETE FROM audit_logs WHERE id = $1", [id]),
+  );
+}
+
+export async function deleteAuditLogsByActor(actorId: string): Promise<void> {
+  await withAuditDb((c) =>
+    c.query("DELETE FROM audit_logs WHERE actor_id = $1", [actorId]),
   );
 }
 

--- a/src/__integration__/helpers/setup-db.ts
+++ b/src/__integration__/helpers/setup-db.ts
@@ -352,6 +352,29 @@ export async function removeAccountCustomerAssignments(
   );
 }
 
+/**
+ * Assigns the account to every customer row currently in `customers`.
+ * Returns the list of customer IDs assigned. Used to defend against
+ * regressions where admin status is inferred from
+ * `assignedIds.length === SELECT COUNT(*) FROM customers`.
+ */
+export async function assignAllExistingCustomersToAccount(
+  accountId: string,
+): Promise<number[]> {
+  return withAuthDb(async (c) => {
+    const { rows } = await c.query<{ id: number }>(
+      "SELECT id FROM customers ORDER BY id",
+    );
+    for (const { id } of rows) {
+      await c.query(
+        "INSERT INTO account_customer (account_id, customer_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+        [accountId, id],
+      );
+    }
+    return rows.map((r) => r.id);
+  });
+}
+
 export async function createCustomerRow(name: string): Promise<number> {
   return withAuthDb(async (c) => {
     const dbName = `customer_test_${name

--- a/src/app/api/audit-logs/route.ts
+++ b/src/app/api/audit-logs/route.ts
@@ -4,7 +4,9 @@ import { NextResponse } from "next/server";
 
 import { queryAudit } from "@/lib/audit/client";
 import { AUDIT_ACTIONS, AUDIT_TARGET_TYPES } from "@/lib/audit/schema";
+import { resolveEffectiveCustomerIds } from "@/lib/auth/customer-scope";
 import { withAuth } from "@/lib/auth/guard";
+import { hasPermission } from "@/lib/auth/permissions";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -63,15 +65,55 @@ const UUID_RE =
 /**
  * GET /api/audit-logs
  *
- * Search and filter audit log entries.  System Administrator only.
+ * Search and filter audit log entries. Requires `audit-logs:read`.
+ * Results are scoped to the caller's effective customer set unless
+ * the caller holds `customers:access-all`.
  *
  * Query parameters:
  *   page, pageSize, from, to, actor, action, targetType, targetId,
  *   correlationId
  */
 export const GET = withAuth(
-  async (request, _context, _session) => {
+  async (request, _context, session) => {
     const url = request.nextUrl;
+
+    // ── Customer scope (project principle 3) ─────────────────────
+    //
+    // Branch on two independent signals:
+    //   1. `isAdmin` — authoritative admin signal from the
+    //      `customers:access-all` permission. Only this branch may
+    //      omit the customer_id predicate (so admins see rows with
+    //      `customer_id IS NULL`).
+    //   2. `allowedCustomerIds` — the predicate values for non-admin
+    //      callers, materialized from `account_customer`. A non-admin
+    //      who happens to be assigned to every customer must still
+    //      receive the explicit `customer_id IN (...)` filter, or
+    //      audit-agnostic (`customer_id IS NULL`) rows would leak via
+    //      the admin-only "no predicate" path.
+    const isAdmin = await hasPermission(session.roles, "customers:access-all");
+    const allowedCustomerIds = isAdmin
+      ? []
+      : await resolveEffectiveCustomerIds(session.accountId, session.roles);
+    if (!isAdmin && allowedCustomerIds.length === 0) {
+      const emptyPage = Math.max(
+        DEFAULT_PAGE,
+        Number.parseInt(url.searchParams.get("page") ?? "", 10) || DEFAULT_PAGE,
+      );
+      const emptyPageSize = Math.min(
+        MAX_PAGE_SIZE,
+        Math.max(
+          1,
+          Number.parseInt(url.searchParams.get("pageSize") ?? "", 10) ||
+            DEFAULT_PAGE_SIZE,
+        ),
+      );
+      return NextResponse.json({
+        data: [],
+        total: 0,
+        page: emptyPage,
+        pageSize: emptyPageSize,
+      });
+    }
 
     // ── Parse pagination ──────────────────────────────────────────
 
@@ -170,6 +212,19 @@ export const GET = withAuth(
       }
       conditions.push(`correlation_id = $${idx++}`);
       params.push(correlationId);
+    }
+
+    // ── Customer scope predicate ──────────────────────────────────
+    //
+    // Restricted callers (`!isAdmin`) get an explicit
+    // `customer_id IN ($N, ...)` predicate. Rows with
+    // `customer_id IS NULL` (audit-agnostic events such as
+    // `account.login`) are intentionally excluded — surfacing them
+    // to a restricted viewer is out of scope for this issue.
+    if (!isAdmin) {
+      const placeholders = allowedCustomerIds.map(() => `$${idx++}`).join(", ");
+      conditions.push(`customer_id IN (${placeholders})`);
+      params.push(...allowedCustomerIds);
     }
 
     // ── Execute queries ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

`/api/audit-logs` was gated by the `audit-logs:read` permission but did not filter results by the caller's effective customer scope. A restricted holder of `audit-logs:read` could read audit rows attributed to customers outside their scope — a project principle 3 (customer isolation) violation.

After the permission check, the route now branches on two independent signals:

- **`isAdmin`** (from `customers:access-all`) — only this branch omits the `customer_id` predicate, so admins still see rows where `customer_id IS NULL`.
- **`allowedCustomerIds`** (from `resolveEffectiveCustomerIds`) — predicate values for non-admin callers. A non-admin assigned to every customer still receives the explicit `customer_id IN (...)` filter so that audit-agnostic NULL-customer rows do not leak via the admin-only "no predicate" path.

Empty-scope non-admins receive an empty result set (not the admin fallback). The total-count query uses the same predicate so `total` matches the visible page.

No detail/single-row endpoint exists under `/api/audit-logs/[id]`, so that part of the issue is N/A.

Integration tests added under `src/__integration__/api/audit-logs.test.ts` cover the four required scenarios plus the all-assigned-non-admin distinction case.

Closes #386

## Test plan

- [x] `pnpm tsc --noEmit`
- [x] `pnpm biome check`
- [x] `pnpm test` — including new `audit-logs.test.ts`:
  - [x] `account-A` GET `/api/audit-logs` returns only customer-A rows; `total` matches
  - [x] `account-B` GET `/api/audit-logs` returns only customer-B rows
  - [x] `admin` GET `/api/audit-logs` returns all rows including the `customer_id IS NULL` row
  - [x] Empty-scope account GET returns `{ data: [], total: 0 }`
  - [x] All-customers-assigned non-admin still excludes `customer_id IS NULL` rows (predicate-applied, not bypassed)
- [x] `pnpm build`