### PR TITLE
Document WEBAUTHN_RP_ORIGIN and tag Origin-mismatch logs with request id (#410)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,23 @@ NEXT_PUBLIC_NODE_STATUS_POLL_MS=10000
 # else (or unset) ships the full set.
 NEXT_PUBLIC_GS_MODE=
 
+# ── WebAuthn relying-party identity ──────────────────────────────
+# WEBAUTHN_RP_ID is the eTLD+1-aligned domain the authenticator
+# scopes credentials to (no scheme, no port). WEBAUTHN_RP_ORIGIN is
+# the public origin browsers use to reach the app and must match
+# what the browser sends in the WebAuthn ceremony.
+#
+# In the prod profile, set both to match the public HTTPS origin
+# (the same value you use for EXPECTED_ORIGIN above):
+#   WEBAUTHN_RP_ID=example.com
+#   WEBAUTHN_RP_ORIGIN=https://example.com
+#
+# When unset, dev falls back to BASE_URL or http://localhost:3000.
+# That dev default silently breaks MFA enrollment on the prod
+# profile — verifyRegistrationResponse rejects the assertion with
+# a non-obvious error. EXPECTED_ORIGIN (CSRF/Origin guard) and
+# WEBAUTHN_RP_ORIGIN guard different code paths but share the same
+# value in this deployment, so set them together.
 WEBAUTHN_RP_ID=
 WEBAUTHN_RP_NAME=AICE
 WEBAUTHN_RP_ORIGIN=

--- a/README.md
+++ b/README.md
@@ -315,10 +315,23 @@ Dockerfile).
    `.env.local`). At minimum set `CSRF_SECRET`, the database URLs,
    the GraphQL endpoints, and:
    - `EXPECTED_ORIGIN=https://your.public.host` so the CSRF/Origin
-     guard accepts mutation requests through the HTTPS proxy.
+     guard accepts mutation requests through the HTTPS proxy. For
+     the prod profile, also set `WEBAUTHN_RP_ORIGIN` to the same
+     public HTTPS origin and `WEBAUTHN_RP_ID` to its host
+     (e.g. `WEBAUTHN_RP_ID=your.public.host`,
+     `WEBAUTHN_RP_ORIGIN=https://your.public.host`). The two env
+     vars guard different code paths — the CSRF/Origin guard and
+     the WebAuthn ceremony — but share the same value in this
+     deployment. Leaving `WEBAUTHN_RP_ORIGIN` at its dev fallback
+     silently breaks MFA enrollment on the prod profile.
    - One of `JWT_SIGNING_KEY_FILE=<path>` (recommended — a Secret
      mount) or `JWT_SIGNING_KEY_AUTOGEN=1` (single-instance dev
      convenience).
+   - The prod nginx config sets `X-Request-ID` on every upstream
+     request and includes `$request_id` in its access log. When an
+     upstream load balancer already mints a request id, override
+     the directive to forward `$http_x_request_id` instead so the
+     id is end-to-end (see `infra/nginx/nginx.prod.conf`).
 2. Make sure the persistent data volume is in place. The
    `docker-compose.yml` shipped here mounts a named `next-app-data`
    volume on `/app/data`; if you customise this, mount your own

--- a/infra/nginx/nginx.prod.conf
+++ b/infra/nginx/nginx.prod.conf
@@ -1,3 +1,12 @@
+# Access log format including nginx's per-request id ($request_id is
+# 16 random bytes in hex, generated per request). Placed at file top
+# so it resolves to the http context — the nginx Docker base config
+# includes conf.d/*.conf inside `http {}`.
+log_format main_with_req_id '$remote_addr - $remote_user [$time_local] '
+                            '"$request" $status $body_bytes_sent '
+                            '"$http_referer" "$http_user_agent" '
+                            'rid=$request_id';
+
 server {
     listen 80;
     return 301 https://$host$request_uri;
@@ -8,6 +17,8 @@ server {
 
     ssl_certificate     /etc/nginx/certs/prod.crt;
     ssl_certificate_key /etc/nginx/certs/prod.key;
+
+    access_log /var/log/nginx/access.log main_with_req_id;
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Frame-Options DENY always;
@@ -31,5 +42,13 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Per-request id forwarded to the upstream so server-side
+        # logs (e.g. CSRF/Origin mismatch warnings) can be
+        # correlated with the nginx access log entry above.
+        # If an upstream load balancer already sets X-Request-ID,
+        # forward that instead by replacing $request_id with
+        # $http_x_request_id (or use a `map` to fall back).
+        proxy_set_header X-Request-ID $request_id;
     }
 }

