### PR TITLE
Install cross-customer isolation regression guards (#388)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           version: 2.4.12
       - run: pnpm check
+      - run: pnpm check:scope
       - run: pnpm typecheck
       - uses: DavidAnson/markdownlint-cli2-action@v23
       - uses: hadolint/hadolint-action@v3.3.0

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -390,13 +390,30 @@ verify that the dispatch context flows into the specific call
 site, only that the symbol is in scope. Deeper correctness still
 relies on code review.
 
-The script strips comments and string literals before applying the
-call and presence regexes, so a commented-out
-`import { buildDispatchContext } from "..."` does NOT satisfy the
-presence requirement, and a commented-out call does NOT count as a
-real call. Call detection runs against the whole comment-stripped
-source so a call split across lines (e.g.
-`return graphqlRequest\n  (QUERY, ...)`) is still recognized.
+The script strips line/block comments AND the contents of string
+literals (single-quoted, double-quoted, and template-string) before
+applying the call and presence regexes, so:
+
+- A commented-out `import { buildDispatchContext } from "..."` does
+  NOT satisfy the presence requirement.
+- A commented-out call does NOT count as a real call.
+- A string literal that happens to contain
+  `import { buildDispatchContext } ...` (e.g. an error message,
+  log line, or fixture) does NOT satisfy the presence requirement
+  either, and a string literal containing `graphqlRequest(...)`
+  does NOT trigger a violation.
+
+Call detection runs against the whole stripped source so a call
+split across lines (e.g. `return graphqlRequest\n  (QUERY, ...)`) is
+still recognized. Newlines are preserved by the stripper so reported
+line numbers stay aligned with the original source. Template-literal
+interpolation expressions (`${...}`) are not parsed back out — a real
+call buried inside `${...}` is missed and an
+`import { buildDispatchContext }` substring inside `${...}` does not
+satisfy the presence check either. Both edges are pathological in
+real source, and the file-level allowlist still catches the only
+meaningful regression: a brand-new server action outside
+`src/lib/{node,detection}` that calls `graphqlRequest`.
 
 To allow a deliberate exception, append an override comment to any
 line of the call expression (start through the opening paren):

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -458,7 +458,12 @@ assertions for its `expects` mode:
 - `200-on-in-scope-404-on-out-of-scope` — account-A's GET on
   customer A returns 200; account-A's GET on customer B returns
   404 (NOT 403 — surfacing 403 would disclose existence); admin gets
-  200 on both.
+  200 on both. An optional `inScopeBodyAssertion` callback runs
+  against the parsed JSON body of every in-scope GET — use it for
+  routes that return a list under a parent path (e.g.
+  `GET /api/accounts/[id]/customers`) so the regression guard
+  actually pins the returned data to the persona's customer rather
+  than only asserting that the path is reachable.
 - `mutation-scope` (POST / PATCH / DELETE) — each persona slot
   declares an optional `inScope` and `outOfScope` variant. The
   harness fires only the variants that are defined and asserts the
@@ -505,23 +510,25 @@ assertions for its `expects` mode:
     customer. The `outOfScope` 404 is the regression-meaningful
     assertion for tenants; the admin in-scope variant covers the
     success path against an orphan customer.
-- `admin-only` — account-A and account-B are rejected (default
-  `nonAdminStatuses: [401, 403]`); admin succeeds with the row's
-  declared `adminSuccessStatus`. Reserve this mode for routes that
-  have **no** tenant-scope branch at all (e.g. `POST /api/customers`
-  — there is no customer to be in/out of scope of). For routes that
-  do have a scope branch but only allow elevated callers to reach
-  it, use `mutation-scope` with `personaUsernames` so the regression
-  guard actually exercises the scope check.
+Routes whose only tenant gate is a permission check with **no**
+per-customer scope branch (e.g. `POST /api/customers`, which only
+needs `customers:write`) are intentionally NOT in this matrix.
+Any holder of the required permission — admin or a tenant-
+administrator-style manager — can hit the success path, so there
+is no cross-customer contract to assert. Permission-gate coverage
+for those routes lives in the route's own integration suite, not
+in this scope guard. Modeling them here would teach future authors
+that the route is "admin-only" when in fact the matrix's manager
+personas would also succeed.
 
 **Adding a new customer-scoped endpoint is a one-line change** to
 `ENDPOINTS`. Pick the appropriate `expects` mode, fill in the
 `name`, `method`, and the mode-specific fields (`path` for
-`list-scoped`, `pathFor` for detail GETs, `request` for mutations
-and admin-only routes), and the harness iterates and asserts
-automatically. If the new endpoint needs a fixture row that is not
-in `Resources`, extend `Resources` and the `beforeAll` seeder;
-otherwise the row alone is enough.
+`list-scoped`, `pathFor` for detail GETs, `request` for mutations),
+and the harness iterates and asserts automatically. If the new
+endpoint needs a fixture row that is not in `Resources`, extend
+`Resources` and the `beforeAll` seeder; otherwise the row alone
+is enough.
 
 Routes that go through `buildDispatchContext` (the node /
 detection API surface backed by REview / Tivan over GraphQL) are

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -345,11 +345,31 @@ sees those rows, restricted callers do not.
 ### Error-message contract
 
 When an error message references a customer identifier the caller
-may not have scope on, redact via
-`redactForScope(customerId, ctx)` before surfacing it. Out-of-scope
-resources should return `404` (not `403`) — anything else discloses
-existence. Internal logs may name the id; the response body must
-not.
+may not have scope on, redact it before surfacing. Use
+`formatScopedError({ template, references }, allowedCustomerIds)`
+from `src/lib/auth/scope-redaction.ts` (or its positional alias
+`redactForScope(template, references, allowedCustomerIds)`). Each
+interpolated identifier is declared as a structured `Reference`
+carrying its kind (`customer` / `sensor` / `address`) and the
+customer it belongs to; the helper substitutes the literal value
+when the caller has scope and replaces it with a generic stand-in
+(`[redacted customer]`, etc.) otherwise:
+
+```ts
+return formatScopedError(
+  {
+    template: 'Customer "{customer}" not found',
+    references: [
+      { kind: "customer", id, placeholder: "customer", literal: name },
+    ],
+  },
+  allowedCustomerIds,
+);
+```
+
+Out-of-scope resources should return `404` (not `403`) — anything
+else discloses existence. Internal logs may name the id; the
+response body must not.
 
 ### Static dispatch-context guard (`pnpm check:scope`)
 
@@ -390,26 +410,53 @@ endpoint against three personas: `account-A`, `account-B`, and
 `admin`. Every row in the `ENDPOINTS` array runs the standard
 assertions for its `expects` mode:
 
-- `list-scoped` — account-A's list contains only customer-A rows;
-  account-B's contains only customer-B rows; admin sees both plus
-  any null-customer fixture rows.
+- `list-scoped` — account-A's list contains the customer-A fixture
+  row and excludes the customer-B row; account-B mirrors that on
+  customer B; admin sees both plus any null-customer fixture rows.
+  When the row payload exposes a single `customer_id` field the
+  harness also asserts every row matches the caller's customer; rows
+  that don't expose one (e.g. accounts list — membership is N:N via
+  `account_customer`) skip the per-row check via
+  `rowCustomerId: () => undefined`.
 - `200-on-in-scope-404-on-out-of-scope` — account-A's GET on
   customer A returns 200; account-A's GET on customer B returns
-  404 (NOT 403); admin gets 200 on both.
-- `admin-only` — non-admin returns 404; admin returns 200.
+  404 (NOT 403 — surfacing 403 would disclose existence); admin gets
+  200 on both.
+- `mutation-scope` (POST / PATCH / DELETE) — for each persona the row
+  declares an in-scope and out-of-scope variant of the request body
+  / path; the harness fires both and asserts the declared
+  `expectStatus` (typically 2xx in-scope, 403 out-of-scope for non-
+  admins; 2xx for both for admin). An optional
+  `cleanupAfterSuccess` hook resets fixture state between mutation
+  rows so the matrix can run repeatedly against a long-lived dev
+  database.
+- `admin-only` — account-A and account-B are rejected (default
+  `nonAdminStatuses: [401, 403]`); admin succeeds with the row's
+  declared `adminSuccessStatus`.
 
 **Adding a new customer-scoped endpoint is a one-line change** to
 `ENDPOINTS`. Pick the appropriate `expects` mode, fill in the
-`name`, `method`, and `path` (or `pathFor` for detail endpoints),
-and the harness iterates and asserts automatically. If the new
-endpoint needs a fixture row that is not in `Resources`, extend
-`Resources` and the `beforeAll` seeder; otherwise the row alone
-is enough.
+`name`, `method`, and the mode-specific fields (`path` for
+`list-scoped`, `pathFor` for detail GETs, `request` for mutations
+and admin-only routes), and the harness iterates and asserts
+automatically. If the new endpoint needs a fixture row that is not
+in `Resources`, extend `Resources` and the `beforeAll` seeder;
+otherwise the row alone is enough.
+
+Routes that go through `buildDispatchContext` (the node /
+detection API surface backed by REview / Tivan over GraphQL) are
+**not** in this matrix — the cross-customer contract there is
+"the dispatch JWT carries the right `customer_ids`", which is a
+structural assertion against the dispatch context rather than a
+row-level DB scope check. Those routes are guarded by
+`pnpm check:scope` (the static dispatch-context guard above) and
+exercised against the `mock-graphql` helper in their feature-
+specific integration files.
 
 The matrix is the regression-test target for both #386 (audit-log
 viewer scoping) and #387 (the hardening sweep). New PRs that
-touch customer-scoped routes should add their endpoint to
-`ENDPOINTS` rather than copying an existing per-endpoint test
+touch a customer-scoped local-DB route should add their endpoint
+to `ENDPOINTS` rather than copying an existing per-endpoint test
 file.
 
 ## Markdown formatting

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -390,8 +390,16 @@ verify that the dispatch context flows into the specific call
 site, only that the symbol is in scope. Deeper correctness still
 relies on code review.
 
-To allow a deliberate exception, append a same-line comment to
-the offending call:
+The script strips comments and string literals before applying the
+call and presence regexes, so a commented-out
+`import { buildDispatchContext } from "..."` does NOT satisfy the
+presence requirement, and a commented-out call does NOT count as a
+real call. Call detection runs against the whole comment-stripped
+source so a call split across lines (e.g.
+`return graphqlRequest\n  (QUERY, ...)`) is still recognized.
+
+To allow a deliberate exception, append an override comment to any
+line of the call expression (start through the opening paren):
 
 ```ts
 return graphqlRequest(QUERY, undefined, ctx); // scope-allowlist: <reason>
@@ -422,14 +430,18 @@ assertions for its `expects` mode:
   customer A returns 200; account-A's GET on customer B returns
   404 (NOT 403 — surfacing 403 would disclose existence); admin gets
   200 on both.
-- `mutation-scope` (POST / PATCH / DELETE) — for each persona the row
-  declares an in-scope and out-of-scope variant of the request body
-  / path; the harness fires both and asserts the declared
-  `expectStatus` (typically 2xx in-scope, 403 out-of-scope for non-
-  admins; 2xx for both for admin). An optional
-  `cleanupAfterSuccess` hook resets fixture state between mutation
-  rows so the matrix can run repeatedly against a long-lived dev
-  database.
+- `mutation-scope` (POST / PATCH / DELETE) — each persona slot
+  declares an optional `inScope` and `outOfScope` variant. The
+  harness fires only the variants that are defined and asserts the
+  response status equals the variant's `expectStatus` (typically 2xx
+  in-scope, 403 out-of-scope for non-admins; 2xx for both for
+  admin). Routes whose tenant in-scope path would mutate fixture
+  state we don't want to restore on every run (e.g.
+  password-reset, mfa-reset) declare only the tenant `outOfScope`
+  variant and leave `inScope` undefined — the regression bar is
+  "out-of-scope is rejected", not "every successful path is
+  exercised". An optional `cleanupAfterSuccess` hook resets fixture
+  state after each 2xx so mutations don't leak between runs.
 - `admin-only` — account-A and account-B are rejected (default
   `nonAdminStatuses: [401, 403]`); admin succeeds with the row's
   declared `adminSuccessStatus`.

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -463,7 +463,7 @@ assertions for its `expects` mode:
   declares an optional `inScope` and `outOfScope` variant. The
   harness fires only the variants that are defined and asserts the
   response status equals the variant's `expectStatus` (typically 2xx
-  in-scope, 403 out-of-scope for non-admins; 2xx for both for
+  in-scope, 403 / 404 out-of-scope for non-admins; 2xx for both for
   admin). Routes whose tenant in-scope path would mutate fixture
   state we don't want to restore on every run (e.g.
   password-reset, mfa-reset) declare only the tenant `outOfScope`
@@ -471,9 +471,48 @@ assertions for its `expects` mode:
   "out-of-scope is rejected", not "every successful path is
   exercised". An optional `cleanupAfterSuccess` hook resets fixture
   state after each 2xx so mutations don't leak between runs.
+  - **Persona overrides.** A row whose route requires a permission
+    the base tenant role doesn't carry (`customers:write`,
+    `customers:delete`, `accounts:delete`) sets
+    `personaUsernames: { accountA: MANAGER_A_USERNAME, accountB:
+    MANAGER_B_USERNAME }`. The harness signs in those personas as
+    the **manager** accounts (a non-`access-all` "tenant-
+    administrator" role that holds the elevated permissions) so the
+    request reaches the route's tenant-scope branch instead of being
+    short-circuited at the permission gate. The persona label in
+    the test name stays `account-A` / `account-B` so the matrix
+    shape stays uniform; only the sign-in user changes. This is the
+    pattern used by `PATCH /api/customers/[id]`,
+    `DELETE /api/customers/[id]`, and `DELETE /api/accounts/[id]`.
+  - **Targets that need a tenant-manageable role.** The
+    `DELETE /api/accounts/[id]` row deletes the dedicated
+    `monitor-target-A` / `-B` accounts (Security Monitor-equivalent
+    role) rather than the tenant accounts, because
+    `validateManagedAccountTarget` rejects targets whose role is
+    not tenant-manageable with 403 before the scope check ever
+    runs. Use the same pattern for any future route that calls
+    `validateManagedAccountTarget` and needs the scope branch
+    exercised.
+  - **Structurally unreachable in-scope paths.** A few routes
+    intentionally leave the tenant `inScope` variant undefined
+    because the success path is blocked by a separate gate
+    downstream of the scope check. `DELETE /api/customers/[id]` is
+    the canonical case: the scope check requires the caller's
+    `account_customer` link to exist, but the next gate
+    (`Cannot delete customer with active account assignments`)
+    refuses any customer with at least one link, so a
+    non-`access-all` caller cannot pass both gates on the same
+    customer. The `outOfScope` 404 is the regression-meaningful
+    assertion for tenants; the admin in-scope variant covers the
+    success path against an orphan customer.
 - `admin-only` — account-A and account-B are rejected (default
   `nonAdminStatuses: [401, 403]`); admin succeeds with the row's
-  declared `adminSuccessStatus`.
+  declared `adminSuccessStatus`. Reserve this mode for routes that
+  have **no** tenant-scope branch at all (e.g. `POST /api/customers`
+  — there is no customer to be in/out of scope of). For routes that
+  do have a scope branch but only allow elevated callers to reach
+  it, use `mutation-scope` with `personaUsernames` so the regression
+  guard actually exercises the scope check.
 
 **Adding a new customer-scoped endpoint is a one-line change** to
 `ENDPOINTS`. Pick the appropriate `expects` mode, fill in the

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -333,14 +333,46 @@ customer-scoped operation:
 
 ### Audit log contract
 
-Every `auditLog.record(...)` call that describes an event tied to
-a specific customer must populate the top-level `customerId` field
-with the relevant customer id (not just place it inside `details`).
-Without it the row is invisible to the audit-log viewer's
+Every `auditLog.record(...)` call whose `target` is a record with a
+**canonical, single customer id** (a customer, a node, a sensor, an
+`account_customer` link row — anything where the customer that owns
+the row is unambiguous) must populate the top-level `customerId`
+field with that id (not just place it inside `details`). Without it
+the row is invisible to the audit-log viewer's
 `customer_id IN (...)` predicate, so the tenant operator who owns
-the resource never sees it. Customer-agnostic events
-(`account.login`, system events) carry `customerId: null`; admin
-sees those rows, restricted callers do not.
+the resource never sees it.
+
+Two categories explicitly fall outside that rule and intentionally
+record `customerId: null`:
+
+- **Customer-agnostic events** — `account.login`, system events
+  (system-settings, role mutations), MFA-credential management on
+  the actor's own account. These have no customer dimension at all.
+  Admin sees those rows; restricted callers do not.
+- **Account-targeted mutations on N:N accounts** — `password.reset`,
+  `account.unlock`, `account.restore`, `account.mfa.reset`,
+  `account.update`, `account.delete`. The `target` is an account,
+  and accounts relate to customers many-to-many through
+  `account_customer` (see `getAccountCustomerIds` in
+  `src/lib/auth/account-management.ts`). There is no single
+  customer id to attribute the event to, and silently picking one
+  member of the set would mislead viewers in the other tenants.
+  These rows are therefore visible to admin only today; widening
+  visibility for in-scope tenant operators on these events would
+  require either a row-fan-out (one audit row per linked customer)
+  or a multi-valued audit schema, both of which are out of scope
+  for #388 and #387 and are tracked separately.
+
+When a future audit row's target *is* unambiguously bound to one
+customer (e.g. a route that operates on `account_customer (account,
+customer)` together, or on a node/sensor whose `customer_id` is a
+column on the row), follow the rule above and populate
+`customerId`. The canonical examples are
+`src/app/api/customers/[id]/route.ts` (target = a customer),
+`src/app/api/accounts/[id]/customers/route.ts` (target = the
+`account_customer` link being created — the customer dimension is
+in the URL), and `src/app/api/nodes/[id]/route.ts` (target = a node
+whose `customer_id` is a column).
 
 ### Error-message contract
 

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -438,10 +438,15 @@ applying the call and presence regexes, so:
 
 Call detection runs against the whole stripped source so a call
 split across lines (e.g. `return graphqlRequest\n  (QUERY, ...)`) is
-still recognized. Newlines are preserved by the stripper so reported
-line numbers stay aligned with the original source. Template-literal
-interpolation expressions (`${...}`) are not parsed back out — a real
-call buried inside `${...}` is missed and an
+still recognized. The scanner also walks past a balanced `<...>`
+generic-arguments block before locating the opening `(`, so the
+generic form (`graphqlRequest<Thing>(...)` and its multiline variant
+`graphqlRequest<Thing>\n  (...)`) is recognized as the same call
+site and the override-line range covers the helper-name line through
+the opening-paren line. Newlines are preserved by the stripper so
+reported line numbers stay aligned with the original source.
+Template-literal interpolation expressions (`${...}`) are not parsed
+back out — a real call buried inside `${...}` is missed and an
 `import { buildDispatchContext }` substring inside `${...}` does not
 satisfy the presence check either. Both edges are pathological in
 real source, and the file-level allowlist still catches the only
@@ -449,7 +454,8 @@ meaningful regression: a brand-new server action outside
 `src/lib/{node,detection}` that calls `graphqlRequest`.
 
 To allow a deliberate exception, append an override comment to any
-line of the call expression (start through the opening paren):
+line of the call expression (helper-name line through the opening
+paren — including the line containing `<` for generic calls):
 
 ```ts
 return graphqlRequest(QUERY, undefined, ctx); // scope-allowlist: <reason>

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -383,18 +383,39 @@ alongside `pnpm check`. It enforces, file-by-file:
   `buildDispatchContext` must either be imported from another
   module or declared locally as a top-level function / const.
   Files that have neither fail CI. The contract is "symbol is in
-  scope at runtime", so two shapes intentionally do NOT satisfy the
-  presence check:
-    - **Type-only imports.** Both `import type { buildDispatchContext } ...`
-      (whole-import type modifier) and `import { type buildDispatchContext } ...`
-      (per-specifier type modifier) are rejected. TypeScript erases
+  scope at runtime", so the guard accepts any of the three shapes
+  that put it there:
+    - **Named import** —
+      `import { buildDispatchContext } from "./dispatch-context"`,
+      with or without an `as` alias. This is the form the Node
+      track uses today.
+    - **Namespace import + member access** —
+      `import * as dispatchContext from "./dispatch-context"`
+      paired with at least one
+      `dispatchContext.buildDispatchContext(...)` reference in the
+      same file. The bare namespace binding alone is not enough: the
+      symbol is reachable through the namespace object, so the guard
+      requires an observed member access to confirm the file is
+      actually using it.
+    - **Local declaration** — `async function buildDispatchContext` /
+      `const buildDispatchContext = ...` declared at the top level
+      (column 0) of the file. This is the shape Detection's
+      `src/lib/detection/server-actions.ts` uses today.
+
+  Three shapes intentionally do NOT satisfy the presence check:
+    - **Type-only imports.** `import type { buildDispatchContext } ...`,
+      `import { type buildDispatchContext } ...`, and
+      `import type * as ns ...` are all rejected. TypeScript erases
       these so the symbol is not in runtime scope when the call site
       executes.
+    - **Namespace imports without member access.** A bare
+      `import * as ns from "..."` with no `ns.buildDispatchContext`
+      reference fails — there is no evidence the file is materializing
+      the symbol from the namespace.
     - **Nested declarations.** `function buildDispatchContext` /
       `const buildDispatchContext` inside another function or block
       does not bring the symbol into file scope. Only top-level
-      (column-0) declarations count — the same shape Detection's
-      `src/lib/detection/server-actions.ts` already uses.
+      (column-0) declarations count.
 
 Both `pnpm check` (Biome) and `pnpm check:scope` must pass before
 a PR can land. The guard is intentionally simple — it does not

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -382,7 +382,19 @@ alongside `pnpm check`. It enforces, file-by-file:
 - For each allowlisted file that calls one of the helpers,
   `buildDispatchContext` must either be imported from another
   module or declared locally as a top-level function / const.
-  Files that have neither fail CI.
+  Files that have neither fail CI. The contract is "symbol is in
+  scope at runtime", so two shapes intentionally do NOT satisfy the
+  presence check:
+    - **Type-only imports.** Both `import type { buildDispatchContext } ...`
+      (whole-import type modifier) and `import { type buildDispatchContext } ...`
+      (per-specifier type modifier) are rejected. TypeScript erases
+      these so the symbol is not in runtime scope when the call site
+      executes.
+    - **Nested declarations.** `function buildDispatchContext` /
+      `const buildDispatchContext` inside another function or block
+      does not bring the symbol into file scope. Only top-level
+      (column-0) declarations count — the same shape Detection's
+      `src/lib/detection/server-actions.ts` already uses.
 
 Both `pnpm check` (Biome) and `pnpm check:scope` must pass before
 a PR can land. The guard is intentionally simple — it does not

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -283,6 +283,135 @@ truth for which strings drive the capture flow.
   languages.
 - Keep the same filename across language directories.
 
+## Customer scope (multi-tenancy contract)
+
+Code that touches customer data must enforce tenant isolation —
+data, audit rows, and even the shape of error messages must not
+leak across customer boundaries. The contract below pins the rules
+for new code and the regression guards installed under issue #388
+(static dispatch-context guard, integration test matrix).
+
+### Project principle
+
+A caller's effective customer scope is whatever
+`resolveEffectiveCustomerIds(accountId, roles)` returns. No code
+path that handles customer-touching data may bypass it except
+through one of the three permitted patterns below. "Empty scope"
+is a hard fail for non-`access-all` callers — never silently widen
+to "all customers".
+
+### Permitted patterns
+
+There are exactly three permitted ways for new code to issue a
+customer-scoped operation:
+
+1. **Dispatch via `buildDispatchContext(session)`** — for any code
+   path that crosses the BFF boundary into REview / Giganto / Tivan
+   over GraphQL. Both the Node track
+   (`src/lib/node/dispatch-context.ts`) and the Detection track
+   (locally declared in `src/lib/detection/server-actions.ts`) use
+   this helper to materialize the caller's scope into a concrete
+   `customer_ids: number[]` list before signing the Context JWT.
+   review-web reads scope from the JWT verbatim; do not pass scope
+   in the GraphQL filter or rely on review-web to re-derive it.
+
+2. **Local DB query with an `account_customer` JOIN** — for
+   queries that read directly from `auth_db` / `audit_db`. Either
+   add `JOIN account_customer ac ON ac.customer_id = <table>.customer_id
+   AND ac.account_id = $session_account` for the account-link
+   pattern, or push an explicit `customer_id IN (...)` predicate
+   sourced from `resolveEffectiveCustomerIds`. The audit-log viewer
+   route (`src/app/api/audit-logs/route.ts`) is the canonical
+   example after #386.
+
+3. **Explicit `customers:access-all` permission check** — when a
+   route legitimately needs to bypass tenant scope (e.g. a
+   System Administrator-only listing of every customer). Always
+   branch on `await hasPermission(session.roles, "customers:access-all")`
+   and never on the audit-only `role[0]` string. Customer scope
+   checks must NOT be inferred from the role name.
+
+### Audit log contract
+
+Every `auditLog.record(...)` call that describes an event tied to
+a specific customer must populate the top-level `customerId` field
+with the relevant customer id (not just place it inside `details`).
+Without it the row is invisible to the audit-log viewer's
+`customer_id IN (...)` predicate, so the tenant operator who owns
+the resource never sees it. Customer-agnostic events
+(`account.login`, system events) carry `customerId: null`; admin
+sees those rows, restricted callers do not.
+
+### Error-message contract
+
+When an error message references a customer identifier the caller
+may not have scope on, redact via
+`redactForScope(customerId, ctx)` before surfacing it. Out-of-scope
+resources should return `404` (not `403`) — anything else discloses
+existence. Internal logs may name the id; the response body must
+not.
+
+### Static dispatch-context guard (`pnpm check:scope`)
+
+A Node script at `scripts/check-dispatch-context.mjs` runs in CI
+alongside `pnpm check`. It enforces, file-by-file:
+
+- Only files under `src/lib/node/`, `src/lib/detection/`, and the
+  GraphQL client modules themselves may call `graphqlRequest` /
+  `graphqlRequestTo`. Any other call site fails CI.
+- For each allowlisted file that calls one of the helpers,
+  `buildDispatchContext` must either be imported from another
+  module or declared locally as a top-level function / const.
+  Files that have neither fail CI.
+
+Both `pnpm check` (Biome) and `pnpm check:scope` must pass before
+a PR can land. The guard is intentionally simple — it does not
+verify that the dispatch context flows into the specific call
+site, only that the symbol is in scope. Deeper correctness still
+relies on code review.
+
+To allow a deliberate exception, append a same-line comment to
+the offending call:
+
+```ts
+return graphqlRequest(QUERY, undefined, ctx); // scope-allowlist: <reason>
+```
+
+The reason must be non-empty and survives review precisely
+because it is loud. Use the override only when the call genuinely
+does not need a customer scope (e.g. a non-customer-scoped manager
+introspection query); never to silence a real violation.
+
+### Cross-customer integration test matrix
+
+`src/__integration__/multi-tenancy/scope.test.ts` is a
+data-driven regression suite that exercises every customer-scoped
+endpoint against three personas: `account-A`, `account-B`, and
+`admin`. Every row in the `ENDPOINTS` array runs the standard
+assertions for its `expects` mode:
+
+- `list-scoped` — account-A's list contains only customer-A rows;
+  account-B's contains only customer-B rows; admin sees both plus
+  any null-customer fixture rows.
+- `200-on-in-scope-404-on-out-of-scope` — account-A's GET on
+  customer A returns 200; account-A's GET on customer B returns
+  404 (NOT 403); admin gets 200 on both.
+- `admin-only` — non-admin returns 404; admin returns 200.
+
+**Adding a new customer-scoped endpoint is a one-line change** to
+`ENDPOINTS`. Pick the appropriate `expects` mode, fill in the
+`name`, `method`, and `path` (or `pathFor` for detail endpoints),
+and the harness iterates and asserts automatically. If the new
+endpoint needs a fixture row that is not in `Resources`, extend
+`Resources` and the `beforeAll` seeder; otherwise the row alone
+is enough.
+
+The matrix is the regression-test target for both #386 (audit-log
+viewer scoping) and #387 (the hardening sweep). New PRs that
+touch customer-scoped routes should add their endpoint to
+`ENDPOINTS` rather than copying an existing per-endpoint test
+file.
+
 ## Markdown formatting
 
 - Use **ATX headings** (`#`, `##`, `###`). Do not skip heading

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -419,8 +419,14 @@ alongside `pnpm check`. It enforces, file-by-file:
   that put it there:
     - **Named import** —
       `import { buildDispatchContext } from "./dispatch-context"`,
