### PR TITLE
Cross-customer hardening sweep: audit customerId, scope guards, redaction helper (#387)

### DIFF
--- a/migrations/auth/0027_apply_attempts_customer_id.sql
+++ b/migrations/auth/0027_apply_attempts_customer_id.sql
@@ -1,0 +1,27 @@
+-- Cross-customer hardening (#387): persist the apply-attempt's owning
+-- customer id on the row so the `node.apply` audit emission can populate
+-- `audit_logs.customer_id`.
+--
+-- Background. The audit-log viewer (#386) scopes rows by
+-- `audit_logs.customer_id IN (caller's effective customer scope)`. A
+-- `node.apply` row written with `customer_id = NULL` is invisible to the
+-- restricted operator who actually owns the customer that ran the
+-- apply. The wrapper at `src/lib/node/apply-actions.ts` (synchronous
+-- emission) and the recovery sweep at
+-- `src/lib/node/apply-attempt-cleanup.ts:recoverPendingNodeApplyAudits`
+-- (post-success backfill) both need to populate `customerId`, but
+-- neither code path holds the customer id directly — only the canonical
+-- node read inside `createApplyAttempt` does.
+--
+-- Persisting the customer id on the attempt row at creation time lets
+-- both emitters read it back without re-reading the manager DB. The
+-- column is NULL-able because a globally-scoped caller may create an
+-- attempt against a node that carries no `customerId` on either profile
+-- — `enforceNodeScope` already permits that path. For those rows the
+-- audit emission stays `customer_id = NULL`, which matches the
+-- semantics: there is no owning customer to scope against.
+--
+-- Idempotent: safe to re-run.
+
+ALTER TABLE apply_attempts
+  ADD COLUMN IF NOT EXISTS customer_id INTEGER;

--- a/src/__tests__/app/api/accounts/[id]/customers/[customerId]/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/customers/[customerId]/route.test.ts
@@ -133,6 +133,8 @@ describe("DELETE /api/accounts/[id]/customers/[customerId]", () => {
         action: "customer.unassign",
         target: "account",
         targetId: TARGET_UUID,
+        // #387: top-level customerId must be populated.
+        customerId: 1,
         details: { customerId: 1 },
       }),
     );
@@ -260,6 +262,8 @@ describe("DELETE /api/accounts/[id]/customers/[customerId]", () => {
         action: "customer.unassign",
         target: "account",
         targetId: TARGET_UUID,
+        // #387: top-level customerId must be populated.
+        customerId: 1,
         details: { customerId: 1 },
       }),
     );

--- a/src/__tests__/app/api/accounts/[id]/customers/route.test.ts
+++ b/src/__tests__/app/api/accounts/[id]/customers/route.test.ts
@@ -290,11 +290,24 @@ describe("POST /api/accounts/[id]/customers", () => {
     expect(response.status).toBe(201);
     expect(body.success).toBe(true);
     expect(body.assigned).toEqual([1, 2]);
+    // #387: one audit row per assigned customer, each carrying a
+    // top-level `customerId`, so the audit-log viewer surfaces the row
+    // to the owning tenant operator under `customer_id IN (...)` scope.
+    expect(mockAuditRecord).toHaveBeenCalledTimes(2);
     expect(mockAuditRecord).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "customer.assign",
         target: "account",
         targetId: TARGET_UUID,
+        customerId: 1,
+      }),
+    );
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.assign",
+        target: "account",
+        targetId: TARGET_UUID,
+        customerId: 2,
       }),
     );
   });
@@ -691,5 +704,44 @@ describe("POST /api/accounts/[id]/customers", () => {
     const response = await POST(request, makeContext());
 
     expect(response.status).toBe(400);
+  });
+
+  it("does not leak existence of out-of-scope customer ids via 'Customers not found' (#387)", async () => {
+    // Regression for the enumeration leak (#387 §4 / §7-2): a tenant
+    // admin without `customers:access-all` must not be able to use the
+    // existence-check error path to distinguish "exists, out of scope"
+    // (would 403 later) from "does not exist" (400 here). Both must
+    // surface as the same 403 with no id list in the body.
+    currentSession = tenantAdminSession;
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    // Account exists with a tenant-manageable role.
+    mockQuery.mockResolvedValueOnce({
+      rows: [makeAccountRoleRow(3, "Security Monitor", [])],
+    });
+    // Caller has scope on customer 1 only.
+    mockGetAccountCustomerIds.mockResolvedValue([1]);
+
+    const { POST } = await import("@/app/api/accounts/[id]/customers/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/accounts/${TARGET_UUID}/customers`,
+      {
+        method: "POST",
+        // 7 is a probe id (out of scope or non-existent — caller cannot
+        // tell from the response); 999 is a probe for a non-existent id.
+        body: JSON.stringify({ customerIds: [7, 999] }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).not.toContain("not found");
+    expect(body.error).not.toContain("999");
+    expect(body.error).not.toContain("7");
   });
 });

--- a/src/__tests__/app/api/accounts/route.test.ts
+++ b/src/__tests__/app/api/accounts/route.test.ts
@@ -865,4 +865,42 @@ describe("POST /api/accounts", () => {
     const response = await POST(request, makeContext());
     expect(response.status).toBe(403);
   });
+
+  it("does not leak existence of out-of-scope customer ids via 'Customers not found' (#387)", async () => {
+    // Regression for the enumeration leak (#387 §4 / §7-2): a tenant
+    // admin without `customers:access-all` must not be able to use the
+    // existence-check error path to distinguish "exists, out of scope"
+    // (would 403 later) from "does not exist" (400 here). Both must
+    // surface as the same 403 with no id list in the body.
+    currentSession = tenantSession;
+    const { POST } = await import("@/app/api/accounts/route");
+    // Use a role with no single-customer cap so the scope check is the
+    // first gate hit by an out-of-scope id (Security Monitor would 400
+    // earlier on the maxCustomerAssignments=1 cap).
+    mockQuery.mockResolvedValueOnce({
+      rows: [makeRoleRow(2, "Tenant Administrator", TENANT_ADMIN_PERMISSIONS)],
+      rowCount: 1,
+    });
+    // Caller has scope on customer 1 only.
+    mockGetAccountCustomerIds.mockResolvedValue([1]);
+
+    const request = new NextRequest("http://localhost:3000/api/accounts", {
+      method: "POST",
+      body: JSON.stringify({
+        username: "test",
+        displayName: "Test",
+        password: "Pass1234!",
+        roleId: 2,
+        // 999 is a probe id — caller has no scope on it, regardless of
+        // whether it exists in the customers table. The handler MUST
+        // reject before the existence check runs.
+        customerIds: [999],
+      }),
+    });
+    const response = await POST(request, makeContext());
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).not.toContain("not found");
+    expect(body.error).not.toContain("999");
+  });
 });