--- a/src/__tests__/lib/auth/guard.test.ts
+++ b/src/__tests__/lib/auth/guard.test.ts
@@ -1210,6 +1210,109 @@ describe("withAuth", () => {
       }
     });
 
+    it("includes request_id from x-request-id header in the warn log", async () => {
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue("https://example.com");
+      mockCheckOrigin.mockReturnValue({
+        ok: false,
+        actual: "https://attacker.example",
+        expected: "https://example.com",
+      });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const handler = vi.fn();
+        const wrapped = guard.withAuth(handler);
+        const request = makeAuthRequest("http://localhost:3000/api/test", {
+          method: "POST",
+          headers: {
+            origin: "https://attacker.example",
+            "x-csrf-token": "tok",
+            "x-request-id": "test-uuid",
+          },
+        });
+
+        await wrapped(request, makeContext());
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        const args = warn.mock.calls[0];
+        expect(args?.[0]).toContain("request_id=%s");
+        expect(args?.[args.length - 1]).toBe("test-uuid");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("logs request_id=unknown when x-request-id header is absent", async () => {
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue("https://example.com");
+      mockCheckOrigin.mockReturnValue({
+        ok: false,
+        actual: "https://attacker.example",
+        expected: "https://example.com",
+      });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const handler = vi.fn();
+        const wrapped = guard.withAuth(handler);
+        const request = makeAuthRequest("http://localhost:3000/api/test", {
+          method: "POST",
+          headers: {
+            origin: "https://attacker.example",
+            "x-csrf-token": "tok",
+          },
+        });
+
+        const response = await wrapped(request, makeContext());
+
+        expect(response.status).toBe(403);
+        expect(warn).toHaveBeenCalledTimes(1);
+        const args = warn.mock.calls[0];
+        expect(args?.[args.length - 1]).toBe("unknown");
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it("truncates an oversize x-request-id header before logging", async () => {
+      mockVerifyJwtFull.mockResolvedValue(validSession);
+      mockGetConfiguredExpectedOrigin.mockReturnValue("https://example.com");
+      mockCheckOrigin.mockReturnValue({
+        ok: false,
+        actual: "https://attacker.example",
+        expected: "https://example.com",
+      });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const handler = vi.fn();
+        const wrapped = guard.withAuth(handler);
+        const oversize = "a".repeat(10_000);
+        const request = makeAuthRequest("http://localhost:3000/api/test", {
+          method: "POST",
+          headers: {
+            origin: "https://attacker.example",
+            "x-csrf-token": "tok",
+            "x-request-id": oversize,
+          },
+        });
+
+        await wrapped(request, makeContext());
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        const args = warn.mock.calls[0];
+        const logged = args?.[args.length - 1] as string;
+        expect(logged.length).toBe(200);
+        expect(logged).toBe("a".repeat(200));
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
     it("hides expected/actual from response body when NODE_ENV === production", async () => {
       vi.stubEnv("NODE_ENV", "production");
 

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -28,6 +28,10 @@ import {
 import { assessIpUaRisk } from "./session-validator";
 import { extractBrowserFingerprint } from "./ua-parser";
 
+// Cap on the X-Request-ID value before it lands in the log line.
+// The header is operator-supplied and must be treated as untrusted.
+const REQUEST_ID_LOG_MAX_LEN = 200;
+
 // ── Types ───────────────────────────────────────────────────────
 
 type RouteHandler = (
@@ -166,14 +170,23 @@ export function withAuth(
         expectedOrigin,
       );
       if (!originResult.ok) {
+        // Operator-supplied X-Request-ID (set by nginx in the prod
+        // profile). Header is untrusted and length-capped before
+        // logging — never used for control flow.
+        const rawRequestId = request.headers.get("x-request-id");
+        const requestId =
+          rawRequestId === null
+            ? "unknown"
+            : rawRequestId.slice(0, REQUEST_ID_LOG_MAX_LEN);
         // Server-side log so operators can see expected/actual without
         // leaking it into the response body in production.
         console.warn(
-          "[csrf] Origin mismatch on %s %s: expected=%s actual=%s",
+          "[csrf] Origin mismatch on %s %s: expected=%s actual=%s request_id=%s",
           request.method,
           request.nextUrl.pathname,
           originResult.expected,
           originResult.actual ?? "<none>",
+          requestId,
         );
         const body: Record<string, unknown> = { error: "Origin mismatch" };
         if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
## Summary

Two operator-facing follow-ups carved out of #408. Both surface only when running behind the nginx HTTPS prod profile, and they ship together because their fix touches the same surface (nginx config + auth-layer code + `.env.example` / README).

### §1 — `WEBAUTHN_RP_ORIGIN` in `.env.example` + README

`WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN` predated the #408 work and were not added to the production-deployment material. The dev fallback (`BASE_URL` or `http://localhost:3000`) silently breaks WebAuthn registration on the prod profile — the CSRF/Origin guard accepts the request, then `verifyRegistrationResponse` rejects the assertion with a non-obvious error.

- `.env.example`: paired comment block for `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN` keyed off `EXPECTED_ORIGIN`, with prod-shaped values.
- README first-boot checklist: bullet that mentions `WEBAUTHN_RP_ORIGIN` in the same paragraph as `EXPECTED_ORIGIN` and explains the two guard different code paths but share the same value in this deployment.

### §2 — request id in the Origin-mismatch warn log

The Origin-mismatch `console.warn` added by #408 logged method + path but not a request id, defeating correlation with nginx access logs. Per #404 §M/N, the warn must carry a request id.

- `infra/nginx/nginx.prod.conf`: file-top `log_format main_with_req_id` that includes `\$request_id`, `access_log` switched to it, and `proxy_set_header X-Request-ID \$request_id` on `location /`. Comment documents the override pattern when an upstream load balancer already mints the id.
- `src/lib/auth/guard.ts`: at the existing Origin-mismatch warn call site, read `x-request-id` directly, length-cap to 200 chars (operator-supplied — treated as untrusted), fall back to `"unknown"` when absent. Format extended to `request_id=%s` — printf-style preserved to match the surrounding lines from #408. ALS deliberately not touched (out of scope per the issue).

Combined diff is ~50 lines of code/config + 3 unit tests covering header-present, header-absent, and oversize-truncation cases.

Closes #410

## Test plan

- [x] `pnpm vitest run src/__tests__/lib/auth/guard.test.ts` passes (55/55)
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm check` (biome) clean for the changed files
- [x] `.env.example` carries `WEBAUTHN_RP_ID` and `WEBAUTHN_RP_ORIGIN` with prod-shaped commented values
- [x] README first-boot checklist mentions both env vars in the same paragraph as `EXPECTED_ORIGIN`
- [x] Unit test: `x-request-id: "test-uuid"` produces `request_id=test-uuid` in the warn line
- [x] Unit test: missing header produces `request_id=unknown` and does not throw
- [x] Unit test: 10 KB `x-request-id` is truncated to 200 chars before logging
- [x] Manual: trigger an Origin mismatch through nginx (`curl -k -H "Origin: https://attacker.example" ... https://localhost/api/...`); confirm the next-app log shows the `X-Request-ID` value visible in the nginx access log for the same request — verified by running `nginx-prod` against a stub upstream: nginx access log emits `rid=b55880e4f6370681ed8f1e61f7b0eda0` and the upstream receives `x-request-id: b55880e4f6370681ed8f1e61f7b0eda0`, paired with the unit tests above that prove the application's warn line consumes that header
- [ ] Manual: deploy with `WEBAUTHN_RP_ORIGIN` unset on the prod profile and confirm MFA enrollment fails (sanity check that the README warning is justified) — not exercised end-to-end (would require building the prod image, standing up Postgres + next-app + nginx, registering an admin, and driving a WebAuthn ceremony with a virtual authenticator). Source-level confirmation in `src/lib/auth/webauthn.ts:46-68`: `getRelyingParty()` falls back to `BASE_URL` or `http://localhost:3000` when `WEBAUTHN_RP_ORIGIN` is unset, and that value flows straight to `verifyRegistrationResponse` as `expectedOrigin`, so a browser whose `Origin` is the public HTTPS host will fail verification.
