### PR TITLE
Trim Next.js standalone output to deployable artifacts (#407)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,8 @@ docker-compose.yml
 .claude
 .agent*
 .github
+# Local key material / runtime state must never enter the Docker
+# build context — even if NFT regresses and pulls /data into the
+# standalone bundle, this keeps the host's keys out of the image.
+data/
+data-e2e/

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,30 @@ const nextConfig: NextConfig = {
     "/api/nodes/**/*": ["./src/lib/node/queries/**/*"],
     "/[locale]/(dashboard)/nodes/**/*": ["./src/lib/node/queries/**/*"],
   },
+  // Backstop against future NFT regressions broadening route
+  // traces to the project root. Only excludes operator-side files
+  // that are never read at runtime — note that excludes do not
+  // apply to `instrumentation.js.nft.json`, so the structural fix
+  // in `data-dir.ts` / `jwt-keys.ts` is what actually keeps the
+  // standalone bundle clean. See #407.
+  outputFileTracingExcludes: {
+    "/*": [
+      "**/*.md",
+      "**/Dockerfile",
+      "**/docker-compose*.yml",
+      "**/biome.json",
+      "**/components.json",
+      "LICENSE",
+      "pnpm-lock.yaml",
+      "decisions/**",
+      "data/**",
+      "data-e2e/**",
+      "e2e/**",
+      "docs/**",
+      "site/**",
+      "playwright-report/**",
+    ],
+  },
   experimental: {
     // Enables the navigation `forbidden()` helper used by the Node
     // Status / Settings tabs to surface a real HTTP 403 (with the

--- a/src/lib/auth/data-dir.ts
+++ b/src/lib/auth/data-dir.ts
@@ -5,8 +5,16 @@ import path from "node:path";
 /**
  * Return the resolved data directory path.
  * Defaults to `./data` relative to the project root.
+ *
+ * The `process.cwd()` fallback is marked opaque to Next.js' File
+ * Tracer so build-time tracing does not assume the whole project
+ * root is the data directory and pull every operator file
+ * (markdowns, configs, decisions/, e2e/, on-disk key material, …)
+ * into `.next/standalone/`. See issue #407 for the trace details.
  */
 export function getDataDir(): string {
-  const dir = process.env.DATA_DIR || path.join(process.cwd(), "data");
-  return path.resolve(dir);
+  if (process.env.DATA_DIR) {
+    return path.resolve(process.env.DATA_DIR);
+  }
+  return path.resolve(/*turbopackIgnore: true*/ process.cwd(), "data");
 }

--- a/src/lib/auth/jwt-keys.ts
+++ b/src/lib/auth/jwt-keys.ts
@@ -54,7 +54,22 @@ const g = globalThis as unknown as {
 // ── File paths ──────────────────────────────────────────────────
 
 function keysDir(): string {
-  return path.join(getDataDir(), "keys");
+  // Build via array-join so the result is opaque to the Next.js File
+  // Tracer: a literal `path.join(getDataDir(), "keys", "jwt-signing.json")`
+  // chain gets statically resolved to `<root>/data/keys/jwt-signing.json`
+  // and pulls runtime key material into `.next/standalone/`. See #407.
+  return [getDataDir(), "keys"].join(path.sep);
+}
+
+function defaultKeyBasename(previous: boolean): string {
+  // Build the basename via array-join so the literal
+  // "jwt-signing[.prev].json" never appears adjacent to `keysDir()` /
+  // `path.join` in source. NFT cannot statically resolve
+  // `Array.prototype.join`, which keeps it from following
+  // readKeyFile() to the on-disk key file at build time. See #407.
+  const stem = ["jwt", "signing"].join("-");
+  const suffix = previous ? [stem, "prev"].join(".") : stem;
+  return [suffix, "json"].join(".");
 }
 
 /**
@@ -68,7 +83,7 @@ function keysDir(): string {
 function currentKeyPath(): string {
   const override = process.env.JWT_SIGNING_KEY_FILE;
   if (override && override.length > 0) return path.resolve(override);
-  return path.join(keysDir(), "jwt-signing.json");
+  return [keysDir(), defaultKeyBasename(false)].join(path.sep);
 }
 
 /**
@@ -83,7 +98,7 @@ function currentKeyPath(): string {
 function previousKeyPath(): string {
   const override = process.env.JWT_SIGNING_KEY_FILE_PREVIOUS;
   if (override && override.length > 0) return path.resolve(override);
-  return path.join(keysDir(), "jwt-signing.prev.json");
+  return [keysDir(), defaultKeyBasename(true)].join(path.sep);
 }
 
 // ── Key file I/O ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`pnpm build` traced the entire project root into `.next/standalone/` (~102 MB), pulling operator files plus the live `data/keys/jwt-signing.json` and `data-e2e/keys/jwt-signing.json` into the bundle. Combined with a permissive `.dockerignore`, that was a credible path for host key material to land in a production image. The dominant cause was the `instrumentation.js.nft.json` trace, not the route trace.

This PR makes the dynamic filesystem operations opaque to the Next.js File Tracer so the standalone bundle is restricted to deployable artifacts.

### Changes

- **`src/lib/auth/data-dir.ts`** — split the env-var branch from the fallback and tag the `process.cwd()` fallback with the `/*turbopackIgnore: true*/` directive Next emits in the warning. NFT no longer assumes the project root is the data directory.
- **`src/lib/auth/jwt-keys.ts`** — rebuild `keysDir()`, `currentKeyPath()`, and `previousKeyPath()` via `Array.prototype.join` and a `defaultKeyBasename()` helper, so the literal `"jwt-signing[.prev].json"` never appears adjacent to a bound `keysDir()`. NFT cannot statically resolve the result and stops following the read into the on-disk key files. The `turbopackIgnore`-at-`readFileSync` option from the issue was verified ineffective on 2026-05-03, so this indirection-by-construction approach is the one that holds.
- **`next.config.ts`** — add `outputFileTracingExcludes` for the `"/*"` route key as a backstop against future route-trace regressions. Note that excludes do not apply to `instrumentation.js.nft.json`, so this is purely a guard, not the actual fix.
- **`.dockerignore`** — exclude `/data` and `/data-e2e` from the Docker build context so even if NFT regresses, host key material cannot reach the production image.

Closes #407

## Test plan

- [x] `pnpm build` no longer prints `Encountered unexpected file in NFT list`. (verified on clean build: 0 occurrences)
- [x] `instrumentation.js.nft.json` no longer enumerates project-root operator files (markdowns, configs, `decisions/`, `site/`, `data/`, `data-e2e/`, …). (149 entries; only `migrations/README.md` plus dependency `LICENSE`/`README.md` files inside `node_modules`)
- [x] `.next/standalone/` does not contain `data/keys/**` or `data-e2e/keys/**`. (neither `data/` nor `data-e2e/` exists under `.next/standalone/`)
- [x] `.next/standalone/` does not contain `AGENTS.md`, `ARCHITECTURE.md`, `CLAUDE.md`, `Dockerfile`, `docker-compose*.yml`, `LICENSE`, `README.md`, `TESTING.md`, `biome.json`, `components.json`, `decisions/`, `docs/`, `e2e/`, `playwright-report/`, `site/`. (verified by `ls .next/standalone/`: only `.next/`, `migrations/`, `node_modules/`, `package.json`, `server.js`, `src/`)
- [x] `.next/standalone/` still contains `.next/`, `migrations/` (with `auth/`, `audit/`, `customer/` SQL), `node_modules/`, `package.json`, `server.js`.
- [x] `du -sh .next/standalone/` is materially smaller than the ~102 MB baseline. (now ~50 MB, ≈51% reduction)
- [x] `.dockerignore` excludes `/data` and `/data-e2e`. (lines 14–15)
- [ ] `docker compose --profile prod up -d` from the rebuilt image still boots end-to-end through `migrateAuthDb()` / `migrateAuditDb()` / `bootstrapAdminAccount()` / `loadSigningKeys()`. (Image Build job in CI passes; full runtime boot smoke not re-run locally — requires real `.env` secrets.)
- [x] Existing `outputFileTracingIncludes` for GraphQL queries still resolves correctly under the new `outputFileTracingExcludes`. (`.next/standalone/src/lib/node/queries/*.graphql` present)