--- a/src/__tests__/app/api/customers/[id]/route.test.ts
+++ b/src/__tests__/app/api/customers/[id]/route.test.ts
@@ -187,6 +187,10 @@ describe("PATCH /api/customers/[id]", () => {
         action: "customer.update",
         target: "customer",
         targetId: "1",
+        // #387: top-level customerId must be populated so the audit-log
+        // viewer surfaces the row to a tenant operator under
+        // `customer_id IN (...)` scope.
+        customerId: 1,
       }),
     );
   });
@@ -342,5 +346,52 @@ describe("DELETE /api/customers/[id]", () => {
     const response = await DELETE(request, makeContext());
 
     expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when Tenant Admin deletes a customer outside their scope (#387)", async () => {
+    // Tenant admin: has customers:delete but not customers:access-all.
+    // The new scope check rejects with 404 before the linked-accounts
+    // check or any database-drop side effect runs.
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 }) // SELECT customer
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // SELECT account_customer (no link)
+
+    const { DELETE } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, makeContext());
+
+    expect(response.status).toBe(404);
+    expect(mockDropCustomerDb).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("populates customerId on the audit record (#387)", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 }) // SELECT customer
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SELECT account_customer
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // DELETE
+
+    const { DELETE } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "DELETE",
+    });
+    await DELETE(request, makeContext());
+
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.delete",
+        targetId: "1",
+        customerId: 1,
+      }),
+    );
   });
 });

--- a/src/__tests__/app/api/customers/route.test.ts
+++ b/src/__tests__/app/api/customers/route.test.ts
@@ -200,6 +200,11 @@ describe("POST /api/customers", () => {
       expect.objectContaining({
         action: "customer.create",
         target: "customer",
+        // #387: top-level customerId must be populated so the audit-log
+        // viewer surfaces the row to a tenant operator under
+        // `customer_id IN (...)` scope after the matching
+        // `account_customer` link is added.
+        customerId: sampleCustomer.id,
       }),
     );
   });

--- a/src/__tests__/components/node/apply-preview-modal.test.tsx
+++ b/src/__tests__/components/node/apply-preview-modal.test.tsx
@@ -71,6 +71,7 @@ function makeRow(
     executingLock: null,
     claimStartedAt: null,
     status,
+    customerId: 5,
   };
 }
 

