### PR TITLE
Make aice-web-next bootable behind nginx HTTPS (#404)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,44 @@ CSRF_SECRET=
 INIT_ADMIN_USERNAME=
 INIT_ADMIN_PASSWORD=
 
+# ── JWT signing key ──────────────────────────────────────────────
+# Two ways to provision the ES256 signing key. They are mutually
+# exclusive in practice: JWT_SIGNING_KEY_FILE wins if both are set.
+#
+# Option A — externally managed key file (recommended for prod).
+#   Point at a key JSON written by `pnpm gen-jwt-key` or rendered
+#   from a K8s Secret / Vault csi mount. The key at this path is
+#   used as the *current* signing key. The previous key (for
+#   rotation) continues to load from
+#   `<DATA_DIR>/keys/jwt-signing.prev.json` unless
+#   JWT_SIGNING_KEY_FILE_PREVIOUS is also set.
+# JWT_SIGNING_KEY_FILE=
+# JWT_SIGNING_KEY_FILE_PREVIOUS=
+#
+# Option B — first-boot autogen (single-instance dev/convenience).
+#   Set to "1" / "true" / "on" / "yes" to generate
+#   `<DATA_DIR>/keys/jwt-signing.json` on first boot if missing.
+#   Idempotent on re-boot. Multi-replica deployments MUST NOT use
+#   this — each replica would generate its own key independently
+#   and inter-replica session validation would fail. Use option A
+#   instead.
+# JWT_SIGNING_KEY_AUTOGEN=
+
+# ── CSRF Origin verification ─────────────────────────────────────
+# Override the expected request Origin for the CSRF/Origin guard.
+# Required when the app is fronted by a TLS-terminating reverse
+# proxy (e.g. nginx-prod profile): browsers send
+# `Origin: https://your.host` while the upstream Next.js sees
+# `request.nextUrl.origin === "http://..."`, and the mutation
+# guard would reject every POST/PUT/PATCH/DELETE.
+#
+# Canonicalized at parse time: trailing slash stripped; scheme and
+# host lowercased. Set to the public HTTPS origin, e.g.:
+#   EXPECTED_ORIGIN=https://app.example.com
+# When unset, behavior is unchanged from today
+# (request.nextUrl.origin only).
+# EXPECTED_ORIGIN=
+
 DEFAULT_LOCALE=en
 
 # Polling cadence for the Nodes Status tab and detail-page dashboard,

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+# Pre-create the data directory with the runtime user as owner so the
+# first-boot JWT autogen path (JWT_SIGNING_KEY_AUTOGEN=1) can write to
+# it. Docker named volumes mounted on this path inherit ownership from
+# this directory on first creation.
+RUN mkdir -p /app/data && chown nextjs:nodejs /app/data
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000 HOSTNAME=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ backend).
 
 ```bash
 pnpm install
-cp .env.example .env.local   # then fill in values (see below)
+cp .env.example .env.local   # local dev (pnpm dev). See env-file note below.
 ```
 
 Start PostgreSQL (via Docker Compose or a local instance), then:
@@ -31,7 +31,20 @@ Open <http://localhost:3000> to see the result.
 
 ## Environment variables
 
