### PR TITLE
Cover not-found under per-request CSP nonce (#411)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,13 +297,14 @@ is staged: the Report-Only mode lands first to surface any inline
 script/style breakages in real traffic before the header is promoted
 to enforcing CSP.
 
-The CSP nonce flow requires dynamic rendering — `app/[locale]/layout.tsx`
-calls `await connection()` so framework script tags receive a fresh
-per-request nonce. Pages added under `app/` that are intentionally
-statically rendered (e.g. the built-in `_not-found` page) will not
-carry a nonce; under enforcing CSP they would be blocked, so the
-Report-Only validation cycle exists in part to identify any such
-paths before promotion.
+The CSP nonce flow requires dynamic rendering — `app/[locale]/layout.tsx`,
+`app/[locale]/not-found.tsx`, and `app/not-found.tsx` all call
+`await connection()` so framework script tags receive a fresh
+per-request nonce.  Any new page added under `app/` must do the same
+(or have no `<script>` tags at all): a statically rendered HTML
+response carries no per-request nonce and would be blocked once CSP
+promotes from Report-Only to enforcing.  Verify with `pnpm build` —
+the route map should mark every HTML route as `ƒ` (dynamic).
 
 The `__Host-csrf` cookie and `Secure` flag on the access token cookie
 are automatically enabled when `NODE_ENV=production` (set by the

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -228,6 +228,42 @@ describe("proxy", () => {
       expect(cspResponse).toBe(cspRequest);
     });
 
+    it("forwards the nonce-bearing CSP request header to the renderer for an unmatched (not-found) path with a valid session", async () => {
+      // The proxy is fail-closed, so an unauthenticated `/missing` would
+      // hit the `/sign-in` redirect branch instead of the not-found
+      // branch.  Driving with a valid JWT exercises the same renderer
+      // path that produces the dynamic not-found HTML, which is the only
+      // way to assert that the per-request nonce reaches the boundary
+      // that issue #411 makes dynamic.
+      mockVerifyJwtStateless.mockResolvedValue({
+        sub: "account-1",
+        sid: "session-1",
+        roles: ["admin"],
+        token_version: 0,
+        kid: "key-1",
+      });
+      mockIntlMiddleware.mockImplementation((request: NextRequest) => {
+        const cspRequest = request.headers.get("Content-Security-Policy");
+        const xNonce = request.headers.get("x-nonce");
+        const response = new Response(null, { status: 404 });
+        if (cspRequest) response.headers.set("x-test-csp-request", cspRequest);
+        if (xNonce) response.headers.set("x-test-nonce", xNonce);
+        return response;
+      });
+
+      const response = await proxy(makeRequest("/missing", "valid-token"));
+
+      const cspRequest = response.headers.get("x-test-csp-request");
+      const nonce = response.headers.get("x-test-nonce");
+      expect(cspRequest).toBeTruthy();
+      expect(nonce).toBeTruthy();
+      expect(cspRequest).toContain(`'nonce-${nonce}'`);
+      const cspResponse = response.headers.get(
+        "Content-Security-Policy-Report-Only",
+      );
+      expect(cspResponse).toBe(cspRequest);
+    });
+
     it("mints a fresh nonce per request", async () => {
       // Return a fresh Response each call so applyCspHeader writes
       // into distinct header objects.

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,31 @@
+import { connection } from "next/server";
+import { getTranslations } from "next-intl/server";
+
+import { Link } from "@/i18n/navigation";
+
+export default async function LocaleNotFound() {
+  // Opt out of static rendering so the per-request CSP nonce minted in
+  // `src/proxy.ts` reaches every framework script tag on this page.
+  // Without this opt-out, Next.js prerenders not-found at build time and
+  // the resulting HTML carries no per-request nonce, which becomes a hard
+  // failure once CSP promotes from Report-Only to enforcing.  See:
+  // https://nextjs.org/docs/app/guides/content-security-policy#static-vs-dynamic-rendering-with-csp
+  await connection();
+
+  const t = await getTranslations("notFound");
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+      <h1 className="text-2xl font-semibold">{t("title")}</h1>
+      <p className="text-muted-foreground max-w-md text-sm">
+        {t("description")}
+      </p>
+      <Link
+        href="/dashboard"
+        className="text-primary text-sm font-medium underline-offset-4 hover:underline"
+      >
+        {t("backToDashboard")}
+      </Link>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,6 +4,12 @@ import { routing } from "@/i18n/routing";
 
 import "./globals.css";
 
+type NotFoundMessages = {
+  title: string;
+  description: string;
+  backToDashboard: string;
+};
+
 export default async function RootNotFound() {
   // Opt out of static rendering so the per-request CSP nonce minted in
   // `src/proxy.ts` reaches every framework script tag.  This boundary
@@ -17,11 +23,16 @@ export default async function RootNotFound() {
 
   // The root layout (`src/app/layout.tsx`) is a pass-through and the
   // locale provider/theme/font shell lives in `[locale]/layout.tsx`, so
-  // this boundary must render its own minimal HTML document.  We render
-  // a static English message rather than reaching for next-intl: the
-  // request that lands here has no resolved locale.
+  // this boundary must render its own minimal HTML document.  The request
+  // that lands here has no resolved locale, so we render the configured
+  // default-locale messages and tag the document with the same locale —
+  // this keeps `lang` and copy in agreement under any `DEFAULT_LOCALE`.
+  const locale = routing.defaultLocale;
+  const messages = (await import(`@/i18n/messages/${locale}.json`)).default;
+  const t = messages.notFound as NotFoundMessages;
+
   return (
-    <html lang={routing.defaultLocale}>
+    <html lang={locale}>
       <body
         style={{
           fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
@@ -39,13 +50,13 @@ export default async function RootNotFound() {
         }}
       >
         <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>
-          404 — Page not found
+          {t.title}
         </h1>
         <p style={{ maxWidth: "32rem", fontSize: "0.875rem", margin: 0 }}>
-          The page you are looking for does not exist or has been moved.
+          {t.description}
         </p>
         <a
-          href="/"
+          href="/dashboard"
           style={{
             fontSize: "0.875rem",
             fontWeight: 500,
@@ -53,7 +64,7 @@ export default async function RootNotFound() {
             textDecoration: "underline",
           }}
         >
-          Back to home
+          {t.backToDashboard}
         </a>
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,8 @@
+import { headers } from "next/headers";
 import { connection } from "next/server";
 
 import { routing } from "@/i18n/routing";
+import { REQUEST_URL_HEADER } from "@/proxy";
 
 import "./globals.css";
 
@@ -9,6 +11,36 @@ type NotFoundMessages = {
   description: string;
   backToDashboard: string;
 };
+
+type Locale = (typeof routing.locales)[number];
+
+function isLocale(value: string): value is Locale {
+  return (routing.locales as readonly string[]).includes(value);
+}
+
+/**
+ * Derive the locale to render the root not-found document under.
+ *
+ * The root boundary catches unmatched URLs that escape the `[locale]`
+ * segment, but the request URL still carries the user's locale intent
+ * for shapes like `/ko/missing` or `/en/missing`.  Reading the original
+ * URL from the `x-request-url` header that `proxy.ts` forwards lets
+ * `<html lang>` and the body copy track the locale the user actually
+ * asked for.  Invalid prefixes (e.g. `/xx/missing`) and the
+ * no-locale-prefix shape (`/missing`, the default-locale form under
+ * `localePrefix: "as-needed"`) fall back to `routing.defaultLocale`.
+ */
+function resolveLocale(requestUrl: string | null): Locale {
+  if (!requestUrl) return routing.defaultLocale;
+  let pathname: string;
+  try {
+    pathname = new URL(requestUrl).pathname;
+  } catch {
+    return routing.defaultLocale;
+  }
+  const firstSegment = pathname.split("/")[1] ?? "";
+  return isLocale(firstSegment) ? firstSegment : routing.defaultLocale;
+}
 
 export default async function RootNotFound() {
   // Opt out of static rendering so the per-request CSP nonce minted in
@@ -23,11 +55,13 @@ export default async function RootNotFound() {
 
   // The root layout (`src/app/layout.tsx`) is a pass-through and the
   // locale provider/theme/font shell lives in `[locale]/layout.tsx`, so
-  // this boundary must render its own minimal HTML document.  The request
-  // that lands here has no resolved locale, so we render the configured
-  // default-locale messages and tag the document with the same locale —
-  // this keeps `lang` and copy in agreement under any `DEFAULT_LOCALE`.
-  const locale = routing.defaultLocale;
+  // this boundary must render its own minimal HTML document.  Derive the
+  // locale from the original request URL forwarded by the proxy so a
+  // `/ko/missing` request renders Korean copy under `<html lang="ko">`
+  // even on an English-default deployment, and vice versa.  Falls back
+  // to `routing.defaultLocale` when the prefix is missing or invalid.
+  const requestUrl = (await headers()).get(REQUEST_URL_HEADER);
+  const locale = resolveLocale(requestUrl);
   const messages = (await import(`@/i18n/messages/${locale}.json`)).default;
   const t = messages.notFound as NotFoundMessages;
 
@@ -56,7 +90,11 @@ export default async function RootNotFound() {
           {t.description}
         </p>
         <a
-          href="/dashboard"
+          href={
+            locale === routing.defaultLocale
+              ? "/dashboard"
+              : `/${locale}/dashboard`
+          }
           style={{
             fontSize: "0.875rem",
             fontWeight: 500,

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,61 @@
+import { connection } from "next/server";
+
+import { routing } from "@/i18n/routing";
+
+import "./globals.css";
+
+export default async function RootNotFound() {
+  // Opt out of static rendering so the per-request CSP nonce minted in
+  // `src/proxy.ts` reaches every framework script tag.  This boundary
+  // catches unmatched URLs that escape the `[locale]` segment (e.g. when
+  // next-intl's middleware does not rewrite the request into a locale).
+  // Without this opt-out, Next.js prerenders the root not-found at build
+  // time and the resulting HTML carries no per-request nonce — which is
+  // a hard failure once CSP promotes from Report-Only to enforcing.  See:
+  // https://nextjs.org/docs/app/guides/content-security-policy#static-vs-dynamic-rendering-with-csp
+  await connection();
+
+  // The root layout (`src/app/layout.tsx`) is a pass-through and the
+  // locale provider/theme/font shell lives in `[locale]/layout.tsx`, so
+  // this boundary must render its own minimal HTML document.  We render
+  // a static English message rather than reaching for next-intl: the
+  // request that lands here has no resolved locale.
+  return (
+    <html lang={routing.defaultLocale}>
+      <body
+        style={{
+          fontFamily: "system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          padding: "1.5rem",
+          textAlign: "center",
+          backgroundColor: "#fff",
+          color: "#111",
+        }}
+      >
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>
+          404 — Page not found
+        </h1>
+        <p style={{ maxWidth: "32rem", fontSize: "0.875rem", margin: 0 }}>
+          The page you are looking for does not exist or has been moved.
+        </p>
+        <a
+          href="/"
+          style={{
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            color: "#2563eb",
+            textDecoration: "underline",
+          }}
+        >
+          Back to home
+        </a>
+      </body>
+    </html>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -10,6 +10,11 @@
     "loading": "Loading...",
     "error": "An error occurred"
   },
+  "notFound": {
+    "title": "404 — Page not found",
+    "description": "The page you are looking for does not exist or has been moved.",
+    "backToDashboard": "Back to dashboard"
+  },
   "auth": {
     "username": "Account ID",
     "password": "Password",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -10,6 +10,11 @@
     "loading": "로딩 중...",
     "error": "오류가 발생했습니다"
   },
+  "notFound": {
+    "title": "404 — 페이지를 찾을 수 없습니다",
+    "description": "요청하신 페이지가 존재하지 않거나 이동되었습니다.",
+    "backToDashboard": "대시보드로 돌아가기"
+  },
   "auth": {
     "username": "계정 ID",
     "password": "비밀번호",


### PR DESCRIPTION
## Summary

Closes #411.

`_not-found` was the one HTML route still statically prerendered after PR #408, so it shipped no per-request nonce — a hard failure once CSP promotes from Report-Only to enforcing. This PR adds a custom not-found at the locale boundary plus a root not-found backstop, both opted out of static rendering with `await connection()`, so every 404 response now carries the same per-request nonce flow as the rest of the app.

- `src/app/[locale]/not-found.tsx` — locale-aware page using next-intl messages, theme/font/locale-provider shell inherited from `[locale]/layout.tsx`.
- `src/app/not-found.tsx` — root backstop for URLs that escape the `[locale]` segment. Per the Next.js not-found file convention, only `app/not-found` is guaranteed to catch every unmatched URL. The root layout is a pass-through and there is no resolved locale on this request, so this boundary renders its own minimal HTML document. Locale is derived from the original request URL forwarded by `proxy.ts` via the `x-request-url` header: a valid first path segment (`en`/`ko`) selects that locale, anything else (no prefix, or an invalid prefix like `/xx/missing`) falls back to `routing.defaultLocale`. Both `<html lang>`, the body copy, and the back-to-dashboard href all track the resolved locale, so a `/ko/missing` request renders Korean copy under `<html lang="ko">` even on an English-default deployment, and vice versa.
- `src/i18n/messages/{en,ko}.json` — `notFound` strings for both the locale boundary and the root backstop.
- `src/__tests__/proxy.test.ts` — assert the proxy attaches the CSP response header and forwards the nonce-bearing request header to the renderer for an unmatched (`/missing`) path. Driven with a valid JWT because the proxy is fail-closed; an unauthenticated `/missing` exercises the `/sign-in` redirect branch, not the not-found branch.
- `README.md` — restate the dynamic-rendering requirement positively for any new HTML route, replacing the prior caveat that singled out `_not-found` as a known exception.

## Static-boundary audit (issue requirement #5)

`pnpm build` against this branch reports every route as `ƒ` (dynamic), including `/_not-found`. There are no `○` (static) HTML entries in the route map, so no further boundaries need conversion:

- `src/app/[locale]/(dashboard)/nodes/forbidden.tsx` and `src/app/[locale]/(dashboard)/nodes/(gate)/settings/loading.tsx` are nested under the `[locale]` segment whose layout already calls `await connection()`, so they inherit dynamic rendering and never ship as standalone static HTML.
- No `error.tsx`, `unauthorized.tsx`, or `global-error.tsx` files exist in `src/app/`.

The CSP enforcing-promotion gate this issue tracks is therefore closed by this PR; promotion itself is still a separate follow-up (see "Out of scope").

## Out of scope

- **End-to-end "response-header nonce equals rendered `<script nonce>`" assertion as automated coverage.** Verified manually under a `next start` prod build (see test plan), but a Playwright e2e or prod-profile smoke test that asserts this on every CI run is left as a follow-up per the issue's "track the e2e/smoke coverage as a follow-up if it is not in scope here" allowance.
- **CSP promotion from Report-Only to enforcing.** Explicitly out of scope per the issue; lands as a follow-up PR after at least one Report-Only release with no new violations against any HTML route.

## Notes from manual verification

- `[locale]/not-found.tsx` does not fire for arbitrary unmatched URLs under `[locale]` (e.g. `/ko/missing`); Next.js falls through to the root `app/not-found.tsx` for every unmatched URL shape. This matches the Next.js not-found file convention noted in the issue, and is the reason the PR adds the root backstop. The locale boundary still serves `notFound()` calls from inside `[locale]` pages with locale-aware UX.
- The root backstop reads the original request URL from the proxy-forwarded `x-request-url` header to recover the user's locale intent. So `/ko/missing` on an `en`-default deployment renders Korean copy under `<html lang="ko">`, and `/en/missing` on a `ko`-default deployment renders English copy under `<html lang="en">`. Invalid prefixes (`/xx/missing`) and the no-prefix shape (`/missing`) fall back to `routing.defaultLocale`.

## Test plan

- [x] `pnpm vitest run` — 2866/2866 pass.
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm biome check` — clean.
- [x] `pnpm build` route map shows `/_not-found` as `ƒ` (dynamic) — confirmed (was `○` static before this change), and no `○` HTML routes remain anywhere in the map.
- [x] All four URL shapes (`/missing`, `/ko/missing`, `/en/missing`, `/xx/missing`) driven through `next start` (prod build) with a valid signed-in session — all return either `404` (rendering the dynamic root not-found) or a `307` redirect to a 404 path. `/en/missing` redirects to `/missing` because `localePrefix: "as-needed"` strips the default-locale prefix; the redirect itself carries the CSP-Report-Only header.
- [x] View source for each shape — every `<script>` tag carries a `nonce="..."` attribute that matches the `Content-Security-Policy-Report-Only` header value on the response.
- [x] Rendered document shell for the root `not-found.tsx` in the prod build — `<html lang="en">` for `/missing` and `/xx/missing` on an `en` default; `<html lang="ko">` for `/ko/missing` (English-default) and for `/missing`/`/en/missing` on a `ko`-default deployment. Body copy and back-to-dashboard href track the same locale.
- [ ] After merge: `Content-Security-Policy-Report-Only` violation reports for the not-found path stop appearing in the browser console / report endpoint.