-      with or without an `as` alias. This is the form the Node
-      track uses today.
+      optionally with a left-side `as` alias
+      (`import { buildDispatchContext as buildCtx } ...`). The
+      *imported* symbol must be `buildDispatchContext`; a right-side
+      rename like `import { otherName as buildDispatchContext } ...`
+      is rejected because it imports a different symbol and merely
+      *names* the local binding `buildDispatchContext`, so the call
+      site would dispatch to the wrong function. This is the form
+      the Node track uses today.
     - **Namespace import + member access** —
       `import * as dispatchContext from "./dispatch-context"`
       paired with at least one

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -496,13 +496,24 @@ assertions for its `expects` mode:
   harness fires only the variants that are defined and asserts the
   response status equals the variant's `expectStatus` (typically 2xx
   in-scope, 403 / 404 out-of-scope for non-admins; 2xx for both for
-  admin). Routes whose tenant in-scope path would mutate fixture
-  state we don't want to restore on every run (e.g.
-  password-reset, mfa-reset) declare only the tenant `outOfScope`
-  variant and leave `inScope` undefined — the regression bar is
-  "out-of-scope is rejected", not "every successful path is
-  exercised". An optional `cleanupAfterSuccess` hook resets fixture
+  admin). An optional `cleanupAfterSuccess` hook resets fixture
   state after each 2xx so mutations don't leak between runs.
+  - **Contract narrowing for auth-state-mutating routes.** The
+    matrix's mandate is the cross-customer scope contract, not
+    end-to-end coverage of every success path. Routes that mutate
+    authentication state (password hash, locked flag, MFA
+    enrolment, token version, live sessions) the matrix's other
+    rows depend on declare ONLY the tenant `outOfScope` variant.
+    Today this applies to `POST /api/accounts/[id]/password-reset`,
+    `/unlock`, and `/mfa-reset`: a single 404 from
+    `validateManagedAccountTarget` is the regression-meaningful
+    assertion (a future PR that drops the scope check turns the row
+    red), and the route-specific integration suites
+    (`src/__integration__/api/unlock.test.ts`, the password / MFA
+    suites) already cover the happy path end-to-end. New routes
+    that share this profile should follow the same pattern; new
+    routes that don't (no auth-state mutation) should declare every
+    persona slot.
   - **Persona overrides.** A row whose route requires a permission
     the base tenant role doesn't carry (`customers:write`,
     `customers:delete`, `accounts:delete`) sets

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "biome check",
     "format": "biome format --write",
     "check": "biome ci --error-on-warnings .",
+    "check:scope": "node scripts/check-dispatch-context.mjs",
     "fix": "biome check --write src",
     "markdownlint": "markdownlint-cli2 '**/*.md'",
     "test": "vitest run",

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -34,6 +34,17 @@
 // override is intentionally noisy in code review so anyone reaching
 // for it has to justify it.
 //
+// Comments and split-line calls. The presence and call-site checks
+// run against a comment-stripped copy of the source so that a
+// commented-out `import { buildDispatchContext } ...` does NOT
+// satisfy the presence requirement, and a commented-out call site
+// does NOT count as a real call. Call-site detection runs against the
+// whole stripped source (not line-by-line) so a call split across
+// lines (e.g. `return graphqlRequest\n  (QUERY, ...)`) is still
+// recognized. Override-comment lookups still scan the *original*
+// lines so the `// scope-allowlist:` annotation can sit on any line
+// of the call expression (start through the opening paren).
+//
 // Run via `pnpm check:scope`. Tests live at
 // `src/__tests__/scripts/check-dispatch-context.test.ts`.
 
@@ -75,8 +86,10 @@ const SOURCE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
 // Matches a real call site (`name(` or `name<…>(`) of the helpers.
 // `\b` ensures we don't match `myGraphqlRequest(`. The `To?` covers
-// both `graphqlRequest` and `graphqlRequestTo`.
-const CALL_RE = /\bgraphqlRequest(?:To)?\s*[<(]/;
+// both `graphqlRequest` and `graphqlRequestTo`. `\s` matches newlines
+// so the regex can detect calls split across lines when run against
+// the whole-source string.
+const CALL_RE = /\bgraphqlRequest(?:To)?\s*[<(]/g;
 
 // Inline override: `// scope-allowlist: <reason>`. Reason must be
 // non-empty (after trimming).
@@ -85,12 +98,14 @@ const OVERRIDE_RE = /\/\/\s*scope-allowlist:\s*(.+?)\s*$/;
 // `import { ..., buildDispatchContext, ... } from "..."`. Allows
 // arbitrary whitespace and `as` aliases between the braces. We do not
 // resolve the import path — any path that brings the symbol in scope
-// counts.
+// counts. Run against comment-stripped source so a commented-out
+// import does not satisfy the check.
 const IMPORT_BUILD_DISPATCH_CONTEXT_RE =
   /import\s*(?:type\s+)?\{[^}]*\bbuildDispatchContext\b[^}]*\}\s*from\s*["'][^"']+["']/;
 
 // `(async )?function buildDispatchContext(...)` or
-// `(export )?const buildDispatchContext = ...`.
+// `(export )?const buildDispatchContext = ...`. Run against
+// comment-stripped source.
 const LOCAL_DECL_RE =
   /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?(?:function\s+buildDispatchContext\b|const\s+buildDispatchContext\b)/;
 
@@ -134,28 +149,99 @@ function isInAllowedDir(relPath) {
   return ALLOWED_DIRS.some((d) => relPath === d || relPath.startsWith(`${d}/`));
 }
 
-function findCallSites(source) {
-  const lines = source.split("\n");
-  const sites = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (CALL_RE.test(line)) {
-      sites.push({ lineNumber: i + 1, line });
+// Strip line and block comments while preserving newlines so line
+// numbers stay aligned with the original source. Naively skips
+// characters inside single-quoted, double-quoted, and template-string
+// literals so a comment-marker inside a string is not treated as a
+// comment. Template-literal interpolation expressions are not parsed
+// recursively; this is a guard, not a TS parser, and the worst case
+// is a missed match — which the file-level allowlist still catches.
+function stripComments(source) {
+  let out = "";
+  let i = 0;
+  let stringDelim = null; // null | '"' | "'" | "`"
+  let inLineComment = false;
+  let inBlockComment = false;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = i + 1 < source.length ? source[i + 1] : "";
+    if (inLineComment) {
+      if (ch === "\n") {
+        inLineComment = false;
+        out += ch;
+      }
+      i++;
+    } else if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false;
+        i += 2;
+      } else {
+        if (ch === "\n") out += ch;
+        i++;
+      }
+    } else if (stringDelim !== null) {
+      if (ch === "\\") {
+        out += ch;
+        if (next) out += next;
+        i += 2;
+        continue;
+      }
+      if (ch === stringDelim) {
+        stringDelim = null;
+      }
+      out += ch;
+      i++;
+    } else if (ch === "/" && next === "/") {
+      inLineComment = true;
+      i += 2;
+    } else if (ch === "/" && next === "*") {
+      inBlockComment = true;
+      i += 2;
+    } else if (ch === '"' || ch === "'" || ch === "`") {
+      stringDelim = ch;
+      out += ch;
+      i++;
+    } else {
+      out += ch;
+      i++;
     }
+  }
+  return out;
+}
+
+function findCallSites(source) {
+  const stripped = stripComments(source);
+  const originalLines = source.split("\n");
+  const sites = [];
+  CALL_RE.lastIndex = 0;
+  for (;;) {
+    const match = CALL_RE.exec(stripped);
+    if (match === null) break;
+    const startLine = stripped.slice(0, match.index).split("\n").length;
+    const endLine = stripped
+      .slice(0, match.index + match[0].length)
+      .split("\n").length;
+    sites.push({
+      startLine,
+      endLine,
+      lines: originalLines.slice(startLine - 1, endLine),
+    });
   }
   return sites;
 }
 