-Copy `.env.example` to `.env.local` and fill in the values:
+Pick the right env file for the path you are running:
+
+- **Local dev (`pnpm dev`):** Next.js loads `.env.local` (and `.env`)
+  from the project root, per the standard
+  [Next.js env-loading rules](https://nextjs.org/docs/app/guides/environment-variables).
+  Most contributors put their secrets in `.env.local`.
+- **Production Docker Compose (`docker compose --profile prod up`):**
+  the `next-app` service has `env_file: .env` in `docker-compose.yml`,
+  so the prod profile **only** reads `.env`. `.env.local` is ignored
+  by Compose. Operators deploying with the prod profile must populate
+  `.env`.
+
+Copy `.env.example` to whichever file matches your path and fill in
+the values:
 
 | Variable | Description |
 |----------|-------------|
@@ -44,8 +57,12 @@ Copy `.env.example` to `.env.local` and fill in the values:
 | `MTLS_CERT_PATH` | Path to the mTLS client certificate |
 | `MTLS_KEY_PATH` | Path to the mTLS private key |
 | `MTLS_CA_PATH` | Path to the mTLS CA certificate |
-| `DATA_DIR` | Directory for runtime data (default: `./data`) |
+| `DATA_DIR` | Directory for runtime data (default: `./data`). When the prod compose profile runs, this directory is backed by the `next-app-data` named volume so JWT keys survive container restarts. |
 | `JWT_EXPIRATION_MINUTES` | Access token lifetime in minutes |
+| `JWT_SIGNING_KEY_FILE` | Path to an externally managed ES256 signing key (e.g. K8s Secret mount, Vault csi driver). Takes precedence over `<DATA_DIR>/keys/jwt-signing.json`. **Recommended for production.** When set, the previous key still loads from `<DATA_DIR>/keys/jwt-signing.prev.json` unless `JWT_SIGNING_KEY_FILE_PREVIOUS` is also set. |
+| `JWT_SIGNING_KEY_FILE_PREVIOUS` | Optional override for the previous (rotated-out) key path. |
+| `JWT_SIGNING_KEY_AUTOGEN` | Set to `1` / `true` / `on` to generate `<DATA_DIR>/keys/jwt-signing.json` on first boot when missing. Idempotent — re-boots load the existing key. **Single-instance only**: every replica would generate its own key, breaking inter-replica session validation. Multi-replica deployments must inject a shared key via `JWT_SIGNING_KEY_FILE` instead. Boot fails fast when `DATA_DIR` is not writable. |
+| `EXPECTED_ORIGIN` | Override the expected request Origin for the CSRF/Origin guard (e.g. `https://app.example.com`). Required when the app is fronted by a TLS-terminating reverse proxy — browsers send `Origin: https://...` while the upstream sees `http://...`, and the mutation guard would otherwise reject every POST/PUT/PATCH/DELETE. Canonicalized at parse time (trailing slash stripped, scheme + host lowercased). When unset, behavior is unchanged from today (`request.nextUrl.origin` only). |
 | `CSRF_SECRET` | Secret for CSRF token HMAC |
 | `INIT_ADMIN_USERNAME` | Initial System Administrator username |
 | `INIT_ADMIN_PASSWORD` | Initial System Administrator password |
@@ -274,9 +291,36 @@ The production nginx config (`infra/nginx/nginx.prod.conf`) enables:
 - Security headers: `X-Frame-Options`, `X-Content-Type-Options`,
   `Referrer-Policy`
 
+`Content-Security-Policy-Report-Only` is emitted by the Next.js app
+(per-request nonce — nginx leaves the header untouched). Enforcement
+is staged: the Report-Only mode lands first to surface any inline
+script/style breakages in real traffic before the header is promoted
+to enforcing CSP.
+
 The `__Host-csrf` cookie and `Secure` flag on the access token cookie
 are automatically enabled when `NODE_ENV=production` (set by the
 Dockerfile).
+
+#### First-boot deployment checklist
+
+1. Populate `.env` (the prod compose profile reads `.env`, not
+   `.env.local`). At minimum set `CSRF_SECRET`, the database URLs,
+   the GraphQL endpoints, and:
+   - `EXPECTED_ORIGIN=https://your.public.host` so the CSRF/Origin
+     guard accepts mutation requests through the HTTPS proxy.
+   - One of `JWT_SIGNING_KEY_FILE=<path>` (recommended — a Secret
+     mount) or `JWT_SIGNING_KEY_AUTOGEN=1` (single-instance dev
+     convenience).
+2. Make sure the persistent data volume is in place. The
+   `docker-compose.yml` shipped here mounts a named `next-app-data`
+   volume on `/app/data`; if you customise this, mount your own
+   volume at `${DATA_DIR}` so the JWT key (and any other persisted
+   state) survives container restarts.
+3. `docker compose --profile prod up -d`.
+
+If autogen is requested but `DATA_DIR` is not writable by the
+container user (uid 1001), the app fails fast at startup with a
+clear error message instead of crash-looping mid-boot.
 
 ### Development with Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,14 @@ is staged: the Report-Only mode lands first to surface any inline
 script/style breakages in real traffic before the header is promoted
 to enforcing CSP.
 
+The CSP nonce flow requires dynamic rendering — `app/[locale]/layout.tsx`
+calls `await connection()` so framework script tags receive a fresh
+per-request nonce. Pages added under `app/` that are intentionally
+statically rendered (e.g. the built-in `_not-found` page) will not
+carry a nonce; under enforcing CSP they would be blocked, so the
+Report-Only validation cycle exists in part to identify any such
+paths before promotion.
+
 The `__Host-csrf` cookie and `Secure` flag on the access token cookie
 are automatically enabled when `NODE_ENV=production` (set by the
 Dockerfile).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
       - "3000"
     env_file:
       - .env
+    # Persist <DATA_DIR> across container restarts so first-boot JWT
+    # autogen (JWT_SIGNING_KEY_AUTOGEN=1) does not regenerate the key
+    # — and therefore invalidate every issued session — on every boot.
+    # Production deployments should override this with a Secret mount
+    # at JWT_SIGNING_KEY_FILE.
+    volumes:
+      - next-app-data:/app/data
     depends_on:
       postgres:
         condition: service_healthy
@@ -56,3 +63,4 @@ services:
 
 volumes:
   pgdata:
+  next-app-data:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "e2e": "playwright test --config e2e/playwright.config.ts",
     "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json",
-    "codegen:detection": "node scripts/codegen-detection-types.mjs"
+    "codegen:detection": "node scripts/codegen-detection-types.mjs",
+    "gen-jwt-key": "node scripts/generate-jwt-key.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/scripts/generate-jwt-key.mjs
+++ b/scripts/generate-jwt-key.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { argv, env, exit } from "node:process";
+
+import { exportJWK, generateKeyPair } from "jose";
+
+// Ops helper for generating an ES256 JWT signing key file outside the
+// app boot path.  Mirrors the layout written by
+// `src/lib/auth/jwt-keys.ts#generateJwtSigningKey` so an operator can
+// pre-seed `<DATA_DIR>/keys/jwt-signing.json` (or a custom location
+// pointed to by `JWT_SIGNING_KEY_FILE`) before starting the container.
+//
+// Refuses to overwrite an existing key by default — overwriting would
+// invalidate every issued session token on the next boot.  Pass
+// `--force` to opt in to overwrite.
+
+function parseArgs(args) {
+  const result = { force: false, output: undefined, algorithm: "ES256" };
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--force" || a === "-f") {
+      result.force = true;
+    } else if (a === "--output" || a === "-o") {
+      result.output = args[i + 1];
+      i += 1;
+    } else if (a.startsWith("--output=")) {
+      result.output = a.slice("--output=".length);
+    } else if (a === "--algorithm") {
+      result.algorithm = args[i + 1];
+      i += 1;
+    } else if (a.startsWith("--algorithm=")) {
+      result.algorithm = a.slice("--algorithm=".length);
+    } else if (a === "--help" || a === "-h") {
+      printHelp();
+      exit(0);
+    } else {
+      console.error(`Unknown argument: ${a}`);
+      printHelp();
+      exit(2);
+    }
+  }
+  return result;
+}
+
+function printHelp() {
+  console.log(
+    `Usage: pnpm gen-jwt-key [--output <path>] [--force] [--algorithm <alg>]
+
+Generate an ES256 JWT signing key and write it to disk.
+
+Resolution order for the output path:
+  1. --output / -o flag
+  2. JWT_SIGNING_KEY_FILE env var
+  3. \${DATA_DIR:-./data}/keys/jwt-signing.json
+
+By default refuses to overwrite an existing file. Use --force to
+overwrite (this invalidates every already-issued session token on the
+next boot).`,
+  );
+}
+
+function resolveOutputPath(cli) {
+  if (cli.output) return path.resolve(cli.output);
+  if (env.JWT_SIGNING_KEY_FILE && env.JWT_SIGNING_KEY_FILE.length > 0) {
+    return path.resolve(env.JWT_SIGNING_KEY_FILE);
+  }
+  const dataDir = env.DATA_DIR
+    ? path.resolve(env.DATA_DIR)
+    : path.resolve(process.cwd(), "data");
+  return path.join(dataDir, "keys", "jwt-signing.json");
+}
+
+async function main() {
+  const cli = parseArgs(argv.slice(2));
+  const keyPath = resolveOutputPath(cli);
+
+  if (existsSync(keyPath) && !cli.force) {
+    console.error(
+      `Refusing to overwrite existing key at ${keyPath}. ` +
+        "Pass --force if this is intentional (overwriting invalidates every issued session token on the next boot).",
+    );
+    exit(1);
+  }
+
+  const { privateKey, publicKey } = await generateKeyPair(cli.algorithm, {
+    extractable: true,
+  });
+  const kid = randomUUID();
+  const privateJwk = await exportJWK(privateKey);
+  const publicJwk = await exportJWK(publicKey);
+  privateJwk.kid = kid;
+  publicJwk.kid = kid;
+
+  const keyFile = {
+    kid,
+    algorithm: cli.algorithm,
+    privateKey: privateJwk,
+    publicKey: publicJwk,
+  };
+
+  const dir = path.dirname(keyPath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // best-effort on platforms that don't honor POSIX perms
+  }
+
+  const tmpPath = `${keyPath}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(keyFile, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    chmodSync(tmpPath, 0o600);
+  } catch {
+    // best-effort
+  }
+  renameSync(tmpPath, keyPath);
+
+  console.log(`Wrote ${cli.algorithm} signing key to ${keyPath} (kid=${kid})`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  exit(1);
+});

--- a/src/__tests__/lib/auth/csrf.test.ts
+++ b/src/__tests__/lib/auth/csrf.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   CSRF_COOKIE_OPTIONS,
   CSRF_HEADER_NAME,
+  canonicalizeOrigin,
+  checkOrigin,
   generateCsrfToken,
+  getConfiguredExpectedOrigin,
   isMutationMethod,
   validateCsrfToken,
   validateOrigin,
@@ -200,6 +203,119 @@ describe("CSRF", () => {
       expect(validateOrigin(EXPECTED, "https://evil.com/path", EXPECTED)).toBe(
         true,
       );
+    });
+  });
+
+  // ── canonicalizeOrigin() ────────────────────────────────────
+
+  describe("canonicalizeOrigin()", () => {
+    it("strips trailing slash", () => {
+      expect(canonicalizeOrigin("https://example.com/")).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("lowercases scheme and host", () => {
+      expect(canonicalizeOrigin("HTTPS://Example.COM")).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("preserves explicit port", () => {
+      expect(canonicalizeOrigin("https://example.com:8443")).toBe(
+        "https://example.com:8443",
+      );
+    });
+
+    it("returns null for opaque origins", () => {
+      expect(canonicalizeOrigin("file:///tmp/foo")).toBeNull();
+    });
+
+    it("returns null for malformed values", () => {
+      expect(canonicalizeOrigin("not-a-url")).toBeNull();
+      expect(canonicalizeOrigin("")).toBeNull();
+    });
+  });
+
+  // ── getConfiguredExpectedOrigin() ────────────────────────────
+
+  describe("getConfiguredExpectedOrigin()", () => {
+    afterEach(() => {
+      delete process.env.EXPECTED_ORIGIN;
+    });
+
+    it("returns null when env var is unset", () => {
+      delete process.env.EXPECTED_ORIGIN;
+      expect(getConfiguredExpectedOrigin()).toBeNull();
+    });
+
+    it("returns null when env var is empty / whitespace", () => {
+      process.env.EXPECTED_ORIGIN = "";
+      expect(getConfiguredExpectedOrigin()).toBeNull();
+      process.env.EXPECTED_ORIGIN = "   ";
+      expect(getConfiguredExpectedOrigin()).toBeNull();
+    });
+
+    it("canonicalizes a valid origin", () => {
+      process.env.EXPECTED_ORIGIN = "HTTPS://Example.com/";
+      expect(getConfiguredExpectedOrigin()).toBe("https://example.com");
+    });
+
+    it("returns null for a malformed value", () => {
+      process.env.EXPECTED_ORIGIN = "not-an-origin";
+      expect(getConfiguredExpectedOrigin()).toBeNull();
+    });
+  });
+
+  // ── checkOrigin() ───────────────────────────────────────────
+
+  describe("checkOrigin()", () => {
+    const EXPECTED = "https://app.example.com";
+
+    it("returns ok=true and the actual origin when matching", () => {
+      const result = checkOrigin(EXPECTED, null, EXPECTED);
+      expect(result.ok).toBe(true);
+      expect(result.actual).toBe(EXPECTED);
+      expect(result.expected).toBe(EXPECTED);
+    });
+
+    it("returns ok=false and the actual origin when mismatching", () => {
+      const result = checkOrigin("https://evil.example", null, EXPECTED);
+      expect(result.ok).toBe(false);
+      expect(result.actual).toBe("https://evil.example");
+      expect(result.expected).toBe(EXPECTED);
+    });
+
+    it("canonicalizes both sides before comparing (trailing slash, case)", () => {
+      const result = checkOrigin(
+        "https://APP.example.com",
+        null,
+        "https://app.example.com/",
+      );
+      expect(result.ok).toBe(true);
+      expect(result.expected).toBe("https://app.example.com");
+    });
+
+    it("uses Referer origin when Origin header is absent", () => {
+      const result = checkOrigin(
+        null,
+        "https://app.example.com/some/path",
+        EXPECTED,
+      );
+      expect(result.ok).toBe(true);
+      expect(result.actual).toBe(EXPECTED);
+    });
+
+    it("returns actual=null when neither header is present", () => {
+      const result = checkOrigin(null, null, EXPECTED);
+      expect(result.ok).toBe(false);
+      expect(result.actual).toBeNull();
+    });
+
+    it("returns actual=null when Referer is malformed", () => {
+      const result = checkOrigin(null, "not-a-url", EXPECTED);
+      expect(result.ok).toBe(false);
+      expect(result.actual).toBeNull();
     });
   });
 

--- a/src/__tests__/lib/auth/guard.test.ts
+++ b/src/__tests__/lib/auth/guard.test.ts
@@ -6,7 +6,8 @@ import type { AuthSession } from "@/lib/auth/jwt";
 const mockVerifyJwtFull = vi.hoisted(() => vi.fn());
 const mockPoolQuery = vi.hoisted(() => vi.fn());
 const mockValidateCsrfToken = vi.hoisted(() => vi.fn());
-const mockValidateOrigin = vi.hoisted(() => vi.fn());
+const mockCheckOrigin = vi.hoisted(() => vi.fn());
+const mockGetConfiguredExpectedOrigin = vi.hoisted(() => vi.fn());
 const mockCheckApiRateLimit = vi.hoisted(() => vi.fn());
 const mockShouldRotate = vi.hoisted(() => vi.fn());
 const mockRotateTokens = vi.hoisted(() => vi.fn());
@@ -46,7 +47,8 @@ vi.mock("@/lib/auth/csrf", () => ({
     new Set(["POST", "PUT", "PATCH", "DELETE"]).has(method.toUpperCase()),
   ),
   validateCsrfToken: mockValidateCsrfToken,
-  validateOrigin: mockValidateOrigin,
+  checkOrigin: mockCheckOrigin,
+  getConfiguredExpectedOrigin: mockGetConfiguredExpectedOrigin,
 }));
 
 vi.mock("@/lib/auth/session-policy", () => ({
@@ -149,7 +151,8 @@ describe("withAuth", () => {
     mockVerifyJwtFull.mockReset();
     mockPoolQuery.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
     mockValidateCsrfToken.mockReset();
-    mockValidateOrigin.mockReset();
+    mockCheckOrigin.mockReset();
+    mockGetConfiguredExpectedOrigin.mockReset().mockReturnValue(null);
     mockCheckApiRateLimit.mockReset().mockResolvedValue({ limited: false });
     mockShouldRotate.mockReset().mockReturnValue(false);
     mockRotateTokens.mockReset().mockResolvedValue(undefined);
@@ -284,12 +287,16 @@ describe("withAuth", () => {
       expect(response.status).toBe(200);
       expect(handler).toHaveBeenCalled();
       expect(mockValidateCsrfToken).not.toHaveBeenCalled();
-      expect(mockValidateOrigin).not.toHaveBeenCalled();
+      expect(mockCheckOrigin).not.toHaveBeenCalled();
     });
 
     it("POST with valid CSRF token and valid Origin passes", async () => {
       mockVerifyJwtFull.mockResolvedValue(validSession);
-      mockValidateOrigin.mockReturnValue(true);
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "http://localhost:3000",
+        expected: "http://localhost:3000",
+      });
       mockValidateCsrfToken.mockReturnValue(true);
 
       const handler = vi
@@ -312,7 +319,11 @@ describe("withAuth", () => {
 
     it("POST without CSRF token returns 403", async () => {
       mockVerifyJwtFull.mockResolvedValue(validSession);
-      mockValidateOrigin.mockReturnValue(true);
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "http://localhost:3000",
+        expected: "http://localhost:3000",
+      });
 
       const handler = vi.fn();
       const wrapped = guard.withAuth(handler);
@@ -332,7 +343,11 @@ describe("withAuth", () => {
 
     it("POST with invalid CSRF token returns 403", async () => {
       mockVerifyJwtFull.mockResolvedValue(validSession);
-      mockValidateOrigin.mockReturnValue(true);
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "http://localhost:3000",
+        expected: "http://localhost:3000",
+      });
       mockValidateCsrfToken.mockReturnValue(false);
 
       const handler = vi.fn();
@@ -356,7 +371,11 @@ describe("withAuth", () => {
 
     it("POST with mismatched Origin returns 403", async () => {
       mockVerifyJwtFull.mockResolvedValue(validSession);
-      mockValidateOrigin.mockReturnValue(false);
+      mockCheckOrigin.mockReturnValue({
+        ok: false,
+        actual: "https://evil.com",
+        expected: "http://localhost:3000",
+      });
 
       const handler = vi.fn();
       const wrapped = guard.withAuth(handler);
@@ -402,7 +421,11 @@ describe("withAuth", () => {
 
     it("passes correct arguments to validateCsrfToken", async () => {
       mockVerifyJwtFull.mockResolvedValue(validSession);
-      mockValidateOrigin.mockReturnValue(true);
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "http://localhost:3000",
+        expected: "http://localhost:3000",
+      });
       mockValidateCsrfToken.mockReturnValue(true);
 
       const handler = vi
@@ -434,7 +457,11 @@ describe("withAuth", () => {
       "DELETE",
     ])("%s request also requires CSRF validation", async (method) => {
       mockVerifyJwtFull.mockResolvedValue(validSession);
-      mockValidateOrigin.mockReturnValue(true);
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "http://localhost:3000",
+        expected: "http://localhost:3000",
+      });
       mockValidateCsrfToken.mockReturnValue(false);
 
       const handler = vi.fn();
@@ -1075,6 +1102,151 @@ describe("withAuth", () => {
         ["System Administrator"],
         "audit-logs:read",
       );
+    });
+  });
+
+  // ── EXPECTED_ORIGIN override + debug response ──────────────────
+
+  describe("EXPECTED_ORIGIN override", () => {
+    it("uses request.nextUrl.origin when EXPECTED_ORIGIN is unset", async () => {
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue(null);
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "http://localhost:3000",
+        expected: "http://localhost:3000",
+      });
+      mockValidateCsrfToken.mockReturnValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      const request = makeAuthRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: {
+          origin: "http://localhost:3000",
+          "x-csrf-token": "ok",
+        },
+      });
+
+      await wrapped(request, makeContext());
+
+      expect(mockCheckOrigin).toHaveBeenCalledWith(
+        "http://localhost:3000",
+        null,
+        "http://localhost:3000",
+      );
+    });
+
+    it("passes EXPECTED_ORIGIN to checkOrigin when set", async () => {
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue("https://example.com");
+      mockCheckOrigin.mockReturnValue({
+        ok: true,
+        actual: "https://example.com",
+        expected: "https://example.com",
+      });
+      mockValidateCsrfToken.mockReturnValue(true);
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(NextResponse.json({ ok: true }));
+      const wrapped = guard.withAuth(handler);
+      // Note: nextUrl.origin would be http://localhost:3000 here, but
+      // EXPECTED_ORIGIN should win.
+      const request = makeAuthRequest("http://localhost:3000/api/test", {
+        method: "POST",
+        headers: {
+          origin: "https://example.com",
+          "x-csrf-token": "ok",
+        },
+      });
+
+      await wrapped(request, makeContext());
+
+      expect(mockCheckOrigin).toHaveBeenCalledWith(
+        "https://example.com",
+        null,
+        "https://example.com",
+      );
+    });
+
+    it("includes expected/actual in response body when NODE_ENV !== production", async () => {
+      vi.stubEnv("NODE_ENV", "development");
+
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue("https://example.com");
+      mockCheckOrigin.mockReturnValue({
+        ok: false,
+        actual: "https://attacker.example",
+        expected: "https://example.com",
+      });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const handler = vi.fn();
+        const wrapped = guard.withAuth(handler);
+        const request = makeAuthRequest("http://localhost:3000/api/test", {
+          method: "POST",
+          headers: {
+            origin: "https://attacker.example",
+            "x-csrf-token": "tok",
+          },
+        });
+
+        const response = await wrapped(request, makeContext());
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toBe("Origin mismatch");
+        expect(body.expected).toBe("https://example.com");
+        expect(body.actual).toBe("https://attacker.example");
+        expect(warn).toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it("hides expected/actual from response body when NODE_ENV === production", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue("https://example.com");
+      mockCheckOrigin.mockReturnValue({
+        ok: false,
+        actual: "https://attacker.example",
+        expected: "https://example.com",
+      });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const handler = vi.fn();
+        const wrapped = guard.withAuth(handler);
+        const request = makeAuthRequest("http://localhost:3000/api/test", {
+          method: "POST",
+          headers: {
+            origin: "https://attacker.example",
+            "x-csrf-token": "tok",
+          },
+        });
+
+        const response = await wrapped(request, makeContext());
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toBe("Origin mismatch");
+        expect(body.expected).toBeUndefined();
+        expect(body.actual).toBeUndefined();
+        // Server-side warn still logs the values for operator debug.
+        expect(warn).toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+        vi.unstubAllEnvs();
+      }
     });
   });
 });

--- a/src/__tests__/lib/auth/jwt-keys.test.ts
+++ b/src/__tests__/lib/auth/jwt-keys.test.ts
@@ -3,10 +3,11 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const tmpDir = path.join(__dirname, ".tmp-jwt-keys");
 const dataDir = path.join(tmpDir, "data");
@@ -26,6 +27,8 @@ describe("jwt-keys", () => {
 
   afterEach(() => {
     delete process.env.DATA_DIR;
+    delete process.env.JWT_SIGNING_KEY_FILE;
+    delete process.env.JWT_SIGNING_KEY_FILE_PREVIOUS;
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -244,6 +247,138 @@ describe("jwt-keys", () => {
       // Remove and verify it's cleared
       jwtKeys.removePreviousKey();
       expect(jwtKeys.getVerificationKey(firstKid)).toBeNull();
+    });
+  });
+
+  // ── perms on generated key file ───────────────────────────────
+
+  describe("generateJwtSigningKey perms", () => {
+    it("writes the key file with mode 0600", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      const keyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const mode = statSync(keyPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it("locks the parent keys directory to mode 0700", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      const keysPath = path.join(dataDir, "keys");
+      const mode = statSync(keysPath).mode & 0o777;
+      expect(mode).toBe(0o700);
+    });
+  });
+
+  // ── JWT_SIGNING_KEY_FILE override ─────────────────────────────
+
+  describe("JWT_SIGNING_KEY_FILE override", () => {
+    it("loadSigningKeys reads the key from the override path", async () => {
+      const customPath = path.join(tmpDir, "custom", "current.json");
+      process.env.JWT_SIGNING_KEY_FILE = customPath;
+
+      // Generate writes to the override path because currentKeyPath
+      // honors the env var.
+      await jwtKeys.generateJwtSigningKey();
+      expect(existsSync(customPath)).toBe(true);
+
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+      expect(jwtKeys.getSigningKey().kid).toBeDefined();
+    });
+
+    it("previous key still loads from <DATA_DIR>/keys when only current is overridden", async () => {
+      // Write a previous key in the standard location.
+      const standardPrevPath = path.join(
+        dataDir,
+        "keys",
+        "jwt-signing.prev.json",
+      );
+      mkdirSync(path.dirname(standardPrevPath), { recursive: true });
+
+      // Generate a key (default location), copy to prev path.
+      await jwtKeys.generateJwtSigningKey();
+      const defaultCurrent = path.join(dataDir, "keys", "jwt-signing.json");
+      writeFileSync(
+        standardPrevPath,
+        readFileSync(defaultCurrent, "utf8"),
+        "utf8",
+      );
+      const prevKid = JSON.parse(readFileSync(standardPrevPath, "utf8")).kid;
+
+      // Now override the current key to a custom path and generate again.
+      const customCurrent = path.join(tmpDir, "custom", "current.json");
+      process.env.JWT_SIGNING_KEY_FILE = customCurrent;
+      await jwtKeys.generateJwtSigningKey();
+
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+
+      // Previous key (from <DATA_DIR>/keys) should still resolve.
+      expect(jwtKeys.getVerificationKey(prevKid)).not.toBeNull();
+    });
+
+    it("JWT_SIGNING_KEY_FILE_PREVIOUS overrides the previous key path too", async () => {
+      const customPrev = path.join(tmpDir, "custom", "prev.json");
+      const customCurrent = path.join(tmpDir, "custom", "current.json");
+      process.env.JWT_SIGNING_KEY_FILE = customCurrent;
+
+      // Generate a current key, copy to the custom prev path.
+      await jwtKeys.generateJwtSigningKey();
+      writeFileSync(customPrev, readFileSync(customCurrent, "utf8"), "utf8");
+      const prevKid = JSON.parse(readFileSync(customPrev, "utf8")).kid;
+
+      // Generate a new current and tell the loader where prev lives.
+      // generateJwtSigningKey overwrites — call again to mint a new kid.
+      await jwtKeys.generateJwtSigningKey();
+      process.env.JWT_SIGNING_KEY_FILE_PREVIOUS = customPrev;
+
+      jwtKeys.resetKeyState();
+      await jwtKeys.loadSigningKeys();
+      expect(jwtKeys.getVerificationKey(prevKid)).not.toBeNull();
+    });
+  });
+
+  // ── autoGenerateJwtSigningKeyIfMissing ────────────────────────
+
+  describe("autoGenerateJwtSigningKeyIfMissing", () => {
+    it("generates a key when none exists", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await jwtKeys.autoGenerateJwtSigningKeyIfMissing();
+
+      const keyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      expect(existsSync(keyPath)).toBe(true);
+      expect(warn).toHaveBeenCalled();
+      const message = warn.mock.calls[0]?.[0] as string;
+      expect(message).toContain("single-instance");
+      warn.mockRestore();
+    });
+
+    it("is a no-op when the key file already exists", async () => {
+      await jwtKeys.generateJwtSigningKey();
+      const keyPath = path.join(dataDir, "keys", "jwt-signing.json");
+      const before = readFileSync(keyPath, "utf8");
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      await jwtKeys.autoGenerateJwtSigningKeyIfMissing();
+      warn.mockRestore();
+
+      const after = readFileSync(keyPath, "utf8");
+      expect(after).toBe(before);
+    });
+
+    it("throws a clear error when DATA_DIR points at a non-directory (e.g. accidental file mount)", async () => {
+      // assertDataDirWritable mkdirSync's the path with recursive:true,
+      // which is a no-op when a directory already exists at that path
+      // — but errors with ENOTDIR / EEXIST when a *file* sits there.
+      // Either way we expect the "not writable" / "not a directory"
+      // error rather than a cryptic crash later in key generation.
+      const accidentalFile = path.join(tmpDir, "accidental-file");
+      writeFileSync(accidentalFile, "definitely a file", "utf8");
+      process.env.DATA_DIR = accidentalFile;
+
+      await expect(
+        jwtKeys.autoGenerateJwtSigningKeyIfMissing(),
+      ).rejects.toThrow(/not writable|not a directory/);
     });
   });
 

--- a/src/__tests__/lib/security/csp.test.ts
+++ b/src/__tests__/lib/security/csp.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCspHeaderValue,
+  CSP_HEADER_NAME,
+  generateCspNonce,
+  NONCE_HEADER,
+} from "@/lib/security/csp";
+
+describe("csp", () => {
+  describe("generateCspNonce()", () => {
+    it("returns a non-empty base64 string", () => {
+      const nonce = generateCspNonce();
+      expect(nonce).toMatch(/^[A-Za-z0-9+/=]+$/);
+      expect(nonce.length).toBeGreaterThan(0);
+    });
+
+    it("produces a distinct nonce per call (collision-resistant)", () => {
+      const a = generateCspNonce();
+      const b = generateCspNonce();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("buildCspHeaderValue()", () => {
+    it("includes the per-request nonce in script-src with strict-dynamic", () => {
+      const csp = buildCspHeaderValue("test-nonce");
+      expect(csp).toContain(
+        "script-src 'self' 'nonce-test-nonce' 'strict-dynamic'",
+      );
+    });
+
+    it("locks down frame-ancestors to none", () => {
+      const csp = buildCspHeaderValue("n");
+      expect(csp).toContain("frame-ancestors 'none'");
+    });
+
+    it("keeps style-src 'unsafe-inline' (Next styled-jsx compatibility)", () => {
+      // Documented constraint — promotion to nonce-based style-src is
+      // a follow-up issue.  The Report-Only roll-out must not break
+      // existing inline styles.
+      const csp = buildCspHeaderValue("n");
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'");
+    });
+
+    it("includes default-src 'self', object-src 'none', base-uri 'self'", () => {
+      const csp = buildCspHeaderValue("n");
+      expect(csp).toContain("default-src 'self'");
+      expect(csp).toContain("object-src 'none'");
+      expect(csp).toContain("base-uri 'self'");
+    });
+  });
+
+  describe("constants", () => {
+    it("CSP_HEADER_NAME is Content-Security-Policy-Report-Only (not enforcing)", () => {
+      // Issue #404 part O — first release ships in Report-Only.
+      expect(CSP_HEADER_NAME).toBe("Content-Security-Policy-Report-Only");
+    });
+
+    it("NONCE_HEADER is the conventional x-nonce", () => {
+      expect(NONCE_HEADER).toBe("x-nonce");
+    });
+  });
+});

--- a/src/__tests__/lib/security/csp.test.ts
+++ b/src/__tests__/lib/security/csp.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCspHeaderValue,
   CSP_HEADER_NAME,
+  CSP_REQUEST_HEADER,
   generateCspNonce,
   NONCE_HEADER,
 } from "@/lib/security/csp";
@@ -59,6 +60,13 @@ describe("csp", () => {
 
     it("NONCE_HEADER is the conventional x-nonce", () => {
       expect(NONCE_HEADER).toBe("x-nonce");
+    });
+
+    it("CSP_REQUEST_HEADER is the unprefixed Content-Security-Policy", () => {
+      // Next's renderer parses this *request* header for the nonce; it
+      // must be the enforcing-style name even when the response ships
+      // CSP in Report-Only mode.
+      expect(CSP_REQUEST_HEADER).toBe("Content-Security-Policy");
     });
   });
 });

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -138,4 +138,85 @@ describe("proxy", () => {
       expect(config.matcher).toBe("/((?!api|trpc|_next|_vercel|.*\\..*).*)");
     });
   });
+
+  describe("CSP header (Report-Only)", () => {
+    it("attaches Content-Security-Policy-Report-Only on the public path response", async () => {
+      const response = await proxy(makeRequest("/sign-in"));
+
+      const csp = response.headers.get("Content-Security-Policy-Report-Only");
+      expect(csp).toBeTruthy();
+      expect(csp).toContain("default-src 'self'");
+      expect(csp).toMatch(
+        /script-src 'self' 'nonce-[A-Za-z0-9+/=]+' 'strict-dynamic'/,
+      );
+      expect(csp).toContain("frame-ancestors 'none'");
+    });
+
+    it("attaches CSP-Report-Only on the sign-in redirect from a protected path", async () => {
+      const response = await proxy(makeRequest("/audit-logs"));
+
+      expect(response.status).toBe(307);
+      expect(
+        response.headers.get("Content-Security-Policy-Report-Only"),
+      ).toBeTruthy();
+    });
+
+    it("attaches CSP-Report-Only on the redirect when JWT verification fails", async () => {
+      mockVerifyJwtStateless.mockRejectedValue(new Error("JWT expired"));
+
+      const response = await proxy(makeRequest("/audit-logs", "bad-token"));
+
+      expect(response.status).toBe(307);
+      expect(
+        response.headers.get("Content-Security-Policy-Report-Only"),
+      ).toBeTruthy();
+    });
+
+    it("does NOT emit the enforcing Content-Security-Policy header (Report-Only only)", async () => {
+      const response = await proxy(makeRequest("/sign-in"));
+
+      // Promotion to enforcing CSP is a separate follow-up after one
+      // release of Report-Only validation.
+      expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    });
+
+    it("forwards the nonce to RSC via the x-nonce request header", async () => {
+      mockIntlMiddleware.mockImplementation((request: NextRequest) => {
+        // Capture the request that the intl middleware sees so we can
+        // assert that x-nonce was forwarded.
+        const nonce = request.headers.get("x-nonce");
+        const response = new Response(null, { status: 200 });
+        if (nonce) response.headers.set("x-test-nonce", nonce);
+        return response;
+      });
+
+      const response = await proxy(makeRequest("/sign-in"));
+
+      const forwardedNonce = response.headers.get("x-test-nonce");
+      expect(forwardedNonce).toBeTruthy();
+      // The same nonce should appear in the CSP header.
+      const csp = response.headers.get("Content-Security-Policy-Report-Only");
+      expect(csp).toContain(`'nonce-${forwardedNonce}'`);
+    });
+
+    it("mints a fresh nonce per request", async () => {
+      // Return a fresh Response each call so applyCspHeader writes
+      // into distinct header objects.
+      mockIntlMiddleware.mockImplementation(
+        () => new Response(null, { status: 200 }),
+      );
+
+      const r1 = await proxy(makeRequest("/sign-in"));
+      const r2 = await proxy(makeRequest("/sign-in"));
+
+      const csp1 = r1.headers.get("Content-Security-Policy-Report-Only") ?? "";
+      const csp2 = r2.headers.get("Content-Security-Policy-Report-Only") ?? "";
+      const nonce1 = csp1.match(/'nonce-([^']+)'/)?.[1];
+      const nonce2 = csp2.match(/'nonce-([^']+)'/)?.[1];
+
+      expect(nonce1).toBeTruthy();
+      expect(nonce2).toBeTruthy();
+      expect(nonce1).not.toBe(nonce2);
+    });
+  });
 });

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -199,6 +199,35 @@ describe("proxy", () => {
       expect(csp).toContain(`'nonce-${forwardedNonce}'`);
     });
 
+    it("forwards the enforcing-style Content-Security-Policy request header so Next's renderer can extract the nonce", async () => {
+      mockIntlMiddleware.mockImplementation((request: NextRequest) => {
+        // Next.js's renderer parses the *request*-side CSP header for
+        // the `'nonce-{value}'` pattern and uses that value as the
+        // nonce attribute on framework scripts.  Capture what the
+        // proxy forwarded.
+        const cspRequest = request.headers.get("Content-Security-Policy");
+        const xNonce = request.headers.get("x-nonce");
+        const response = new Response(null, { status: 200 });
+        if (cspRequest) response.headers.set("x-test-csp-request", cspRequest);
+        if (xNonce) response.headers.set("x-test-nonce", xNonce);
+        return response;
+      });
+
+      const response = await proxy(makeRequest("/sign-in"));
+
+      const cspRequest = response.headers.get("x-test-csp-request");
+      const nonce = response.headers.get("x-test-nonce");
+      expect(cspRequest).toBeTruthy();
+      expect(nonce).toBeTruthy();
+      // The forwarded request header carries the same nonce as the
+      // browser-facing Report-Only response header.
+      expect(cspRequest).toContain(`'nonce-${nonce}'`);
+      const cspResponse = response.headers.get(
+        "Content-Security-Policy-Report-Only",
+      );
+      expect(cspResponse).toBe(cspRequest);
+    });
+
     it("mints a fresh nonce per request", async () => {
       // Return a fresh Response each call so applyCspHeader writes
       // into distinct header objects.

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Roboto } from "next/font/google";
 import { notFound } from "next/navigation";
+import { connection } from "next/server";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { ThemeProvider } from "next-themes";
@@ -21,10 +22,6 @@ export const metadata: Metadata = {
   description: "Clumit Security",
 };
 
-export function generateStaticParams() {
-  return routing.locales.map((locale) => ({ locale }));
-}
-
 export default async function LocaleLayout({
   children,
   params,
@@ -32,6 +29,13 @@ export default async function LocaleLayout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }>) {
+  // Opt out of static rendering so the per-request CSP nonce minted in
+  // `src/proxy.ts` actually reaches every framework script tag.  Next's
+  // CSP/nonce flow only injects nonces during dynamic SSR — pages
+  // generated at build time have no per-request nonce to attach.  See
+  // Next.js docs: https://nextjs.org/docs/app/guides/content-security-policy#static-vs-dynamic-rendering-with-csp
+  await connection();
+
   const { locale } = await params;
 
   if (!hasLocale(routing.locales, locale)) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,16 @@
+import { connection } from "next/server";
+
 import { Logo } from "@/components/layout/logo";
 
-export default function Home() {
+export default async function Home() {
+  // Opt out of static rendering so the per-request CSP nonce minted in
+  // `src/proxy.ts` reaches every framework script tag.  In practice
+  // next-intl rewrites `/` to `/[defaultLocale]` so this page is rarely
+  // reached, but if it ever is, dynamic rendering is required for the
+  // nonce flow to work — see Next.js docs:
+  // https://nextjs.org/docs/app/guides/content-security-policy#static-vs-dynamic-rendering-with-csp
+  await connection();
+
   return (
     <main className="flex min-h-screen items-center justify-center">
       <Logo className="scale-150" />

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,9 +2,11 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { runStartupMigrations } = await import("@/lib/db/migrate");
     const { bootstrapAdminAccount } = await import("@/lib/auth/bootstrap");
-    const { loadSigningKeys, getPublicKeyData } = await import(
-      "@/lib/auth/jwt-keys"
-    );
+    const {
+      loadSigningKeys,
+      getPublicKeyData,
+      autoGenerateJwtSigningKeyIfMissing,
+    } = await import("@/lib/auth/jwt-keys");
     const { initStatelessKeys } = await import(
       "@/lib/auth/jwt-verify-stateless"
     );
@@ -15,8 +17,27 @@ export async function register() {
 
     await runStartupMigrations();
     await bootstrapAdminAccount();
+
+    // First-boot convenience: when the operator opts in with
+    // JWT_SIGNING_KEY_AUTOGEN=1 and is not pointing at an externally
+    // managed key via JWT_SIGNING_KEY_FILE, generate an ES256 key on
+    // disk before loadSigningKeys() runs. Idempotent — re-boots load
+    // the existing key.
+    if (
+      isTruthyEnv(process.env.JWT_SIGNING_KEY_AUTOGEN) &&
+      !process.env.JWT_SIGNING_KEY_FILE
+    ) {
+      await autoGenerateJwtSigningKeyIfMissing();
+    }
+
     await loadSigningKeys();
     await initStatelessKeys(getPublicKeyData());
     await emergencyMfaReset();
   }
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const v = value.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "on" || v === "yes";
 }

--- a/src/lib/auth/csrf.ts
+++ b/src/lib/auth/csrf.ts
@@ -101,6 +101,47 @@ export function validateCsrfToken(
 // ── Origin / Referer verification ────────────────────────────────
 
 /**
+ * Canonicalize an origin string for comparison.
+ *
+ * Strips any trailing slash and lowercases scheme + host.  Browsers
+ * send `Origin` without a trailing slash and with a lowercase
+ * scheme/host; canonicalizing here means that
+ * `EXPECTED_ORIGIN=https://Example.com/` does not silently mismatch
+ * `Origin: https://example.com`.
+ *
+ * Returns `null` if the input is not a parseable absolute origin.
+ */
+export function canonicalizeOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    // URL parsing already lowercases the scheme and host; constructing
+    // the origin via the URL API drops any path/query/fragment and
+    // also drops a trailing slash because `URL.origin` never includes
+    // one.
+    if (!url.origin || url.origin === "null") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the configured `EXPECTED_ORIGIN`, canonicalized.
+ *
+ * Returns `null` when the env var is unset or not a parseable origin.
+ * A malformed value is treated as unset rather than crashing the
+ * mutation guard — the caller falls back to `request.nextUrl.origin`,
+ * preserving today's behavior.
+ */
+export function getConfiguredExpectedOrigin(): string | null {
+  const raw = process.env.EXPECTED_ORIGIN;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  return canonicalizeOrigin(trimmed);
+}
+
+/**
  * Verify that the request originates from the expected app origin.
  *
  * Checks the `Origin` header first; falls back to extracting the
@@ -108,26 +149,54 @@ export function validateCsrfToken(
  * present or if neither matches.
  *
  * This is a defense-in-depth measure alongside the HMAC token.
+ *
+ * Returns the actual origin (Origin header value, or the parsed
+ * Referer origin) when the headers are usable but mismatch — useful
+ * for non-production debug responses and for server-side warning
+ * logs.  Returns `null` when neither header is present / parseable.
+ */
+export interface OriginCheckResult {
+  ok: boolean;
+  /** Origin actually presented by the request, when extractable. */
+  actual: string | null;
+  /** Expected origin used in the comparison (canonicalized). */
+  expected: string;
+}
+
+export function checkOrigin(
+  originHeader: string | null,
+  refererHeader: string | null,
+  expectedOrigin: string,
+): OriginCheckResult {
+  const expected = canonicalizeOrigin(expectedOrigin) ?? expectedOrigin;
+
+  if (originHeader) {
+    const actual = canonicalizeOrigin(originHeader) ?? originHeader;
+    return { ok: actual === expected, actual, expected };
+  }
+
+  if (refererHeader) {
+    const actual = canonicalizeOrigin(refererHeader);
+    if (actual === null) {
+      return { ok: false, actual: null, expected };
+    }
+    return { ok: actual === expected, actual, expected };
+  }
+
+  // Neither Origin nor Referer present — reject
+  return { ok: false, actual: null, expected };
+}
+
+/**
+ * Boolean shorthand for {@link checkOrigin}, retained for the
+ * existing callers and tests.
  */
 export function validateOrigin(
   originHeader: string | null,
   refererHeader: string | null,
   expectedOrigin: string,
 ): boolean {
-  if (originHeader) {
-    return originHeader === expectedOrigin;
-  }
-
-  if (refererHeader) {
-    try {
-      return new URL(refererHeader).origin === expectedOrigin;
-    } catch {
-      return false;
-    }
-  }
-
-  // Neither Origin nor Referer present — reject
-  return false;
+  return checkOrigin(originHeader, refererHeader, expectedOrigin).ok;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -9,9 +9,10 @@ import { checkApiRateLimit } from "@/lib/rate-limit/limiter";
 import { ACCESS_TOKEN_COOKIE } from "./cookies";
 import {
   CSRF_HEADER_NAME,
+  checkOrigin,
+  getConfiguredExpectedOrigin,
   isMutationMethod,
   validateCsrfToken,
-  validateOrigin,
 } from "./csrf";
 import { extractClientIp } from "./ip";
 import type { AuthSession } from "./jwt";
@@ -148,15 +149,38 @@ export function withAuth(
         );
       }
 
-      // Step 4a: Origin / Referer verification
-      if (
-        !validateOrigin(
-          request.headers.get("origin"),
-          request.headers.get("referer"),
-          request.nextUrl.origin,
-        )
-      ) {
-        return NextResponse.json({ error: "Origin mismatch" }, { status: 403 });
+      // Step 4a: Origin / Referer verification.
+      //
+      // EXPECTED_ORIGIN (canonicalized) wins when set, so deployments
+      // behind a TLS-terminating reverse proxy (where the upstream
+      // sees `http://...` while the browser's Origin header is
+      // `https://...`) can pin the comparison to the public origin.
+      // When unset, behavior is unchanged from today
+      // (`request.nextUrl.origin` only). No proxy header trust is
+      // introduced here — TRUSTED_PROXIES is deferred.
+      const expectedOrigin =
+        getConfiguredExpectedOrigin() ?? request.nextUrl.origin;
+      const originResult = checkOrigin(
+        request.headers.get("origin"),
+        request.headers.get("referer"),
+        expectedOrigin,
+      );
+      if (!originResult.ok) {
+        // Server-side log so operators can see expected/actual without
+        // leaking it into the response body in production.
+        console.warn(
+          "[csrf] Origin mismatch on %s %s: expected=%s actual=%s",
+          request.method,
+          request.nextUrl.pathname,
+          originResult.expected,
+          originResult.actual ?? "<none>",
+        );
+        const body: Record<string, unknown> = { error: "Origin mismatch" };
+        if (process.env.NODE_ENV !== "production") {
+          body.expected = originResult.expected;
+          body.actual = originResult.actual;
+        }
+        return NextResponse.json(body, { status: 403 });
       }
 
       // Step 4b: CSRF token verification

--- a/src/lib/auth/jwt-keys.ts
+++ b/src/lib/auth/jwt-keys.ts
@@ -2,9 +2,14 @@ import "server-only";
 
 import { randomUUID } from "node:crypto";
 import {
+  accessSync,
+  chmodSync,
+  existsSync,
+  constants as fsConstants,
   mkdirSync,
   readFileSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -52,11 +57,32 @@ function keysDir(): string {
   return path.join(getDataDir(), "keys");
 }
 
+/**
+ * Resolve the current key file path.
+ *
+ * `JWT_SIGNING_KEY_FILE` takes precedence (intended for externally
+ * managed key material — Kubernetes Secret mounts, Vault csi driver,
+ * etc.).  Otherwise the standard `<DATA_DIR>/keys/jwt-signing.json`
+ * location is used.
+ */
 function currentKeyPath(): string {
+  const override = process.env.JWT_SIGNING_KEY_FILE;
+  if (override && override.length > 0) return path.resolve(override);
   return path.join(keysDir(), "jwt-signing.json");
 }
 
+/**
+ * Resolve the previous key file path.
+ *
+ * `JWT_SIGNING_KEY_FILE_PREVIOUS` takes precedence.  When only
+ * `JWT_SIGNING_KEY_FILE` is set, the previous key continues to load
+ * from the standard `<DATA_DIR>/keys/jwt-signing.prev.json` location
+ * — this preserves the existing rotation flow and avoids
+ * rollout-time session invalidation.
+ */
 function previousKeyPath(): string {
+  const override = process.env.JWT_SIGNING_KEY_FILE_PREVIOUS;
+  if (override && override.length > 0) return path.resolve(override);
   return path.join(keysDir(), "jwt-signing.prev.json");
 }
 
@@ -177,10 +203,21 @@ export function getPublicKeyData(): Array<{
 /**
  * Generate a new JWT signing key pair and write it to disk.
  * Defaults to ES256 (ECDSA P-256).
+ *
+ * Writes the key file with `0600` perms and the parent directory
+ * with `0700` perms so the private JWK is not world-readable.
+ *
+ * Overwrites any existing key at the resolved path — this is the
+ * primitive used by the rotation flow.  First-boot autogen and the
+ * `gen-jwt-key` ops script must use {@link autoGenerateJwtSigningKeyIfMissing}
+ * (or check existence themselves) to avoid invalidating already-issued
+ * session tokens.
  */
 export async function generateJwtSigningKey(
   algorithm = "ES256",
 ): Promise<void> {
+  const keyPath = currentKeyPath();
+
   const { privateKey, publicKey } = await generateKeyPair(algorithm, {
     extractable: true,
   });
@@ -199,12 +236,98 @@ export async function generateJwtSigningKey(
     publicKey: publicJwk,
   };
 
-  const dir = keysDir();
-  mkdirSync(dir, { recursive: true });
-  const keyPath = currentKeyPath();
+  // currentKeyPath was resolved at function entry above; reuse it
+  // here so JWT_SIGNING_KEY_FILE callers write to the configured
+  // location.
+  const dir = path.dirname(keyPath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // mkdirSync only applies the mode to newly created directories;
+  // tighten it explicitly so a pre-existing parent is also locked down.
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // Best effort — some platforms (Windows, certain mounted volumes)
+    // do not honor POSIX perms.  The file write below still proceeds.
+  }
+
   const tmpPath = `${keyPath}.${process.pid}.${randomUUID()}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(keyFile, null, 2), "utf8");
+  // writeFileSync's `mode` only applies on file creation; force perms
+  // afterwards so the umask cannot loosen them.
+  writeFileSync(tmpPath, JSON.stringify(keyFile, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    chmodSync(tmpPath, 0o600);
+  } catch {
+    // see chmod note above
+  }
   renameSync(tmpPath, keyPath);
+}
+
+/**
+ * Throw if `<DATA_DIR>` is not writable.  Called by the autogen
+ * boot path so the operator gets a clear error instead of a cryptic
+ * EACCES partway through key generation.
+ */
+export function assertDataDirWritable(): void {
+  const dir = getDataDir();
+
+  // If something already exists at the path, validate it before any
+  // mkdir so a stray file (or a wedged mount) produces a clear
+  // diagnostic rather than an EEXIST/ENOTDIR deeper in.
+  if (existsSync(dir) && !statSync(dir).isDirectory()) {
+    throw new Error(
+      `JWT_SIGNING_KEY_AUTOGEN=1 was requested but DATA_DIR (${dir}) is not a directory.`,
+    );
+  }
+
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch (cause) {
+    throw new Error(
+      `JWT_SIGNING_KEY_AUTOGEN=1 was requested but DATA_DIR (${dir}) is not writable. ` +
+        "Mount a writable volume at this path or inject the key via JWT_SIGNING_KEY_FILE.",
+      { cause },
+    );
+  }
+
+  try {
+    accessSync(dir, fsConstants.W_OK);
+  } catch (cause) {
+    throw new Error(
+      `JWT_SIGNING_KEY_AUTOGEN=1 was requested but DATA_DIR (${dir}) is not writable. ` +
+        "Mount a writable volume at this path or inject the key via JWT_SIGNING_KEY_FILE.",
+      { cause },
+    );
+  }
+}
+
+/**
+ * Idempotent first-boot key generation.
+ *
+ * Caller is responsible for honoring `JWT_SIGNING_KEY_AUTOGEN=1` and
+ * for ensuring no `JWT_SIGNING_KEY_FILE` is set (autogen is for
+ * single-instance dev/convenience; multi-replica deployments must
+ * inject a shared key via `JWT_SIGNING_KEY_FILE`).
+ *
+ * Logs a warning once per process so the single-instance constraint
+ * is visible in startup logs.
+ */
+export async function autoGenerateJwtSigningKeyIfMissing(): Promise<void> {
+  const keyPath = currentKeyPath();
+  if (existsSync(keyPath)) return;
+
+  assertDataDirWritable();
+
+  console.warn(
+    "[jwt-keys] JWT_SIGNING_KEY_AUTOGEN=1: generating a new ES256 signing key at " +
+      `${keyPath}. This is a single-instance convenience — multi-replica ` +
+      "deployments must inject a shared key via JWT_SIGNING_KEY_FILE so every " +
+      "replica validates tokens against the same key.",
+  );
+
+  await generateJwtSigningKey();
 }
 
 /** Delete the previous key file and clear it from memory. */

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -17,6 +17,18 @@
 export const NONCE_HEADER = "x-nonce";
 
 /**
+ * Request header that Next.js's renderer parses to extract the nonce
+ * via the `'nonce-{value}'` pattern; the framework then attaches that
+ * nonce to all framework scripts, page bundles, and inline scripts it
+ * emits. Even when the response advertises CSP in Report-Only mode,
+ * this request header MUST contain the enforcing-style policy value
+ * (i.e. unprefixed `Content-Security-Policy`) for the renderer to
+ * pick the nonce up. See Next.js docs:
+ * https://nextjs.org/docs/app/guides/content-security-policy#how-nonces-work-in-nextjs
+ */
+export const CSP_REQUEST_HEADER = "Content-Security-Policy";
+
+/**
  * Generate a CSP nonce.
  *
  * Uses the Edge runtime's global `crypto.getRandomValues` so the same

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,0 +1,67 @@
+/**
+ * Content-Security-Policy nonce + header builder.
+ *
+ * Used by the request `proxy` (Next 16's middleware equivalent) to
+ * mint a per-request nonce, propagate it to RSC layouts via the
+ * `x-nonce` request header, and emit the
+ * `Content-Security-Policy-Report-Only` response header.
+ *
+ * The header is shipped in Report-Only mode first so any Next.js
+ * inline-style/script breakages surface in real traffic before the
+ * policy is promoted to enforcing.  Promotion to
+ * `Content-Security-Policy` is a follow-up after one release of
+ * Report-Only validation.
+ */
+
+/** Header forwarded to RSC layouts so they can read the per-request nonce. */
+export const NONCE_HEADER = "x-nonce";
+
+/**
+ * Generate a CSP nonce.
+ *
+ * Uses the Edge runtime's global `crypto.getRandomValues` so the same
+ * implementation runs in both the Node and Edge proxy runtimes.
+ * 16 bytes of entropy (encoded base64) is the conventional minimum.
+ */
+export function generateCspNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // Cross-runtime base64: avoid relying on Node's `Buffer` so this
+  // also works in the Edge runtime.
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  // btoa is available in both Node 24 and Edge.
+  return btoa(binary);
+}
+
+/**
+ * Build the Content-Security-Policy header value for the given
+ * request nonce.
+ *
+ * `style-src` keeps `'unsafe-inline'` for now — Next.js styled-jsx
+ * and a number of inline styles in the app would break under a
+ * strict `style-src`.  Nonce-based hardening for styles is tracked
+ * as a follow-up issue.
+ */
+export function buildCspHeaderValue(nonce: string): string {
+  // `'strict-dynamic'` lets the framework's nonce-trusted scripts
+  // load further scripts they author, which is required for the
+  // Next.js client-side hydration entry to succeed under a strict
+  // script-src.
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ];
+  return directives.join("; ");
+}
+
+/** Header name we emit. Shipped in Report-Only mode for one release. */
+export const CSP_HEADER_NAME = "Content-Security-Policy-Report-Only";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import { AUTH_COOKIE_NAME, isPublicPath } from "./lib/auth/proxy-auth";
 import {
   buildCspHeaderValue,
   CSP_HEADER_NAME,
+  CSP_REQUEST_HEADER,
   generateCspNonce,
   NONCE_HEADER,
 } from "./lib/security/csp";
@@ -31,12 +32,23 @@ export default async function proxy(request: NextRequest) {
 
   // Mint a per-request CSP nonce. The proxy's matcher already
   // excludes `/api/*` and other non-HTML paths, so every request
-  // that lands here gets a nonce + CSP header.  Forward the nonce to
-  // RSC layouts via a request header so the framework's nonce-aware
-  // script injection picks it up.
+  // that lands here gets a nonce + CSP header.
+  //
+  // Two request headers must be set so Next.js's renderer attaches
+  // `nonce` attributes to framework scripts, page bundles, and inline
+  // scripts it emits:
+  //   • `x-nonce` — read by app code that wants the raw nonce
+  //   • `Content-Security-Policy` — parsed by Next's renderer for the
+  //     `'nonce-{value}'` pattern; the value here is the enforcing
+  //     policy even though the response ships it as Report-Only.
+  // Mutating in place is sufficient because next-intl's middleware
+  // forwards the request headers via
+  // `NextResponse.next/rewrite({ request: { headers: new Headers(req.headers) } })`,
+  // so our mutations propagate to the RSC render path.
   const nonce = generateCspNonce();
   const cspHeaderValue = buildCspHeaderValue(nonce);
   request.headers.set(NONCE_HEADER, nonce);
+  request.headers.set(CSP_REQUEST_HEADER, cspHeaderValue);
 
   // Forward the request URL on every request — public and protected
   // alike — so the gate layouts can read it via `headers()` regardless

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,12 @@ import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { verifyJwtStateless } from "./lib/auth/jwt-verify-stateless";
 import { AUTH_COOKIE_NAME, isPublicPath } from "./lib/auth/proxy-auth";
+import {
+  buildCspHeaderValue,
+  CSP_HEADER_NAME,
+  generateCspNonce,
+  NONCE_HEADER,
+} from "./lib/security/csp";
 
 const intlMiddleware = createMiddleware(routing);
 
@@ -23,6 +29,15 @@ export const REQUEST_URL_HEADER = "x-request-url";
 export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  // Mint a per-request CSP nonce. The proxy's matcher already
+  // excludes `/api/*` and other non-HTML paths, so every request
+  // that lands here gets a nonce + CSP header.  Forward the nonce to
+  // RSC layouts via a request header so the framework's nonce-aware
+  // script injection picks it up.
+  const nonce = generateCspNonce();
+  const cspHeaderValue = buildCspHeaderValue(nonce);
+  request.headers.set(NONCE_HEADER, nonce);
+
   // Forward the request URL on every request — public and protected
   // alike — so the gate layouts can read it via `headers()` regardless
   // of which auth path was taken. Mutating `request.headers` in-place
@@ -32,23 +47,42 @@ export default async function proxy(request: NextRequest) {
 
   // Public paths: skip auth, run locale middleware
   if (isPublicPath(pathname)) {
-    return intlMiddleware(request);
+    const response = intlMiddleware(request);
+    return applyCspHeader(response, cspHeaderValue);
   }
 
   // Protected path: require valid JWT
   const token = request.cookies.get(AUTH_COOKIE_NAME)?.value;
   if (!token) {
-    return redirectToSignIn(request);
+    return applyCspHeader(redirectToSignIn(request), cspHeaderValue);
   }
 
   try {
     await verifyJwtStateless(token);
   } catch (err) {
     console.error("[proxy] JWT verification failed:", (err as Error).message);
-    return redirectToSignIn(request);
+    return applyCspHeader(redirectToSignIn(request), cspHeaderValue);
   }
 
-  return intlMiddleware(request);
+  const response = intlMiddleware(request);
+  return applyCspHeader(response, cspHeaderValue);
+}
+
+/**
+ * Attach the Content-Security-Policy-Report-Only header to a
+ * response on its way back to the browser.  Works for both `Response`
+ * (intl middleware result) and `NextResponse` (sign-in redirect).
+ *
+ * Idempotent — replaces any existing CSP header so a downstream
+ * handler can override the policy if it really needs to (none do
+ * today).
+ */
+function applyCspHeader<R extends Response>(
+  response: R,
+  cspHeaderValue: string,
+): R {
+  response.headers.set(CSP_HEADER_NAME, cspHeaderValue);
+  return response;
 }
 
 function redirectToSignIn(request: NextRequest): NextResponse {


### PR DESCRIPTION
## Summary

Fixes the four blockers that surfaced in the 2026-05-03 integration test of `docker compose --profile prod up -d` against `main`. With this branch, a clean checkout boots end-to-end behind nginx HTTPS, mutations are accepted, and CSP is in place (Report-Only).

The issue contemplated three separate PRs (D, M+N, O). They are landed here as **separate commits in one PR** for review convenience; the commit boundaries match the original split so the security-sensitive M/N diff can be read in isolation. Reviewers who prefer the three-PR shape can request a split.

### D — First-boot JWT signing key autogen (`ee87a31`)

- `JWT_SIGNING_KEY_AUTOGEN=1` generates an ES256 key at `<DATA_DIR>/keys/jwt-signing.json` on first boot when missing. Idempotent: never overwrites an existing key, so already-issued sessions are not invalidated on re-boot.
- `JWT_SIGNING_KEY_FILE=<path>` (recommended for prod) overrides the current key path. The previous key continues to load from `<DATA_DIR>/keys/jwt-signing.prev.json` unless `JWT_SIGNING_KEY_FILE_PREVIOUS` is also set — preserves the existing rotation flow and avoids rollout-time session invalidation. **This PR takes the recommended default; rollout does not silently invalidate already-issued sessions.**
- `generateJwtSigningKey()` now applies `0600`/`0700` perms on the key file and parent dir, so both the autogen path and the new `pnpm gen-jwt-key` script inherit them.
- New `pnpm gen-jwt-key` (`scripts/generate-jwt-key.mjs`) for ops use outside the app boot.
- `docker-compose.yml` mounts a named `next-app-data` volume on `/app/data` so first-boot autogen actually persists; the Dockerfile pre-creates `/app/data` with the runtime user as owner.
- Boot fails fast with a clear error when autogen is requested but `DATA_DIR` is not writable. The check is gated on autogen; deployments that only use `JWT_SIGNING_KEY_FILE` are not gated.
- Autogen logs a `console.warn` on first invocation flagging the single-instance constraint. README + this PR description call it out.

### M / N — `EXPECTED_ORIGIN` override for the CSRF Origin guard (`18ceec1`)

- `EXPECTED_ORIGIN` env overrides the computed origin in the mutation guard (`src/lib/auth/guard.ts` + `src/lib/auth/csrf.ts`).
- Canonicalized at parse time: trailing slash stripped, scheme + host lowercased, so `EXPECTED_ORIGIN=https://Example.com/` does not silently mismatch `Origin: https://example.com`.
- Malformed values are treated as unset (fall back to `request.nextUrl.origin`) rather than crashing the request.
- When unset, behavior is unchanged from today — no silent default change.
- Origin mismatch responses now include `expected`/`actual` fields when `NODE_ENV !== "production"`. Production responses remain `{"error":"Origin mismatch"}`; the expected/actual pair is logged server-side at `console.warn` with the request method + path.
- **No proxy header trust is introduced.** `TRUSTED_PROXIES` is deferred — see Not addressed below.

### O — `Content-Security-Policy-Report-Only` header (`9cf954a`, plus Round-1 follow-ups in this branch)

- Per-request CSP nonce is minted in the Next.js proxy (`src/proxy.ts`). The proxy now sets **two** request headers Next's renderer needs to inject `nonce` attributes onto framework scripts, page bundles, and inline scripts:
  - `x-nonce` for app code that wants the raw nonce, and
  - `Content-Security-Policy` (the enforcing-style name) carrying the same nonce-bearing policy. Next parses this request header for the `'nonce-{value}'` pattern; without it, the response would advertise `'nonce-…' 'strict-dynamic'` while real Next-rendered HTML had no matching nonce attributes (Round-1 reviewer-flagged regression — fixed).
- Mutating in place is sufficient: `next-intl/middleware` forwards request headers via `NextResponse.next/rewrite({ request: { headers: new Headers(req.headers) } })`, so the proxy's mutations propagate to the RSC render path.
- `Content-Security-Policy-Report-Only` is attached on every HTML response path (public pages, sign-in redirects, protected routes). API JSON paths are excluded by the proxy matcher and do not need CSP.
- nginx leaves the CSP header untouched and continues to own HSTS / X-Frame-Options / nosniff / Referrer-Policy. CSP is not double-emitted.
- **Dynamic rendering** is now explicit: `src/app/[locale]/layout.tsx` and `src/app/page.tsx` call `await connection()`. Next's nonce flow only runs during dynamic SSR — statically rendered pages have no per-request nonce to attach, so without this opt-out the policy would not be promotable to enforcing without further changes (Round-1 reviewer-flagged — fixed). Build output confirms every locale route is dynamic (`ƒ`).
  - One known exception: `_not-found` is still statically rendered. Under enforcing CSP it would be blocked; the Report-Only validation cycle is the right place to surface it. Tracked as a follow-up before promotion.
- Starting policy: `default-src 'self'`; `script-src 'self' 'nonce-<request-nonce>' 'strict-dynamic'`; `style-src 'self' 'unsafe-inline'` (Next.js styled-jsx requires it; nonce hardening for styles is a follow-up); `img-src 'self' data:`; `font-src 'self' data:`; `connect-src 'self'`; `frame-ancestors 'none'`; `base-uri 'self'`; `form-action 'self'`; `object-src 'none'`.

### Documentation (`1efec90`, plus Round-1 update in this branch)

- README: separates dev (`pnpm dev` → `.env.local`) from prod (`docker compose --profile prod` → `.env`); documents new env vars; calls out the `next-app-data` named volume; notes Report-Only CSP rollout, the `await connection()` dynamic-rendering requirement, and the `_not-found` Report-Only-validation gap; first-boot deployment checklist.
- `.env.example`: adds `JWT_SIGNING_KEY_AUTOGEN`, `JWT_SIGNING_KEY_FILE`, `JWT_SIGNING_KEY_FILE_PREVIOUS`, `EXPECTED_ORIGIN` with comments.

## Security guardrails (per the issue)

- [x] No silent X-Forwarded-* trust (M/N PR introduces no trusted-proxy logic — `EXPECTED_ORIGIN` only)
- [x] No multi-replica autogen (D autogen path logs a `console.warn` at first invocation; README calls out the single-instance constraint)
- [x] No production debug leaks (N expected/actual values gated on `NODE_ENV !== "production"`)
- [x] No CSP without report-only validation (O ships as `Content-Security-Policy-Report-Only`)

Closes #404

## Not addressed

The issue explicitly carves these as out-of-scope for #404 follow-ups; this PR does not touch them:

- **`TRUSTED_PROXIES` (CIDR-based proxy trust).** Deferred per the issue. Reusing `extractClientIp()` would let a direct attacker spoof their source IP into the trusted set via `X-Forwarded-For`; a correct implementation needs a separate raw-socket-IP path. Filed as a follow-up.
- **Existing `extractClientIp` `X-Forwarded-For` trust** (`src/lib/auth/ip.ts`). Not changed; will be revisited together with `TRUSTED_PROXIES`.
- **Promotion of CSP from Report-Only to enforcing.** Per the issue, requires one release of Report-Only validation in real traffic. Follow-up.
- **Nonce-based hardening of `style-src`** (replacing `'unsafe-inline'`). Follow-up.
- **Nonce coverage of `_not-found`.** Static today; the Report-Only validation cycle exists to surface this kind of gap. Tracked as #411 (must land before promoting CSP from Report-Only to enforcing).
- **Proxy/edge-layer request id in the Origin-mismatch log.** No `X-Request-ID` header is forwarded by `infra/nginx/nginx.prod.conf`, and the existing `withCorrelationId` ALS context (`src/lib/audit/correlation.ts`) is route-handler scoped — `correlation.ts:19` explicitly documents that ALS does not propagate from middleware/Edge into the handler context. Tracked as #410 (nginx `proxy_set_header X-Request-ID $request_id;` + direct header read in the warn site, no ALS refactor).
- **WebAuthn manual sanity check.** Resolved by post-merge code analysis: `src/lib/auth/webauthn.ts:46`'s `getRelyingParty()` reads `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN` env directly (no `request.nextUrl.origin` involvement), so this PR's `EXPECTED_ORIGIN` change does not affect WebAuthn. The remaining operator-error path — leaving `WEBAUTHN_RP_ORIGIN` at the dev default while setting `EXPECTED_ORIGIN` — is closed by the README/`.env.example` work in #410.
- **Manual pages (`docs/`) + screenshots.** Per the issue, all changes are operator-facing (env vars, boot behavior, HTTP headers) with no end-user UI impact, so no manual update is required.

## Test plan

- [x] `docker compose --profile prod up -d` against this branch boots without `docker exec` workarounds (`.env` populated with `JWT_SIGNING_KEY_AUTOGEN=1` + `EXPECTED_ORIGIN=https://localhost`).
- [x] Sign in via browser, change password, enroll TOTP — all succeed through the HTTPS proxy.
- [ ] Manual: register **and** authenticate a WebAuthn credential at least once to confirm the proxied-HTTPS RP ID/origin path is not broken (file follow-up if it is).
- [x] N — dev/prod debug-leak check: build with `NODE_ENV=development`, trigger an Origin mismatch, confirm the JSON response body includes `expected` and `actual`. Build with `NODE_ENV=production`, trigger the same mismatch, confirm the response body contains only `{"error":"Origin mismatch"}`.
- [x] Response headers include `Content-Security-Policy-Report-Only` on HTML response paths (RSC, non-RSC, sign-in redirect, error/not-found boundaries). API JSON responses do not need CSP.
- [x] CSP **request** header (`Content-Security-Policy`) carrying the nonce-bearing policy is forwarded to Next's renderer (covered by new test in `src/__tests__/proxy.test.ts`).
- [x] All `[locale]/*` routes report as dynamic (`ƒ`) in `pnpm build` output, confirming the per-request nonce can attach to framework scripts.
- [x] With `EXPECTED_ORIGIN` unset, behavior matches today (regression check on the no-config default).
- [x] With `EXPECTED_ORIGIN=https://localhost`, a direct hit to `http://next-app:3000/api/auth/password` bypassing nginx, with `Origin: https://example.com` spoofed, returns `{"error":"Origin mismatch"}`.
- [x] D — re-boot idempotency: boot once with autogen, confirm key file appears; boot again, confirm the key file is unchanged (mtime/contents) and existing sessions still validate.
- [x] D — autogen fail-fast: set `JWT_SIGNING_KEY_AUTOGEN=1` with `DATA_DIR` pointing at a read-only path; container exits with the clear "DATA_DIR is not writable" error, not a cryptic mid-boot crash.
- [x] D — `JWT_SIGNING_KEY_FILE` only path: with `JWT_SIGNING_KEY_FILE` set and autogen unset, boot succeeds without writing under `DATA_DIR`; the previous key still loads from the standard `<DATA_DIR>/keys/jwt-signing.prev.json` location unless `JWT_SIGNING_KEY_FILE_PREVIOUS` is also set.
- [x] `pnpm gen-jwt-key` writes a key file with `0600` perms and parent directory `0700`.
- [x] `pnpm typecheck` passes.
- [x] `pnpm vitest run src/__tests__/lib/auth/csrf.test.ts src/__tests__/lib/auth/guard.test.ts src/__tests__/lib/auth/jwt-keys.test.ts src/__tests__/lib/security/csp.test.ts src/__tests__/proxy.test.ts` passes (152 tests, +2 new for CSP request-header forwarding).
- [x] `pnpm check` reports no errors.
- [x] `pnpm build` succeeds; route map confirms `/` and every `/[locale]/*` route is dynamic.

