### PR TITLE
Self-heal audit_writer grants and harden init script (#406)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,14 @@ MTLS_CERT_PATH=
 MTLS_KEY_PATH=
 MTLS_CA_PATH=
 
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/auth_db
-DATABASE_ADMIN_URL=postgres://postgres:postgres@localhost:5432/postgres
-AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5432/audit_db
+# Host-side DSNs default to port 5434 to avoid colliding with any other
+# Postgres instance on the host. The compose `next-app` service connects
+# to `postgres:5432` over the compose network — that internal port is
+# unchanged. Override the host port with `AICE_POSTGRES_HOST_PORT` (and
+# update these DSNs to match) if you need to publish on a different port.
+DATABASE_URL=postgres://postgres:postgres@localhost:5434/auth_db
+DATABASE_ADMIN_URL=postgres://postgres:postgres@localhost:5434/postgres
+AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5434/audit_db
 
 DATA_DIR=./data
 JWT_EXPIRATION_MINUTES=15

--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,23 @@ MTLS_CERT_PATH=
 MTLS_KEY_PATH=
 MTLS_CA_PATH=
 
-# Host-side DSNs default to port 5434 to avoid colliding with any other
-# Postgres instance on the host. The compose `next-app` service connects
-# to `postgres:5432` over the compose network — that internal port is
-# unchanged. Override the host port with `AICE_POSTGRES_HOST_PORT` (and
-# update these DSNs to match) if you need to publish on a different port.
+# These defaults are *host-side* (for `pnpm dev` and host tooling like
+# psql or the Vitest integration suite). The host port defaults to 5434
+# so aice-web-next does not collide with any other Postgres on the host.
+#
+# The prod compose profile (`docker compose --profile prod up -d`) passes
+# this file directly into the `next-app` container. Inside that container
+# `localhost` is the container itself, so the DSNs below will NOT reach
+# the compose `postgres` service. For the prod profile, override these
+# to the compose-network address:
+#
+#   DATABASE_URL=postgres://postgres:postgres@postgres:5432/auth_db
+#   DATABASE_ADMIN_URL=postgres://postgres:postgres@postgres:5432/postgres
+#   AUDIT_DATABASE_URL=postgres://audit_writer:changeme@postgres:5432/audit_db
+#
+# See the README "First-boot deployment checklist" for the full prod path.
+# Override the host-published port with `AICE_POSTGRES_HOST_PORT` (and
+# update the host-side DSNs below to match) if you need a different port.
 DATABASE_URL=postgres://postgres:postgres@localhost:5434/auth_db
 DATABASE_ADMIN_URL=postgres://postgres:postgres@localhost:5434/postgres
 AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5434/audit_db

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ the values:
 
 | Variable | Description |
 |----------|-------------|
-| `DATABASE_URL` | PostgreSQL connection string for `auth_db` |
-| `DATABASE_ADMIN_URL` | Admin connection to create databases at runtime |
-| `AUDIT_DATABASE_URL` | PostgreSQL connection string for `audit_db` |
+| `DATABASE_URL` | PostgreSQL connection string for `auth_db`. Host-side DSN — defaults to `localhost:5434` to match the published compose port (see `AICE_POSTGRES_HOST_PORT`). |
+| `DATABASE_ADMIN_URL` | Admin connection to create databases at runtime. Host-side DSN; same port-mapping note as `DATABASE_URL`. |
+| `AUDIT_DATABASE_URL` | PostgreSQL connection string for `audit_db`. Host-side DSN; same port-mapping note as `DATABASE_URL`. |
+| `AICE_POSTGRES_HOST_PORT` | Host port the compose `postgres` service publishes on. Default `5434` so aice-web-next does not collide with any other Postgres on the host. The compose `next-app` service still reaches Postgres at `postgres:5432` over the compose network — only the host-published port shifts. Operators with an existing 5432-bound deployment can override with `AICE_POSTGRES_HOST_PORT=5432` and update the host-side DSNs above accordingly. |
 | `REVIEW_GRAPHQL_ENDPOINT` | `review-web` (manager) GraphQL endpoint URL |
 | `GIGANTO_GRAPHQL_ENDPOINT` | Giganto GraphQL endpoint URL (direct mTLS, not proxied through review-web) |
 | `TIVAN_GRAPHQL_ENDPOINT` | Tivan GraphQL endpoint URL (direct mTLS, not proxied through review-web) |
@@ -308,6 +309,62 @@ paths before promotion.
 The `__Host-csrf` cookie and `Secure` flag on the access token cookie
 are automatically enabled when `NODE_ENV=production` (set by the
 Dockerfile).
+
+#### Postgres host port and the dev/prod address split
+
+The compose `postgres` service publishes its container port `5432` on the
+host as `${AICE_POSTGRES_HOST_PORT:-5434}` so aice-web-next does not
+collide with any other Postgres instance running on the same host (e.g.
+bootroot's own Postgres for step-ca state). Two distinct addresses
+result:
+
+- **Host tooling (`psql`, DBeaver, ad-hoc `pg_dump`, CI jobs, the
+  Vitest integration suite running outside the container):** connect to
+  `localhost:${AICE_POSTGRES_HOST_PORT:-5434}`.
+- **The compose `next-app` service:** connects internally over the
+  compose network at `postgres:5432`. The container-internal port is
+  unchanged.
+
+**Breaking change for external clients on upgrade.** Any host-side
+tooling that previously connected to `localhost:5432` (psql sessions,
+DBeaver/TablePlus profiles, ad-hoc `pg_dump` scripts, CI jobs that bind
+nothing but assume the published port) breaks after this version is
+deployed until reconfigured to `5434`. Operators who need to keep the
+previous behavior can override with
+`AICE_POSTGRES_HOST_PORT=5432`. The shipped `.env.example` already uses
+the new default.
+
+#### Postgres init script and re-applying grants
+
+The `infra/postgres/init-audit-db.sql` script is mounted into
+`docker-entrypoint-initdb.d`, which Postgres only runs **on first volume
+init**. Edits to the script after the volume already exists are ignored
+by compose. To force the script to re-run at compose-init time, the
+volume must be removed:
+
+```bash
+docker compose down -v
+docker volume rm <project>_pgdata
+```
+
+The init script itself is now safe to run by hand against an existing
+cluster:
+
+```bash
+psql -h localhost -p 5434 -U postgres -f infra/postgres/init-audit-db.sql
+```
+
+Both `CREATE DATABASE audit_db` and `CREATE ROLE audit_writer` are
+guarded so re-runs are no-ops, not errors.
+
+The runtime grant helper in `src/lib/db/migrate.ts`
+(`ensureAuditRolePermissions{Preflight,Postflight}`) re-applies
+`audit_writer` privileges on every boot, so operator-induced privilege
+drift heals automatically without re-running the init script. The
+preflight pass runs *before* `migrateAuditDb()` because the audit
+migrations themselves need `CREATE` on `public`; the postflight pass
+re-applies table and sequence grants once the migration has created the
+audit table.
 
 #### First-boot deployment checklist
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ the values:
 
 | Variable | Description |
 |----------|-------------|
-| `DATABASE_URL` | PostgreSQL connection string for `auth_db`. Host-side DSN — defaults to `localhost:5434` to match the published compose port (see `AICE_POSTGRES_HOST_PORT`). |
-| `DATABASE_ADMIN_URL` | Admin connection to create databases at runtime. Host-side DSN; same port-mapping note as `DATABASE_URL`. |
-| `AUDIT_DATABASE_URL` | PostgreSQL connection string for `audit_db`. Host-side DSN; same port-mapping note as `DATABASE_URL`. |
+| `DATABASE_URL` | PostgreSQL connection string for `auth_db`. **The shipped `.env.example` value is host-side** (`localhost:5434`, for `pnpm dev` and host tooling). The prod compose profile passes `.env` directly into the `next-app` container, where `localhost` is the container itself — set this to `postgres://postgres:postgres@postgres:5432/auth_db` for prod. See the [first-boot deployment checklist](#first-boot-deployment-checklist) and `AICE_POSTGRES_HOST_PORT`. |
+| `DATABASE_ADMIN_URL` | Admin connection to create databases at runtime. Same dev-vs-prod address split as `DATABASE_URL`; for prod use `postgres://postgres:postgres@postgres:5432/postgres`. |
+| `AUDIT_DATABASE_URL` | PostgreSQL connection string for `audit_db`. Same dev-vs-prod address split as `DATABASE_URL`; for prod use `postgres://audit_writer:changeme@postgres:5432/audit_db`. |
 | `AICE_POSTGRES_HOST_PORT` | Host port the compose `postgres` service publishes on. Default `5434` so aice-web-next does not collide with any other Postgres on the host. The compose `next-app` service still reaches Postgres at `postgres:5432` over the compose network — only the host-published port shifts. Operators with an existing 5432-bound deployment can override with `AICE_POSTGRES_HOST_PORT=5432` and update the host-side DSNs above accordingly. |
 | `REVIEW_GRAPHQL_ENDPOINT` | `review-web` (manager) GraphQL endpoint URL |
 | `GIGANTO_GRAPHQL_ENDPOINT` | Giganto GraphQL endpoint URL (direct mTLS, not proxied through review-web) |
@@ -369,8 +369,25 @@ audit table.
 #### First-boot deployment checklist
 
 1. Populate `.env` (the prod compose profile reads `.env`, not
-   `.env.local`). At minimum set `CSRF_SECRET`, the database URLs,
-   the GraphQL endpoints, and:
+   `.env.local`). The prod compose passes `.env` *directly into the
+   `next-app` container*, so the database URLs must use the
+   compose-network address `postgres:5432`, not the host-side
+   `localhost:${AICE_POSTGRES_HOST_PORT:-5434}` that the shipped
+   `.env.example` ships with for `pnpm dev`. Concretely, override the
+   three DSNs to:
+
+   ```env
+   DATABASE_URL=postgres://postgres:postgres@postgres:5432/auth_db
+   DATABASE_ADMIN_URL=postgres://postgres:postgres@postgres:5432/postgres
+   AUDIT_DATABASE_URL=postgres://audit_writer:changeme@postgres:5432/audit_db
+   ```
+
+   Host tooling (`psql`, the Vitest integration suite, DBeaver, etc.)
+   continues to use the `.env.example` defaults at
+   `localhost:${AICE_POSTGRES_HOST_PORT:-5434}` — a separate file
+   (e.g. `.env.local`) is the natural place to keep them.
+
+   At minimum also set `CSRF_SECRET`, the GraphQL endpoints, and:
    - `EXPECTED_ORIGIN=https://your.public.host` so the CSRF/Origin
      guard accepts mutation requests through the HTTPS proxy.
    - One of `JWT_SIGNING_KEY_FILE=<path>` (recommended — a Secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
-      - "5432:5432"
+      - "${AICE_POSTGRES_HOST_PORT:-5434}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/18/docker
       - ./infra/postgres/init-audit-db.sql:/docker-entrypoint-initdb.d/init-audit-db.sql:ro

--- a/infra/postgres/init-audit-db.sql
+++ b/infra/postgres/init-audit-db.sql
@@ -1,14 +1,28 @@
--- This script runs once when the PostgreSQL volume is first initialized
--- (via docker-entrypoint-initdb.d). It creates the audit_db database
--- and the restricted audit_writer role used by the application at runtime.
+-- This script runs on first volume init via docker-entrypoint-initdb.d, but
+-- is also intentionally safe to run by hand against an existing cluster
+-- (e.g. `psql -U postgres -f init-audit-db.sql`). Every statement is
+-- guarded so re-runs are no-ops, not errors, which avoids the
+-- `docker volume rm <project>_pgdata` recovery dance when an operator
+-- needs to re-apply provisioning.
 
-CREATE DATABASE audit_db;
+-- CREATE DATABASE cannot run inside DO blocks; use the `\gexec` pattern
+-- to skip when audit_db already exists.
+SELECT 'CREATE DATABASE audit_db'
+WHERE NOT EXISTS (
+  SELECT FROM pg_database WHERE datname = 'audit_db'
+)\gexec
 
 -- The audit_writer role has INSERT/SELECT only on audit_logs (granted by
--- migration 0001_init_audit_logs.sql after the table is created).
--- Password should be overridden via POSTGRES_INITDB_ARGS or changed
--- after provisioning for production deployments.
-CREATE ROLE audit_writer WITH LOGIN PASSWORD 'changeme';
+-- migration 0001_init_audit_logs.sql after the table is created, and
+-- re-applied at boot by ensureAuditRolePermissions in
+-- src/lib/db/migrate.ts). Password should be overridden via
+-- POSTGRES_INITDB_ARGS or changed after provisioning for production
+-- deployments.
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'audit_writer') THEN
+    CREATE ROLE audit_writer WITH LOGIN PASSWORD 'changeme';
+  END IF;
+END $$;
 
 -- PostgreSQL 15+ revokes CREATE on the public schema from PUBLIC by
 -- default.  The application runs migrations (CREATE TABLE) as

--- a/src/__tests__/lib/db/migrate.test.ts
+++ b/src/__tests__/lib/db/migrate.test.ts
@@ -532,9 +532,9 @@ describe("migrate", () => {
   // ── runStartupMigrations ──────────────────────────────────────────
 
   describe("runStartupMigrations", () => {
-    it("runs auth → audit → customer migrations in order", async () => {
+    it("runs auth → audit → customer migrations in order with grant helpers around audit", async () => {
       process.env.AUDIT_DATABASE_URL =
-        "postgres://postgres:postgres@localhost:5432/audit_db";
+        "postgres://audit_writer:changeme@localhost:5432/audit_db";
 
       writeMigration("auth", "0001_init.sql", "SELECT 1");
       writeMigration("audit", "0001_init.sql", "SELECT 1");
@@ -553,9 +553,18 @@ describe("migrate", () => {
           } as never;
         }
 
-        if (url.includes("auth_db")) callOrder.push("auth");
-        else if (url.includes("audit_db")) callOrder.push("audit");
-        else callOrder.push("customer");
+        // The grant helper connects to the admin user (postgres) against
+        // /audit_db. Distinguish it from the audit migration runner,
+        // which uses AUDIT_DATABASE_URL (audit_writer) on /audit_db.
+        if (url.includes("audit_db") && url.includes("postgres:postgres")) {
+          callOrder.push("audit-admin");
+        } else if (url.includes("auth_db")) {
+          callOrder.push("auth");
+        } else if (url.includes("audit_db")) {
+          callOrder.push("audit");
+        } else {
+          callOrder.push("customer");
+        }
         return {
           query: mockPoolQuery,
           connect: mockPoolConnect,
@@ -577,7 +586,13 @@ describe("migrate", () => {
 
       await migrate.runStartupMigrations();
 
-      expect(callOrder).toEqual(["auth", "audit", "customer"]);
+      expect(callOrder).toEqual([
+        "auth",
+        "audit-admin",
+        "audit",
+        "audit-admin",
+        "customer",
+      ]);
     });
 
     it("uses the admin connection when cleaning stale provisioning databases", async () => {
@@ -618,6 +633,176 @@ describe("migrate", () => {
       expect(mockAdminPoolQuery).toHaveBeenCalledWith(
         'DROP DATABASE IF EXISTS "customer_stale"',
       );
+    });
+  });
+
+  // ── ensureAuditRolePermissionsPreflight ────────────────────────────
+
+  describe("ensureAuditRolePermissionsPreflight", () => {
+    it("connects to /audit_db using the admin DSN, not the audit DSN", async () => {
+      const { connectTo } = await import("@/lib/db/client");
+      const observed: string[] = [];
+
+      vi.mocked(connectTo).mockImplementation((url: string) => {
+        observed.push(url);
+        return {
+          query: vi
+            .fn()
+            // SELECT EXISTS — role exists
+            .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+            // GRANT
+            .mockResolvedValue({ rows: [], rowCount: 0 }),
+          connect: mockPoolConnect,
+          end: mockPoolEnd,
+        } as never;
+      });
+
+      await migrate.ensureAuditRolePermissionsPreflight();
+
+      expect(observed).toHaveLength(1);
+      const built = new URL(observed[0]);
+      expect(built.pathname).toBe("/audit_db");
+      expect(built.username).toBe("postgres");
+    });
+
+    it("issues GRANT CREATE, USAGE ON SCHEMA public when role exists", async () => {
+      const grantQuery = vi.fn();
+      const { connectTo } = await import("@/lib/db/client");
+
+      vi.mocked(connectTo).mockReturnValue({
+        query: grantQuery
+          .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+          .mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: mockPoolConnect,
+        end: mockPoolEnd,
+      } as never);
+
+      await migrate.ensureAuditRolePermissionsPreflight();
+
+      const calls = grantQuery.mock.calls.map((c) => c[0]);
+      expect(calls).toContain(
+        "GRANT CREATE, USAGE ON SCHEMA public TO audit_writer",
+      );
+    });
+
+    it("short-circuits when audit_writer role does not exist", async () => {
+      const queryFn = vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 });
+      const { connectTo } = await import("@/lib/db/client");
+
+      vi.mocked(connectTo).mockReturnValue({
+        query: queryFn,
+        connect: mockPoolConnect,
+        end: mockPoolEnd,
+      } as never);
+
+      await migrate.ensureAuditRolePermissionsPreflight();
+
+      // Only the existence-check query ran; no GRANT.
+      expect(queryFn).toHaveBeenCalledTimes(1);
+      const calls = queryFn.mock.calls.map((c) => c[0]);
+      expect(calls.some((q) => String(q).startsWith("GRANT"))).toBe(false);
+    });
+
+    it("does not log the admin DSN", async () => {
+      const consoleSpies = [
+        vi.spyOn(console, "log").mockImplementation(() => {}),
+        vi.spyOn(console, "info").mockImplementation(() => {}),
+        vi.spyOn(console, "warn").mockImplementation(() => {}),
+        vi.spyOn(console, "error").mockImplementation(() => {}),
+        vi.spyOn(console, "debug").mockImplementation(() => {}),
+      ];
+      const { connectTo } = await import("@/lib/db/client");
+
+      vi.mocked(connectTo).mockReturnValue({
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 })
+          .mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: mockPoolConnect,
+        end: mockPoolEnd,
+      } as never);
+
+      await migrate.ensureAuditRolePermissionsPreflight();
+
+      const adminDsn = process.env.DATABASE_ADMIN_URL ?? "";
+      for (const spy of consoleSpies) {
+        for (const call of spy.mock.calls) {
+          for (const arg of call) {
+            expect(String(arg)).not.toContain(adminDsn);
+            expect(String(arg)).not.toContain("postgres:postgres@");
+          }
+        }
+      }
+    });
+  });
+
+  // ── ensureAuditRolePermissionsPostflight ───────────────────────────
+
+  describe("ensureAuditRolePermissionsPostflight", () => {
+    it("issues table and sequence grants when role and table both exist", async () => {
+      const queryFn = vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 }) // role
+        .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 }) // table
+        .mockResolvedValue({ rows: [], rowCount: 0 });
+      const { connectTo } = await import("@/lib/db/client");
+
+      vi.mocked(connectTo).mockReturnValue({
+        query: queryFn,
+        connect: mockPoolConnect,
+        end: mockPoolEnd,
+      } as never);
+
+      await migrate.ensureAuditRolePermissionsPostflight();
+
+      const calls = queryFn.mock.calls.map((c) => c[0]);
+      expect(calls).toContain(
+        "GRANT INSERT, SELECT ON audit_logs TO audit_writer",
+      );
+      expect(calls).toContain(
+        "GRANT USAGE, SELECT ON SEQUENCE audit_logs_id_seq TO audit_writer",
+      );
+    });
+
+    it("short-circuits when audit_writer role does not exist", async () => {
+      const queryFn = vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 });
+      const { connectTo } = await import("@/lib/db/client");
+
+      vi.mocked(connectTo).mockReturnValue({
+        query: queryFn,
+        connect: mockPoolConnect,
+        end: mockPoolEnd,
+      } as never);
+
+      await migrate.ensureAuditRolePermissionsPostflight();
+
+      expect(queryFn).toHaveBeenCalledTimes(1);
+      const calls = queryFn.mock.calls.map((c) => c[0]);
+      expect(calls.some((q) => String(q).startsWith("GRANT"))).toBe(false);
+    });
+
+    it("short-circuits when audit_logs table does not yet exist", async () => {
+      const queryFn = vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 }) // role
+        .mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 }); // table
+      const { connectTo } = await import("@/lib/db/client");
+
+      vi.mocked(connectTo).mockReturnValue({
+        query: queryFn,
+        connect: mockPoolConnect,
+        end: mockPoolEnd,
+      } as never);
+
+      await migrate.ensureAuditRolePermissionsPostflight();
+
+      expect(queryFn).toHaveBeenCalledTimes(2);
+      const calls = queryFn.mock.calls.map((c) => c[0]);
+      expect(calls.some((q) => String(q).startsWith("GRANT"))).toBe(false);
     });
   });
 });

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -215,6 +215,63 @@ async function runAdminQuery(sql: string): Promise<void> {
   }
 }
 