-function hasOverride(line) {
-  const match = line.match(OVERRIDE_RE);
-  if (!match) return false;
-  const reason = match[1].trim();
-  return reason.length > 0;
+function hasOverride(lines) {
+  for (const line of lines) {
+    const m = line.match(OVERRIDE_RE);
+    if (m && m[1].trim().length > 0) return true;
+  }
+  return false;
 }
 
 function hasBuildDispatchContext(source) {
-  if (IMPORT_BUILD_DISPATCH_CONTEXT_RE.test(source)) return true;
-  if (LOCAL_DECL_RE.test(source)) return true;
+  const stripped = stripComments(source);
+  if (IMPORT_BUILD_DISPATCH_CONTEXT_RE.test(stripped)) return true;
+  if (LOCAL_DECL_RE.test(stripped)) return true;
   return false;
 }
 
@@ -177,14 +263,14 @@ export function checkFiles(files) {
     const allowed = isClientModule || isInAllowedDir(relPath);
 
     for (const site of sites) {
-      if (hasOverride(site.line)) continue;
+      if (hasOverride(site.lines)) continue;
 
       if (!allowed) {
         violations.push({
           relPath,
-          lineNumber: site.lineNumber,
+          lineNumber: site.startLine,
           message:
-            `Call to graphqlRequest/graphqlRequestTo from ${relPath}:${site.lineNumber} ` +
+            `Call to graphqlRequest/graphqlRequestTo from ${relPath}:${site.startLine} ` +
             "is outside the dispatch-context allowlist. Customer-scoped " +
             "GraphQL requests must originate from src/lib/node, " +
             "src/lib/detection, or the GraphQL client modules. If the call " +
@@ -202,9 +288,9 @@ export function checkFiles(files) {
       if (!hasBuildDispatchContext(source)) {
         violations.push({
           relPath,
-          lineNumber: site.lineNumber,
+          lineNumber: site.startLine,
           message:
-            `${relPath}:${site.lineNumber} calls graphqlRequest/graphqlRequestTo ` +
+            `${relPath}:${site.startLine} calls graphqlRequest/graphqlRequestTo ` +
             "but neither imports nor locally declares `buildDispatchContext`. " +
             "Customer scope must be materialized through " +
             "`buildDispatchContext(session)` before dispatch. Use " +

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -353,12 +353,16 @@ function hasBuildDispatchContextImport(stripped) {
       // Reject `{ type buildDispatchContext }` (per-specifier type
       // modifier).
       if (/^type\s+/.test(spec)) continue;
-      // Match either a direct specifier (`buildDispatchContext` /
-      // `buildDispatchContext as foo`) or a renamed import that
-      // brings the symbol into local scope (`foo as
-      // buildDispatchContext`). \b boundaries keep us off
-      // `myBuildDispatchContext` etc.
-      if (/\bbuildDispatchContext\b/.test(spec)) return true;
+      // The imported symbol is the left side of `as`, or the whole
+      // specifier when there is no rename. Only `buildDispatchContext`
+      // or `buildDispatchContext as <alias>` brings the real helper
+      // into scope. A right-side rename (`otherName as
+      // buildDispatchContext`) imports a different symbol and merely
+      // *names* the local binding `buildDispatchContext`, so the call
+      // site dispatches to the wrong function — must NOT satisfy the
+      // presence check.
+      const importedName = spec.split(/\s+as\s+/, 1)[0].trim();
+      if (importedName === "buildDispatchContext") return true;
     }
   }
 }

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -26,13 +26,23 @@
 //      locally as a top-level function / const. Detection's track
 //      uses the local-declaration form today
 //      (`src/lib/detection/server-actions.ts`); the Node track
-//      imports it from `src/lib/node/dispatch-context.ts`. Both
-//      patterns are accepted, but the contract is "symbol is in
-//      scope at runtime", so two shapes intentionally do NOT
-//      satisfy the check:
-//        * Type-only imports — both `import type { buildDispatchContext } ...`
-//          and `import { type buildDispatchContext } ...`. TypeScript
-//          erases these so the symbol is not in runtime scope.
+//      imports it from `src/lib/node/dispatch-context.ts` via a
+//      named import. Both named imports
+//      (`import { buildDispatchContext } from "..."`) and namespace
+//      imports paired with member access
+//      (`import * as ns from "..."` followed by
+//      `ns.buildDispatchContext(...)`) are accepted, as is the
+//      local-declaration form — the contract is "symbol is in scope
+//      at runtime", so any of those bring it into scope. Three
+//      shapes intentionally do NOT satisfy the check:
+//        * Type-only imports — `import type { buildDispatchContext } ...`,
+//          `import { type buildDispatchContext } ...`, and
+//          `import type * as ns ...`. TypeScript erases these so the
+//          symbol is not in runtime scope.
+//        * Namespace imports without a `<alias>.buildDispatchContext`
+//          access. The bare namespace binding does not put the symbol
+//          in scope under its own name; without the member access we
+//          have no evidence the file is using it.
 //        * Nested declarations — `function buildDispatchContext` /
 //          `const buildDispatchContext` inside another function or
 //          block. Only top-level (column-0) declarations count.
@@ -133,6 +143,16 @@ const OVERRIDE_RE = /\/\/\s*scope-allowlist:\s*(.+?)\s*$/;
 // stripped source so a commented-out import or a string literal that
 // happens to contain the import substring is not honoured.
 const IMPORT_RE = /\bimport\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["'][^"']*["']/g;
+
+// `import * as <alias> from "..."`. Captures the alias so we can
+// verify the file actually accesses `<alias>.buildDispatchContext`
+// somewhere — the namespace import alone only binds the namespace
+// object, not the symbol, so requiring an observed access matches
+// the contract "symbol is in scope at runtime". A type-only namespace
+// import (`import type * as ...`) is rejected the same way as the
+// named-import variant — TypeScript erases it.
+const NAMESPACE_IMPORT_RE =
+  /\bimport\s+(type\s+)?\*\s+as\s+(\w+)\s+from\s*["'][^"']*["']/g;
 
 // Top-level declaration only — must start at column 0 (no leading
 // whitespace). Nested `function buildDispatchContext` /
@@ -314,9 +334,23 @@ function hasBuildDispatchContextImport(stripped) {
   }
 }
 
+function hasBuildDispatchContextNamespaceImport(stripped) {
+  NAMESPACE_IMPORT_RE.lastIndex = 0;
+  for (;;) {
+    const match = NAMESPACE_IMPORT_RE.exec(stripped);
+    if (match === null) return false;
+    // Reject `import type * as <alias>` — erased at runtime.
+    if (match[1]) continue;
+    const alias = match[2];
+    const usageRe = new RegExp(`\\b${alias}\\.buildDispatchContext\\b`);
+    if (usageRe.test(stripped)) return true;
+  }
+}
+
 function hasBuildDispatchContext(source) {
   const stripped = stripCommentsAndStrings(source);
   if (hasBuildDispatchContextImport(stripped)) return true;
+  if (hasBuildDispatchContextNamespaceImport(stripped)) return true;
   if (LOCAL_DECL_RE.test(stripped)) return true;
   return false;
 }

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -34,16 +34,33 @@
 // override is intentionally noisy in code review so anyone reaching
 // for it has to justify it.
 //
-// Comments and split-line calls. The presence and call-site checks
-// run against a comment-stripped copy of the source so that a
-// commented-out `import { buildDispatchContext } ...` does NOT
-// satisfy the presence requirement, and a commented-out call site
-// does NOT count as a real call. Call-site detection runs against the
-// whole stripped source (not line-by-line) so a call split across
-// lines (e.g. `return graphqlRequest\n  (QUERY, ...)`) is still
-// recognized. Override-comment lookups still scan the *original*
-// lines so the `// scope-allowlist:` annotation can sit on any line
-// of the call expression (start through the opening paren).
+// Comments, string literals, and split-line calls. The presence and
+// call-site checks run against a stripped copy of the source so
+// non-executable text — line/block comments AND the *contents* of
+// single-quoted, double-quoted, and template-string literals — does
+// not influence the result. That means a commented-out
+// `import { buildDispatchContext } ...` does NOT satisfy the presence
+// requirement, a commented-out call site does NOT count as a real
+// call, and a string literal that happens to contain
+// `graphqlRequest(...)` or `import { buildDispatchContext } ...`
+// (e.g. an error message, log line, or fixture) does NOT trigger or
+// satisfy the guard either. The stripper preserves newlines and
+// pads non-newline characters inside strings/comments with spaces
+// so line/column offsets stay aligned for line-number reporting.
+// Call-site detection runs against the whole stripped source (not
+// line-by-line) so a call split across lines
+// (e.g. `return graphqlRequest\n  (QUERY, ...)`) is still recognized.
+// Override-comment lookups still scan the *original* lines so the
+// `// scope-allowlist:` annotation can sit on any line of the call
+// expression (start through the opening paren).
+//
+// Caveat: template-literal interpolation expressions (`${...}`) are
+// not parsed back out, so a real call buried inside `${...}` is
+// missed and an `import { buildDispatchContext }` substring inside
+// `${...}` doesn't satisfy the presence check either. Both edges are
+// pathological in real source, and the file-level allowlist still
+// catches the only meaningful regression — a brand-new server action
+// outside `src/lib/{node,detection}` that calls `graphqlRequest`.
 //
 // Run via `pnpm check:scope`. Tests live at
 // `src/__tests__/scripts/check-dispatch-context.test.ts`.
@@ -98,14 +115,16 @@ const OVERRIDE_RE = /\/\/\s*scope-allowlist:\s*(.+?)\s*$/;
 // `import { ..., buildDispatchContext, ... } from "..."`. Allows
 // arbitrary whitespace and `as` aliases between the braces. We do not
 // resolve the import path — any path that brings the symbol in scope
-// counts. Run against comment-stripped source so a commented-out
-// import does not satisfy the check.
+// counts. Run against the stripped source so neither a commented-out
+// import nor a string literal containing the import substring
+// satisfies the check; the path quotes survive the strip but the path
+// contents become spaces.
 const IMPORT_BUILD_DISPATCH_CONTEXT_RE =
-  /import\s*(?:type\s+)?\{[^}]*\bbuildDispatchContext\b[^}]*\}\s*from\s*["'][^"']+["']/;
+  /import\s*(?:type\s+)?\{[^}]*\bbuildDispatchContext\b[^}]*\}\s*from\s*["'][^"']*["']/;
 
 // `(async )?function buildDispatchContext(...)` or
-// `(export )?const buildDispatchContext = ...`. Run against
-// comment-stripped source.
+// `(export )?const buildDispatchContext = ...`. Run against the
+// stripped source.
 const LOCAL_DECL_RE =
   /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?(?:function\s+buildDispatchContext\b|const\s+buildDispatchContext\b)/;
 
@@ -149,14 +168,19 @@ function isInAllowedDir(relPath) {
   return ALLOWED_DIRS.some((d) => relPath === d || relPath.startsWith(`${d}/`));
 }
 
-// Strip line and block comments while preserving newlines so line
-// numbers stay aligned with the original source. Naively skips
-// characters inside single-quoted, double-quoted, and template-string
-// literals so a comment-marker inside a string is not treated as a
-// comment. Template-literal interpolation expressions are not parsed
-// recursively; this is a guard, not a TS parser, and the worst case
-// is a missed match — which the file-level allowlist still catches.
-function stripComments(source) {
+// Strip line/block comments AND the contents of string literals while
+// preserving newlines so line numbers stay aligned with the original
+// source. Inside a string or comment, non-newline characters become
+// spaces and newlines are kept verbatim; the string delimiters
+// themselves are emitted so that an `import { ... } from "..."`
+// statement still parses as an import (the path content is replaced
+// with spaces, but `[^"']*` still matches). Template-literal
+// interpolation expressions are NOT parsed back out — `${...}`
+// content is treated as part of the string and its substrings will
+// not match the call/import regexes. This is a guard, not a TS
+// parser; the worst case is a missed match, which the file-level
+// allowlist still catches.
+function stripCommentsAndStrings(source) {
   let out = "";
   let i = 0;
   let stringDelim = null; // null | '"' | "'" | "`"
@@ -169,33 +193,44 @@ function stripComments(source) {
       if (ch === "\n") {
         inLineComment = false;
         out += ch;
+      } else {
+        out += " ";
       }
       i++;
     } else if (inBlockComment) {
       if (ch === "*" && next === "/") {
         inBlockComment = false;
+        out += "  ";
         i += 2;
       } else {
-        if (ch === "\n") out += ch;
+        out += ch === "\n" ? "\n" : " ";
         i++;
       }
     } else if (stringDelim !== null) {
       if (ch === "\\") {
-        out += ch;
-        if (next) out += next;
+        // Escape sequence: blank both the backslash and the next
+        // character, preserving an actual newline in `\<newline>` so
+        // line counts stay aligned.
+        out += " ";
+        if (next) out += next === "\n" ? "\n" : " ";
         i += 2;
         continue;
       }
       if (ch === stringDelim) {
         stringDelim = null;
+        out += ch;
+        i++;
+        continue;
       }
-      out += ch;
+      out += ch === "\n" ? "\n" : " ";
       i++;
     } else if (ch === "/" && next === "/") {
       inLineComment = true;
+      out += "  ";
       i += 2;
     } else if (ch === "/" && next === "*") {
       inBlockComment = true;
+      out += "  ";
       i += 2;
     } else if (ch === '"' || ch === "'" || ch === "`") {
       stringDelim = ch;
@@ -210,7 +245,7 @@ function stripComments(source) {
 }
 
 function findCallSites(source) {
-  const stripped = stripComments(source);
+  const stripped = stripCommentsAndStrings(source);
   const originalLines = source.split("\n");
   const sites = [];
   CALL_RE.lastIndex = 0;
@@ -239,7 +274,7 @@ function hasOverride(lines) {
 }
 
 function hasBuildDispatchContext(source) {
-  const stripped = stripComments(source);
+  const stripped = stripCommentsAndStrings(source);
   if (IMPORT_BUILD_DISPATCH_CONTEXT_RE.test(stripped)) return true;
   if (LOCAL_DECL_RE.test(stripped)) return true;
   return false;

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -68,9 +68,15 @@
 // Call-site detection runs against the whole stripped source (not
 // line-by-line) so a call split across lines
 // (e.g. `return graphqlRequest\n  (QUERY, ...)`) is still recognized.
-// Override-comment lookups still scan the *original* lines so the
-// `// scope-allowlist:` annotation can sit on any line of the call
-// expression (start through the opening paren).
+// The scanner also walks past a balanced `<...>` generic-arguments
+// block before locating the opening `(`, so the generic form
+// (`graphqlRequest<Thing>(...)`, including its multiline variant
+// `graphqlRequest<Thing>\n  (...)`) is recognized as the same call
+// site and the override-line range covers the helper-name line
+// through the opening-paren line. Override-comment lookups still
+// scan the *original* lines so the `// scope-allowlist:` annotation
+// can sit on any line of the call expression (helper name through
+// the opening paren).
 //
 // Caveat: template-literal interpolation expressions (`${...}`) are
 // not parsed back out, so a real call buried inside `${...}` is
@@ -119,12 +125,14 @@ const EXCLUDED_DIRS = [
 // Source extensions to scan.
 const SOURCE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
-// Matches a real call site (`name(` or `name<…>(`) of the helpers.
-// `\b` ensures we don't match `myGraphqlRequest(`. The `To?` covers
-// both `graphqlRequest` and `graphqlRequestTo`. `\s` matches newlines
-// so the regex can detect calls split across lines when run against
-// the whole-source string.
-const CALL_RE = /\bgraphqlRequest(?:To)?\s*[<(]/g;
+// Matches the helper name itself. `\b` keeps us off `myGraphqlRequest`
+// and similar; the `To?` covers both `graphqlRequest` and
+// `graphqlRequestTo`. We deliberately do NOT bake the opening `(` (or
+// `<` for generic calls) into this regex — `findCallSites()` walks
+// forward from the name and skips a balanced `<…>` generic-arguments
+// block before locating the real `(`, so `endLine` always points at
+// the opening-paren line even for `graphqlRequest<Thing>\n  (...)`.
+const NAME_RE = /\bgraphqlRequest(?:To)?\b/g;
 
 // Inline override: `// scope-allowlist: <reason>`. Reason must be
 // non-empty (after trimming).
@@ -284,14 +292,35 @@ function findCallSites(source) {
   const stripped = stripCommentsAndStrings(source);
   const originalLines = source.split("\n");
   const sites = [];
-  CALL_RE.lastIndex = 0;
+  NAME_RE.lastIndex = 0;
   for (;;) {
-    const match = CALL_RE.exec(stripped);
+    const match = NAME_RE.exec(stripped);
     if (match === null) break;
+    let i = match.index + match[0].length;
+    // Skip whitespace between the helper name and the next token.
+    while (i < stripped.length && /\s/.test(stripped[i])) i++;
+    // If the next token is `<`, walk a balanced generic-arguments
+    // block so the opening-paren scan resumes after `>`. We need
+    // depth-counted scanning because TS generics nest
+    // (e.g. `graphqlRequest<A<B, C>>(...)`). Strings/comments are
+    // already blanked so any `<`/`>` we encounter is real syntax.
+    if (stripped[i] === "<") {
+      let depth = 1;
+      i++;
+      while (i < stripped.length && depth > 0) {
+        if (stripped[i] === "<") depth++;
+        else if (stripped[i] === ">") depth--;
+        i++;
+      }
+      if (depth !== 0) continue; // Unbalanced — not a call site we can pin.
+      while (i < stripped.length && /\s/.test(stripped[i])) i++;
+    }
+    // A real call has `(` here. Anything else (e.g. an `import { ...,
+    // graphqlRequest, ... }` specifier, a re-export, an object-property
+    // shorthand) is not a call and is skipped.
+    if (stripped[i] !== "(") continue;
     const startLine = stripped.slice(0, match.index).split("\n").length;
-    const endLine = stripped
-      .slice(0, match.index + match[0].length)
-      .split("\n").length;
+    const endLine = stripped.slice(0, i + 1).split("\n").length;
     sites.push({
       startLine,
       endLine,

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Static dispatch-context guard.
+//
+// Fails CI when a `graphqlRequest` / `graphqlRequestTo` call site is
+// added in a file that is not allowed to issue customer-scoped
+// requests, or in an allowlisted file that has neither an import nor
+// a local declaration of `buildDispatchContext`. The guard is a
+// pragmatic file-level check, not a deep dataflow analysis: deeper
+// correctness (e.g. "the value passed as the third argument was
+// actually derived from `buildDispatchContext` for *this* call site")
+// still relies on code review. The point is to catch the regression
+// where a new server action wires up `graphqlRequest` and forgets the
+// scope plumbing entirely.
+//
+// Two layers:
+//
+//   1. File-level allowlist. Only files matching one of the patterns
+//      in `ALLOWED_DIRS` may call `graphqlRequest` /
+//      `graphqlRequestTo`. The GraphQL client modules themselves
+//      (`src/lib/graphql/client.ts`, `src/lib/graphql/external-client.ts`)
+//      are also allowed because that is where the helpers live.
+//
+//   2. `buildDispatchContext` presence. For every allowlisted file
+//      that calls one of the helpers, the file must either import
+//      `buildDispatchContext` from another module **or** declare it
+//      locally as a top-level function / const. Detection's track
+//      uses the local-declaration form today
+//      (`src/lib/detection/server-actions.ts`); the Node track
+//      imports it from `src/lib/node/dispatch-context.ts`. Both
+//      patterns are accepted.
+//
+// Per-line override: append `// scope-allowlist: <reason>` to the
+// offending call-site line. The reason must be non-empty. The
+// override is intentionally noisy in code review so anyone reaching
+// for it has to justify it.
+//
+// Run via `pnpm check:scope`. Tests live at
+// `src/__tests__/scripts/check-dispatch-context.test.ts`.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), "..");
+
+// Files that are permitted to issue customer-scoped GraphQL requests.
+// Keep this list small and explicit. New entries should accompany an
+// architectural change, not an ordinary feature PR.
+const ALLOWED_DIRS = ["src/lib/node", "src/lib/detection"];
+
+// The GraphQL client modules themselves define and re-dispatch the
+// helpers; they have no caller-side scope to materialize and are
+// exempt from the `buildDispatchContext` presence check. Listing them
+// explicitly (rather than folding them into `ALLOWED_DIRS`) keeps the
+// "every consumer must build a dispatch context" rule unambiguous for
+// every other allowlisted file.
+const CLIENT_MODULES = new Set([
+  "src/lib/graphql/client.ts",
+  "src/lib/graphql/external-client.ts",
+]);
+
+// Directories that are excluded from the scan entirely. Tests and the
+// test harness exercise the helpers against fixtures and mock servers
+// where customer scope is supplied by the test fixture, not derived
+// from a real session.
+const EXCLUDED_DIRS = [
+  "src/__tests__",
+  "src/__integration__",
+  "src/test-harness",
+];
+
+// Source extensions to scan.
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+
+// Matches a real call site (`name(` or `name<…>(`) of the helpers.
+// `\b` ensures we don't match `myGraphqlRequest(`. The `To?` covers
+// both `graphqlRequest` and `graphqlRequestTo`.
+const CALL_RE = /\bgraphqlRequest(?:To)?\s*[<(]/;
+
+// Inline override: `// scope-allowlist: <reason>`. Reason must be
+// non-empty (after trimming).
+const OVERRIDE_RE = /\/\/\s*scope-allowlist:\s*(.+?)\s*$/;
+
+// `import { ..., buildDispatchContext, ... } from "..."`. Allows
+// arbitrary whitespace and `as` aliases between the braces. We do not
+// resolve the import path — any path that brings the symbol in scope
+// counts.
+const IMPORT_BUILD_DISPATCH_CONTEXT_RE =
+  /import\s*(?:type\s+)?\{[^}]*\bbuildDispatchContext\b[^}]*\}\s*from\s*["'][^"']+["']/;
+
+// `(async )?function buildDispatchContext(...)` or
+// `(export )?const buildDispatchContext = ...`.
+const LOCAL_DECL_RE =
+  /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?(?:function\s+buildDispatchContext\b|const\s+buildDispatchContext\b)/;
+
+function listSourceFiles(dir) {
+  const out = [];
+  walk(dir, out);
+  return out;
+}
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const abs = path.join(dir, entry);
+    let st;
+    try {
+      st = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      // Skip excluded test dirs early — even files within them that
+      // mention `graphqlRequest` are out of scope for the guard.
+      const rel = path.relative(ROOT, abs).split(path.sep).join("/");
+      if (EXCLUDED_DIRS.some((d) => rel === d || rel.startsWith(`${d}/`))) {
+        continue;
+      }
+      if (entry === "node_modules" || entry === ".next") continue;
+      walk(abs, out);
+    } else if (SOURCE_EXTS.has(path.extname(entry))) {
+      out.push(abs);
+    }
+  }
+}
+
+function isInAllowedDir(relPath) {
+  return ALLOWED_DIRS.some((d) => relPath === d || relPath.startsWith(`${d}/`));
+}
+
+function findCallSites(source) {
+  const lines = source.split("\n");
+  const sites = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (CALL_RE.test(line)) {
+      sites.push({ lineNumber: i + 1, line });
+    }
+  }
+  return sites;
+}
+
+function hasOverride(line) {
+  const match = line.match(OVERRIDE_RE);
+  if (!match) return false;
+  const reason = match[1].trim();
+  return reason.length > 0;
+}
+
+function hasBuildDispatchContext(source) {
+  if (IMPORT_BUILD_DISPATCH_CONTEXT_RE.test(source)) return true;
+  if (LOCAL_DECL_RE.test(source)) return true;
+  return false;
+}
+
+/**
+ * Run the guard against a virtual file system. Used by tests so they
+ * can supply fixture sources without touching the worktree.
+ *
+ * @param {Array<{ relPath: string, source: string }>} files
+ * @returns {Array<{ relPath: string, lineNumber: number, message: string }>}
+ *   List of violations. Empty array means the guard passes.
+ */
+export function checkFiles(files) {
+  const violations = [];
+  for (const { relPath, source } of files) {
+    const sites = findCallSites(source);
+    if (sites.length === 0) continue;
+
+    const isClientModule = CLIENT_MODULES.has(relPath);
+    const allowed = isClientModule || isInAllowedDir(relPath);
+
+    for (const site of sites) {
+      if (hasOverride(site.line)) continue;
+
+      if (!allowed) {
+        violations.push({
+          relPath,
+          lineNumber: site.lineNumber,
+          message:
+            `Call to graphqlRequest/graphqlRequestTo from ${relPath}:${site.lineNumber} ` +
+            "is outside the dispatch-context allowlist. Customer-scoped " +
+            "GraphQL requests must originate from src/lib/node, " +
+            "src/lib/detection, or the GraphQL client modules. If the call " +
+            "is intentional, append `// scope-allowlist: <reason>` to the " +
+            "line with a justification.",
+        });
+        continue;
+      }
+
+      // Client modules define / pass through the helpers and have no
+      // caller-side scope to materialize — skip the presence check.
+      if (isClientModule) continue;
+
+      // Allowlisted file: confirm `buildDispatchContext` is in scope.
+      if (!hasBuildDispatchContext(source)) {
+        violations.push({
+          relPath,
+          lineNumber: site.lineNumber,
+          message:
+            `${relPath}:${site.lineNumber} calls graphqlRequest/graphqlRequestTo ` +
+            "but neither imports nor locally declares `buildDispatchContext`. " +
+            "Customer scope must be materialized through " +
+            "`buildDispatchContext(session)` before dispatch. Use " +
+            "`// scope-allowlist: <reason>` only when the omission is " +
+            "deliberate (e.g. a non-customer-scoped manager query).",
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const srcDir = path.join(ROOT, "src");
+  const files = listSourceFiles(srcDir);
+  const inputs = files.map((abs) => ({
+    relPath: path.relative(ROOT, abs).split(path.sep).join("/"),
+    source: readFileSync(abs, "utf8"),
+  }));
+
+  const violations = checkFiles(inputs);
+  if (violations.length === 0) {
+    console.log(
+      `[check:scope] OK — scanned ${inputs.length} file(s), no violations.`,
+    );
+    return 0;
+  }
+
+  console.error(`[check:scope] FAIL — ${violations.length} violation(s):\n`);
+  for (const v of violations) {
+    console.error(`  • ${v.relPath}:${v.lineNumber}`);
+    console.error(`    ${v.message}\n`);
+  }
+  return 1;
+}
+
+// Only run the CLI when invoked directly (not when imported by tests).
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/scripts/check-dispatch-context.mjs
+++ b/scripts/check-dispatch-context.mjs
@@ -27,7 +27,15 @@
 //      uses the local-declaration form today
 //      (`src/lib/detection/server-actions.ts`); the Node track
 //      imports it from `src/lib/node/dispatch-context.ts`. Both
-//      patterns are accepted.
+//      patterns are accepted, but the contract is "symbol is in
+//      scope at runtime", so two shapes intentionally do NOT
+//      satisfy the check:
+//        * Type-only imports — both `import type { buildDispatchContext } ...`
+//          and `import { type buildDispatchContext } ...`. TypeScript
+//          erases these so the symbol is not in runtime scope.
+//        * Nested declarations — `function buildDispatchContext` /
+//          `const buildDispatchContext` inside another function or
+//          block. Only top-level (column-0) declarations count.
 //
 // Per-line override: append `// scope-allowlist: <reason>` to the
 // offending call-site line. The reason must be non-empty. The
@@ -112,21 +120,29 @@ const CALL_RE = /\bgraphqlRequest(?:To)?\s*[<(]/g;
 // non-empty (after trimming).
 const OVERRIDE_RE = /\/\/\s*scope-allowlist:\s*(.+?)\s*$/;
 
-// `import { ..., buildDispatchContext, ... } from "..."`. Allows
-// arbitrary whitespace and `as` aliases between the braces. We do not
-// resolve the import path — any path that brings the symbol in scope
-// counts. Run against the stripped source so neither a commented-out
-// import nor a string literal containing the import substring
-// satisfies the check; the path quotes survive the strip but the path
-// contents become spaces.
-const IMPORT_BUILD_DISPATCH_CONTEXT_RE =
-  /import\s*(?:type\s+)?\{[^}]*\bbuildDispatchContext\b[^}]*\}\s*from\s*["'][^"']*["']/;
+// `import { ..., buildDispatchContext, ... } from "..."`. Iterates
+// every `import { ... } from "..."` statement in the stripped source
+// and inspects each specifier individually so type-only imports do
+// NOT count: `import type { buildDispatchContext } ...` (whole-import
+// type modifier) and `import { type buildDispatchContext } ...`
+// (per-specifier type modifier) are both rejected because TypeScript
+// erases them at runtime — the symbol is not actually in scope when
+// the call site executes. `as` aliases are accepted (the symbol is in
+// scope under either name). We do not resolve the import path — any
+// path that brings the symbol in scope counts. Run against the
+// stripped source so a commented-out import or a string literal that
+// happens to contain the import substring is not honoured.
+const IMPORT_RE = /\bimport\s+(?:type\s+)?\{([^}]*)\}\s*from\s*["'][^"']*["']/g;
 
-// `(async )?function buildDispatchContext(...)` or
-// `(export )?const buildDispatchContext = ...`. Run against the
-// stripped source.
+// Top-level declaration only — must start at column 0 (no leading
+// whitespace). Nested `function buildDispatchContext` /
+// `const buildDispatchContext` declarations inside another function
+// or block do NOT bring the symbol into file scope, so they must NOT
+// satisfy the presence check. Run against the stripped source so a
+// commented-out declaration is not honoured. Anchored on `^` or `\n`
+// followed directly by the keyword (no `\s*`) to enforce column 0.
 const LOCAL_DECL_RE =
-  /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?(?:function\s+buildDispatchContext\b|const\s+buildDispatchContext\b)/;
+  /(?:^|\n)(?:export\s+)?(?:async\s+)?(?:function\s+buildDispatchContext\b|const\s+buildDispatchContext\b)/;
 
 function listSourceFiles(dir) {
   const out = [];
@@ -273,9 +289,34 @@ function hasOverride(lines) {
   return false;
 }
 
+function hasBuildDispatchContextImport(stripped) {
+  IMPORT_RE.lastIndex = 0;
+  for (;;) {
+    const match = IMPORT_RE.exec(stripped);
+    if (match === null) return false;
+    // Reject `import type { ... }` (whole-import type modifier).
+    // The leading `\b` in IMPORT_RE means `match[0]` starts at
+    // `import`, so we can test for `type` directly after it.
+    if (/^import\s+type\b/.test(match[0])) continue;
+    for (const rawSpec of match[1].split(",")) {
+      const spec = rawSpec.trim();
+      if (spec.length === 0) continue;
+      // Reject `{ type buildDispatchContext }` (per-specifier type
+      // modifier).
+      if (/^type\s+/.test(spec)) continue;
+      // Match either a direct specifier (`buildDispatchContext` /
+      // `buildDispatchContext as foo`) or a renamed import that
+      // brings the symbol into local scope (`foo as
+      // buildDispatchContext`). \b boundaries keep us off
+      // `myBuildDispatchContext` etc.
+      if (/\bbuildDispatchContext\b/.test(spec)) return true;
+    }
+  }
+}
+
 function hasBuildDispatchContext(source) {
   const stripped = stripCommentsAndStrings(source);
-  if (IMPORT_BUILD_DISPATCH_CONTEXT_RE.test(stripped)) return true;
+  if (hasBuildDispatchContextImport(stripped)) return true;
   if (LOCAL_DECL_RE.test(stripped)) return true;
   return false;
 }

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -24,6 +24,12 @@
  *       - account-A out-of-scope GET: 404 (not 403 — surfacing 403
  *         would disclose existence to the caller).
  *       - admin in-scope and out-of-scope GETs: 200.
+ *       - Optional `inScopeBodyAssertion` runs against the parsed
+ *         JSON body of in-scope GETs and is the regression hook for
+ *         routes that return a list under a parent path
+ *         (e.g. `/api/accounts/[id]/customers`) — without it a
+ *         200 only proves the path is reachable, not that the
+ *         response body is scoped.
  *
  *   - `mutation-scope` (POST / PATCH / DELETE):
  *       - Each per-persona slot has an optional `inScope` and
@@ -48,17 +54,15 @@
  *         tenant-administrator-style role: tenant scope plus the
  *         elevated permissions, but no `customers:access-all`.
  *
- *   - `admin-only`:
- *       - account-A and account-B: 4xx (typically 403 — neither holds
- *         the operation's permission).
- *       - admin: success status declared on the row.
- *       - Reserved for routes with no tenant-scope branch at all
- *         (e.g. POST /api/customers — there is no customer to be
- *         in/out of scope of). Routes that DO have a scope branch
- *         but require an elevated permission to reach it use
- *         `mutation-scope` with `personaUsernames` so the regression
- *         guard actually exercises the scope check, not just the
- *         permission gate.
+ * Routes whose only tenant gate is a permission check with no
+ * per-customer scope branch (e.g. `POST /api/customers`, which only
+ * needs `customers:write`) are intentionally **not** in this matrix.
+ * The matrix asserts the cross-customer scope contract; for those
+ * routes there is no customer to be in/out of scope of, so the
+ * regression-meaningful coverage is a permission-gate test in the
+ * route's own integration suite, not a row here. Adding such a route
+ * here would teach future authors that it is "admin-only" when in
+ * fact any holder of the required permission can succeed.
  *
  * The audit-log and customer rows are the regression tests for #386
  * and #387; the accounts rows cover the post-#387 customer-scoped
@@ -231,6 +235,23 @@ interface DetailEndpoint {
   /** Resource the path resolves against ("A" / "B"). */
   pathFor: (resources: Resources) => { inScopeA: string; inScopeB: string };
   expects: "200-on-in-scope-404-on-out-of-scope";
+  /**
+   * Optional assertion against the in-scope GET response body. Used by
+   * routes that return a list under a parent path (e.g.
+   * `GET /api/accounts/[id]/customers`) — a bare 200/404 status check
+   * only proves the route is reachable, not that the returned data
+   * itself is scoped. When defined, the harness fires this for the
+   * tenant in-scope variants of both account-A and account-B (and for
+   * the admin in-scope variants where the admin still hits a
+   * single-tenant target) so a future change that lets a parent route
+   * return a row belonging to the other customer is caught.
+   */
+  inScopeBodyAssertion?: (
+    body: unknown,
+    persona: Persona,
+    target: "A" | "B",
+    resources: Resources,
+  ) => void;
 }
 
 interface MutationVariant {
@@ -298,36 +319,7 @@ interface MutationEndpoint {
   ) => Promise<void>;
 }
 
-interface AdminOnlyEndpoint {
-  name: string;
-  method: "GET" | "POST" | "PATCH" | "DELETE";
-  expects: "admin-only";
-  /** Single request shape — admin-only routes have no per-persona scope. */
-  request: (resources: Resources) => {
-    path: string;
-    body?: unknown;
-  };
-  /** Status the admin call must produce (e.g. 200, 201). */
-  adminSuccessStatus: number;
-  /**
-   * Status non-admin callers must produce. Defaults to `[401, 403]`
-   * since admin-only routes typically refuse non-holders of the
-   * operation's permission with 403, but a few surface 401 if the
-   * route checks auth before perm.
-   */
-  nonAdminStatuses?: readonly number[];
-  /** Optional post-success cleanup mirroring `MutationEndpoint`. */
-  cleanupAfterSuccess?: (
-    resources: Resources,
-    adminSession: AuthSession,
-  ) => Promise<void>;
-}
-
-type Endpoint =
-  | ListEndpoint
-  | DetailEndpoint
-  | MutationEndpoint
-  | AdminOnlyEndpoint;
+type Endpoint = ListEndpoint | DetailEndpoint | MutationEndpoint;
 
 const ENDPOINTS: Endpoint[] = [
   // ── audit-logs (regression target for #386) ────────────────────
@@ -542,6 +534,13 @@ const ENDPOINTS: Endpoint[] = [
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
   },
+  // GET /api/accounts/[id]/customers — once the overlap gate clears,
+  // the route returns *every* assignment on the target account
+  // (`src/app/api/accounts/[id]/customers/route.ts:71-83`). A future
+  // change (or fixture extension) that linked an A-visible account to
+  // a B customer would leak that B customer to caller-A, with the
+  // status-only `200` check still green. Pin the in-scope body to the
+  // persona's own customer so that regression is caught.
   {
     name: "GET /api/accounts/[id]/customers",
     method: "GET",
@@ -550,6 +549,15 @@ const ENDPOINTS: Endpoint[] = [
       inScopeB: `/api/accounts/${r.accountBId}/customers`,
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
+    inScopeBodyAssertion: (body, _persona, target, r) => {
+      const data = (body as { data: Array<{ customer_id: number }> }).data;
+      expect(Array.isArray(data)).toBe(true);
+      const expectedCustomerId = target === "A" ? r.customerAId : r.customerBId;
+      const opposingCustomerId = target === "A" ? r.customerBId : r.customerAId;
+      const customerIds = data.map((row) => row.customer_id);
+      expect(customerIds).toContain(expectedCustomerId);
+      expect(customerIds).not.toContain(opposingCustomerId);
+    },
   },
   // POST /api/accounts — the regression we want to guard is the
   // customer-scope branch ("Cannot assign customers outside your
@@ -945,22 +953,15 @@ const ENDPOINTS: Endpoint[] = [
       admin: {},
     }),
   },
-  // ── admin-only example: POST /api/customers ────────────────────
-  //
-  // Creating a customer requires `customers:write`, which the
-  // tenant-style test role does not hold; this exercises the
-  // admin-only branch end-to-end. The created row is cleaned up via
-  // `deleteCustomersByPrefix` since the name carries `TEST_PREFIX`.
-  {
-    name: "POST /api/customers",
-    method: "POST",
-    expects: "admin-only",
-    request: () => ({
-      path: "/api/customers",
-      body: { name: `${TEST_PREFIX}AdminOnly-${Date.now()}` },
-    }),
-    adminSuccessStatus: 201,
-  },
+  // `POST /api/customers` is intentionally NOT in the matrix. It only
+  // requires `customers:write` and has no per-customer scope branch
+  // (no customer parameter to be in/out of scope of), so any holder
+  // of that permission — admin or a tenant-administrator-style
+  // manager — can hit the success path. Modeling it here would teach
+  // future authors that the route is "admin-only" when in fact the
+  // matrix's manager personas would also succeed; permission-gate
+  // coverage for the route lives in its own integration suite, not
+  // in this cross-customer scope guard.
 ];
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -991,23 +992,6 @@ async function fireMutation(
       return authPatch(session, variant.path, variant.body);
     case "DELETE":
       return authDelete(session, variant.path, variant.body);
-  }
-}
-
-async function fireAdminOnly(
-  session: AuthSession,
-  method: AdminOnlyEndpoint["method"],
-  request: { path: string; body?: unknown },
-): Promise<Response> {
-  switch (method) {
-    case "GET":
-      return authGet(session, request.path);
-    case "POST":
-      return authPost(session, request.path, request.body);
-    case "PATCH":
-      return authPatch(session, request.path, request.body);
-    case "DELETE":
-      return authDelete(session, request.path, request.body);
   }
 }
 
@@ -1324,12 +1308,24 @@ describe("Cross-customer scope matrix", () => {
       } else if (endpoint.expects === "200-on-in-scope-404-on-out-of-scope") {
         const detail = endpoint;
 
+        async function assertInScope(
+          response: Response,
+          persona: Persona,
+          target: "A" | "B",
+        ): Promise<void> {
+          expect(response.status).toBe(200);
+          if (detail.inScopeBodyAssertion) {
+            const body = await response.json();
+            detail.inScopeBodyAssertion(body, persona, target, resources);
+          }
+        }
+
         it("account-A: 200 on in-scope, 404 on out-of-scope", async () => {
           const session = await signIn(ACCOUNT_A_USERNAME);
           const paths = detail.pathFor(resources);
 
           const inScope = await authGet(session, paths.inScopeA);
-          expect(inScope.status).toBe(200);
+          await assertInScope(inScope, "account-A", "A");
 
           const outOfScope = await authGet(session, paths.inScopeB);
           // 404, not 403 — surfacing 403 would disclose existence of
@@ -1342,7 +1338,7 @@ describe("Cross-customer scope matrix", () => {
           const paths = detail.pathFor(resources);
 
           const inScope = await authGet(session, paths.inScopeB);
-          expect(inScope.status).toBe(200);
+          await assertInScope(inScope, "account-B", "B");
 
           const outOfScope = await authGet(session, paths.inScopeA);
           expect(outOfScope.status).toBe(404);
@@ -1353,10 +1349,10 @@ describe("Cross-customer scope matrix", () => {
           const paths = detail.pathFor(resources);
 
           const a = await authGet(session, paths.inScopeA);
-          expect(a.status).toBe(200);
+          await assertInScope(a, "admin", "A");
 
           const b = await authGet(session, paths.inScopeB);
-          expect(b.status).toBe(200);
+          await assertInScope(b, "admin", "B");
         });
       } else if (endpoint.expects === "mutation-scope") {
         const mutation = endpoint;
@@ -1422,32 +1418,6 @@ describe("Cross-customer scope matrix", () => {
             }
           });
         }
-      } else {
-        const adminOnly = endpoint;
-        const nonAdminStatuses = adminOnly.nonAdminStatuses ?? [401, 403];
-
-        for (const username of [ACCOUNT_A_USERNAME, ACCOUNT_B_USERNAME]) {
-          it(`${username}: rejected (no admin permission)`, async () => {
-            const session = await signIn(username);
-            const req = adminOnly.request(resources);
-            const res = await fireAdminOnly(session, adminOnly.method, req);
-            expect(nonAdminStatuses).toContain(res.status);
-          });
-        }
-
-        it("admin: succeeds", async () => {
-          const session = await signIn(ADMIN_USERNAME);
-          const req = adminOnly.request(resources);
-          const res = await fireAdminOnly(session, adminOnly.method, req);
-          expect(res.status).toBe(adminOnly.adminSuccessStatus);
-          if (
-            adminOnly.cleanupAfterSuccess &&
-            res.status >= 200 &&
-            res.status < 300
-          ) {
-            await adminOnly.cleanupAfterSuccess(resources, session);
-          }
-        });
       }
     });
   }

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -9,22 +9,47 @@
  * Per-row assertions (per the issue #388 contract):
  *
  *   - `list-scoped`:
- *       - account-A list: every row references customer A (or null
- *         only when the caller has `customers:access-all`).
- *       - account-B list: every row references customer B.
+ *       - account-A list: includes the customer-A fixture row, excludes
+ *         the customer-B fixture row. If the row payload exposes a
+ *         single `customer_id` field, every row's customer matches the
+ *         caller's customer (rows that don't expose one — e.g. the
+ *         accounts list, where the link is via `account_customer` and
+ *         not on the row — skip the per-row assertion).
+ *       - account-B list: mirror of account-A on customer B.
  *       - admin list: includes the customer-A row, the customer-B
  *         row, and any null-customer fixture row.
  *
  *   - `200-on-in-scope-404-on-out-of-scope`:
  *       - account-A in-scope GET: 200.
- *       - account-A out-of-scope GET: 404 (not 403 — that would
- *         disclose existence to the caller).
+ *       - account-A out-of-scope GET: 404 (not 403 — surfacing 403
+ *         would disclose existence to the caller).
  *       - admin in-scope and out-of-scope GETs: 200.
  *
- * The matrix is intentionally not exhaustive at landing time; it
- * pins the patterns and the regression tests for the hardening sweep
- * (#387) and audit-log viewer fix (#386). Extending it as more
- * customer-scoped endpoints land is the explicit goal.
+ *   - `mutation-scope` (POST / PATCH / DELETE):
+ *       - account-A with in-scope params: 2xx.
+ *       - account-A with out-of-scope params: 4xx (typically 403 for a
+ *         mutation that names an out-of-scope resource — distinct from
+ *         the read-side 404 since the caller is asserting they own the
+ *         input ids).
+ *       - account-B mirrors account-A on customer B.
+ *       - admin: 2xx for both in-scope and out-of-scope variants.
+ *
+ *   - `admin-only`:
+ *       - account-A and account-B: 4xx (typically 403 — neither holds
+ *         the operation's permission).
+ *       - admin: success status declared on the row.
+ *
+ * The audit-log and customer rows are the regression tests for #386
+ * and #387; the accounts rows cover the post-#387 customer-scoped
+ * surface that does not flow through `buildDispatchContext`. Routes
+ * that *do* flow through `buildDispatchContext` (e.g. the node API
+ * surface backed by REview / Tivan) are guarded by the static
+ * `pnpm check:scope` check and exercised against the `mock-graphql`
+ * helper in their feature-specific integration files; they are not
+ * driven by this matrix because the cross-customer contract there is
+ * "the JWT carries the right `customer_ids`", which is a structural
+ * assertion against the dispatch context, not a row-level DB scope
+ * check.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -32,7 +57,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   ADMIN_USERNAME,
   type AuthSession,
+  authDelete,
   authGet,
+  authPatch,
+  authPost,
   resetRateLimits,
   signIn,
 } from "../helpers/auth";
@@ -42,6 +70,7 @@ import {
   createTestAccount,
   createTestRole,
   deleteAuditLogById,
+  deleteAuditLogsByActor,
   deleteCustomersByPrefix,
   deleteRolesByPrefix,
   deleteTestAccount,
@@ -65,10 +94,14 @@ const COMMON_PASSWORD = "ScopeMatrix1234!";
 interface Resources {
   customerAId: number;
   customerBId: number;
+  accountAId: string;
+  accountBId: string;
   auditLogARowId: string;
   auditLogBRowId: string;
   auditLogNullRowId: string;
 }
+
+type Persona = "account-A" | "account-B" | "admin";
 
 // ── Endpoint matrix ──────────────────────────────────────────────
 //
@@ -82,10 +115,13 @@ interface ListEndpoint {
   path: string;
   expects: "list-scoped";
   /**
-   * Pull the customer id from a list row. Null means "row is
-   * customer-agnostic" — only admins should see those rows.
+   * Pull the customer id from a list row. Returning `null` means
+   * "customer-agnostic row" — only admins should see those. Returning
+   * `undefined` means "this row payload doesn't expose a single
+   * customer id" — skip the per-row customer assertion (e.g. accounts
+   * list, where membership is N:N via `account_customer`).
    */
-  rowCustomerId: (row: Record<string, unknown>) => number | null;
+  rowCustomerId: (row: Record<string, unknown>) => number | null | undefined;
   /**
    * Map of fixture row ids the matrix expects each persona to see /
    * not see. Keyed off `Resources` field names so the harness can
@@ -108,9 +144,77 @@ interface DetailEndpoint {
   expects: "200-on-in-scope-404-on-out-of-scope";
 }
 
-type Endpoint = ListEndpoint | DetailEndpoint;
+interface MutationVariant {
+  path: string;
+  body?: unknown;
+  expectStatus: number;
+}
+
+interface MutationEndpoint {
+  name: string;
+  method: "POST" | "PATCH" | "DELETE";
+  expects: "mutation-scope";
+  /**
+   * Build the request variants for each persona. The harness fires:
+   *   - account-A: `accountA.inScope` then `accountA.outOfScope`
+   *   - account-B: `accountB.inScope` then `accountB.outOfScope`
+   *   - admin:     `admin.inScope` then `admin.outOfScope`
+   * and asserts each response status equals the variant's
+   * `expectStatus`. Optional cleanup runs after each successful 2xx so
+   * mutation rows don't leak fixture state into later test runs.
+   */
+  request: (resources: Resources) => {
+    accountA: { inScope: MutationVariant; outOfScope: MutationVariant };
+    accountB: { inScope: MutationVariant; outOfScope: MutationVariant };
+    admin: { inScope: MutationVariant; outOfScope: MutationVariant };
+  };
+  /**
+   * Optional post-success cleanup. Fired after every 2xx mutation so
+   * the matrix can run against a long-lived dev DB without the
+   * mutations piling up. Receives the fixture, the persona, and the
+   * variant tag the call corresponds to.
+   */
+  cleanupAfterSuccess?: (
+    resources: Resources,
+    adminSession: AuthSession,
+    persona: Persona,
+    variant: "in-scope" | "out-of-scope",
+  ) => Promise<void>;
+}
+
+interface AdminOnlyEndpoint {
+  name: string;
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  expects: "admin-only";
+  /** Single request shape — admin-only routes have no per-persona scope. */
+  request: (resources: Resources) => {
+    path: string;
+    body?: unknown;
+  };
+  /** Status the admin call must produce (e.g. 200, 201). */
+  adminSuccessStatus: number;
+  /**
+   * Status non-admin callers must produce. Defaults to `[401, 403]`
+   * since admin-only routes typically refuse non-holders of the
+   * operation's permission with 403, but a few surface 401 if the
+   * route checks auth before perm.
+   */
+  nonAdminStatuses?: readonly number[];
+  /** Optional post-success cleanup mirroring `MutationEndpoint`. */
+  cleanupAfterSuccess?: (
+    resources: Resources,
+    adminSession: AuthSession,
+  ) => Promise<void>;
+}
+
+type Endpoint =
+  | ListEndpoint
+  | DetailEndpoint
+  | MutationEndpoint
+  | AdminOnlyEndpoint;
 
 const ENDPOINTS: Endpoint[] = [
+  // ── audit-logs (regression target for #386) ────────────────────
   {
     name: "GET /api/audit-logs",
     method: "GET",
@@ -133,6 +237,7 @@ const ENDPOINTS: Endpoint[] = [
       },
     },
   },
+  // ── customers (regression target for #387) ─────────────────────
   {
     name: "GET /api/customers",
     method: "GET",
@@ -163,6 +268,133 @@ const ENDPOINTS: Endpoint[] = [
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
   },
+  // ── accounts (post-#387 surface, local-DB scoped) ──────────────
+  {
+    name: "GET /api/accounts",
+    method: "GET",
+    path: "/api/accounts?pageSize=100",
+    expects: "list-scoped",
+    // Account rows don't expose a single customer_id (membership is
+    // N:N via `account_customer`); skip the per-row check and rely on
+    // include/exclude alone.
+    rowCustomerId: () => undefined,
+    rowId: (row) => String(row.id),
+    expectedRows: {
+      "account-A": {
+        include: ["accountAId"],
+        exclude: ["accountBId"],
+      },
+      "account-B": {
+        include: ["accountBId"],
+        exclude: ["accountAId"],
+      },
+      admin: {
+        include: ["accountAId", "accountBId"],
+      },
+    },
+  },
+  {
+    name: "GET /api/accounts/[id]",
+    method: "GET",
+    pathFor: (r) => ({
+      inScopeA: `/api/accounts/${r.accountAId}`,
+      inScopeB: `/api/accounts/${r.accountBId}`,
+    }),
+    expects: "200-on-in-scope-404-on-out-of-scope",
+  },
+  {
+    name: "GET /api/accounts/[id]/customers",
+    method: "GET",
+    pathFor: (r) => ({
+      inScopeA: `/api/accounts/${r.accountAId}/customers`,
+      inScopeB: `/api/accounts/${r.accountBId}/customers`,
+    }),
+    expects: "200-on-in-scope-404-on-out-of-scope",
+  },
+  // ── accounts mutation surface ──────────────────────────────────
+  //
+  // POST /api/accounts/[id]/customers — assigning customers to an
+  // account. In-scope: caller assigns one of their own customer ids
+  // to their own account. Out-of-scope: caller asks for a customer id
+  // outside their scope; the route must 403 BEFORE existence checks
+  // (see #387 P1 §4 / §7-2).
+  {
+    name: "POST /api/accounts/[id]/customers",
+    method: "POST",
+    expects: "mutation-scope",
+    request: (r) => ({
+      accountA: {
+        inScope: {
+          path: `/api/accounts/${r.accountAId}/customers`,
+          body: { customerIds: [r.customerAId] },
+          expectStatus: 201,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountAId}/customers`,
+          body: { customerIds: [r.customerBId] },
+          expectStatus: 403,
+        },
+      },
+      accountB: {
+        inScope: {
+          path: `/api/accounts/${r.accountBId}/customers`,
+          body: { customerIds: [r.customerBId] },
+          expectStatus: 201,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/customers`,
+          body: { customerIds: [r.customerAId] },
+          expectStatus: 403,
+        },
+      },
+      admin: {
+        // Admin can assign any customer to any account; "out-of-scope"
+        // doesn't apply, so both variants are real assignments. Use a
+        // distinct (account, customer) pair per variant so the second
+        // one isn't a no-op against the same row.
+        inScope: {
+          path: `/api/accounts/${r.accountAId}/customers`,
+          body: { customerIds: [r.customerBId] },
+          expectStatus: 201,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/customers`,
+          body: { customerIds: [r.customerAId] },
+          expectStatus: 201,
+        },
+      },
+    }),
+    cleanupAfterSuccess: async (resources, _adminSession) => {
+      // Reset to the canonical per-suite assignment so subsequent
+      // mutation rows / re-runs see the same fixture state.
+      await removeAccountCustomerAssignments(resources.accountAId);
+      await removeAccountCustomerAssignments(resources.accountBId);
+      await assignCustomerToAccount(
+        resources.accountAId,
+        resources.customerAId,
+      );
+      await assignCustomerToAccount(
+        resources.accountBId,
+        resources.customerBId,
+      );
+    },
+  },
+  // ── admin-only example: POST /api/customers ────────────────────
+  //
+  // Creating a customer requires `customers:write`, which the
+  // tenant-style test role does not hold; this exercises the
+  // admin-only branch end-to-end. The created row is cleaned up via
+  // `deleteCustomersByPrefix` since the name carries `TEST_PREFIX`.
+  {
+    name: "POST /api/customers",
+    method: "POST",
+    expects: "admin-only",
+    request: () => ({
+      path: "/api/customers",
+      body: { name: `${TEST_PREFIX}AdminOnly-${Date.now()}` },
+    }),
+    adminSuccessStatus: 201,
+  },
 ];
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -181,6 +413,38 @@ function resolveIds(resources: Resources, keys: (keyof Resources)[]): string[] {
   return keys.map((k) => String(resources[k]));
 }
 
+async function fireMutation(
+  session: AuthSession,
+  method: MutationEndpoint["method"],
+  variant: MutationVariant,
+): Promise<Response> {
+  switch (method) {
+    case "POST":
+      return authPost(session, variant.path, variant.body);
+    case "PATCH":
+      return authPatch(session, variant.path, variant.body);
+    case "DELETE":
+      return authDelete(session, variant.path, variant.body);
+  }
+}
+
+async function fireAdminOnly(
+  session: AuthSession,
+  method: AdminOnlyEndpoint["method"],
+  request: { path: string; body?: unknown },
+): Promise<Response> {
+  switch (method) {
+    case "GET":
+      return authGet(session, request.path);
+    case "POST":
+      return authPost(session, request.path, request.body);
+    case "PATCH":
+      return authPatch(session, request.path, request.body);
+    case "DELETE":
+      return authDelete(session, request.path, request.body);
+  }
+}
+
 // ── Suite ────────────────────────────────────────────────────────
 
 describe("Cross-customer scope matrix", () => {
@@ -197,11 +461,14 @@ describe("Cross-customer scope matrix", () => {
     await deleteRolesByPrefix("integ-scope-");
     await deleteCustomersByPrefix(TEST_PREFIX);
 
-    // Tenant-style role: read-only on customers and audit logs, no
-    // `customers:access-all`. The matrix only exercises read paths.
+    // Tenant-style role: scoped read on accounts/customers/audit-logs
+    // plus accounts:write so the mutation-scope row can exercise
+    // POST /api/accounts/[id]/customers from a non-admin caller.
+    // No `customers:access-all`, no `customers:write` — those gate the
+    // admin-only assertions.
     await createTestRole(
       ROLE_NAME,
-      ["customers:read", "audit-logs:read"],
+      ["customers:read", "audit-logs:read", "accounts:read", "accounts:write"],
       "Integration scope-matrix tenant role",
     );
 
@@ -241,6 +508,8 @@ describe("Cross-customer scope matrix", () => {
     resources = {
       customerAId,
       customerBId,
+      accountAId,
+      accountBId,
       auditLogARowId,
       auditLogBRowId,
       auditLogNullRowId,
@@ -259,6 +528,16 @@ describe("Cross-customer scope matrix", () => {
     await deleteAuditLogById(resources.auditLogBRowId);
     await deleteAuditLogById(resources.auditLogNullRowId);
 
+    // The mutation row emits `customer.assign` audit entries via the
+    // route under test (`POST /api/accounts/[id]/customers`). Those
+    // live in `audit_db` so they are not cascaded by the auth_db
+    // account/role/customer cleanup below — drop them by actor before
+    // detaching the test accounts so re-runs see a clean slate. Only
+    // the test-account actors are dropped; admin's row count is not
+    // touched since admin's audit history belongs to the dev DB.
+    await deleteAuditLogsByActor(resources.accountAId);
+    await deleteAuditLogsByActor(resources.accountBId);
+
     for (const username of [ACCOUNT_A_USERNAME, ACCOUNT_B_USERNAME]) {
       const id = await getAccountId(username).catch(() => null);
       if (id) await removeAccountCustomerAssignments(id);
@@ -275,57 +554,61 @@ describe("Cross-customer scope matrix", () => {
       if (endpoint.expects === "list-scoped") {
         const list = endpoint;
 
-        it("account-A sees only customer-A rows", async () => {
-          const session = await signIn(ACCOUNT_A_USERNAME);
-          const rows = await listRows(session, list.path);
-          const includeIds = resolveIds(
-            resources,
-            list.expectedRows["account-A"].include,
-          );
-          const excludeIds = resolveIds(
-            resources,
-            list.expectedRows["account-A"].exclude,
-          );
-          const rowIds = rows.map(list.rowId);
-          for (const id of includeIds) expect(rowIds).toContain(id);
-          for (const id of excludeIds) expect(rowIds).not.toContain(id);
-          for (const row of rows) {
-            const customerId = list.rowCustomerId(row);
-            expect(customerId).toBe(resources.customerAId);
-          }
-        });
+        const personaCases: Array<{
+          persona: Persona;
+          username: string;
+          customerKey: keyof Resources | null;
+          spec: { include: (keyof Resources)[]; exclude?: (keyof Resources)[] };
+        }> = [
+          {
+            persona: "account-A",
+            username: ACCOUNT_A_USERNAME,
+            customerKey: "customerAId",
+            spec: list.expectedRows["account-A"],
+          },
+          {
+            persona: "account-B",
+            username: ACCOUNT_B_USERNAME,
+            customerKey: "customerBId",
+            spec: list.expectedRows["account-B"],
+          },
+          {
+            persona: "admin",
+            username: ADMIN_USERNAME,
+            customerKey: null,
+            spec: list.expectedRows.admin,
+          },
+        ];
 
-        it("account-B sees only customer-B rows", async () => {
-          const session = await signIn(ACCOUNT_B_USERNAME);
-          const rows = await listRows(session, list.path);
-          const includeIds = resolveIds(
-            resources,
-            list.expectedRows["account-B"].include,
-          );
-          const excludeIds = resolveIds(
-            resources,
-            list.expectedRows["account-B"].exclude,
-          );
-          const rowIds = rows.map(list.rowId);
-          for (const id of includeIds) expect(rowIds).toContain(id);
-          for (const id of excludeIds) expect(rowIds).not.toContain(id);
-          for (const row of rows) {
-            const customerId = list.rowCustomerId(row);
-            expect(customerId).toBe(resources.customerBId);
-          }
-        });
+        for (const c of personaCases) {
+          it(`${c.persona} sees the expected rows`, async () => {
+            const session = await signIn(c.username);
+            const rows = await listRows(session, list.path);
+            const includeIds = resolveIds(resources, c.spec.include);
+            const rowIds = rows.map(list.rowId);
+            for (const id of includeIds) expect(rowIds).toContain(id);
 
-        it("admin sees rows from both customers (and null-customer rows when applicable)", async () => {
-          const session = await signIn(ADMIN_USERNAME);
-          const rows = await listRows(session, list.path);
-          const includeIds = resolveIds(
-            resources,
-            list.expectedRows.admin.include,
-          );
-          const rowIds = rows.map(list.rowId);
-          for (const id of includeIds) expect(rowIds).toContain(id);
-        });
-      } else {
+            if (c.spec.exclude) {
+              const excludeIds = resolveIds(resources, c.spec.exclude);
+              for (const id of excludeIds) expect(rowIds).not.toContain(id);
+            }
+
+            // Per-row customer-id check: skip when the endpoint can't
+            // expose a single customer per row (rowCustomerId returns
+            // undefined) or when the persona is admin (admin sees
+            // every customer).
+            if (c.persona !== "admin" && c.customerKey) {
+              const expectedCustomerId = resources[c.customerKey];
+              for (const row of rows) {
+                const customerId = list.rowCustomerId(row);
+                if (customerId !== undefined) {
+                  expect(customerId).toBe(expectedCustomerId);
+                }
+              }
+            }
+          });
+        }
+      } else if (endpoint.expects === "200-on-in-scope-404-on-out-of-scope") {
         const detail = endpoint;
 
         it("account-A: 200 on in-scope, 404 on out-of-scope", async () => {
@@ -361,6 +644,100 @@ describe("Cross-customer scope matrix", () => {
 
           const b = await authGet(session, paths.inScopeB);
           expect(b.status).toBe(200);
+        });
+      } else if (endpoint.expects === "mutation-scope") {
+        const mutation = endpoint;
+
+        const personaCases: Array<{
+          persona: Persona;
+          username: string;
+        }> = [
+          { persona: "account-A", username: ACCOUNT_A_USERNAME },
+          { persona: "account-B", username: ACCOUNT_B_USERNAME },
+          { persona: "admin", username: ADMIN_USERNAME },
+        ];
+
+        for (const c of personaCases) {
+          it(`${c.persona}: in-scope succeeds, out-of-scope is rejected`, async () => {
+            const variants = mutation.request(resources);
+            const personaVariants =
+              c.persona === "account-A"
+                ? variants.accountA
+                : c.persona === "account-B"
+                  ? variants.accountB
+                  : variants.admin;
+            const session = await signIn(c.username);
+
+            const inScopeRes = await fireMutation(
+              session,
+              mutation.method,
+              personaVariants.inScope,
+            );
+            expect(inScopeRes.status).toBe(
+              personaVariants.inScope.expectStatus,
+            );
+            if (
+              inScopeRes.status >= 200 &&
+              inScopeRes.status < 300 &&
+              mutation.cleanupAfterSuccess
+            ) {
+              const adminSession = await signIn(ADMIN_USERNAME);
+              await mutation.cleanupAfterSuccess(
+                resources,
+                adminSession,
+                c.persona,
+                "in-scope",
+              );
+            }
+
+            const outOfScopeRes = await fireMutation(
+              session,
+              mutation.method,
+              personaVariants.outOfScope,
+            );
+            expect(outOfScopeRes.status).toBe(
+              personaVariants.outOfScope.expectStatus,
+            );
+            if (
+              outOfScopeRes.status >= 200 &&
+              outOfScopeRes.status < 300 &&
+              mutation.cleanupAfterSuccess
+            ) {
+              const adminSession = await signIn(ADMIN_USERNAME);
+              await mutation.cleanupAfterSuccess(
+                resources,
+                adminSession,
+                c.persona,
+                "out-of-scope",
+              );
+            }
+          });
+        }
+      } else {
+        const adminOnly = endpoint;
+        const nonAdminStatuses = adminOnly.nonAdminStatuses ?? [401, 403];
+
+        for (const username of [ACCOUNT_A_USERNAME, ACCOUNT_B_USERNAME]) {
+          it(`${username}: rejected (no admin permission)`, async () => {
+            const session = await signIn(username);
+            const req = adminOnly.request(resources);
+            const res = await fireAdminOnly(session, adminOnly.method, req);
+            expect(nonAdminStatuses).toContain(res.status);
+          });
+        }
+
+        it("admin: succeeds", async () => {
+          const session = await signIn(ADMIN_USERNAME);
+          const req = adminOnly.request(resources);
+          const res = await fireAdminOnly(session, adminOnly.method, req);
+          expect(res.status).toBe(adminOnly.adminSuccessStatus);
+          if (
+            adminOnly.cleanupAfterSuccess &&
+            res.status >= 200 &&
+            res.status < 300
+          ) {
+            await adminOnly.cleanupAfterSuccess(resources, session);
+          }
         });
       }
     });

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -90,6 +90,10 @@ import {
 
 const TEST_PREFIX = "Integ-Scope-";
 const ROLE_NAME = "integ-scope-tenant";
+// Security Monitor-equivalent role used as the **target role** by the
+// `POST /api/accounts` row. Listed under the same `integ-scope-`
+// prefix so the suite cleanup picks it up via `deleteRolesByPrefix`.
+const MONITOR_ROLE_NAME = "integ-scope-monitor";
 
 const ACCOUNT_A_USERNAME = "integ-scope-account-a";
 const ACCOUNT_B_USERNAME = "integ-scope-account-b";
@@ -106,8 +110,15 @@ interface Resources {
   customerOrphanId: number;
   accountAId: string;
   accountBId: string;
-  /** Role id for the tenant test role; used by `POST /api/accounts`. */
-  tenantRoleId: number;
+  /**
+   * Role id for a Security Monitor-equivalent role (only allow-listed
+   * read permissions). Used as the **target role** by the
+   * `POST /api/accounts` row so the request reaches the customer-scope
+   * branch instead of failing at the tenant-manageability gate. The
+   * tenant caller's own role is unrelated; what matters is that the
+   * target role qualifies under `tenantManageable`.
+   */
+  monitorRoleId: number;
   auditLogARowId: string;
   auditLogBRowId: string;
   auditLogNullRowId: string;
@@ -367,35 +378,78 @@ const ENDPOINTS: Endpoint[] = [
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
   },
-  // POST /api/accounts — tenant role can call (it has accounts:write)
-  // but is rejected by the role-creation policy when the target role
-  // isn't Security Monitor-equivalent. The matrix doesn't seed a
-  // monitor-equiv role, so the tenant call will 403; admin uses the
-  // tenant role itself (which is fine for system-admin callers) to
-  // create a throwaway account that the cleanup deletes.
+  // POST /api/accounts — the regression we want to guard is the
+  // customer-scope branch ("Cannot assign customers outside your
+  // scope" at route step 5), so the request body has to reach that
+  // branch. That requires the **target role** to be tenant-manageable
+  // (Security Monitor-equivalent), otherwise tenant callers fail at
+  // the role-policy gate (step 3) and the scope check is never
+  // exercised. The matrix seeds a dedicated `monitorRoleId` for that
+  // purpose; the tenant caller's own role still lacks
+  // `customers:access-all`, so out-of-scope `customerIds` produce
+  // 403 and in-scope `customerIds` produce 201. Admin (System
+  // Administrator, has `customers:access-all`) can create with any
+  // customer set, so both variants succeed.
   {
     name: "POST /api/accounts",
     method: "POST",
-    expects: "admin-only",
-    request: (r) => ({
-      path: "/api/accounts",
-      body: {
-        username: `${TEST_PREFIX}created-${Date.now()}`.toLowerCase(),
-        displayName: `${TEST_PREFIX}created`,
+    expects: "mutation-scope",
+    request: (r) => {
+      const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const buildBody = (
+        suffix: string,
+        customerIds: number[],
+      ): Record<string, unknown> => ({
+        username: `${TEST_PREFIX}created-${suffix}-${stamp}`.toLowerCase(),
+        displayName: `${TEST_PREFIX}created-${suffix}`,
         password: COMMON_PASSWORD,
-        roleId: r.tenantRoleId,
-        customerIds: [r.customerAId],
-      },
-    }),
-    adminSuccessStatus: 201,
-    nonAdminStatuses: [403],
+        roleId: r.monitorRoleId,
+        customerIds,
+      });
+      return {
+        accountA: {
+          inScope: {
+            path: "/api/accounts",
+            body: buildBody("a-in", [r.customerAId]),
+            expectStatus: 201,
+          },
+          outOfScope: {
+            path: "/api/accounts",
+            body: buildBody("a-out", [r.customerBId]),
+            expectStatus: 403,
+          },
+        },
+        accountB: {
+          inScope: {
+            path: "/api/accounts",
+            body: buildBody("b-in", [r.customerBId]),
+            expectStatus: 201,
+          },
+          outOfScope: {
+            path: "/api/accounts",
+            body: buildBody("b-out", [r.customerAId]),
+            expectStatus: 403,
+          },
+        },
+        admin: {
+          inScope: {
+            path: "/api/accounts",
+            body: buildBody("admin-a", [r.customerAId]),
+            expectStatus: 201,
+          },
+          outOfScope: {
+            path: "/api/accounts",
+            body: buildBody("admin-b", [r.customerBId]),
+            expectStatus: 201,
+          },
+        },
+      };
+    },
     cleanupAfterSuccess: async () => {
-      // Drop every account whose username matches the matrix prefix.
-      // The admin variant generates a new timestamp-suffixed username
-      // each invocation, so a prefix sweep is the simplest way to
-      // keep the dev DB clean across re-runs.
-      // We use a SQL-level helper inline to avoid plumbing yet
-      // another helper for a single use.
+      // Sweep every account whose username matches the matrix prefix.
+      // Variants generate fresh timestamp+random usernames each run,
+      // so a prefix sweep is the simplest way to keep the dev DB
+      // clean across re-runs.
       await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`);
     },
   },
@@ -818,10 +872,21 @@ describe("Cross-customer scope matrix", () => {
     // mfa-reset from a non-admin caller. No `customers:access-all`,
     // `customers:write`, `customers:delete`, or `accounts:delete` —
     // those gate the admin-only assertions.
-    const tenantRoleId = await createTestRole(
+    await createTestRole(
       ROLE_NAME,
       ["customers:read", "audit-logs:read", "accounts:read", "accounts:write"],
       "Integration scope-matrix tenant role",
+    );
+
+    // Security Monitor-equivalent role used as the **target role** for
+    // `POST /api/accounts`. Permissions must all be drawn from the
+    // monitor allow-list in `account-role-policy.ts` so
+    // `tenantManageable` is true; otherwise the route's step-3 gate
+    // shorts the tenant's request before the customer-scope check.
+    const monitorRoleId = await createTestRole(
+      MONITOR_ROLE_NAME,
+      ["audit-logs:read"],
+      "Integration scope-matrix monitor-equivalent role",
     );
 
     const customerAId = await createCustomerRow(`${TEST_PREFIX}CustomerA`);
@@ -864,7 +929,7 @@ describe("Cross-customer scope matrix", () => {
       customerOrphanId,
       accountAId,
       accountBId,
-      tenantRoleId,
+      monitorRoleId,
       auditLogARowId,
       auditLogBRowId,
       auditLogNullRowId,
@@ -902,6 +967,7 @@ describe("Cross-customer scope matrix", () => {
     }
     await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`.toLowerCase());
     await deleteTestRole(ROLE_NAME);
+    await deleteTestRole(MONITOR_ROLE_NAME);
     await deleteCustomersByPrefix(TEST_PREFIX);
   });
 

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -35,13 +35,28 @@
  *       - Each per-persona slot has an optional `inScope` and
  *         `outOfScope` variant. The harness only fires variants that
  *         are defined and asserts each response status equals the
- *         variant's `expectStatus`. Routes whose tenant in-scope path
- *         would mutate fixture state we don't want to restore (e.g.
- *         password-reset, mfa-reset) only declare the tenant
- *         out-of-scope variant — the regression bar is "out-of-scope
- *         is rejected", not "every successful path is exercised".
- *         Optional `cleanupAfterSuccess` runs after each 2xx so
- *         mutation rows don't leak fixture state into later runs.
+ *         variant's `expectStatus`. Optional `cleanupAfterSuccess`
+ *         runs after each 2xx so mutation rows don't leak fixture
+ *         state into later runs.
+ *       - **Contract narrowing for auth-state-mutating routes.** The
+ *         issue describes a uniform three-persona / two-variant
+ *         matrix, but `POST /api/accounts/[id]/password-reset`,
+ *         `/unlock`, and `/mfa-reset` declare ONLY the tenant
+ *         `outOfScope` variant (no tenant in-scope, no admin success).
+ *         The cross-customer regression those routes can introduce
+ *         is "tenant reaches another tenant's account at all" — a
+ *         single 404 from `validateManagedAccountTarget` on an
+ *         out-of-scope target is the regression-meaningful assertion
+ *         and a future PR that drops the scope check will turn that
+ *         row red. The success paths are excluded on purpose: they
+ *         mutate authentication state (password hash, locked flag,
+ *         MFA enrolment, token version, live sessions) that the
+ *         matrix's other rows depend on, and the route-specific
+ *         integration suites (`src/__integration__/api/unlock.test.ts`,
+ *         the password / MFA suites) already cover the happy path
+ *         end-to-end. The intent is that this matrix freezes the
+ *         scope contract, not that it duplicates every per-route
+ *         success-path test.
  *       - Optional `personaUsernames` overrides the sign-in user for
  *         a persona slot (the persona label in the test name stays
  *         `account-A` / `account-B` so the matrix shape is uniform).
@@ -817,7 +832,10 @@ const ENDPOINTS: Endpoint[] = [
   // from their own account (200), then the cleanup re-adds. Out-of-
   // scope: tenant tries to unassign the OTHER tenant's customer from
   // the OTHER tenant's account; the assignment exists, so the route
-  // reaches the scope check and rejects with 403.
+  // reaches the scope check and rejects with 403. Admin
+  // (`customers:access-all`) reaches the route's success path on
+  // either side; both admin variants assert 200 and the cleanup
+  // re-establishes the canonical assignments after each success.
   {
     name: "DELETE /api/accounts/[id]/customers/[customerId]",
     method: "DELETE",
@@ -843,13 +861,16 @@ const ENDPOINTS: Endpoint[] = [
           expectStatus: 403,
         },
       },
-      // Admin variants intentionally omitted: re-firing admin-driven
-      // mutations on the same (account, customer) pair after the
-      // tenant in-scope variants would race the cleanup ordering.
-      // The route's "admin can do anything" path is exercised by the
-      // sibling POST row above; what this row guards is the tenant
-      // scope check, which the two non-admin personas already cover.
-      admin: {},
+      admin: {
+        inScope: {
+          path: `/api/accounts/${r.accountAId}/customers/${r.customerAId}`,
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/customers/${r.customerBId}`,
+          expectStatus: 200,
+        },
+      },
     }),
     cleanupAfterSuccess: async (
       resources,
@@ -1216,10 +1237,18 @@ describe("Cross-customer scope matrix", () => {
     // `DELETE /api/accounts/[id]`, etc.). Those live in `audit_db` so
     // they are not cascaded by the auth_db account/role/customer
     // cleanup below — drop them by actor before detaching the test
-    // accounts so re-runs see a clean slate. Only the test-account
-    // actors (and admin, since admin's matrix-driven rows also emit)
-    // are touched: admin's audit history outside the matrix isn't
-    // affected because we filter by actor_id, not by action.
+    // accounts so re-runs see a clean slate.
+    //
+    // Only the test-account actor ids are swept here. Admin-driven
+    // matrix rows also emit, but `deleteAuditLogsByActor(adminId)`
+    // would delete every admin audit entry on the dev database —
+    // including unrelated history outside this matrix — which is
+    // worse than leaving the matrix's admin entries in place. Those
+    // entries are pre-tagged with the matrix's prefixed test
+    // resources (created accounts under `${TEST_PREFIX}created-...`,
+    // descriptions like `${TEST_PREFIX}admin-a`) so they're easy to
+    // identify and drop manually if a developer ever wants the dev
+    // DB pristine.
     await deleteAuditLogsByActor(resources.accountAId);
     await deleteAuditLogsByActor(resources.accountBId);
     await deleteAuditLogsByActor(resources.managerAId);

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Cross-customer isolation matrix.
+ *
+ * One file, one fixture, one row per endpoint. Adding a new
+ * customer-scoped endpoint after this PR is a one-line change to
+ * `ENDPOINTS` below — the harness iterates and runs the standard
+ * assertions per row.
+ *
+ * Per-row assertions (per the issue #388 contract):
+ *
+ *   - `list-scoped`:
+ *       - account-A list: every row references customer A (or null
+ *         only when the caller has `customers:access-all`).
+ *       - account-B list: every row references customer B.
+ *       - admin list: includes the customer-A row, the customer-B
+ *         row, and any null-customer fixture row.
+ *
+ *   - `200-on-in-scope-404-on-out-of-scope`:
+ *       - account-A in-scope GET: 200.
+ *       - account-A out-of-scope GET: 404 (not 403 — that would
+ *         disclose existence to the caller).
+ *       - admin in-scope and out-of-scope GETs: 200.
+ *
+ * The matrix is intentionally not exhaustive at landing time; it
+ * pins the patterns and the regression tests for the hardening sweep
+ * (#387) and audit-log viewer fix (#386). Extending it as more
+ * customer-scoped endpoints land is the explicit goal.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ADMIN_USERNAME,
+  type AuthSession,
+  authGet,
+  resetRateLimits,
+  signIn,
+} from "../helpers/auth";
+import {
+  assignCustomerToAccount,
+  createCustomerRow,
+  createTestAccount,
+  createTestRole,
+  deleteAuditLogById,
+  deleteCustomersByPrefix,
+  deleteRolesByPrefix,
+  deleteTestAccount,
+  deleteTestRole,
+  getAccountId,
+  insertAuditLog,
+  removeAccountCustomerAssignments,
+  resetAccountDefaults,
+  revokeAllSessions,
+} from "../helpers/setup-db";
+
+// ── Fixtures ─────────────────────────────────────────────────────
+
+const TEST_PREFIX = "Integ-Scope-";
+const ROLE_NAME = "integ-scope-tenant";
+
+const ACCOUNT_A_USERNAME = "integ-scope-account-a";
+const ACCOUNT_B_USERNAME = "integ-scope-account-b";
+const COMMON_PASSWORD = "ScopeMatrix1234!";
+
+interface Resources {
+  customerAId: number;
+  customerBId: number;
+  auditLogARowId: string;
+  auditLogBRowId: string;
+  auditLogNullRowId: string;
+}
+
+// ── Endpoint matrix ──────────────────────────────────────────────
+//
+// Each row describes one customer-scoped endpoint and how to assert
+// scope behaviour against it. The harness runs the assertions for
+// every persona (account-A, account-B, admin) automatically.
+
+interface ListEndpoint {
+  name: string;
+  method: "GET";
+  path: string;
+  expects: "list-scoped";
+  /**
+   * Pull the customer id from a list row. Null means "row is
+   * customer-agnostic" — only admins should see those rows.
+   */
+  rowCustomerId: (row: Record<string, unknown>) => number | null;
+  /**
+   * Map of fixture row ids the matrix expects each persona to see /
+   * not see. Keyed off `Resources` field names so the harness can
+   * resolve them at run time without leaking ids into the matrix.
+   */
+  expectedRows: {
+    "account-A": { include: (keyof Resources)[]; exclude: (keyof Resources)[] };
+    "account-B": { include: (keyof Resources)[]; exclude: (keyof Resources)[] };
+    admin: { include: (keyof Resources)[] };
+  };
+  /** Pull a stable row identifier for inclusion checks. */
+  rowId: (row: Record<string, unknown>) => string;
+}
+
+interface DetailEndpoint {
+  name: string;
+  method: "GET";
+  /** Resource the path resolves against ("A" / "B"). */
+  pathFor: (resources: Resources) => { inScopeA: string; inScopeB: string };
+  expects: "200-on-in-scope-404-on-out-of-scope";
+}
+
+type Endpoint = ListEndpoint | DetailEndpoint;
+
+const ENDPOINTS: Endpoint[] = [
+  {
+    name: "GET /api/audit-logs",
+    method: "GET",
+    path: "/api/audit-logs?pageSize=100",
+    expects: "list-scoped",
+    rowCustomerId: (row) =>
+      typeof row.customer_id === "number" ? row.customer_id : null,
+    rowId: (row) => String(row.id),
+    expectedRows: {
+      "account-A": {
+        include: ["auditLogARowId"],
+        exclude: ["auditLogBRowId", "auditLogNullRowId"],
+      },
+      "account-B": {
+        include: ["auditLogBRowId"],
+        exclude: ["auditLogARowId", "auditLogNullRowId"],
+      },
+      admin: {
+        include: ["auditLogARowId", "auditLogBRowId", "auditLogNullRowId"],
+      },
+    },
+  },
+  {
+    name: "GET /api/customers",
+    method: "GET",
+    path: "/api/customers",
+    expects: "list-scoped",
+    rowCustomerId: (row) => (typeof row.id === "number" ? row.id : null),
+    rowId: (row) => String(row.id),
+    expectedRows: {
+      "account-A": {
+        include: ["customerAId"],
+        exclude: ["customerBId"],
+      },
+      "account-B": {
+        include: ["customerBId"],
+        exclude: ["customerAId"],
+      },
+      admin: {
+        include: ["customerAId", "customerBId"],
+      },
+    },
+  },
+  {
+    name: "GET /api/customers/[id]",
+    method: "GET",
+    pathFor: (r) => ({
+      inScopeA: `/api/customers/${r.customerAId}`,
+      inScopeB: `/api/customers/${r.customerBId}`,
+    }),
+    expects: "200-on-in-scope-404-on-out-of-scope",
+  },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function listRows(
+  session: AuthSession,
+  path: string,
+): Promise<Record<string, unknown>[]> {
+  const response = await authGet(session, path);
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { data: Record<string, unknown>[] };
+  return body.data;
+}
+
+function resolveIds(resources: Resources, keys: (keyof Resources)[]): string[] {
+  return keys.map((k) => String(resources[k]));
+}
+
+// ── Suite ────────────────────────────────────────────────────────
+
+describe("Cross-customer scope matrix", () => {
+  let resources: Resources;
+
+  beforeAll(async () => {
+    await resetRateLimits();
+    await resetAccountDefaults(ADMIN_USERNAME);
+
+    // Clean up any prior state.
+    await deleteTestAccount(ACCOUNT_A_USERNAME);
+    await deleteTestAccount(ACCOUNT_B_USERNAME);
+    await deleteTestRole(ROLE_NAME);
+    await deleteRolesByPrefix("integ-scope-");
+    await deleteCustomersByPrefix(TEST_PREFIX);
+
+    // Tenant-style role: read-only on customers and audit logs, no
+    // `customers:access-all`. The matrix only exercises read paths.
+    await createTestRole(
+      ROLE_NAME,
+      ["customers:read", "audit-logs:read"],
+      "Integration scope-matrix tenant role",
+    );
+
+    const customerAId = await createCustomerRow(`${TEST_PREFIX}CustomerA`);
+    const customerBId = await createCustomerRow(`${TEST_PREFIX}CustomerB`);
+
+    await createTestAccount(ACCOUNT_A_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+    await createTestAccount(ACCOUNT_B_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+
+    const accountAId = await getAccountId(ACCOUNT_A_USERNAME);
+    const accountBId = await getAccountId(ACCOUNT_B_USERNAME);
+    await assignCustomerToAccount(accountAId, customerAId);
+    await assignCustomerToAccount(accountBId, customerBId);
+
+    const auditLogARowId = await insertAuditLog({
+      actorId: accountAId,
+      action: "customer.assign",
+      targetType: "account",
+      targetId: accountAId,
+      customerId: customerAId,
+    });
+    const auditLogBRowId = await insertAuditLog({
+      actorId: accountBId,
+      action: "customer.assign",
+      targetType: "account",
+      targetId: accountBId,
+      customerId: customerBId,
+    });
+    const auditLogNullRowId = await insertAuditLog({
+      actorId: "system",
+      action: "account.login",
+      targetType: "account",
+      targetId: accountAId,
+      customerId: null,
+    });
+
+    resources = {
+      customerAId,
+      customerBId,
+      auditLogARowId,
+      auditLogBRowId,
+      auditLogNullRowId,
+    };
+  });
+
+  beforeEach(async () => {
+    await resetRateLimits();
+    await revokeAllSessions(ADMIN_USERNAME);
+    await revokeAllSessions(ACCOUNT_A_USERNAME);
+    await revokeAllSessions(ACCOUNT_B_USERNAME);
+  });
+
+  afterAll(async () => {
+    await deleteAuditLogById(resources.auditLogARowId);
+    await deleteAuditLogById(resources.auditLogBRowId);
+    await deleteAuditLogById(resources.auditLogNullRowId);
+
+    for (const username of [ACCOUNT_A_USERNAME, ACCOUNT_B_USERNAME]) {
+      const id = await getAccountId(username).catch(() => null);
+      if (id) await removeAccountCustomerAssignments(id);
+      await deleteTestAccount(username);
+    }
+    await deleteTestRole(ROLE_NAME);
+    await deleteCustomersByPrefix(TEST_PREFIX);
+  });
+
+  // The matrix is generated at import time; vitest needs `describe.each`
+  // to discover the row names, so iterate manually.
+  for (const endpoint of ENDPOINTS) {
+    describe(endpoint.name, () => {
+      if (endpoint.expects === "list-scoped") {
+        const list = endpoint;
+
+        it("account-A sees only customer-A rows", async () => {
+          const session = await signIn(ACCOUNT_A_USERNAME);
+          const rows = await listRows(session, list.path);
+          const includeIds = resolveIds(
+            resources,
+            list.expectedRows["account-A"].include,
+          );
+          const excludeIds = resolveIds(
+            resources,
+            list.expectedRows["account-A"].exclude,
+          );
+          const rowIds = rows.map(list.rowId);
+          for (const id of includeIds) expect(rowIds).toContain(id);
+          for (const id of excludeIds) expect(rowIds).not.toContain(id);
+          for (const row of rows) {
+            const customerId = list.rowCustomerId(row);
+            expect(customerId).toBe(resources.customerAId);
+          }
+        });
+
+        it("account-B sees only customer-B rows", async () => {
+          const session = await signIn(ACCOUNT_B_USERNAME);
+          const rows = await listRows(session, list.path);
+          const includeIds = resolveIds(
+            resources,
+            list.expectedRows["account-B"].include,
+          );
+          const excludeIds = resolveIds(
+            resources,
+            list.expectedRows["account-B"].exclude,
+          );
+          const rowIds = rows.map(list.rowId);
+          for (const id of includeIds) expect(rowIds).toContain(id);
+          for (const id of excludeIds) expect(rowIds).not.toContain(id);
+          for (const row of rows) {
+            const customerId = list.rowCustomerId(row);
+            expect(customerId).toBe(resources.customerBId);
+          }
+        });
+
+        it("admin sees rows from both customers (and null-customer rows when applicable)", async () => {
+          const session = await signIn(ADMIN_USERNAME);
+          const rows = await listRows(session, list.path);
+          const includeIds = resolveIds(
+            resources,
+            list.expectedRows.admin.include,
+          );
+          const rowIds = rows.map(list.rowId);
+          for (const id of includeIds) expect(rowIds).toContain(id);
+        });
+      } else {
+        const detail = endpoint;
+
+        it("account-A: 200 on in-scope, 404 on out-of-scope", async () => {
+          const session = await signIn(ACCOUNT_A_USERNAME);
+          const paths = detail.pathFor(resources);
+
+          const inScope = await authGet(session, paths.inScopeA);
+          expect(inScope.status).toBe(200);
+
+          const outOfScope = await authGet(session, paths.inScopeB);
+          // 404, not 403 — surfacing 403 would disclose existence of
+          // an out-of-scope resource to the caller.
+          expect(outOfScope.status).toBe(404);
+        });
+
+        it("account-B: 200 on in-scope, 404 on out-of-scope", async () => {
+          const session = await signIn(ACCOUNT_B_USERNAME);
+          const paths = detail.pathFor(resources);
+
+          const inScope = await authGet(session, paths.inScopeB);
+          expect(inScope.status).toBe(200);
+
+          const outOfScope = await authGet(session, paths.inScopeA);
+          expect(outOfScope.status).toBe(404);
+        });
+
+        it("admin: 200 on every resource", async () => {
+          const session = await signIn(ADMIN_USERNAME);
+          const paths = detail.pathFor(resources);
+
+          const a = await authGet(session, paths.inScopeA);
+          expect(a.status).toBe(200);
+
+          const b = await authGet(session, paths.inScopeB);
+          expect(b.status).toBe(200);
+        });
+      }
+    });
+  }
+});

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -504,20 +504,32 @@ const ENDPOINTS: Endpoint[] = [
     expects: "list-scoped",
     // Account rows don't expose a single customer_id (membership is
     // N:N via `account_customer`); skip the per-row check and rely on
-    // include/exclude alone.
+    // include/exclude alone. The route scopes by shared-customer
+    // overlap (`src/app/api/accounts/route.ts:42-93`), so the
+    // include/exclude lists must enumerate every seeded fixture
+    // account on each side: a tenant caller must see every account
+    // linked to its customer (self + manager + monitor-target) and
+    // must NOT see any account linked to the opposite customer.
     rowCustomerId: () => undefined,
     rowId: (row) => String(row.id),
     expectedRows: {
       "account-A": {
-        include: ["accountAId"],
-        exclude: ["accountBId"],
+        include: ["accountAId", "managerAId", "monitorTargetAId"],
+        exclude: ["accountBId", "managerBId", "monitorTargetBId"],
       },
       "account-B": {
-        include: ["accountBId"],
-        exclude: ["accountAId"],
+        include: ["accountBId", "managerBId", "monitorTargetBId"],
+        exclude: ["accountAId", "managerAId", "monitorTargetAId"],
       },
       admin: {
-        include: ["accountAId", "accountBId"],
+        include: [
+          "accountAId",
+          "accountBId",
+          "managerAId",
+          "managerBId",
+          "monitorTargetAId",
+          "monitorTargetBId",
+        ],
       },
     },
   },

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -36,11 +36,29 @@
  *         is rejected", not "every successful path is exercised".
  *         Optional `cleanupAfterSuccess` runs after each 2xx so
  *         mutation rows don't leak fixture state into later runs.
+ *       - Optional `personaUsernames` overrides the sign-in user for
+ *         a persona slot (the persona label in the test name stays
+ *         `account-A` / `account-B` so the matrix shape is uniform).
+ *         Used by rows whose route requires a permission the base
+ *         tenant role doesn't carry (`customers:write`,
+ *         `customers:delete`, `accounts:delete`) so the request
+ *         actually reaches the tenant-scope branch instead of being
+ *         short-circuited at the permission gate. The override
+ *         personas (`manager-A` / `manager-B`) are seeded with a
+ *         tenant-administrator-style role: tenant scope plus the
+ *         elevated permissions, but no `customers:access-all`.
  *
  *   - `admin-only`:
  *       - account-A and account-B: 4xx (typically 403 — neither holds
  *         the operation's permission).
  *       - admin: success status declared on the row.
+ *       - Reserved for routes with no tenant-scope branch at all
+ *         (e.g. POST /api/customers — there is no customer to be
+ *         in/out of scope of). Routes that DO have a scope branch
+ *         but require an elevated permission to reach it use
+ *         `mutation-scope` with `personaUsernames` so the regression
+ *         guard actually exercises the scope check, not just the
+ *         permission gate.
  *
  * The audit-log and customer rows are the regression tests for #386
  * and #387; the accounts rows cover the post-#387 customer-scoped
@@ -91,25 +109,73 @@ import {
 const TEST_PREFIX = "Integ-Scope-";
 const ROLE_NAME = "integ-scope-tenant";
 // Security Monitor-equivalent role used as the **target role** by the
-// `POST /api/accounts` row. Listed under the same `integ-scope-`
-// prefix so the suite cleanup picks it up via `deleteRolesByPrefix`.
+// `POST /api/accounts` row, and also as the role assigned to the
+// `monitor-target-A` / `-B` accounts that the `DELETE /api/accounts/[id]`
+// row deletes (the route requires the target role to be tenant-
+// manageable, i.e. monitor-equivalent). Listed under the same
+// `integ-scope-` prefix so the suite cleanup picks it up via
+// `deleteRolesByPrefix`.
 const MONITOR_ROLE_NAME = "integ-scope-monitor";
+// Tenant-administrator-style role used by the `manager-A` / `-B`
+// personas. Carries the elevated permissions
+// (`customers:write` / `customers:delete` / `accounts:delete`) that
+// the rows for `PATCH /api/customers/[id]`,
+// `DELETE /api/customers/[id]`, and `DELETE /api/accounts/[id]` need
+// the caller to hold so the request reaches the route's tenant-scope
+// check. Crucially, no `customers:access-all` — that's what makes the
+// scope check fire.
+const MANAGER_ROLE_NAME = "integ-scope-manager";
 
 const ACCOUNT_A_USERNAME = "integ-scope-account-a";
 const ACCOUNT_B_USERNAME = "integ-scope-account-b";
+// Manager personas — same `accounts:write`, `accounts:read`,
+// `customers:read`, `audit-logs:read` as the tenant role, plus
+// `customers:write`, `customers:delete`, `accounts:delete`. Customer
+// scope: A on customer-A, B on customer-B (mirrors the tenant fixture).
+const MANAGER_A_USERNAME = "integ-scope-manager-a";
+const MANAGER_B_USERNAME = "integ-scope-manager-b";
+// Monitor-target accounts used as the **target** of the
+// `DELETE /api/accounts/[id]` row. The route's
+// `validateManagedAccountTarget` rejects targets whose role is not
+// tenant-manageable (i.e. anything outside the Security Monitor
+// allow-list), so the tenant accounts above can't be the deletion
+// target. These two accounts hold the monitor role and are linked to
+// customer-A / customer-B respectively so the manager personas can
+// reach the scope branch.
+const MONITOR_TARGET_A_USERNAME = "integ-scope-monitor-target-a";
+const MONITOR_TARGET_B_USERNAME = "integ-scope-monitor-target-b";
 const COMMON_PASSWORD = "ScopeMatrix1234!";
 
 interface Resources {
   customerAId: number;
   customerBId: number;
   /**
-   * Customer with no account assignments. Used by the
-   * `DELETE /api/customers/[id]` row, since the route refuses to drop
-   * a customer that still has linked accounts.
+   * Customer with no account assignments. Used by the admin in-scope
+   * variant of the `DELETE /api/customers/[id]` row, since the route
+   * refuses to drop a customer that still has linked accounts.
    */
   customerOrphanId: number;
   accountAId: string;
   accountBId: string;
+  /**
+   * Manager personas — non-`access-all` callers carrying
+   * `customers:write` / `customers:delete` / `accounts:delete`. Used
+   * by the rows that need a non-admin caller to reach the route's
+   * tenant-scope branch (`PATCH /api/customers/[id]`,
+   * `DELETE /api/customers/[id]` out-of-scope variant,
+   * `DELETE /api/accounts/[id]`). Manager-A is scoped to customer-A,
+   * manager-B to customer-B.
+   */
+  managerAId: string;
+  managerBId: string;
+  /**
+   * Monitor-equivalent target accounts deleted by the
+   * `DELETE /api/accounts/[id]` row. Linked to customer-A / customer-B
+   * respectively so the manager personas can reach the scope branch
+   * (in-scope → 200, out-of-scope → 404 from `validateManagedAccountTarget`).
+   */
+  monitorTargetAId: string;
+  monitorTargetBId: string;
   /**
    * Role id for a Security Monitor-equivalent role (only allow-listed
    * read permissions). Used as the **target role** by the
@@ -202,6 +268,21 @@ interface MutationEndpoint {
     accountA: PersonaMutationVariants;
     accountB: PersonaMutationVariants;
     admin: PersonaMutationVariants;
+  };
+  /**
+   * Optional per-persona sign-in override. Defaults to the suite's
+   * `account-A` / `account-B` / `admin` usernames; rows whose route
+   * requires a permission the tenant role doesn't carry (e.g.
+   * `customers:write`, `customers:delete`, `accounts:delete`) override
+   * the `accountA` / `accountB` slots to the manager personas so the
+   * request reaches the route's tenant-scope branch. The persona
+   * label in the test name stays `account-A` / `account-B` so the
+   * matrix shape stays uniform.
+   */
+  personaUsernames?: {
+    accountA?: string;
+    accountB?: string;
+    admin?: string;
   };
   /**
    * Optional post-success cleanup. Fired after every 2xx mutation so
@@ -303,34 +384,114 @@ const ENDPOINTS: Endpoint[] = [
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
   },
+  // PATCH /api/customers/[id] — needs `customers:write`. The route's
+  // tenant scope check fires for any non-`access-all` caller; a
+  // regression that drops the check would let a tenant edit a
+  // customer they have no scope on. The base tenant role doesn't
+  // carry `customers:write`, so the row uses the manager personas
+  // (which do) — that's how the request actually reaches the scope
+  // branch instead of being rejected at the permission gate.
   {
     name: "PATCH /api/customers/[id]",
     method: "PATCH",
-    expects: "admin-only",
+    expects: "mutation-scope",
+    personaUsernames: {
+      accountA: MANAGER_A_USERNAME,
+      accountB: MANAGER_B_USERNAME,
+    },
     request: (r) => ({
-      path: `/api/customers/${r.customerOrphanId}`,
-      body: { description: `${TEST_PREFIX}admin-only-patched` },
+      accountA: {
+        inScope: {
+          path: `/api/customers/${r.customerAId}`,
+          body: { description: `${TEST_PREFIX}manager-a-in` },
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/customers/${r.customerBId}`,
+          body: { description: `${TEST_PREFIX}manager-a-out` },
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        inScope: {
+          path: `/api/customers/${r.customerBId}`,
+          body: { description: `${TEST_PREFIX}manager-b-in` },
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/customers/${r.customerAId}`,
+          body: { description: `${TEST_PREFIX}manager-b-out` },
+          expectStatus: 404,
+        },
+      },
+      admin: {
+        inScope: {
+          path: `/api/customers/${r.customerAId}`,
+          body: { description: `${TEST_PREFIX}admin-a` },
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/customers/${r.customerBId}`,
+          body: { description: `${TEST_PREFIX}admin-b` },
+          expectStatus: 200,
+        },
+      },
     }),
-    adminSuccessStatus: 200,
     cleanupAfterSuccess: async (r, adminSession) => {
-      // Restore the description to its original empty state so
-      // re-runs don't drift the fixture.
-      await authPatch(adminSession, `/api/customers/${r.customerOrphanId}`, {
+      // Restore both customers' descriptions to their original empty
+      // state so re-runs against a long-lived dev DB stay stable.
+      await authPatch(adminSession, `/api/customers/${r.customerAId}`, {
+        description: null,
+      });
+      await authPatch(adminSession, `/api/customers/${r.customerBId}`, {
         description: null,
       });
     },
   },
+  // DELETE /api/customers/[id] — needs `customers:delete`. Same
+  // reasoning as PATCH above for using the manager personas. The
+  // tenant in-scope path is intentionally NOT exercised because the
+  // route is structurally unreachable for tenants: the scope check
+  // requires the caller to be linked to the customer
+  // (`account_customer` row exists) and the next gate
+  // (`Cannot delete customer with active account assignments`)
+  // refuses any customer with at least one link — so a non-
+  // `access-all` caller cannot pass both gates on the same customer.
+  // The regression-meaningful path for tenants is the out-of-scope
+  // 404; for admin we exercise the orphan-customer in-scope success
+  // (cleanup recreates the orphan).
   {
     name: "DELETE /api/customers/[id]",
     method: "DELETE",
-    expects: "admin-only",
-    request: (r) => ({ path: `/api/customers/${r.customerOrphanId}` }),
-    adminSuccessStatus: 200,
+    expects: "mutation-scope",
+    personaUsernames: {
+      accountA: MANAGER_A_USERNAME,
+      accountB: MANAGER_B_USERNAME,
+    },
+    request: (r) => ({
+      accountA: {
+        outOfScope: {
+          path: `/api/customers/${r.customerBId}`,
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        outOfScope: {
+          path: `/api/customers/${r.customerAId}`,
+          expectStatus: 404,
+        },
+      },
+      admin: {
+        inScope: {
+          path: `/api/customers/${r.customerOrphanId}`,
+          expectStatus: 200,
+        },
+      },
+    }),
     cleanupAfterSuccess: async (r) => {
       // The admin success deletes the orphan customer. Recreate it so
       // the fixture state is consistent for re-runs against a
-      // long-lived dev DB. The id changes, but the matrix doesn't
-      // re-read `r.customerOrphanId` after this row runs.
+      // long-lived dev DB.
       await deleteCustomersByPrefix(`${TEST_PREFIX}Orphan`);
       r.customerOrphanId = await createCustomerRow(`${TEST_PREFIX}Orphan`);
     },
@@ -504,18 +665,63 @@ const ENDPOINTS: Endpoint[] = [
       },
     }),
   },
-  // DELETE /api/accounts/[id] — admin-only because tenant role lacks
-  // `accounts:delete`. The admin success disables account-A; the
-  // cleanup re-enables it so subsequent rows / re-runs aren't broken.
+  // DELETE /api/accounts/[id] — needs `accounts:delete`, AND the
+  // target's role must be tenant-manageable (Security Monitor-
+  // equivalent) for the non-admin path to clear
+  // `validateManagedAccountTarget`'s role-policy gate. Manager
+  // personas hold `accounts:delete`; the deletion targets are the
+  // dedicated monitor-target accounts (not the tenant accounts above,
+  // which have non-monitor permissions and would 403 at the role-
+  // policy gate before the scope check). With those in place the
+  // route reaches the scope branch: in-scope (overlap with target's
+  // customer) → 200, out-of-scope (no overlap) → 404. Admin holds
+  // `customers:access-all`, so both variants succeed; cleanup
+  // re-enables both monitor targets.
   {
     name: "DELETE /api/accounts/[id]",
     method: "DELETE",
-    expects: "admin-only",
-    request: (r) => ({ path: `/api/accounts/${r.accountAId}` }),
-    adminSuccessStatus: 200,
-    nonAdminStatuses: [403],
+    expects: "mutation-scope",
+    personaUsernames: {
+      accountA: MANAGER_A_USERNAME,
+      accountB: MANAGER_B_USERNAME,
+    },
+    request: (r) => ({
+      accountA: {
+        inScope: {
+          path: `/api/accounts/${r.monitorTargetAId}`,
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.monitorTargetBId}`,
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        inScope: {
+          path: `/api/accounts/${r.monitorTargetBId}`,
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.monitorTargetAId}`,
+          expectStatus: 404,
+        },
+      },
+      admin: {
+        inScope: {
+          path: `/api/accounts/${r.monitorTargetAId}`,
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.monitorTargetBId}`,
+          expectStatus: 200,
+        },
+      },
+    }),
     cleanupAfterSuccess: async () => {
-      await setAccountStatus(ACCOUNT_A_USERNAME, "active", null);
+      // Re-enable both monitor targets so the subsequent variants /
+      // re-runs see them in their original active state.
+      await setAccountStatus(MONITOR_TARGET_A_USERNAME, "active", null);
+      await setAccountStatus(MONITOR_TARGET_B_USERNAME, "active", null);
     },
   },
   // ── accounts mutation surface ──────────────────────────────────
@@ -860,6 +1066,10 @@ describe("Cross-customer scope matrix", () => {
     // Clean up any prior state.
     await deleteTestAccount(ACCOUNT_A_USERNAME);
     await deleteTestAccount(ACCOUNT_B_USERNAME);
+    await deleteTestAccount(MANAGER_A_USERNAME);
+    await deleteTestAccount(MANAGER_B_USERNAME);
+    await deleteTestAccount(MONITOR_TARGET_A_USERNAME);
+    await deleteTestAccount(MONITOR_TARGET_B_USERNAME);
     await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`.toLowerCase());
     await deleteTestRole(ROLE_NAME);
     await deleteRolesByPrefix("integ-scope-");
@@ -871,18 +1081,41 @@ describe("Cross-customer scope matrix", () => {
     // and the admin-bypass rows on password-reset / unlock /
     // mfa-reset from a non-admin caller. No `customers:access-all`,
     // `customers:write`, `customers:delete`, or `accounts:delete` —
-    // those gate the admin-only assertions.
+    // those are carried by the manager role below so the
+    // PATCH /api/customers/[id], DELETE /api/customers/[id], and
+    // DELETE /api/accounts/[id] rows reach the route's tenant scope
+    // branch instead of being short-circuited at the permission gate.
     await createTestRole(
       ROLE_NAME,
       ["customers:read", "audit-logs:read", "accounts:read", "accounts:write"],
       "Integration scope-matrix tenant role",
     );
 
-    // Security Monitor-equivalent role used as the **target role** for
-    // `POST /api/accounts`. Permissions must all be drawn from the
-    // monitor allow-list in `account-role-policy.ts` so
-    // `tenantManageable` is true; otherwise the route's step-3 gate
-    // shorts the tenant's request before the customer-scope check.
+    // Manager (tenant administrator-style) role: tenant role +
+    // `customers:write`, `customers:delete`, `accounts:delete`. No
+    // `customers:access-all` — that's what makes the route-level scope
+    // checks fire.
+    await createTestRole(
+      MANAGER_ROLE_NAME,
+      [
+        "customers:read",
+        "customers:write",
+        "customers:delete",
+        "audit-logs:read",
+        "accounts:read",
+        "accounts:write",
+        "accounts:delete",
+      ],
+      "Integration scope-matrix manager (tenant-admin) role",
+    );
+
+    // Security Monitor-equivalent role used as (a) the **target role**
+    // for `POST /api/accounts` and (b) the role assigned to the
+    // monitor-target accounts deleted by `DELETE /api/accounts/[id]`.
+    // Permissions must all be drawn from the monitor allow-list in
+    // `account-role-policy.ts` so `tenantManageable` is true;
+    // otherwise the route's step-3 gate shorts the tenant's request
+    // before the customer-scope check.
     const monitorRoleId = await createTestRole(
       MONITOR_ROLE_NAME,
       ["audit-logs:read"],
@@ -895,11 +1128,39 @@ describe("Cross-customer scope matrix", () => {
 
     await createTestAccount(ACCOUNT_A_USERNAME, COMMON_PASSWORD, ROLE_NAME);
     await createTestAccount(ACCOUNT_B_USERNAME, COMMON_PASSWORD, ROLE_NAME);
+    await createTestAccount(
+      MANAGER_A_USERNAME,
+      COMMON_PASSWORD,
+      MANAGER_ROLE_NAME,
+    );
+    await createTestAccount(
+      MANAGER_B_USERNAME,
+      COMMON_PASSWORD,
+      MANAGER_ROLE_NAME,
+    );
+    await createTestAccount(
+      MONITOR_TARGET_A_USERNAME,
+      COMMON_PASSWORD,
+      MONITOR_ROLE_NAME,
+    );
+    await createTestAccount(
+      MONITOR_TARGET_B_USERNAME,
+      COMMON_PASSWORD,
+      MONITOR_ROLE_NAME,
+    );
 
     const accountAId = await getAccountId(ACCOUNT_A_USERNAME);
     const accountBId = await getAccountId(ACCOUNT_B_USERNAME);
+    const managerAId = await getAccountId(MANAGER_A_USERNAME);
+    const managerBId = await getAccountId(MANAGER_B_USERNAME);
+    const monitorTargetAId = await getAccountId(MONITOR_TARGET_A_USERNAME);
+    const monitorTargetBId = await getAccountId(MONITOR_TARGET_B_USERNAME);
     await assignCustomerToAccount(accountAId, customerAId);
     await assignCustomerToAccount(accountBId, customerBId);
+    await assignCustomerToAccount(managerAId, customerAId);
+    await assignCustomerToAccount(managerBId, customerBId);
+    await assignCustomerToAccount(monitorTargetAId, customerAId);
+    await assignCustomerToAccount(monitorTargetBId, customerBId);
 
     const auditLogARowId = await insertAuditLog({
       actorId: accountAId,
@@ -929,6 +1190,10 @@ describe("Cross-customer scope matrix", () => {
       customerOrphanId,
       accountAId,
       accountBId,
+      managerAId,
+      managerBId,
+      monitorTargetAId,
+      monitorTargetBId,
       monitorRoleId,
       auditLogARowId,
       auditLogBRowId,
@@ -941,6 +1206,8 @@ describe("Cross-customer scope matrix", () => {
     await revokeAllSessions(ADMIN_USERNAME);
     await revokeAllSessions(ACCOUNT_A_USERNAME);
     await revokeAllSessions(ACCOUNT_B_USERNAME);
+    await revokeAllSessions(MANAGER_A_USERNAME);
+    await revokeAllSessions(MANAGER_B_USERNAME);
   });
 
   afterAll(async () => {
@@ -959,14 +1226,24 @@ describe("Cross-customer scope matrix", () => {
     // affected because we filter by actor_id, not by action.
     await deleteAuditLogsByActor(resources.accountAId);
     await deleteAuditLogsByActor(resources.accountBId);
+    await deleteAuditLogsByActor(resources.managerAId);
+    await deleteAuditLogsByActor(resources.managerBId);
 
-    for (const username of [ACCOUNT_A_USERNAME, ACCOUNT_B_USERNAME]) {
+    for (const username of [
+      ACCOUNT_A_USERNAME,
+      ACCOUNT_B_USERNAME,
+      MANAGER_A_USERNAME,
+      MANAGER_B_USERNAME,
+      MONITOR_TARGET_A_USERNAME,
+      MONITOR_TARGET_B_USERNAME,
+    ]) {
       const id = await getAccountId(username).catch(() => null);
       if (id) await removeAccountCustomerAssignments(id);
       await deleteTestAccount(username);
     }
     await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`.toLowerCase());
     await deleteTestRole(ROLE_NAME);
+    await deleteTestRole(MANAGER_ROLE_NAME);
     await deleteTestRole(MONITOR_ROLE_NAME);
     await deleteCustomersByPrefix(TEST_PREFIX);
   });
@@ -1071,14 +1348,24 @@ describe("Cross-customer scope matrix", () => {
         });
       } else if (endpoint.expects === "mutation-scope") {
         const mutation = endpoint;
+        const overrides = mutation.personaUsernames ?? {};
 
         const personaCases: Array<{
           persona: Persona;
           username: string;
         }> = [
-          { persona: "account-A", username: ACCOUNT_A_USERNAME },
-          { persona: "account-B", username: ACCOUNT_B_USERNAME },
-          { persona: "admin", username: ADMIN_USERNAME },
+          {
+            persona: "account-A",
+            username: overrides.accountA ?? ACCOUNT_A_USERNAME,
+          },
+          {
+            persona: "account-B",
+            username: overrides.accountB ?? ACCOUNT_B_USERNAME,
+          },
+          {
+            persona: "admin",
+            username: overrides.admin ?? ADMIN_USERNAME,
+          },
         ];
 
         for (const c of personaCases) {

--- a/src/__integration__/multi-tenancy/scope.test.ts
+++ b/src/__integration__/multi-tenancy/scope.test.ts
@@ -26,13 +26,16 @@
  *       - admin in-scope and out-of-scope GETs: 200.
  *
  *   - `mutation-scope` (POST / PATCH / DELETE):
- *       - account-A with in-scope params: 2xx.
- *       - account-A with out-of-scope params: 4xx (typically 403 for a
- *         mutation that names an out-of-scope resource — distinct from
- *         the read-side 404 since the caller is asserting they own the
- *         input ids).
- *       - account-B mirrors account-A on customer B.
- *       - admin: 2xx for both in-scope and out-of-scope variants.
+ *       - Each per-persona slot has an optional `inScope` and
+ *         `outOfScope` variant. The harness only fires variants that
+ *         are defined and asserts each response status equals the
+ *         variant's `expectStatus`. Routes whose tenant in-scope path
+ *         would mutate fixture state we don't want to restore (e.g.
+ *         password-reset, mfa-reset) only declare the tenant
+ *         out-of-scope variant — the regression bar is "out-of-scope
+ *         is rejected", not "every successful path is exercised".
+ *         Optional `cleanupAfterSuccess` runs after each 2xx so
+ *         mutation rows don't leak fixture state into later runs.
  *
  *   - `admin-only`:
  *       - account-A and account-B: 4xx (typically 403 — neither holds
@@ -80,6 +83,7 @@ import {
   removeAccountCustomerAssignments,
   resetAccountDefaults,
   revokeAllSessions,
+  setAccountStatus,
 } from "../helpers/setup-db";
 
 // ── Fixtures ─────────────────────────────────────────────────────
@@ -94,8 +98,16 @@ const COMMON_PASSWORD = "ScopeMatrix1234!";
 interface Resources {
   customerAId: number;
   customerBId: number;
+  /**
+   * Customer with no account assignments. Used by the
+   * `DELETE /api/customers/[id]` row, since the route refuses to drop
+   * a customer that still has linked accounts.
+   */
+  customerOrphanId: number;
   accountAId: string;
   accountBId: string;
+  /** Role id for the tenant test role; used by `POST /api/accounts`. */
+  tenantRoleId: number;
   auditLogARowId: string;
   auditLogBRowId: string;
   auditLogNullRowId: string;
@@ -150,23 +162,35 @@ interface MutationVariant {
   expectStatus: number;
 }
 
+interface PersonaMutationVariants {
+  /**
+   * The persona's "in-scope" call (e.g. tenant acting on their own
+   * resource). Optional: omit when the in-scope path requires fixture
+   * state we don't want to restore (e.g. tenant password-reset on a
+   * managed Security Monitor account that doesn't exist in this
+   * matrix). The out-of-scope variant alone is sufficient regression
+   * coverage for those routes.
+   */
+  inScope?: MutationVariant;
+  /** The persona's "out-of-scope" call. */
+  outOfScope?: MutationVariant;
+}
+
 interface MutationEndpoint {
   name: string;
   method: "POST" | "PATCH" | "DELETE";
   expects: "mutation-scope";
   /**
-   * Build the request variants for each persona. The harness fires:
-   *   - account-A: `accountA.inScope` then `accountA.outOfScope`
-   *   - account-B: `accountB.inScope` then `accountB.outOfScope`
-   *   - admin:     `admin.inScope` then `admin.outOfScope`
-   * and asserts each response status equals the variant's
-   * `expectStatus`. Optional cleanup runs after each successful 2xx so
-   * mutation rows don't leak fixture state into later test runs.
+   * Build the request variants for each persona. The harness fires
+   * each defined variant in order (`inScope`, then `outOfScope`) and
+   * asserts the response status equals the variant's `expectStatus`.
+   * Optional cleanup runs after each successful 2xx so mutations
+   * don't leak fixture state into later runs.
    */
   request: (resources: Resources) => {
-    accountA: { inScope: MutationVariant; outOfScope: MutationVariant };
-    accountB: { inScope: MutationVariant; outOfScope: MutationVariant };
-    admin: { inScope: MutationVariant; outOfScope: MutationVariant };
+    accountA: PersonaMutationVariants;
+    accountB: PersonaMutationVariants;
+    admin: PersonaMutationVariants;
   };
   /**
    * Optional post-success cleanup. Fired after every 2xx mutation so
@@ -268,6 +292,38 @@ const ENDPOINTS: Endpoint[] = [
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
   },
+  {
+    name: "PATCH /api/customers/[id]",
+    method: "PATCH",
+    expects: "admin-only",
+    request: (r) => ({
+      path: `/api/customers/${r.customerOrphanId}`,
+      body: { description: `${TEST_PREFIX}admin-only-patched` },
+    }),
+    adminSuccessStatus: 200,
+    cleanupAfterSuccess: async (r, adminSession) => {
+      // Restore the description to its original empty state so
+      // re-runs don't drift the fixture.
+      await authPatch(adminSession, `/api/customers/${r.customerOrphanId}`, {
+        description: null,
+      });
+    },
+  },
+  {
+    name: "DELETE /api/customers/[id]",
+    method: "DELETE",
+    expects: "admin-only",
+    request: (r) => ({ path: `/api/customers/${r.customerOrphanId}` }),
+    adminSuccessStatus: 200,
+    cleanupAfterSuccess: async (r) => {
+      // The admin success deletes the orphan customer. Recreate it so
+      // the fixture state is consistent for re-runs against a
+      // long-lived dev DB. The id changes, but the matrix doesn't
+      // re-read `r.customerOrphanId` after this row runs.
+      await deleteCustomersByPrefix(`${TEST_PREFIX}Orphan`);
+      r.customerOrphanId = await createCustomerRow(`${TEST_PREFIX}Orphan`);
+    },
+  },
   // ── accounts (post-#387 surface, local-DB scoped) ──────────────
   {
     name: "GET /api/accounts",
@@ -310,6 +366,103 @@ const ENDPOINTS: Endpoint[] = [
       inScopeB: `/api/accounts/${r.accountBId}/customers`,
     }),
     expects: "200-on-in-scope-404-on-out-of-scope",
+  },
+  // POST /api/accounts — tenant role can call (it has accounts:write)
+  // but is rejected by the role-creation policy when the target role
+  // isn't Security Monitor-equivalent. The matrix doesn't seed a
+  // monitor-equiv role, so the tenant call will 403; admin uses the
+  // tenant role itself (which is fine for system-admin callers) to
+  // create a throwaway account that the cleanup deletes.
+  {
+    name: "POST /api/accounts",
+    method: "POST",
+    expects: "admin-only",
+    request: (r) => ({
+      path: "/api/accounts",
+      body: {
+        username: `${TEST_PREFIX}created-${Date.now()}`.toLowerCase(),
+        displayName: `${TEST_PREFIX}created`,
+        password: COMMON_PASSWORD,
+        roleId: r.tenantRoleId,
+        customerIds: [r.customerAId],
+      },
+    }),
+    adminSuccessStatus: 201,
+    nonAdminStatuses: [403],
+    cleanupAfterSuccess: async () => {
+      // Drop every account whose username matches the matrix prefix.
+      // The admin variant generates a new timestamp-suffixed username
+      // each invocation, so a prefix sweep is the simplest way to
+      // keep the dev DB clean across re-runs.
+      // We use a SQL-level helper inline to avoid plumbing yet
+      // another helper for a single use.
+      await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`);
+    },
+  },
+  // PATCH /api/accounts/[id] — accounts:write held by tenants, scope
+  // enforced by validateManagedAccountTarget. Self-patch on basic
+  // fields is the in-scope path; cross-tenant target is the out-of-
+  // scope path (404 since accounts share no customers in the
+  // fixture).
+  {
+    name: "PATCH /api/accounts/[id]",
+    method: "PATCH",
+    expects: "mutation-scope",
+    request: (r) => ({
+      accountA: {
+        inScope: {
+          path: `/api/accounts/${r.accountAId}`,
+          body: { displayName: ACCOUNT_A_USERNAME },
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}`,
+          body: { displayName: "should-not-apply" },
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        inScope: {
+          path: `/api/accounts/${r.accountBId}`,
+          body: { displayName: ACCOUNT_B_USERNAME },
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountAId}`,
+          body: { displayName: "should-not-apply" },
+          expectStatus: 404,
+        },
+      },
+      // Admin can patch any account; both variants succeed and are
+      // idempotent (display_name reset to the original username), so
+      // no per-variant cleanup is needed.
+      admin: {
+        inScope: {
+          path: `/api/accounts/${r.accountAId}`,
+          body: { displayName: ACCOUNT_A_USERNAME },
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}`,
+          body: { displayName: ACCOUNT_B_USERNAME },
+          expectStatus: 200,
+        },
+      },
+    }),
+  },
+  // DELETE /api/accounts/[id] — admin-only because tenant role lacks
+  // `accounts:delete`. The admin success disables account-A; the
+  // cleanup re-enables it so subsequent rows / re-runs aren't broken.
+  {
+    name: "DELETE /api/accounts/[id]",
+    method: "DELETE",
+    expects: "admin-only",
+    request: (r) => ({ path: `/api/accounts/${r.accountAId}` }),
+    adminSuccessStatus: 200,
+    nonAdminStatuses: [403],
+    cleanupAfterSuccess: async () => {
+      await setAccountStatus(ACCOUNT_A_USERNAME, "active", null);
+    },
   },
   // ── accounts mutation surface ──────────────────────────────────
   //
@@ -379,6 +532,147 @@ const ENDPOINTS: Endpoint[] = [
       );
     },
   },
+  // DELETE /api/accounts/[id]/customers/[customerId] — tenants have
+  // accounts:write. In-scope: tenant unassigns their own customer
+  // from their own account (200), then the cleanup re-adds. Out-of-
+  // scope: tenant tries to unassign the OTHER tenant's customer from
+  // the OTHER tenant's account; the assignment exists, so the route
+  // reaches the scope check and rejects with 403.
+  {
+    name: "DELETE /api/accounts/[id]/customers/[customerId]",
+    method: "DELETE",
+    expects: "mutation-scope",
+    request: (r) => ({
+      accountA: {
+        inScope: {
+          path: `/api/accounts/${r.accountAId}/customers/${r.customerAId}`,
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/customers/${r.customerBId}`,
+          expectStatus: 403,
+        },
+      },
+      accountB: {
+        inScope: {
+          path: `/api/accounts/${r.accountBId}/customers/${r.customerBId}`,
+          expectStatus: 200,
+        },
+        outOfScope: {
+          path: `/api/accounts/${r.accountAId}/customers/${r.customerAId}`,
+          expectStatus: 403,
+        },
+      },
+      // Admin variants intentionally omitted: re-firing admin-driven
+      // mutations on the same (account, customer) pair after the
+      // tenant in-scope variants would race the cleanup ordering.
+      // The route's "admin can do anything" path is exercised by the
+      // sibling POST row above; what this row guards is the tenant
+      // scope check, which the two non-admin personas already cover.
+      admin: {},
+    }),
+    cleanupAfterSuccess: async (
+      resources,
+      _adminSession,
+      _persona,
+      _variant,
+    ) => {
+      // Re-establish the canonical (accountA→customerA, accountB→
+      // customerB) assignments after every successful unassign.
+      await assignCustomerToAccount(
+        resources.accountAId,
+        resources.customerAId,
+      );
+      await assignCustomerToAccount(
+        resources.accountBId,
+        resources.customerBId,
+      );
+    },
+  },
+  // POST /api/accounts/[id]/password-reset — tenants have
+  // accounts:write but the route forbids self-reset (400) and
+  // validateManagedAccountTarget rejects out-of-scope targets (404).
+  // Only the out-of-scope variant is meaningful for regression
+  // detection: a future change that drops the scope check would let
+  // a tenant reset another tenant's password, which is exactly the
+  // gap we're guarding against. Admin variants omitted because the
+  // success path mutates password state we don't want to restore on
+  // every run.
+  {
+    name: "POST /api/accounts/[id]/password-reset",
+    method: "POST",
+    expects: "mutation-scope",
+    request: (r) => ({
+      accountA: {
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/password-reset`,
+          body: { newPassword: COMMON_PASSWORD },
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        outOfScope: {
+          path: `/api/accounts/${r.accountAId}/password-reset`,
+          body: { newPassword: COMMON_PASSWORD },
+          expectStatus: 404,
+        },
+      },
+      admin: {},
+    }),
+  },
+  // POST /api/accounts/[id]/unlock — same shape as password-reset:
+  // out-of-scope is the regression-meaningful assertion. Admin
+  // success requires the target to be locked or suspended, which the
+  // matrix fixture doesn't seed; the dedicated unlock test in
+  // src/__integration__/api/unlock.test.ts already covers the happy
+  // path.
+  {
+    name: "POST /api/accounts/[id]/unlock",
+    method: "POST",
+    expects: "mutation-scope",
+    request: (r) => ({
+      accountA: {
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/unlock`,
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        outOfScope: {
+          path: `/api/accounts/${r.accountAId}/unlock`,
+          expectStatus: 404,
+        },
+      },
+      admin: {},
+    }),
+  },
+  // POST /api/accounts/[id]/mfa-reset — out-of-scope rejected by
+  // validateManagedAccountTarget (404) before the step-up auth and
+  // MFA-existence checks run. The dedicated MFA tests cover the
+  // happy path; what this row protects is "tenant cannot reach
+  // another tenant's MFA reset at all".
+  {
+    name: "POST /api/accounts/[id]/mfa-reset",
+    method: "POST",
+    expects: "mutation-scope",
+    request: (r) => ({
+      accountA: {
+        outOfScope: {
+          path: `/api/accounts/${r.accountBId}/mfa-reset`,
+          body: { password: COMMON_PASSWORD },
+          expectStatus: 404,
+        },
+      },
+      accountB: {
+        outOfScope: {
+          path: `/api/accounts/${r.accountAId}/mfa-reset`,
+          body: { password: COMMON_PASSWORD },
+          expectStatus: 404,
+        },
+      },
+      admin: {},
+    }),
+  },
   // ── admin-only example: POST /api/customers ────────────────────
   //
   // Creating a customer requires `customers:write`, which the
@@ -445,6 +739,61 @@ async function fireAdminOnly(
   }
 }
 
+/**
+ * Drop every account row whose username starts with `prefix`,
+ * cascading through the related child tables that `deleteTestAccount`
+ * handles. Used by the `POST /api/accounts` cleanup, which generates
+ * a unique timestamped username on every admin invocation.
+ */
+async function dropAccountsByUsernamePrefix(prefix: string): Promise<void> {
+  const pg = await import("pg");
+  const { readFileSync } = await import("node:fs");
+  const { resolve } = await import("node:path");
+  let connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    try {
+      const env = readFileSync(resolve(".env.local"), "utf8");
+      const m = env.match(/^DATABASE_URL=(.+)$/m);
+      if (m) connectionString = m[1].trim();
+    } catch {
+      /* fall through */
+    }
+  }
+  if (!connectionString) {
+    connectionString = "postgres://postgres:postgres@localhost:5432/auth_db";
+  }
+  const client = new pg.Client({ connectionString });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ username: string }>(
+      "SELECT username FROM accounts WHERE username LIKE $1",
+      [`${prefix}%`],
+    );
+    for (const row of rows) {
+      await client.query(
+        `DELETE FROM sessions
+         WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+        [row.username],
+      );
+      await client.query(
+        `DELETE FROM account_customer
+         WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+        [row.username],
+      );
+      await client.query(
+        `DELETE FROM password_history
+         WHERE account_id = (SELECT id FROM accounts WHERE username = $1)`,
+        [row.username],
+      );
+      await client.query("DELETE FROM accounts WHERE username = $1", [
+        row.username,
+      ]);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
 // ── Suite ────────────────────────────────────────────────────────
 
 describe("Cross-customer scope matrix", () => {
@@ -457,16 +806,19 @@ describe("Cross-customer scope matrix", () => {
     // Clean up any prior state.
     await deleteTestAccount(ACCOUNT_A_USERNAME);
     await deleteTestAccount(ACCOUNT_B_USERNAME);
+    await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`.toLowerCase());
     await deleteTestRole(ROLE_NAME);
     await deleteRolesByPrefix("integ-scope-");
     await deleteCustomersByPrefix(TEST_PREFIX);
 
     // Tenant-style role: scoped read on accounts/customers/audit-logs
-    // plus accounts:write so the mutation-scope row can exercise
-    // POST /api/accounts/[id]/customers from a non-admin caller.
-    // No `customers:access-all`, no `customers:write` — those gate the
-    // admin-only assertions.
-    await createTestRole(
+    // plus accounts:write so the mutation-scope rows can exercise
+    // PATCH /api/accounts/[id], POST /api/accounts/[id]/customers,
+    // and the admin-bypass rows on password-reset / unlock /
+    // mfa-reset from a non-admin caller. No `customers:access-all`,
+    // `customers:write`, `customers:delete`, or `accounts:delete` —
+    // those gate the admin-only assertions.
+    const tenantRoleId = await createTestRole(
       ROLE_NAME,
       ["customers:read", "audit-logs:read", "accounts:read", "accounts:write"],
       "Integration scope-matrix tenant role",
@@ -474,6 +826,7 @@ describe("Cross-customer scope matrix", () => {
 
     const customerAId = await createCustomerRow(`${TEST_PREFIX}CustomerA`);
     const customerBId = await createCustomerRow(`${TEST_PREFIX}CustomerB`);
+    const customerOrphanId = await createCustomerRow(`${TEST_PREFIX}Orphan`);
 
     await createTestAccount(ACCOUNT_A_USERNAME, COMMON_PASSWORD, ROLE_NAME);
     await createTestAccount(ACCOUNT_B_USERNAME, COMMON_PASSWORD, ROLE_NAME);
@@ -508,8 +861,10 @@ describe("Cross-customer scope matrix", () => {
     resources = {
       customerAId,
       customerBId,
+      customerOrphanId,
       accountAId,
       accountBId,
+      tenantRoleId,
       auditLogARowId,
       auditLogBRowId,
       auditLogNullRowId,
@@ -528,13 +883,15 @@ describe("Cross-customer scope matrix", () => {
     await deleteAuditLogById(resources.auditLogBRowId);
     await deleteAuditLogById(resources.auditLogNullRowId);
 
-    // The mutation row emits `customer.assign` audit entries via the
-    // route under test (`POST /api/accounts/[id]/customers`). Those
-    // live in `audit_db` so they are not cascaded by the auth_db
-    // account/role/customer cleanup below — drop them by actor before
-    // detaching the test accounts so re-runs see a clean slate. Only
-    // the test-account actors are dropped; admin's row count is not
-    // touched since admin's audit history belongs to the dev DB.
+    // The mutation rows emit audit entries via the routes under test
+    // (`POST /api/accounts/[id]/customers`, `PATCH /api/accounts/[id]`,
+    // `DELETE /api/accounts/[id]`, etc.). Those live in `audit_db` so
+    // they are not cascaded by the auth_db account/role/customer
+    // cleanup below — drop them by actor before detaching the test
+    // accounts so re-runs see a clean slate. Only the test-account
+    // actors (and admin, since admin's matrix-driven rows also emit)
+    // are touched: admin's audit history outside the matrix isn't
+    // affected because we filter by actor_id, not by action.
     await deleteAuditLogsByActor(resources.accountAId);
     await deleteAuditLogsByActor(resources.accountBId);
 
@@ -543,6 +900,7 @@ describe("Cross-customer scope matrix", () => {
       if (id) await removeAccountCustomerAssignments(id);
       await deleteTestAccount(username);
     }
+    await dropAccountsByUsernamePrefix(`${TEST_PREFIX}created`.toLowerCase());
     await deleteTestRole(ROLE_NAME);
     await deleteCustomersByPrefix(TEST_PREFIX);
   });
@@ -658,7 +1016,7 @@ describe("Cross-customer scope matrix", () => {
         ];
 
         for (const c of personaCases) {
-          it(`${c.persona}: in-scope succeeds, out-of-scope is rejected`, async () => {
+          it(`${c.persona}: defined variants pass scope assertions`, async () => {
             const variants = mutation.request(resources);
             const personaVariants =
               c.persona === "account-A"
@@ -666,50 +1024,36 @@ describe("Cross-customer scope matrix", () => {
                 : c.persona === "account-B"
                   ? variants.accountB
                   : variants.admin;
-            const session = await signIn(c.username);
 
-            const inScopeRes = await fireMutation(
-              session,
-              mutation.method,
-              personaVariants.inScope,
-            );
-            expect(inScopeRes.status).toBe(
-              personaVariants.inScope.expectStatus,
-            );
-            if (
-              inScopeRes.status >= 200 &&
-              inScopeRes.status < 300 &&
-              mutation.cleanupAfterSuccess
-            ) {
-              const adminSession = await signIn(ADMIN_USERNAME);
-              await mutation.cleanupAfterSuccess(
-                resources,
-                adminSession,
-                c.persona,
-                "in-scope",
-              );
+            // Skip the test cleanly when neither variant is defined
+            // (e.g. admin: {} for routes whose admin path needs
+            // stateful setup we don't seed in this matrix).
+            if (!personaVariants.inScope && !personaVariants.outOfScope) {
+              return;
             }
 
-            const outOfScopeRes = await fireMutation(
-              session,
-              mutation.method,
-              personaVariants.outOfScope,
-            );
-            expect(outOfScopeRes.status).toBe(
-              personaVariants.outOfScope.expectStatus,
-            );
-            if (
-              outOfScopeRes.status >= 200 &&
-              outOfScopeRes.status < 300 &&
-              mutation.cleanupAfterSuccess
-            ) {
-              const adminSession = await signIn(ADMIN_USERNAME);
-              await mutation.cleanupAfterSuccess(
-                resources,
-                adminSession,
-                c.persona,
-                "out-of-scope",
-              );
+            const session = await signIn(c.username);
+
+            for (const [tag, variant] of [
+              ["in-scope", personaVariants.inScope],
+              ["out-of-scope", personaVariants.outOfScope],
+            ] as const) {
+              if (!variant) continue;
+              const res = await fireMutation(session, mutation.method, variant);
+              expect(res.status).toBe(variant.expectStatus);
+              if (
+                res.status >= 200 &&
+                res.status < 300 &&
+                mutation.cleanupAfterSuccess
+              ) {
+                const adminSession = await signIn(ADMIN_USERNAME);
+                await mutation.cleanupAfterSuccess(
+                  resources,
+                  adminSession,
+                  c.persona,
+                  tag,
+                );
+              }
             }
           });
         }

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import { checkFiles } from "../../../scripts/check-dispatch-context.mjs";
+
+interface FixtureFile {
+  relPath: string;
+  source: string;
+}
+
+interface Violation {
+  relPath: string;
+  lineNumber: number;
+  message: string;
+}
+
+function run(files: FixtureFile[]): Violation[] {
+  return checkFiles(files) as Violation[];
+}
+
+describe("check-dispatch-context guard", () => {
+  it("flags a graphqlRequest call site outside the allowlist", () => {
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+export async function GET() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].relPath).toBe("src/app/api/feature/route.ts");
+    expect(violations[0].message).toMatch(/outside the dispatch-context/);
+  });
+
+  it("accepts an out-of-allowlist call site with a non-empty override", () => {
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+export async function GET() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" }); // scope-allowlist: introspection-only health probe
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("rejects an empty override reason", () => {
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+export async function GET() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" }); // scope-allowlist:
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+  });
+
+  it("accepts an allowlisted file that imports buildDispatchContext", () => {
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import { buildDispatchContext } from "./dispatch-context";
+
+export async function listNodes(session) {
+  const ctx = await buildDispatchContext(session);
+  return graphqlRequest(NODE_LIST_QUERY, undefined, ctx);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("accepts an allowlisted file that locally declares buildDispatchContext", () => {
+    const violations = run([
+      {
+        relPath: "src/lib/detection/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+async function buildDispatchContext(session, filter) {
+  return { role: session.roles[0], customerIds: [], filter };
+}
+
+export async function listEvents(session, filter) {
+  const ctx = await buildDispatchContext(session, filter);
+  return graphqlRequest(EVENT_LIST_QUERY, undefined, ctx);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("flags an allowlisted file that has neither import nor local declaration", () => {
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("ignores files that do not call the helpers", () => {
+    const violations = run([
+      {
+        relPath: "src/components/whatever.tsx",
+        source: `export function Whatever() {
+  return null;
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("matches both graphqlRequest and graphqlRequestTo", () => {
+    const violations = run([
+      {
+        relPath: "src/app/api/other/route.ts",
+        source: `import { graphqlRequestTo } from "@/lib/graphql/client";
+
+export async function GET() {
+  return graphqlRequestTo(URL, QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].lineNumber).toBe(4);
+  });
+
+  it("treats the GraphQL client modules as pass-through (no buildDispatchContext required)", () => {
+    const violations = run([
+      {
+        relPath: "src/lib/graphql/external-client.ts",
+        source: `import { graphqlRequestTo } from "./client";
+
+export async function gigantoClient(document, variables, context) {
+  return graphqlRequestTo(URL, document, variables, context);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -324,6 +324,82 @@ export function GET() {
     expect(violations).toEqual([]);
   });
 
+  it("does NOT count `import type { buildDispatchContext } ...` as in-scope", () => {
+    // Regression test for the round-4 review: type-only imports are
+    // erased by the TS compiler so the symbol is not actually in
+    // runtime scope. The previous regex accepted them.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import type { buildDispatchContext } from "./dispatch-context";
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("does NOT count `import { type buildDispatchContext } ...` as in-scope", () => {
+    // Per-specifier `type` modifier — also erased at runtime, so the
+    // symbol is not in scope for the call site to use.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import { type buildDispatchContext } from "./dispatch-context";
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("does NOT count a nested `function buildDispatchContext` as in-scope", () => {
+    // Regression test for the round-4 review: a nested declaration
+    // inside another function does not bring the symbol into file
+    // scope, so it must NOT satisfy the presence check. The previous
+    // regex permitted leading whitespace and matched indented
+    // declarations.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+function wrapper() {
+  async function buildDispatchContext() {
+    return { role: "admin", customerIds: [] };
+  }
+  return buildDispatchContext;
+}
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
   it("treats the GraphQL client modules as pass-through (no buildDispatchContext required)", () => {
     const violations = run([
       {

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -262,6 +262,68 @@ export function GET() {
     expect(violations).toEqual([]);
   });
 
+  it("does NOT count an `import { buildDispatchContext } ...` substring inside a string literal as in-scope", () => {
+    // Regression test for the round-3 review: the previous stripper
+    // preserved string contents, so a fixture-style string literal
+    // that happened to contain the import substring satisfied the
+    // presence check. Stripping string contents fixes this.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+const fixture = "import { buildDispatchContext } from './dispatch-context';";
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("does NOT report a `graphqlRequest(...)` substring inside a string literal as a call site", () => {
+    // Regression test for the round-3 review: the previous stripper
+    // preserved string contents, so a string literal in a non-
+    // allowlisted file that contained `graphqlRequest(QUERY)` was
+    // reported as an out-of-allowlist call. Stripping string
+    // contents avoids the false positive.
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `const fixture = "graphqlRequest(QUERY)";
+
+export function GET() {
+  return new Response(fixture);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does NOT report a `graphqlRequest(...)` substring inside a template literal as a call site", () => {
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `const fixture = \`example: graphqlRequest(QUERY)\`;
+
+export function GET() {
+  return new Response(fixture);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
   it("treats the GraphQL client modules as pass-through (no buildDispatchContext required)", () => {
     const violations = run([
       {

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -197,6 +197,60 @@ export async function GET() {
     expect(violations).toEqual([]);
   });
 
+  it("accepts an override on the opening-paren line of a multiline generic call", () => {
+    // Regression test for the round-9 review: when the helper is
+    // invoked with TS generic arguments split across lines
+    // (`graphqlRequest<Thing>\n  (...)`), the call-site scan must
+    // extend `endLine` through the real opening `(` — not stop at
+    // the line containing `<` — so a `// scope-allowlist:` annotation
+    // on the opening-paren line still suppresses the violation.
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+interface Thing {
+  id: string;
+}
+
+export async function GET() {
+  return graphqlRequest<Thing>
+    (QUERY, undefined, { role: "admin" }); // scope-allowlist: intentional exception
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("flags a multiline generic call without an override", () => {
+    // Companion to the override case above: with no override, the
+    // out-of-allowlist multiline generic call must still be reported,
+    // and the reported line number must be the helper-name line so
+    // the message points at where the call begins.
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+interface Thing {
+  id: string;
+}
+
+export async function GET() {
+  return graphqlRequest<Thing>
+    (QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].lineNumber).toBe(8);
+    expect(violations[0].message).toMatch(/outside the dispatch-context/);
+  });
+
   it("does NOT count a commented-out import of buildDispatchContext as in-scope", () => {
     // Regression test for the round-2 review: the previous presence
     // check ran the import regex against raw source, so a

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -400,6 +400,80 @@ export async function listNodes() {
     );
   });
 
+  it("accepts an allowlisted file that uses a namespace import + `<alias>.buildDispatchContext` access", () => {
+    // Regression test for the round-8 review: a namespace import
+    // genuinely puts the symbol in runtime scope (via the namespace
+    // object). The previous regex only matched named imports, so a
+    // valid future refactor would have failed `pnpm check:scope`.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import * as dispatchContext from "./dispatch-context";
+
+export async function listNodes(session) {
+  const ctx = await dispatchContext.buildDispatchContext(session);
+  return graphqlRequest(NODE_LIST_QUERY, undefined, ctx);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does NOT count a namespace import without a `<alias>.buildDispatchContext` access as in-scope", () => {
+    // The namespace alone only binds the namespace object — without
+    // an observed member access there is no evidence the file is
+    // materializing the symbol from it. The named-import contract
+    // works because the named specifier itself binds the symbol; a
+    // bare `import * as ns ...` does not.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import * as dispatchContext from "./dispatch-context";
+
+export async function listNodes() {
+  // dispatchContext is imported but never reaches buildDispatchContext.
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("does NOT count `import type * as ns ...` paired with member access as in-scope", () => {
+    // Whole-import type modifier on a namespace import — TypeScript
+    // erases it, so the namespace object is not actually in runtime
+    // scope. The matching `.buildDispatchContext` reference on its
+    // own does not satisfy the contract.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import type * as dispatchContext from "./dispatch-context";
+
+export async function listNodes() {
+  const ref: typeof dispatchContext.buildDispatchContext | undefined = undefined;
+  void ref;
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
   it("treats the GraphQL client modules as pass-through (no buildDispatchContext required)", () => {
     const violations = run([
       {

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -401,6 +401,54 @@ export async function listNodes() {
     );
   });
 
+  it("does NOT count `import { other as buildDispatchContext } ...` as in-scope", () => {
+    // Regression test for the round-12 review: a right-side rename
+    // imports a different symbol and merely names the local binding
+    // `buildDispatchContext`, so any call dispatches to the wrong
+    // function. The previous regex matched the token anywhere in the
+    // specifier and accepted this case. The matcher must inspect the
+    // imported name (left of `as`) only.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import { notBuildDispatchContext as buildDispatchContext } from "./dispatch-context";
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("accepts `import { buildDispatchContext as alias } ...` (left-side bound to the real helper)", () => {
+    // Companion positive case for the round-12 fix: a left-side
+    // alias (`buildDispatchContext as alias`) DOES import the real
+    // helper — the local binding is just renamed. This must still
+    // satisfy the presence check so the matcher does not over-narrow.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+import { buildDispatchContext as buildCtx } from "./dispatch-context";
+
+export async function listNodes(session) {
+  const ctx = await buildCtx(session);
+  return graphqlRequest(QUERY, undefined, ctx);
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
   it("does NOT count `import { type buildDispatchContext } ...` as in-scope", () => {
     // Per-specifier `type` modifier — also erased at runtime, so the
     // symbol is not in scope for the call site to use.

--- a/src/__tests__/scripts/check-dispatch-context.test.ts
+++ b/src/__tests__/scripts/check-dispatch-context.test.ts
@@ -157,6 +157,111 @@ export async function GET() {
     expect(violations[0].lineNumber).toBe(4);
   });
 
+  it("flags an out-of-allowlist call site that is split across lines", () => {
+    // Regression test for the round-2 review: the previous
+    // line-by-line scanner missed `graphqlRequest\n  (...)` because
+    // the helper name and the `(` were not on the same line. The
+    // whole-source scan should still find the call.
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+export async function GET() {
+  return graphqlRequest
+    (QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].relPath).toBe("src/app/api/feature/route.ts");
+    expect(violations[0].message).toMatch(/outside the dispatch-context/);
+  });
+
+  it("accepts a split-line override comment on any line of the call expression", () => {
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+
+export async function GET() {
+  return graphqlRequest
+    (QUERY, undefined, { role: "admin" }); // scope-allowlist: introspection-only health probe
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it("does NOT count a commented-out import of buildDispatchContext as in-scope", () => {
+    // Regression test for the round-2 review: the previous presence
+    // check ran the import regex against raw source, so a
+    // `// import { buildDispatchContext } ...` line satisfied it even
+    // though the symbol is not actually in scope.
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+// import { buildDispatchContext } from "./dispatch-context";
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("does NOT count a block-commented import as in-scope", () => {
+    const violations = run([
+      {
+        relPath: "src/lib/node/server-actions.ts",
+        source: `import { graphqlRequest } from "@/lib/graphql/client";
+/*
+import { buildDispatchContext } from "./dispatch-context";
+*/
+
+export async function listNodes() {
+  return graphqlRequest(QUERY, undefined, { role: "admin" });
+}
+`,
+      },
+    ]);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toMatch(
+      /neither imports nor locally declares/,
+    );
+  });
+
+  it("does NOT count a commented-out call site as a call", () => {
+    // A commented-out invocation in an allowlisted file shouldn't
+    // trigger the presence check (and likewise shouldn't cause a
+    // violation when the file is OUT of the allowlist).
+    const violations = run([
+      {
+        relPath: "src/app/api/feature/route.ts",
+        source: `// const x = graphqlRequest(QUERY, undefined, ctx);
+
+export function GET() {
+  return new Response("ok");
+}
+`,
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
   it("treats the GraphQL client modules as pass-through (no buildDispatchContext required)", () => {
     const violations = run([
       {


### PR DESCRIPTION
## Summary

Final PR for the multi-tenancy hardening epic (#382). Installs three regression guards on top of the gaps closed by #386 (audit-log viewer) and #387 (hardening sweep) so future PRs cannot reintroduce them.

- **Static dispatch-context guard.** New `scripts/check-dispatch-context.mjs`, surfaced as `pnpm check:scope` and wired into the CI `lint` job. The guard is a pragmatic file-level check (no full TS AST traversal): only files under `src/lib/node` and `src/lib/detection` (plus the GraphQL client modules themselves) may call `graphqlRequest` / `graphqlRequestTo`, and every allowlisted call site must have `buildDispatchContext` in scope at runtime. Three shapes satisfy the presence check: a named import where the *imported* symbol is `buildDispatchContext` (`import { buildDispatchContext } from "..."`, optionally with a left-side `as` alias like `{ buildDispatchContext as buildCtx }`), a namespace import paired with at least one observed `<alias>.buildDispatchContext` member access (`import * as ns from "..."` plus `ns.buildDispatchContext(...)`), or a top-level local declaration. Per-line `// scope-allowlist: <reason>` overrides are accepted when the reason is non-empty. The script strips comments AND the contents of string literals before applying its regexes, so a commented-out `import { buildDispatchContext } ...` does NOT satisfy the presence check, a string literal containing the same substring does NOT either, and a string literal that happens to contain `graphqlRequest(QUERY)` does NOT trigger a false-positive violation. Call detection runs against the whole stripped source so a call split across lines (e.g. `return graphqlRequest\n  (QUERY, ...)`) is still recognized; the scanner also walks past a balanced `<…>` generic-arguments block before locating the opening `(`, so the generic form (`graphqlRequest<Thing>(...)`, including the multiline variant `graphqlRequest<Thing>\n  (...)`) is recognized as the same call site and the override-line range covers the helper-name line through the opening-paren line. The presence check rejects shapes that look correct but are not: type-only imports (`import type { buildDispatchContext } ...`, `import { type buildDispatchContext } ...`, and `import type * as ns ...`, all erased by the TS compiler), right-side renames (`import { otherName as buildDispatchContext } ...`, which import a different symbol and merely *name* the local binding `buildDispatchContext` so the call would dispatch to the wrong function), namespace imports without a `<alias>.buildDispatchContext` member access (the bare namespace binding alone is not evidence the file is materializing the symbol), and nested declarations (a `function buildDispatchContext` inside another function/block, which doesn't bring the symbol into file scope) — only top-level (column-0) declarations count, matching Detection's actual pattern. Template-literal interpolation expressions (`${...}`) are intentionally not parsed back out — both edges (a real call buried in `${...}`, an `import { buildDispatchContext }` substring inside `${...}`) are pathological in real source and the file-level allowlist still catches the only meaningful regression.
- **Cross-customer integration test matrix.** New `src/__integration__/multi-tenancy/scope.test.ts`. A single data-driven `ENDPOINTS` array drives standard assertions against three personas (account-A, account-B, admin). Three `expects` modes cover the customer-scoped local-DB surface, so adding a new customer-scoped endpoint is a one-line change:
    - `list-scoped` — caller-A's list contains only customer-A's fixture row, mirror for B, admin sees both. The per-row `customer_id` assertion is skipped when the row payload doesn't expose one (e.g. accounts list, where membership is N:N via `account_customer`).
    - `200-on-in-scope-404-on-out-of-scope` — out-of-scope GET returns 404 (NOT 403, to avoid existence disclosure). An optional `inScopeBodyAssertion` callback runs against the parsed JSON body of every in-scope GET (admin and tenant) so list-returning detail routes (e.g. `GET /api/accounts/[id]/customers`) can pin the returned data to the persona's customer instead of only asserting the path is reachable — without it, a future change that let an A-visible parent leak a B child would stay green on a status-only check.
    - `mutation-scope` (POST / PATCH / DELETE) — per-persona slots with optional `inScope` / `outOfScope` variants. The harness fires only the variants that are defined and asserts each response status equals the variant's `expectStatus`. Optional `cleanupAfterSuccess` so mutations don't leak between runs. Optional `personaUsernames` overrides the sign-in user for a persona slot — the persona label in the test name stays `account-A` / `account-B` so the matrix shape is uniform; the override is used by rows whose route requires a permission the base tenant role doesn't carry (`customers:write`, `customers:delete`, `accounts:delete`) so the request actually reaches the route's tenant-scope branch instead of being short-circuited at the permission gate.

      **Contract narrowing for auth-state-mutating routes.** `POST /api/accounts/[id]/password-reset`, `/unlock`, and `/mfa-reset` declare ONLY the tenant `outOfScope` variant — no tenant in-scope, no admin success. The cross-customer regression those routes can introduce is "tenant reaches another tenant's account at all"; a single 404 from `validateManagedAccountTarget` on an out-of-scope target is the regression-meaningful assertion (a future PR that drops the scope check turns the row red). The success paths are excluded on purpose: they mutate authentication state (password hash, locked flag, MFA enrolment, token version, live sessions) that the matrix's other rows depend on, and the route-specific integration suites already cover the happy path end-to-end. The narrowing is documented prominently in both the suite docstring and `docs/AUTHORING.md` so it can't drift back into a silent omission.

    Seeded rows cover the customer-scoped local-DB surface: `GET /api/audit-logs` (regression target for #386), `GET /api/customers` + `GET /api/customers/[id]`, `GET /api/accounts` + `GET /api/accounts/[id]` + `GET /api/accounts/[id]/customers` (with the body-level customer-id assertion above), `POST /api/accounts/[id]/customers` and `DELETE /api/accounts/[id]/customers/[customerId]` (admin variants land both in-scope and out-of-scope at 200 since `customers:access-all` clears the route's scope check; the cleanup re-establishes the canonical assignments after each success), `POST /api/accounts/[id]/password-reset`, `POST /api/accounts/[id]/unlock`, `POST /api/accounts/[id]/mfa-reset` (under the contract narrowing above), `POST /api/accounts`, `PATCH /api/customers/[id]`, `DELETE /api/customers/[id]`, and `DELETE /api/accounts/[id]`. The PATCH/DELETE rows use `personaUsernames` pointing at dedicated **manager** personas (a tenant-administrator-style role: tenant scope plus `customers:write` / `customers:delete` / `accounts:delete`, no `customers:access-all`). The DELETE accounts row deletes dedicated **monitor-target** accounts (Security Monitor-equivalent role) so `validateManagedAccountTarget`'s tenant-manageable role gate clears and the request reaches the scope branch (in-scope → 200, out-of-scope → 404). The DELETE customers row leaves the tenant in-scope variant undefined because the route is structurally unreachable for non-`access-all` callers (scope check requires the caller's `account_customer` link, the next gate refuses any customer with at least one link); admin in-scope deletes the orphan customer instead, and cleanup recreates it. The `POST /api/accounts` row uses a Security Monitor-equivalent target role so the request reaches the route's step-5 customer-scope check (`Cannot assign customers outside your scope`).

    `POST /api/customers` is intentionally **not** in the matrix. It only requires `customers:write` and has no per-customer scope branch (no customer parameter to be in/out of scope of), so any holder of that permission — admin or a tenant-administrator-style manager — can hit the success path. Modeling it here would teach future authors that the route is "admin-only" when in fact the matrix's manager personas would also succeed; permission-gate coverage for it lives in its own integration suite, not in this cross-customer scope guard.

    Routes that flow through `buildDispatchContext` (node API surface backed by REview / Tivan over GraphQL) intentionally stay out of this matrix — their cross-customer contract is "the JWT carries the right `customer_ids`", which is a structural assertion against the dispatch context, exercised in feature-specific integration files via `mock-graphql` and protected by the static guard above.

    The `afterAll` audit-log cleanup deletes rows by tenant/manager actor id only (`accountAId`, `accountBId`, `managerAId`, `managerBId`). Admin-driven matrix rows also emit audit entries, but `deleteAuditLogsByActor(adminId)` would delete every admin audit entry on the dev database — including unrelated history outside this matrix — which is worse than leaving the matrix's admin entries in place. Those entries are pre-tagged with the matrix's prefixed test resources (created accounts under `${TEST_PREFIX}created-...`, descriptions like `${TEST_PREFIX}admin-a`) so they're easy to identify and drop manually if a developer ever wants the dev DB pristine.
- **Documentation.** New "Customer scope (multi-tenancy contract)" section in `docs/AUTHORING.md` pinning the project principle, the three permitted patterns for customer-touching code, the audit-log and error-message contracts (using the real `formatScopedError({ template, references }, allowedCustomerIds)` API from `src/lib/auth/scope-redaction.ts`), and how to extend both regression guards (including the comment / string-literal / split-line behaviour, the named-import / namespace-import-with-member-access / local-declaration acceptance set, the type-only-import (named, per-specifier, and namespace), right-side-rename, and nested-declaration carve-outs, the template-literal interpolation caveat, the optional `inScope`/`outOfScope` mutation variants, the auth-state contract narrowing for password-reset / unlock / mfa-reset, the `personaUsernames` persona-override pattern for routes that need an elevated caller to reach the scope branch, the `inScopeBodyAssertion` hook for list-returning detail routes, the tenant-manageable target requirement for `DELETE /api/accounts/[id]`-style routes, and the structurally unreachable in-scope caveat for `DELETE /api/customers/[id]`). The audit-log contract is scoped explicitly to events whose `target` has a canonical, single customer id (a customer, a node/sensor, an `account_customer` link row); account-targeted mutations on the N:N `account_customer` model (`password.reset`, `account.unlock`, `account.restore`, `account.mfa.reset`, `account.update`, `account.delete`) and customer-agnostic events (`account.login`, system events) intentionally record `customerId: null` because there is no canonical single customer to attribute the event to. Widening visibility for in-scope tenant operators on those N:N events would require row fan-out or a multi-valued audit schema, both out of scope for #388 and #387.

Closes #388

## Test plan

- [x] `pnpm check` passes locally.
- [x] `pnpm check:scope` passes locally on the unmodified worktree.
- [x] `pnpm check:scope` *fails* when a `graphqlRequest` call is added to a non-allowlisted file (e.g. `src/app/api/foo/route.ts`).
- [x] Same fixture above passes once `// scope-allowlist: <reason>` (non-empty) is appended to the call line.
- [x] `pnpm vitest run src/__tests__/scripts/check-dispatch-context.test.ts` — all 27 guard fixtures pass.
- [x] `pnpm tsc --noEmit` passes.
- [x] `pnpm test` passes (2715 tests).
- [x] CI `lint` job runs both `pnpm check` and `pnpm check:scope` as separate steps.
- [x] Integration matrix (`src/__integration__/multi-tenancy/scope.test.ts`) — all rows pass against the dev environment, including the audit-logs list (regression target for #386), customers list + detail (regression target for #387), accounts list + detail, the body-level customer-id assertion on `GET /api/accounts/[id]/customers`, and the round-10 admin coverage on `DELETE /api/accounts/[id]/customers/[customerId]`.
- [x] `docs/AUTHORING.md` renders cleanly (markdownlint passes; no broken cross-links).
- [x] `pnpm build` succeeds.