--- a/src/__tests__/components/node/node-detail-dashboard.test.tsx
+++ b/src/__tests__/components/node/node-detail-dashboard.test.tsx
@@ -516,6 +516,7 @@ describe("NodeDetailDashboard — apply preview modal wiring", () => {
       executingLock: null,
       claimStartedAt: null,
       status: "failed_retryable",
+      customerId: 5,
     };
     const succeededRow: ApplyAttemptRow = {
       ...failedRow,

--- a/src/__tests__/lib/audit/customer-scope-policy.test.ts
+++ b/src/__tests__/lib/audit/customer-scope-policy.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUDIT_ACTION_CUSTOMER_SCOPE,
+  customerScopeForAction,
+  listAllAuditActions,
+} from "@/lib/audit/customer-scope-policy";
+import type { AuditAction } from "@/lib/audit/schema";
+
+/**
+ * Guard for #387 P1 finding §3 (audit-log `customer_id` mapping).
+ *
+ * The audit-log viewer (#386) scopes rows by
+ * `audit_logs.customer_id IN (caller's effective customer scope)`. A
+ * customer-scoped action emitted with `customer_id = NULL` is invisible
+ * to the tenant operator who actually owns the customer. To prevent a
+ * future PR from silently introducing a customer-scoped action without
+ * a `customerId` mapping, every `AuditAction` MUST be classified in
+ * `AUDIT_ACTION_CUSTOMER_SCOPE` as either `customer-scoped` or
+ * `customer-agnostic`. CI fails here if the schema and the policy drift.
+ */
+describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
+  it("classifies every AuditAction declared in the schema", () => {
+    const missing: AuditAction[] = [];
+    for (const action of listAllAuditActions()) {
+      if (AUDIT_ACTION_CUSTOMER_SCOPE[action] === undefined) {
+        missing.push(action);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("does not register any action that is not in the schema", () => {
+    const known = new Set<AuditAction>(listAllAuditActions());
+    const stale: string[] = [];
+    for (const action of Object.keys(AUDIT_ACTION_CUSTOMER_SCOPE)) {
+      if (!known.has(action as AuditAction)) {
+        stale.push(action);
+      }
+    }
+    expect(stale).toEqual([]);
+  });
+
+  it("uses only the two recognised classification values", () => {
+    const bad: { action: string; value: string }[] = [];
+    for (const [action, value] of Object.entries(AUDIT_ACTION_CUSTOMER_SCOPE)) {
+      if (value !== "customer-scoped" && value !== "customer-agnostic") {
+        bad.push({ action, value });
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+
+  it("flags the customer.* and node.* / service.* actions as customer-scoped", () => {
+    const expectedScoped: AuditAction[] = [
+      "customer.create",
+      "customer.update",
+      "customer.delete",
+      "customer.assign",
+      "customer.unassign",
+      "node.create",
+      "node.update",
+      "node.delete",
+      "node.restart",
+      "node.shutdown",
+      "node.apply",
+      "service.draft_save",
+      "service.set_mode",
+    ];
+    for (const action of expectedScoped) {
+      expect(customerScopeForAction(action)).toBe("customer-scoped");
+    }
+  });
+
+  it("flags every non-customer / non-node / non-service action as customer-agnostic", () => {
+    const scopedPrefixes = ["customer.", "node.", "service."];
+    for (const action of listAllAuditActions()) {
+      const isCustomerScopedPrefix = scopedPrefixes.some((p) =>
+        action.startsWith(p),
+      );
+      if (!isCustomerScopedPrefix) {
+        expect(customerScopeForAction(action)).toBe("customer-agnostic");
+      }
+    }
+  });
+});
+
+describe("customerScopeForAction — runtime guard", () => {
+  it("throws TypeError for an unregistered action string", () => {
+    expect(() =>
+      // Cast through unknown so the test exercises the runtime path.
+      customerScopeForAction("not.a.real.action" as unknown as AuditAction),
+    ).toThrow(TypeError);
+  });
+});

--- a/src/__tests__/lib/auth/scope-redaction.test.ts
+++ b/src/__tests__/lib/auth/scope-redaction.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatScopedError,
+  type Reference,
+  redactForScope,
+} from "@/lib/auth/scope-redaction";
+
+describe("formatScopedError — single customer reference", () => {
+  it("emits the literal when the referenced customer is in scope", () => {
+    const out = formatScopedError(
+      {
+        template: 'Customer "{customer}" not found',
+        references: [
+          { kind: "customer", id: 5, placeholder: "customer", literal: "Acme" },
+        ],
+      },
+      [5],
+    );
+    expect(out).toBe('Customer "Acme" not found');
+  });
+
+  it("redacts the literal when the referenced customer is out of scope", () => {
+    const out = formatScopedError(
+      {
+        template: 'Customer "{customer}" not found',
+        references: [
+          { kind: "customer", id: 7, placeholder: "customer", literal: "Acme" },
+        ],
+      },
+      [5],
+    );
+    expect(out).toBe('Customer "[redacted customer]" not found');
+  });
+
+  it("redacts when the allowed list is empty", () => {
+    const out = formatScopedError(
+      {
+        template: "missing: {customer}",
+        references: [
+          { kind: "customer", id: 5, placeholder: "customer", literal: "Acme" },
+        ],
+      },
+      [],
+    );
+    expect(out).toBe("missing: [redacted customer]");
+  });
+});
+
+describe("formatScopedError — multiple references, mixed scope", () => {
+  it("substitutes per-reference based on the allowed scope", () => {
+    const out = formatScopedError(
+      {
+        template: "Sensor {sensor} (customer {customer}) at {addr} unreachable",
+        references: [
+          {
+            kind: "sensor",
+            customerId: 5,
+            placeholder: "sensor",
+            literal: "edge-1",
+          },
+          {
+            kind: "customer",
+            id: 7,
+            placeholder: "customer",
+            literal: "Globex",
+          },
+          {
+            kind: "address",
+            customerId: 5,
+            placeholder: "addr",
+            literal: "10.0.0.1",
+          },
+        ],
+      },
+      [5],
+    );
+    expect(out).toBe(
+      "Sensor edge-1 (customer [redacted customer]) at 10.0.0.1 unreachable",
+    );
+  });
+
+  it("emits every literal when every reference is in scope", () => {
+    const out = formatScopedError(
+      {
+        template: "{a} / {b}",
+        references: [
+          { kind: "customer", id: 5, placeholder: "a", literal: "Acme" },
+          { kind: "sensor", customerId: 5, placeholder: "b", literal: "s-1" },
+        ],
+      },
+      [5, 6, 7],
+    );
+    expect(out).toBe("Acme / s-1");
+  });
+
+  it("redacts every literal when no reference is in scope", () => {
+    const out = formatScopedError(
+      {
+        template: "{a} / {b}",
+        references: [
+          { kind: "customer", id: 9, placeholder: "a", literal: "Acme" },
+          {
+            kind: "address",
+            customerId: 9,
+            placeholder: "b",
+            literal: "1.2.3.4",
+          },
+        ],
+      },
+      [5],
+    );
+    expect(out).toBe("[redacted customer] / [redacted address]");
+  });
+});
+
+describe("formatScopedError — fallback / edge cases", () => {
+  it("returns the template unchanged when references is empty", () => {
+    const out = formatScopedError(
+      { template: "no references here", references: [] },
+      [5],
+    );
+    expect(out).toBe("no references here");
+  });
+
+  it("ignores references whose placeholder is absent from the template", () => {
+    const out = formatScopedError(
+      {
+        template: "static",
+        references: [
+          { kind: "customer", id: 5, placeholder: "ghost", literal: "Acme" },
+        ],
+      },
+      [5],
+    );
+    expect(out).toBe("static");
+  });
+
+  it("substitutes every occurrence of a repeated placeholder", () => {
+    const out = formatScopedError(
+      {
+        template: "{c} and {c} again",
+        references: [
+          { kind: "customer", id: 5, placeholder: "c", literal: "Acme" },
+        ],
+      },
+      [5],
+    );
+    expect(out).toBe("Acme and Acme again");
+  });
+});
+
+describe("redactForScope — positional alias", () => {
+  it("matches formatScopedError for the same input", () => {
+    const refs: Reference[] = [
+      { kind: "customer", id: 5, placeholder: "c", literal: "Acme" },
+    ];
+    expect(redactForScope("Customer {c}", refs, [5])).toBe(
+      formatScopedError({ template: "Customer {c}", references: refs }, [5]),
+    );
+    expect(redactForScope("Customer {c}", refs, [])).toBe(
+      formatScopedError({ template: "Customer {c}", references: refs }, []),
+    );
+  });
+});

--- a/src/__tests__/lib/node/apply-actions.test.ts
+++ b/src/__tests__/lib/node/apply-actions.test.ts
@@ -124,6 +124,7 @@ function makeRow(
     claimStartedAt: null,
     status:
       status as import("@/lib/node/apply-attempt-types").ApplyAttemptStatus,
+    customerId: 5,
     ...overrides,
   };
 }
@@ -161,6 +162,7 @@ beforeEach(() => {
     executingLock: null,
     claimStartedAt: null,
     status: "pending",
+    customerId: 5,
   });
   mockGetCurrentSession.mockResolvedValue(makeSession());
   // Default: every wrapper-level canonical-node read resolves to an
@@ -390,6 +392,32 @@ describe("node.apply audit emission — exactly once per attempt that reaches su
     // `audit_logs(correlation_id) WHERE action = 'node.apply'` makes a
     // second insert for the same attempt physically impossible.
     expect(event.correlationId).toBe("att-1");
+    // #387: customerId snapshotted on the apply-attempt row is now
+    // forwarded to the audit emission so the audit-log viewer (#386)
+    // surfaces the row to the tenant operator under
+    // `audit_logs.customer_id IN (...)` scope.
+    expect(event.customerId).toBe(5);
+  });
+
+  it("omits customerId from the audit when the apply-attempt row's customer_id is NULL (#387)", async () => {
+    // A node with no `customerId` on either profile is reachable only
+    // by a globally-scoped caller (see `enforceNodeScope`). For those
+    // attempts the persisted `apply_attempts.customer_id` is NULL and
+    // the audit row's `customer_id` should stay NULL — there is no
+    // owning customer to scope against.
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([5]);
+    mockInternalConfirm.mockResolvedValue(
+      makeRow("succeeded", { customerId: null }),
+    );
+    const { confirmApplyAttempt } = await import("@/lib/node/apply-actions");
+    await confirmApplyAttempt({ attemptId: "att-1" });
+    expect(mockAuditRecord).toHaveBeenCalledTimes(1);
+    const event = mockAuditRecord.mock.calls[0][0];
+    expect(event.action).toBe("node.apply");
+    expect(
+      "customerId" in event ? event.customerId : undefined,
+    ).toBeUndefined();
   });
 
   it("does NOT emit on idempotent re-confirm of an already-succeeded row (slot already claimed)", async () => {

--- a/src/__tests__/lib/node/apply-attempt-cleanup.test.ts
+++ b/src/__tests__/lib/node/apply-attempt-cleanup.test.ts
@@ -229,6 +229,86 @@ describe("recoverPendingNodeApplyAudits", () => {
     expect(event.correlationId).toBe("att-stuck");
   });
 
+  it("forwards the persisted apply_attempts.customer_id onto the recovered audit (#387)", async () => {
+    // Recovery sweep half of #387 P1 finding §3 — the candidate SELECT
+    // must include `customer_id`, and a non-null value MUST be
+    // forwarded to `auditLog.record({ customerId })` so the
+    // audit-log viewer scopes the recovered row to the tenant operator
+    // who actually owns the customer that ran the apply.
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          attempt_id: "att-stuck",
+          node_id: "node-1",
+          audit_actor: "actor-1",
+          slot_claimed: true,
+          customer_id: 5,
+          planned_dispatches: [
+            {
+              dispatchId: "d-mgr",
+              kind: "MANAGER",
+              state: "succeeded",
+              attemptCount: 1,
+              lastError: null,
+            },
+          ],
+        },
+      ],
+      rowCount: 1,
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{}], rowCount: 1 });
+
+    const { recoverPendingNodeApplyAudits } = await import(
+      "@/lib/node/apply-attempt-cleanup"
+    );
+    await recoverPendingNodeApplyAudits();
+    const selectSql = mockQuery.mock.calls[0][0] as string;
+    expect(selectSql).toMatch(/customer_id/);
+    expect(mockAuditRecord).toHaveBeenCalledTimes(1);
+    const event = mockAuditRecord.mock.calls[0][0];
+    expect(event.customerId).toBe(5);
+  });
+
+  it("omits customerId on the recovered audit when apply_attempts.customer_id is NULL (#387)", async () => {
+    // A globally-scoped caller's attempt against a node with no
+    // `customerId` persists `customer_id = NULL`. The recovered audit
+    // event must omit `customerId` rather than send `null`/`undefined`
+    // — `audit_logs.customer_id` then stays NULL by design (no owning
+    // customer to scope against).
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          attempt_id: "att-stuck",
+          node_id: "node-1",
+          audit_actor: "actor-1",
+          slot_claimed: true,
+          customer_id: null,
+          planned_dispatches: [
+            {
+              dispatchId: "d-mgr",
+              kind: "MANAGER",
+              state: "succeeded",
+              attemptCount: 1,
+              lastError: null,
+            },
+          ],
+        },
+      ],
+      rowCount: 1,
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [{}], rowCount: 1 });
+
+    const { recoverPendingNodeApplyAudits } = await import(
+      "@/lib/node/apply-attempt-cleanup"
+    );
+    await recoverPendingNodeApplyAudits();
+    expect(mockAuditRecord).toHaveBeenCalledTimes(1);
+    const event = mockAuditRecord.mock.calls[0][0];
+    expect(
+      "customerId" in event ? event.customerId : undefined,
+    ).toBeUndefined();
+  });
+
   it("leaves the slot CLAIMED when the audit DB still rejects the insert so the next sweep can re-pick the row (round 4)", async () => {
     // Round-4 acceptance: on a non-23505 audit-DB failure during
     // recovery, the sweep MUST NOT release the slot. The candidate

--- a/src/__tests__/lib/node/apply-attempts.test.ts
+++ b/src/__tests__/lib/node/apply-attempts.test.ts
@@ -149,9 +149,13 @@ describe("createApplyAttempt — happy path", () => {
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const [sql, params] = mockQuery.mock.calls[0];
     expect(sql).toMatch(/INSERT INTO apply_attempts/);
+    expect(sql).toMatch(/customer_id/);
     expect(params?.[0]).toBe(result.attemptId);
     expect(params?.[1]).toBe("node-1");
     expect(params?.[4]).toBe("00000000-0000-0000-0000-000000000001");
+    // #387: customer_id is snapshotted from the canonical node so the
+    // node.apply audit emission can populate audit_logs.customer_id.
+    expect(params?.[5]).toBe(5);
 
     // Manager mutation MUST NOT be invoked during create.
     expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);

--- a/src/app/api/accounts/[id]/customers/[customerId]/route.ts
+++ b/src/app/api/accounts/[id]/customers/[customerId]/route.ts
@@ -91,6 +91,10 @@ export const DELETE = withAuth(
       targetId: accountId,
       ip: extractClientIp(request),
       sid: session.sessionId,
+      // Top-level `customerId` populated so the audit-log viewer (#386)
+      // surfaces this unassign to the tenant operator who owns the
+      // customer.
+      customerId,
       details: { customerId },
     });
 

--- a/src/app/api/accounts/[id]/customers/route.ts
+++ b/src/app/api/accounts/[id]/customers/route.ts
@@ -155,21 +155,12 @@ export const POST = withAuth(
       return NextResponse.json({ error: "Account not found" }, { status: 404 });
     }
 
-    // Verify all customer IDs exist
-    const { rows: existingCustomers } = await query<{ id: number }>(
-      `SELECT id FROM customers WHERE id = ANY($1)`,
-      [uniqueIds],
-    );
-    if (existingCustomers.length !== uniqueIds.length) {
-      const found = new Set(existingCustomers.map((r) => r.id));
-      const missing = uniqueIds.filter((id) => !found.has(id));
-      return NextResponse.json(
-        { error: `Customers not found: ${missing.join(", ")}` },
-        { status: 400 },
-      );
-    }
-
-    // Tenant scope: Tenant Admin can only assign their own customers
+    // Tenant scope: Tenant Admin can only assign their own customers.
+    // Run the scope check BEFORE the existence check so an out-of-scope
+    // input id is rejected at the same surface as a non-existent one —
+    // otherwise the existence-check error path leaks "exists, out of
+    // scope" vs "does not exist" to a tenant admin probing arbitrary
+    // ids (#387 P1 finding §4 / §7-2).
     const accessAll = await hasPermission(
       session.roles,
       "customers:access-all",
@@ -184,6 +175,25 @@ export const POST = withAuth(
           { status: 403 },
         );
       }
+    }
+
+    // Verify all customer IDs exist. Reachable only after the scope
+    // check above has cleared every id, so listing the missing ones is
+    // safe: an `access-all` caller already has access to the full
+    // customer list, and a tenant-scoped caller can only have reached
+    // here for ids inside their own scope (out-of-scope ids would have
+    // hit the 403 above with no enumeration distinction).
+    const { rows: existingCustomers } = await query<{ id: number }>(
+      `SELECT id FROM customers WHERE id = ANY($1)`,
+      [uniqueIds],
+    );
+    if (existingCustomers.length !== uniqueIds.length) {
+      const found = new Set(existingCustomers.map((r) => r.id));
+      const missing = uniqueIds.filter((id) => !found.has(id));
+      return NextResponse.json(
+        { error: `Customers not found: ${missing.join(", ")}` },
+        { status: 400 },
+      );
     }
 
     const targetRole = deriveAccountRolePolicy({
@@ -240,16 +250,24 @@ export const POST = withAuth(
       );
     }
 
-    // Audit
-    await auditLog.record({
-      actor: session.accountId,
-      action: "customer.assign",
-      target: "account",
-      targetId: accountId,
-      ip: extractClientIp(request),
-      sid: session.sessionId,
-      details: { customerIds: assigned },
-    });
+    // Audit. One row per assigned customer so each row carries a
+    // top-level `customerId` and is visible to the tenant operator who
+    // owns it under the audit-log viewer's `customer_id IN (...)` scope
+    // (#386). A single row with `customerIds: [...]` in `details` would
+    // be invisible to a restricted operator after #386 lands.
+    const ip = extractClientIp(request);
+    for (const assignedCustomerId of assigned) {
+      await auditLog.record({
+        actor: session.accountId,
+        action: "customer.assign",
+        target: "account",
+        targetId: accountId,
+        ip,
+        sid: session.sessionId,
+        customerId: assignedCustomerId,
+        details: { customerId: assignedCustomerId },
+      });
+    }
 
     return NextResponse.json({ success: true, assigned }, { status: 201 });
   },

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -313,7 +313,29 @@ export const POST = withAuth(
     // Deduplicate
     const uniqueCustomerIds = customerIds ? [...new Set(customerIds)] : [];
 
-    // Verify customers exist
+    // Tenant Admin scope: can only assign their own customers. Run the
+    // scope check BEFORE the existence check so an out-of-scope input
+    // id is rejected at the same surface as a non-existent one —
+    // otherwise the existence-check error path leaks "exists, out of
+    // scope" vs "does not exist" to a tenant admin probing arbitrary
+    // ids (#387 P1 finding §4 / §7-2).
+    if (!callerAccessAll && uniqueCustomerIds.length > 0) {
+      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
+      const callerSet = new Set(callerCustomerIds);
+      const outOfScope = uniqueCustomerIds.filter((id) => !callerSet.has(id));
+      if (outOfScope.length > 0) {
+        return NextResponse.json(
+          { error: "Cannot assign customers outside your scope" },
+          { status: 403 },
+        );
+      }
+    }
+
+    // Verify customers exist. Reachable only after the scope check
+    // above has cleared every id, so listing the missing ones is safe:
+    // an `access-all` caller has access to the full customer list, and
+    // a tenant-scoped caller can only have reached here for ids inside
+    // their own scope.
     if (uniqueCustomerIds.length > 0) {
       const { rows: existingCustomers } = await query<{ id: number }>(
         "SELECT id FROM customers WHERE id = ANY($1)",
@@ -325,19 +347,6 @@ export const POST = withAuth(
         return NextResponse.json(
           { error: `Customers not found: ${missing.join(", ")}` },
           { status: 400 },
-        );
-      }
-    }
-
-    // Tenant Admin scope: can only assign their own customers
-    if (!callerAccessAll && uniqueCustomerIds.length > 0) {
-      const callerCustomerIds = await getAccountCustomerIds(session.accountId);
-      const callerSet = new Set(callerCustomerIds);
-      const outOfScope = uniqueCustomerIds.filter((id) => !callerSet.has(id));
-      if (outOfScope.length > 0) {
-        return NextResponse.json(
-          { error: "Cannot assign customers outside your scope" },
-          { status: 403 },
         );
       }
     }

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -181,6 +181,9 @@ export const PATCH = withAuth(
       targetId: String(customerId),
       ip: extractClientIp(request),
       sid: session.sessionId,
+      // Top-level `customerId` populated so the audit-log viewer (#386)
+      // surfaces the row to the tenant operator who owns this customer.
+      customerId,
       details: {
         ...(name !== undefined && { name: name.trim() }),
         ...(description !== undefined && {
@@ -228,6 +231,26 @@ export const DELETE = withAuth(
 
     const customer = rows[0];
 
+    // Tenant scope check — mirrors GET / PATCH on the same resource. A
+    // non-`access-all` caller with `customers:delete` must not be able
+    // to drop a customer outside their scope.
+    const accessAll = await hasPermission(
+      session.roles,
+      "customers:access-all",
+    );
+    if (!accessAll) {
+      const { rows: scopeRows } = await query<{ customer_id: number }>(
+        "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+        [session.accountId, customerId],
+      );
+      if (scopeRows.length === 0) {
+        return NextResponse.json(
+          { error: "Customer not found" },
+          { status: 404 },
+        );
+      }
+    }
+
     // Check for linked accounts
     const { rows: linkRows } = await query<{ customer_id: number }>(
       "SELECT customer_id FROM account_customer WHERE customer_id = $1 LIMIT 1",
@@ -252,6 +275,11 @@ export const DELETE = withAuth(
       targetId: String(customerId),
       ip: extractClientIp(request),
       sid: session.sessionId,
+      // Top-level `customerId` populated so the audit-log viewer (#386)
+      // surfaces this delete to the tenant operator who owned the
+      // customer (now removed). Without it the row is invisible under a
+      // `customer_id IN (...)` predicate.
+      customerId,
       details: { name: customer.name, databaseName: customer.database_name },
     });
 

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -150,6 +150,10 @@ export const POST = withAuth(
       targetId: String(customer.id),
       ip: extractClientIp(request),
       sid: session.sessionId,
+      // Top-level `customerId` populated so the audit-log viewer (#386)
+      // surfaces this create to a tenant operator after the matching
+      // `account_customer` link is added.
+      customerId: customer.id,
       details: { name, databaseName },
     });
 

--- a/src/lib/audit/customer-scope-policy.ts
+++ b/src/lib/audit/customer-scope-policy.ts
@@ -1,0 +1,111 @@
+import type { AuditAction } from "@/lib/audit/schema";
+import { AUDIT_ACTIONS } from "@/lib/audit/schema";
+
+/**
+ * Customer-scope classification of every `AuditAction`.
+ *
+ * - `customer-scoped` — the action concerns a specific customer; the
+ *   call site MUST populate `customerId` on the audit event so the
+ *   audit-log viewer (#386) surfaces the row to a tenant operator under
+ *   the `audit_logs.customer_id IN (...)` predicate.
+ * - `customer-agnostic` — the action targets account / session / role /
+ *   MFA / system-settings state that has no `customer_id` axis. The
+ *   call site intentionally omits `customerId`.
+ *
+ * The map is exhaustive: every member of `AuditAction` MUST appear here.
+ * The accompanying test
+ * (`src/__tests__/lib/audit/customer-scope-policy.test.ts`) fails CI if
+ * a new `AuditAction` is added without an explicit classification, so a
+ * future PR cannot silently introduce a customer-scoped action that
+ * records `customer_id: null`.
+ */
+export const AUDIT_ACTION_CUSTOMER_SCOPE: {
+  readonly [A in AuditAction]: "customer-scoped" | "customer-agnostic";
+} = {
+  // Auth — session / credential surface (no per-customer axis).
+  "auth.sign_in.success": "customer-agnostic",
+  "auth.sign_in.failure": "customer-agnostic",
+  "auth.sign_out": "customer-agnostic",
+  "session.ip_mismatch": "customer-agnostic",
+  "session.ua_mismatch": "customer-agnostic",
+  "session.revoke": "customer-agnostic",
+  "session.reauth_success": "customer-agnostic",
+  "session.reauth_failure": "customer-agnostic",
+  "session.idle_timeout": "customer-agnostic",
+  "session.absolute_timeout": "customer-agnostic",
+  // Account axis — tenant overlap is enforced on the *account*, not on
+  // a customer; the audit row carries no `customer_id`.
+  "account.create": "customer-agnostic",
+  "account.update": "customer-agnostic",
+  "account.delete": "customer-agnostic",
+  "account.lock": "customer-agnostic",
+  "account.unlock": "customer-agnostic",
+  "account.suspend": "customer-agnostic",
+  "account.restore": "customer-agnostic",
+  "password.change": "customer-agnostic",
+  "password.reset": "customer-agnostic",
+  // Customer axis — the row IS scoped to a specific customer; emitter
+  // MUST populate `customerId`.
+  "customer.create": "customer-scoped",
+  "customer.update": "customer-scoped",
+  "customer.delete": "customer-scoped",
+  "customer.assign": "customer-scoped",
+  "customer.unassign": "customer-scoped",
+  // System-wide config / role admin — no per-customer axis.
+  "system_settings.update": "customer-agnostic",
+  "role.create": "customer-agnostic",
+  "role.update": "customer-agnostic",
+  "role.delete": "customer-agnostic",
+  // MFA — self-service / break-glass / admin reset; account-axis only.
+  "mfa.totp.enroll": "customer-agnostic",
+  "mfa.totp.remove": "customer-agnostic",
+  "mfa.totp.verify.success": "customer-agnostic",
+  "mfa.totp.verify.failure": "customer-agnostic",
+  "mfa.webauthn.register": "customer-agnostic",
+  "mfa.webauthn.remove": "customer-agnostic",
+  "mfa.webauthn.verify.success": "customer-agnostic",
+  "mfa.webauthn.verify.failure": "customer-agnostic",
+  "mfa.recovery.generate": "customer-agnostic",
+  "mfa.recovery.use": "customer-agnostic",
+  "mfa.enforcement.blocked": "customer-agnostic",
+  "mfa.enrollment.complete": "customer-agnostic",
+  "mfa.admin.reset": "customer-agnostic",
+  "mfa.emergency.reset": "customer-agnostic",
+  // Node / service axis — bound to a customer via the node's
+  // `customerId`. Emitter MUST populate `customerId` on the audit
+  // event (resolved from the canonical node or the persisted
+  // `apply_attempts.customer_id` snapshot).
+  "node.create": "customer-scoped",
+  "node.update": "customer-scoped",
+  "node.delete": "customer-scoped",
+  "node.restart": "customer-scoped",
+  "node.shutdown": "customer-scoped",
+  "node.apply": "customer-scoped",
+  "service.draft_save": "customer-scoped",
+  "service.set_mode": "customer-scoped",
+};
+
+/**
+ * Returns the customer-scope classification for an audit action.
+ * Throws `TypeError` if the action is not registered — call this from
+ * code paths that want a runtime guard rather than a compile-time one.
+ */
+export function customerScopeForAction(
+  action: AuditAction,
+): "customer-scoped" | "customer-agnostic" {
+  const classification = AUDIT_ACTION_CUSTOMER_SCOPE[action];
+  if (!classification) {
+    throw new TypeError(
+      `Unregistered audit action: ${action}. Add an entry to AUDIT_ACTION_CUSTOMER_SCOPE.`,
+    );
+  }
+  return classification;
+}
+
+/**
+ * Used by the test guard to enumerate every action declared in the
+ * schema and assert one-to-one coverage with the policy map.
+ */
+export function listAllAuditActions(): readonly AuditAction[] {
+  return AUDIT_ACTIONS;
+}

--- a/src/lib/auth/scope-redaction.ts
+++ b/src/lib/auth/scope-redaction.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+/**
+ * Scope-aware error / log message helper (#387).
+ *
+ * The umbrella's principle is that an account restricted to a subset of
+ * customers must not reach any path — UI, API, log, error message — that
+ * exposes information about a customer outside that subset. Naive string
+ * redaction (`message.replace(...)`) cannot honour this contract: the
+ * helper has no way to know which substring is a customer name vs a
+ * sensor name vs an unrelated word. The structured form below pushes the
+ * decision back to the call site: each interpolated identifier is
+ * declared as a `Reference` carrying both its kind (`customer`,
+ * `sensor`, or `address`) and the customer it belongs to. The helper
+ * substitutes the literal value when the caller has scope on the
+ * referenced customer, and replaces it with a generic stand-in
+ * otherwise.
+ *
+ * Call-site pattern (mechanical refactor of an embedded literal):
+ *
+ *     // Before (literal embedded in the format string — cannot be
+ *     // redacted without parsing the string):
+ *     return `Customer "${name}" not found`;
+ *
+ *     // After (template + structured references):
+ *     return formatScopedError(
+ *       {
+ *         template: 'Customer "{customer}" not found',
+ *         references: [
+ *           { kind: "customer", id, placeholder: "customer", literal: name },
+ *         ],
+ *       },
+ *       allowedCustomerIds,
+ *     );
+ *
+ * The helper is deterministic and side-effect-free. It does not consult
+ * the request context — every input is explicit.
+ */
+
+export type Reference =
+  | {
+      kind: "customer";
+      id: number;
+      placeholder: string;
+      literal: string;
+    }
+  | {
+      kind: "sensor";
+      customerId: number;
+      placeholder: string;
+      literal: string;
+    }
+  | {
+      kind: "address";
+      customerId: number;
+      placeholder: string;
+      literal: string;
+    };
+
+export interface ScopedMessage {
+  /** Template string with `{placeholder}` markers. */
+  template: string;
+  /** Structured references, one per `{placeholder}` in the template. */
+  references: readonly Reference[];
+}
+
+const REDACTED_BY_KIND = {
+  customer: "[redacted customer]",
+  sensor: "[redacted sensor]",
+  address: "[redacted address]",
+} as const;
+
+function customerOf(ref: Reference): number {
+  return ref.kind === "customer" ? ref.id : ref.customerId;
+}
+
+/**
+ * Substitute every `{placeholder}` in `template` using `references`.
+ *
+ * For each reference, the literal value is emitted iff the referenced
+ * customer is present in `allowedCustomerIds`. Otherwise a kind-specific
+ * stand-in (`[redacted customer]`, `[redacted sensor]`, `[redacted
+ * address]`) is emitted in its place.
+ *
+ * Templates with no references degrade to a plain `template` (no
+ * substitution work). A reference whose `placeholder` does not appear in
+ * the template is silently ignored — the call site is responsible for
+ * keeping the two in sync, but a stale reference is harmless.
+ */
+export function formatScopedError(
+  message: ScopedMessage,
+  allowedCustomerIds: readonly number[],
+): string {
+  if (message.references.length === 0) return message.template;
+  const allowed = new Set(allowedCustomerIds);
+  let out = message.template;
+  for (const ref of message.references) {
+    const value = allowed.has(customerOf(ref))
+      ? ref.literal
+      : REDACTED_BY_KIND[ref.kind];
+    out = out.replaceAll(`{${ref.placeholder}}`, value);
+  }
+  return out;
+}
+
+/**
+ * Thin alias kept for callers that prefer a positional signature
+ * (`message, references, allowedCustomerIds`) over the object form.
+ * Behaviour is identical to `formatScopedError`.
+ */
+export function redactForScope(
+  template: string,
+  references: readonly Reference[],
+  allowedCustomerIds: readonly number[],
+): string {
+  return formatScopedError({ template, references }, allowedCustomerIds);
+}

--- a/src/lib/node/apply-actions.ts
+++ b/src/lib/node/apply-actions.ts
@@ -344,6 +344,10 @@ async function maybeEmitNodeApplyAudit(
       targetId: result.nodeId,
       details: { appliedServices },
       sid: session.sessionId,
+      // Pulled from `apply_attempts.customer_id`, snapshotted at attempt
+      // creation. NULL is permitted and intentional for nodes that
+      // carry no `customerId` (only globally-scoped callers reach those).
+      ...(result.customerId !== null && { customerId: result.customerId }),
       // Stable per-attempt key. Used by the partial unique index on
       // `audit_logs` (Layer A above) to make a second insert for the
       // same attempt physically impossible.

--- a/src/lib/node/apply-attempt-cleanup.ts
+++ b/src/lib/node/apply-attempt-cleanup.ts
@@ -107,6 +107,7 @@ interface RawAttemptRow {
   executing_lock: string | null;
   claim_started_at: Date | null;
   status: ApplyAttemptStatus;
+  customer_id: number | null;
 }
 
 function rowFromDb(raw: RawAttemptRow): ApplyAttemptRow {
@@ -121,6 +122,7 @@ function rowFromDb(raw: RawAttemptRow): ApplyAttemptRow {
     executingLock: raw.executing_lock,
     claimStartedAt: raw.claim_started_at,
     status: raw.status,
+    customerId: raw.customer_id,
   };
 }
 
@@ -445,7 +447,8 @@ export async function readApplyAttempt(
       expires_at,
       executing_lock,
       claim_started_at,
-      status
+      status,
+      customer_id
     FROM apply_attempts
     WHERE attempt_id = $1
   `;
@@ -606,6 +609,7 @@ interface PendingAuditRecoveryRow {
   audit_actor: string;
   planned_dispatches: PlannedDispatch[];
   slot_claimed: boolean;
+  customer_id: number | null;
 }
 
 /**
@@ -702,7 +706,8 @@ export async function recoverPendingNodeApplyAudits(): Promise<number> {
       node_id,
       audit_actor,
       planned_dispatches,
-      (succeeded_audit_emitted_at IS NOT NULL) AS slot_claimed
+      (succeeded_audit_emitted_at IS NOT NULL) AS slot_claimed,
+      customer_id
     FROM apply_attempts
     WHERE status = 'succeeded'
       AND succeeded_audit_completed_at IS NULL
@@ -741,6 +746,11 @@ export async function recoverPendingNodeApplyAudits(): Promise<number> {
         target: "node",
         targetId: row.node_id,
         details: { appliedServices },
+        // Pulled from `apply_attempts.customer_id`, snapshotted at
+        // attempt creation. NULL is permitted and intentional for nodes
+        // that carry no `customerId` (only globally-scoped callers
+        // reach those — there is no owning customer to scope against).
+        ...(row.customer_id !== null && { customerId: row.customer_id }),
         correlationId: row.attempt_id,
       });
     } catch (err) {

--- a/src/lib/node/apply-attempt-types.ts
+++ b/src/lib/node/apply-attempt-types.ts
@@ -91,6 +91,15 @@ export interface ApplyAttemptRow {
   executingLock: string | null;
   claimStartedAt: Date | null;
   status: ApplyAttemptStatus;
+  /**
+   * Owning customer id snapshotted at attempt-creation time. NULL only
+   * for nodes that carry no `customerId` on either profile — reachable
+   * exclusively by globally-scoped callers (see `enforceNodeScope`).
+   * Read by both audit emitters so `node.apply` rows populate
+   * `audit_logs.customer_id` and remain visible to a tenant-scoped
+   * audit-log viewer.
+   */
+  customerId: number | null;
 }
 
 /**

--- a/src/lib/node/apply-attempts.ts
+++ b/src/lib/node/apply-attempts.ts
@@ -133,6 +133,17 @@ export async function createApplyAttempt(
   const fingerprint = computeDraftFingerprint(snapshot);
   const ttlMs = getAttemptTtlMs();
 
+  // Resolve the node's owning customer id once, here, so the
+  // synchronous wrapper emission and the recovery sweep both populate
+  // `audit_logs.customer_id` for the eventual `node.apply` audit
+  // without re-reading the manager DB. NULL is permitted: a node that
+  // carries no `customerId` on either profile is reachable only by a
+  // globally-scoped caller (see `enforceNodeScope`); for that case the
+  // audit row's `customer_id` stays NULL by design.
+  const rawCustomerId =
+    node.profile?.customerId ?? node.profileDraft?.customerId;
+  const customerId = rawCustomerId === undefined ? null : Number(rawCustomerId);
+
   const attemptId = randomUUID();
   // `audit_actor` is a non-cascading snapshot of the creator's id
   // (round 8). The audit-recovery sweep reads it for the `node.apply`
@@ -150,6 +161,7 @@ export async function createApplyAttempt(
       planned_dispatches,
       created_by,
       audit_actor,
+      customer_id,
       expires_at,
       status
     )
@@ -160,7 +172,8 @@ export async function createApplyAttempt(
       $4::jsonb,
       $5,
       $5,
-      NOW() + ($6 || ' milliseconds')::interval,
+      $6,
+      NOW() + ($7 || ' milliseconds')::interval,
       'pending'
     )
     RETURNING created_at, expires_at
@@ -171,6 +184,7 @@ export async function createApplyAttempt(
       fingerprint.bytes,
       JSON.stringify(plannedDispatches),
       session.accountId,
+      customerId,
       String(ttlMs),
     ],
   );


### PR DESCRIPTION
## Summary

Hardening sweep that closes every P1 finding from the cross-customer isolation gap report (#385). Three categories addressed:

1. **Audit-log `customerId` call-site gaps** — populated on every customer-scoped emission so the audit-log viewer (#386) surfaces rows under `audit_logs.customer_id IN (...)` to the tenant operator who owns the data.
2. **DB query / handler scoping gaps** — added the missing tenant-scope check to `DELETE /api/customers/[id]`, and snapshotted the apply-attempt's owning customer id on the row so both `node.apply` audit emitters can populate `customer_id`.
3. **Error-message redaction infrastructure** — shipped `formatScopedError` / `redactForScope` (structured-reference API), and dropped the customer-id enumeration leak in the `/api/accounts*` "Customers not found" error path by reordering the scope check ahead of the existence check.

A fail-closed test guard (`AUDIT_ACTION_CUSTOMER_SCOPE`) prevents a future PR from silently introducing a customer-scoped action without a `customerId` mapping.

Closes #387

## Mapping: gap-report findings → fixes

| # | Finding (from #385 §7) | Fix |
|---|---|---|
| §2 (P1) | `Customers not found: <ids>` enumeration leak | `src/app/api/accounts/route.ts`, `src/app/api/accounts/[id]/customers/route.ts` — reorder so the tenant-scope check runs first and a generic 403 fires before the existence check; existing 400 with the missing-id list runs only on ids the caller already has scope on. |
| §3 (P1) | `node.apply` audit missing `customerId` (wrapper + recovery sweep) | New `apply_attempts.customer_id` column (migration 0027) snapshotted at attempt creation in `src/lib/node/apply-attempts.ts`. Both emitters (`src/lib/node/apply-actions.ts`, `src/lib/node/apply-attempt-cleanup.ts`) read the snapshot back and forward it on the audit event. NULL is preserved for nodes without a `customerId` (only globally-scoped callers reach those). |
| §4 (P1) | `customer.{assign,unassign}` audit missing `customerId` | `src/app/api/accounts/[id]/customers/route.ts`, `src/app/api/accounts/[id]/customers/[customerId]/route.ts` — populate `customerId`; for the bulk `customer.assign` case, emit one audit row per assigned customer id instead of a single row with a list in `details`. |
| §5 (P1) | `customer.{create,update,delete}` audit missing `customerId` | `src/app/api/customers/route.ts`, `src/app/api/customers/[id]/route.ts` — populate `customerId` on the audit event. |
| §6 (P1) | `DELETE /api/customers/[id]` missing caller-scope check | `src/app/api/customers/[id]/route.ts` — mirror the GET / PATCH guard (`customers:access-all` OR `account_customer` JOIN) before the linked-accounts check, returning 404 on out-of-scope. |

## Audit-action customer-scope policy guard

`src/lib/audit/customer-scope-policy.ts` defines `AUDIT_ACTION_CUSTOMER_SCOPE`, an exhaustive map from every `AuditAction` to either `customer-scoped` or `customer-agnostic`. Test `src/__tests__/lib/audit/customer-scope-policy.test.ts` fails CI if a new `AuditAction` is added without an explicit classification.

## `redactForScope` / `formatScopedError`

`src/lib/auth/scope-redaction.ts` ships the structured-reference helper described in the issue. Tests cover single / multiple references, mixed in-scope / out-of-scope, no-op on empty references, and the positional alias.

The single P1 string-leak finding (`Customers not found: <ids>`) is closed structurally (reorder scope check ahead of existence check), so no call sites adopt the helper in this PR. The helper is in place for future call-site adoption (e.g. node / sensor error paths once those gain a customer-scope axis).

## Not addressed

- **P0 finding §1** — `/api/audit-logs` viewer leak. Owned by #386, already merged separately on this branch's history (`6394805 Scope /api/audit-logs to caller customer set`). No action under #387 per the issue's non-goals.
- **P2 findings §7–§10** — client-side cache scope keys (Detection analytics, Detection tabs `sessionStorage`, sensor drawer cache, nodes status polling). Deferred to #393 per the gap report's recommendation: each is conditional on confirming the scope-change-without-reload pathway exists.
- **Integration-test matrix** — explicit non-goal of #387; tracked separately under the regression-guards sub-issue.
- **Static dispatch-context guard** — explicit non-goal of #387; tracked separately.
- **Detection BFF intersection check (#384)** — separate sub-issue.

## Test plan

- [x] `pnpm test` (2655 tests pass)
- [x] `pnpm typecheck` (clean)
- [x] `pnpm check` (biome clean)
- [x] `pnpm build` (success)
- [x] Tenant admin without `customers:access-all` cannot enumerate out-of-scope customer ids via `POST /api/accounts` or `POST /api/accounts/[id]/customers` — both return 403 without an id list. Verified by `src/__tests__/app/api/accounts/route.test.ts` and `src/__tests__/app/api/accounts/[id]/customers/route.test.ts` (`does not leak existence of out-of-scope customer ids via 'Customers not found' (#387)`).
- [x] Tenant admin without `customers:access-all` receives 404 (not destructive 200) on `DELETE /api/customers/[id]` for an out-of-scope customer; no audit row is written and the customer DB is not dropped. Verified by `src/__tests__/app/api/customers/[id]/route.test.ts` (`returns 404 when Tenant Admin deletes a customer outside their scope (#387)`).
- [x] After migration 0027, a successful `node.apply` writes `audit_logs.customer_id` with the owning customer's id. Verified by `src/__tests__/lib/node/apply-actions.test.ts` (`emits node.apply once when confirmApplyAttempt drives the row from pending → succeeded` asserts `event.customerId` matches the snapshotted `apply_attempts.customer_id`); NULL case covered by the sibling `omits customerId from the audit when the apply-attempt row's customer_id is NULL (#387)` test.
- [x] Recovery sweep (`recoverPendingNodeApplyAudits`) on a stuck row also forwards `customer_id` to the recovered audit event. Verified by `src/__tests__/lib/node/apply-attempt-cleanup.test.ts` (`forwards the persisted apply_attempts.customer_id onto the recovered audit (#387)` and the NULL counterpart).
- [x] `customer.{create,update,delete,assign,unassign}` audit rows all carry `customer_id` matching the affected customer; the bulk-assign case writes one row per assigned customer. Verified by `src/__tests__/app/api/customers/route.test.ts`, `src/__tests__/app/api/customers/[id]/route.test.ts` (`populates customerId on the audit record (#387)`), `src/__tests__/app/api/accounts/[id]/customers/route.test.ts` (one row per assigned id with top-level `customerId`), and `src/__tests__/app/api/accounts/[id]/customers/[customerId]/route.test.ts`.