+function buildAuditAdminUrl(): string {
+  const url = new URL(requireDatabaseAdminUrl());
+  url.pathname = "/audit_db";
+  return url.toString();
+}
+
+async function auditWriterRoleExists(pool: pg.Pool): Promise<boolean> {
+  const result = await pool.query<{ exists: boolean }>(
+    "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'audit_writer') AS exists",
+  );
+  return result.rows[0]?.exists === true;
+}
+
+/**
+ * Re-apply schema-level grants the audit migrations themselves depend on.
+ * Run before `migrateAuditDb()` so a freshly-restored database (or one
+ * where `audit_writer` has been inadvertently revoked) heals before the
+ * migration runner connects as `audit_writer` and tries to CREATE TABLE.
+ *
+ * Short-circuits cleanly when the role does not exist (fresh cluster
+ * before init-audit-db.sql has run, or non-Docker environments).
+ */
+export async function ensureAuditRolePermissionsPreflight(): Promise<void> {
+  const pool = connectTo(buildAuditAdminUrl());
+  try {
+    if (!(await auditWriterRoleExists(pool))) return;
+    await pool.query("GRANT CREATE, USAGE ON SCHEMA public TO audit_writer");
+  } finally {
+    await pool.end();
+  }
+}
+
+/**
+ * Re-apply table- and sequence-level grants. Run after `migrateAuditDb()`
+ * because on a fresh cluster `audit_logs` does not exist until 0001
+ * runs. Guarded with `to_regclass(...)` so the helper is also safe
+ * to call before the table exists.
+ */
+export async function ensureAuditRolePermissionsPostflight(): Promise<void> {
+  const pool = connectTo(buildAuditAdminUrl());
+  try {
+    if (!(await auditWriterRoleExists(pool))) return;
+
+    const tableExists = await pool.query<{ exists: boolean }>(
+      "SELECT to_regclass('public.audit_logs') IS NOT NULL AS exists",
+    );
+    if (tableExists.rows[0]?.exists !== true) return;
+
+    await pool.query("GRANT INSERT, SELECT ON audit_logs TO audit_writer");
+    await pool.query(
+      "GRANT USAGE, SELECT ON SEQUENCE audit_logs_id_seq TO audit_writer",
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
 export async function migrateAuthDb(): Promise<number> {
   const migrations = scanMigrations(getMigrationsDir("auth"));
   if (migrations.length === 0) return 0;
@@ -279,7 +336,14 @@ export async function dropCustomerDb(dbName: string): Promise<void> {
 
 export async function runStartupMigrations(): Promise<void> {
   await migrateAuthDb();
+  // Heal schema-level grants before the audit migration runner connects
+  // as `audit_writer`. A drifted GRANT CREATE on `public` would surface
+  // as `permission denied for schema public` from migrateAuditDb().
+  await ensureAuditRolePermissionsPreflight();
   await migrateAuditDb();
+  // Re-apply table/sequence grants on every boot. Idempotent; safe
+  // against operator-induced privilege drift.
+  await ensureAuditRolePermissionsPostflight();
 
   // Clean up stale provisioning rows (crashed mid-provision)
   const stale = await query<{ database_name: string }>(


### PR DESCRIPTION
## Summary

Implements **A** (port-shifted host DSNs) and **H** (runtime grant helper + idempotent init script) from #406. The full prod-deployment guide (**F**) is intentionally held for a follow-up PR per the issue's split-PR plan, since it depends on the env-var names that #404 finalized and should land as docs-only.

### A — port-shifted host DSNs

- `docker-compose.yml` already published `${AICE_POSTGRES_HOST_PORT:-5434}:5432` on `main`, but `.env.example` still pointed `DATABASE_URL` / `DATABASE_ADMIN_URL` / `AUDIT_DATABASE_URL` at `localhost:5432`, so a fresh checkout's example values did not work against the published port. Updated to `localhost:5434`, with a header comment explaining the dev-host vs prod-container address split.
- `README.md` documents the dev (`localhost:5434`) vs in-compose (`postgres:5432`) split, the `AICE_POSTGRES_HOST_PORT` override knob, and the breaking-change note for tooling that previously bound to `localhost:5432`.

### H — runtime grant helper + idempotent init script

- New `ensureAuditRolePermissionsPreflight()` and `ensureAuditRolePermissionsPostflight()` in `src/lib/db/migrate.ts`. Wired into `runStartupMigrations()` so the preflight pass runs **between** `migrateAuthDb()` and `migrateAuditDb()` (an audit migration that itself needs `CREATE` on `public` would fail before a post-migration helper had a chance to re-grant), and the postflight pass runs after `migrateAuditDb()` to re-apply table/sequence grants.
- Both helpers connect with the admin DSN against `/audit_db` (built by replacing the pathname on `DATABASE_ADMIN_URL`, mirroring the URL-mutation pattern in `provisionCustomerDb`). Both short-circuit cleanly when `audit_writer` does not exist (fresh cluster path). Neither logs the admin DSN — covered by a test that spies on every console method.
- `infra/postgres/init-audit-db.sql` is now safe to re-run by hand against an existing cluster. `CREATE DATABASE` is wrapped in the `\gexec` pattern (it cannot live inside a DO block); `CREATE ROLE` is wrapped in a DO block guarded by `pg_roles`. Re-runs are no-ops, not errors.
- README documents the `docker-entrypoint-initdb.d` once-per-volume semantics, the `docker volume rm` recovery dance for true script changes, and the fact that the runtime helper now covers the GRANT case automatically.

### Why option 1 (runtime helper), not editing the existing migration

Migrations are checksum-validated and pending-only, so editing `0001_init_audit_logs.sql` in place would break every existing deployment with a checksum mismatch and never re-run on boot anyway. Option 2 (a new `0004_*` audit migration) was rejected as not-self-heal — it runs once per deployment, so subsequent operator-induced privilege drift would not be fixed.

Part of #406

## Not addressed

- **F — production-deployment guide.** Held for a follow-up docs-only PR per the issue's split-PR directive ("F as a docs-only PR landed after #404's D/M/N decisions are merged"). With #404 now merged, F is unblocked but kept separate so it can be reviewed as docs in isolation. The minimum README notes that A and H require (port split, init script semantics, runtime helper behavior) are included in this PR; the full prod guide (mTLS cert mount example, `extra_hosts` examples, JWT key autogen reference, `WEBAUTHN_RP_ORIGIN` template per scheme, trusted-proxy reference, `.env.example` dev/prod/k8s sectioning) lands in the follow-up.

## Test plan

- [x] `pnpm vitest run src/__tests__/lib/db/migrate.test.ts` — preflight/postflight helper unit tests pass (existence short-circuit, table-existence short-circuit, GRANT statements emitted, admin DSN never logged, helpers invoked in the documented call order around `migrateAuditDb`).
- [x] `pnpm vitest run` — full suite passes (no regression in unrelated migrate / startup tests).
- [x] `pnpm tsc --noEmit` and `pnpm biome check` clean on changed files.
- [x] Fresh checkout, `docker compose --profile prod up -d`: postgres binds to host `:5434` by default; `AICE_POSTGRES_HOST_PORT=5432 docker compose --profile prod up -d` overrides cleanly. No port collision with bootroot or any other 5432 user.
- [x] `.env.example` host DSNs (`localhost:5434/...`) work as-is against the published port from a host-side `psql`.
- [x] Drop `GRANT CREATE ON SCHEMA public FROM audit_writer` on a populated cluster, then restart: the next boot completes `migrateAuditDb()` without `permission denied for schema public` (preflight self-healed before the audit migration ran).
- [x] `psql -h localhost -p 5434 -U postgres -f infra/postgres/init-audit-db.sql` against a populated cluster: succeeds without errors (idempotent guards on both `CREATE DATABASE` and `CREATE ROLE`).
- [x] Boot logs do not contain the admin DSN or the `postgres:postgres@` credentials substring.
