### PR TITLE
Document remaining production deployment guidance (#417)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,133 +1,172 @@
+# ════════════════════════════════════════════════════════════════
+# Common — required regardless of profile
+# ════════════════════════════════════════════════════════════════
+# Upstream GraphQL endpoints. The host portion of each URL must
+# match the SAN on that upstream's server certificate (mTLS),
+# and that hostname must resolve in whichever environment the
+# app runs. See README → "Upstream FQDN resolution".
 REVIEW_GRAPHQL_ENDPOINT=
 GIGANTO_GRAPHQL_ENDPOINT=
 TIVAN_GRAPHQL_ENDPOINT=
+
+# Client mTLS material used to dial the upstreams above. See
+# README → "mTLS upstream certificate mount" for the
+# bind-mount + uid 1001 permission pattern in Docker, and
+# `docs/en/operations/mtls-rotation.md` for in-place rotation.
 MTLS_CERT_PATH=
 MTLS_KEY_PATH=
 MTLS_CA_PATH=
 
-# These defaults are *host-side* (for `pnpm dev` and host tooling like
-# psql or the Vitest integration suite). The host port defaults to 5434
-# so aice-web-next does not collide with any other Postgres on the host.
+CSRF_SECRET=
+INIT_ADMIN_USERNAME=
+INIT_ADMIN_PASSWORD=
+DEFAULT_LOCALE=en
+
+# ════════════════════════════════════════════════════════════════
+# Profile: DEV  (`pnpm dev` and host tooling)
+# ════════════════════════════════════════════════════════════════
+# Host-side DSNs. `localhost:5434` is the compose `postgres`
+# service published on the host port — the default is 5434 (not
+# 5432) so aice-web-next does not collide with any other
+# Postgres instance running on the same host. Override the host
+# port with AICE_POSTGRES_HOST_PORT (and update the DSNs to
+# match) if you need a different port.
 #
-# The prod compose profile (`docker compose --profile prod up -d`) passes
-# this file directly into the `next-app` container. Inside that container
-# `localhost` is the container itself, so the DSNs below will NOT reach
-# the compose `postgres` service. For the prod profile, override these
-# to the compose-network address:
-#
-#   DATABASE_URL=postgres://postgres:postgres@postgres:5432/auth_db
-#   DATABASE_ADMIN_URL=postgres://postgres:postgres@postgres:5432/postgres
-#   AUDIT_DATABASE_URL=postgres://audit_writer:changeme@postgres:5432/audit_db
-#
-# See the README "First-boot deployment checklist" for the full prod path.
-# Override the host-published port with `AICE_POSTGRES_HOST_PORT` (and
-# update the host-side DSNs below to match) if you need a different port.
+# These DSNs are also what the Vitest integration suite, psql,
+# and DBeaver use.
 DATABASE_URL=postgres://postgres:postgres@localhost:5434/auth_db
 DATABASE_ADMIN_URL=postgres://postgres:postgres@localhost:5434/postgres
 AUDIT_DATABASE_URL=postgres://audit_writer:changeme@localhost:5434/audit_db
 
 DATA_DIR=./data
 JWT_EXPIRATION_MINUTES=15
-CSRF_SECRET=
-INIT_ADMIN_USERNAME=
-INIT_ADMIN_PASSWORD=
 
-# ── JWT signing key ──────────────────────────────────────────────
-# Two ways to provision the ES256 signing key. They are mutually
-# exclusive in practice: JWT_SIGNING_KEY_FILE wins if both are set.
+# ════════════════════════════════════════════════════════════════
+# Profile: PROD  (`docker compose --profile prod up -d`)
+# ════════════════════════════════════════════════════════════════
+# The prod compose profile passes this file directly into the
+# `next-app` container, where `localhost` is the container
+# itself — so the DEV DSNs above will NOT reach the compose
+# `postgres` service. Replace them with the compose-network
+# DSNs by uncommenting the block below (and commenting out the
+# DEV DSNs).
+#
+# See README → "First-boot deployment checklist" for the
+# end-to-end prod boot path.
+#
+# DATABASE_URL=postgres://postgres:postgres@postgres:5432/auth_db
+# DATABASE_ADMIN_URL=postgres://postgres:postgres@postgres:5432/postgres
+# AUDIT_DATABASE_URL=postgres://audit_writer:changeme@postgres:5432/audit_db
+
+# ── CSRF / Origin guard ─────────────────────────────────────────
+# Required when the app is fronted by a TLS-terminating reverse
+# proxy (e.g. the prod nginx profile): browsers send
+# `Origin: https://your.host` while the upstream Next.js sees
+# `request.nextUrl.origin === "http://..."`, and the mutation
+# guard would reject every POST/PUT/PATCH/DELETE.
+#
+# Canonicalized at parse time: trailing slash stripped; scheme
+# and host lowercased. Set to the public HTTPS origin.
+# EXPECTED_ORIGIN=https://app.example.com
+
+# ── WebAuthn relying-party identity ─────────────────────────────
+# WEBAUTHN_RP_ID is the eTLD+1-aligned domain the authenticator
+# scopes credentials to (no scheme, no port). WEBAUTHN_RP_ORIGIN
+# is the public origin browsers use to reach the app and must
+# match what the browser sends in the WebAuthn ceremony.
+#
+# In the prod profile, set both to match the public HTTPS origin
+# (the same value as EXPECTED_ORIGIN above). The two env vars
+# guard different code paths — the CSRF/Origin guard and the
+# WebAuthn ceremony — but share the same value in this
+# deployment, so set them together. Leaving WEBAUTHN_RP_ORIGIN
+# at its dev fallback (BASE_URL or http://localhost:3000)
+# silently breaks MFA enrollment on the prod profile —
+# verifyRegistrationResponse rejects the assertion with a
+# non-obvious error.
+WEBAUTHN_RP_ID=
+WEBAUTHN_RP_NAME=AICE
+WEBAUTHN_RP_ORIGIN=
+
+# ── JWT signing key ─────────────────────────────────────────────
+# Two ways to provision the ES256 signing key. They are
+# mutually exclusive in practice: JWT_SIGNING_KEY_FILE wins if
+# both are set.
 #
 # Option A — externally managed key file (recommended for prod).
-#   Point at a key JSON written by `pnpm gen-jwt-key` or rendered
-#   from a K8s Secret / Vault csi mount. The key at this path is
-#   used as the *current* signing key. The previous key (for
-#   rotation) continues to load from
+#   Point at a key JSON written by `pnpm gen-jwt-key` or
+#   rendered from a K8s Secret / Vault csi mount. The key at
+#   this path is used as the *current* signing key. The
+#   previous key (for rotation) continues to load from
 #   `<DATA_DIR>/keys/jwt-signing.prev.json` unless
 #   JWT_SIGNING_KEY_FILE_PREVIOUS is also set.
 # JWT_SIGNING_KEY_FILE=
 # JWT_SIGNING_KEY_FILE_PREVIOUS=
 #
-# Option B — first-boot autogen (single-instance dev/convenience).
+# Option B — first-boot autogen (single-instance dev convenience).
 #   Set to "1" / "true" / "on" / "yes" to generate
 #   `<DATA_DIR>/keys/jwt-signing.json` on first boot if missing.
-#   Idempotent on re-boot. Multi-replica deployments MUST NOT use
-#   this — each replica would generate its own key independently
-#   and inter-replica session validation would fail. Use option A
-#   instead.
+#   Idempotent on re-boot. Multi-replica deployments MUST NOT
+#   use this — each replica would generate its own key
+#   independently and inter-replica session validation would
+#   fail. Use option A instead.
 # JWT_SIGNING_KEY_AUTOGEN=
 
-# ── CSRF Origin verification ─────────────────────────────────────
-# Override the expected request Origin for the CSRF/Origin guard.
-# Required when the app is fronted by a TLS-terminating reverse
-# proxy (e.g. nginx-prod profile): browsers send
-# `Origin: https://your.host` while the upstream Next.js sees
-# `request.nextUrl.origin === "http://..."`, and the mutation
-# guard would reject every POST/PUT/PATCH/DELETE.
+# ════════════════════════════════════════════════════════════════
+# Profile: K8S  (multi-replica Kubernetes deployment)
+# ════════════════════════════════════════════════════════════════
+# Same env vars as PROD above, with two non-negotiables:
 #
-# Canonicalized at parse time: trailing slash stripped; scheme and
-# host lowercased. Set to the public HTTPS origin, e.g.:
-#   EXPECTED_ORIGIN=https://app.example.com
-# When unset, behavior is unchanged from today
-# (request.nextUrl.origin only).
-# EXPECTED_ORIGIN=
+# 1. JWT_SIGNING_KEY_FILE must be injected (Secret mount).
+#    JWT_SIGNING_KEY_AUTOGEN cannot be used — every replica
+#    would mint its own key and inter-replica session
+#    validation would fail.
+# 2. The upstream FQDN must resolve to the right address inside
+#    the cluster (CoreDNS rewrite or a `Service` whose name
+#    matches the SAN). See README → "Upstream FQDN resolution".
 
-DEFAULT_LOCALE=en
-
-# Polling cadence for the Nodes Status tab and detail-page dashboard,
-# in milliseconds. Default 10000. Values outside [5000, 300000] clamp
-# at the call site.
+# ════════════════════════════════════════════════════════════════
+# Tunables — apply to all profiles
+# ════════════════════════════════════════════════════════════════
+# Polling cadence for the Nodes Status tab and detail-page
+# dashboard, in milliseconds. Default 10000. Values outside
+# [5000, 300000] clamp at the call site.
 #
-# The detail-page sparkline buffer length is fixed at 60 samples
-# (NODE_STATUS_SPARKLINE_SAMPLES in src/lib/node/status.ts) and is not
-# operator-configurable in v1. With the default poll interval that is
-# ~10 minutes of history per node; samples older than the cap are
-# dropped on a rolling basis.
+# The detail-page sparkline buffer length is fixed at 60
+# samples (NODE_STATUS_SPARKLINE_SAMPLES in
+# src/lib/node/status.ts) and is not operator-configurable in
+# v1. With the default poll interval that is ~10 minutes of
+# history per node; samples older than the cap are dropped on
+# a rolling basis.
 NEXT_PUBLIC_NODE_STATUS_POLL_MS=10000
 
-# Set to "1", "true", or "on" to ship the gs-build subset of the Hog
-# `active_models` list (mirrors aice-web's `gs` Cargo feature). Anything
-# else (or unset) ships the full set.
+# Set to "1", "true", or "on" to ship the gs-build subset of
+# the Hog `active_models` list (mirrors aice-web's `gs` Cargo
+# feature). Anything else (or unset) ships the full set.
 NEXT_PUBLIC_GS_MODE=
 
-# ── WebAuthn relying-party identity ──────────────────────────────
-# WEBAUTHN_RP_ID is the eTLD+1-aligned domain the authenticator
-# scopes credentials to (no scheme, no port). WEBAUTHN_RP_ORIGIN is
-# the public origin browsers use to reach the app and must match
-# what the browser sends in the WebAuthn ceremony.
-#
-# In the prod profile, set both to match the public HTTPS origin
-# (the same value you use for EXPECTED_ORIGIN above):
-#   WEBAUTHN_RP_ID=example.com
-#   WEBAUTHN_RP_ORIGIN=https://example.com
-#
-# When unset, dev falls back to BASE_URL or http://localhost:3000.
-# That dev default silently breaks MFA enrollment on the prod
-# profile — verifyRegistrationResponse rejects the assertion with
-# a non-obvious error. EXPECTED_ORIGIN (CSRF/Origin guard) and
-# WEBAUTHN_RP_ORIGIN guard different code paths but share the same
-# value in this deployment, so set them together.
-WEBAUTHN_RP_ID=
-WEBAUTHN_RP_NAME=AICE
-WEBAUTHN_RP_ORIGIN=
-
-# ── ApplyAttempt lifecycle (Phase Node-9a, #359) ─────────────────
-# Execution deadline for a non-terminal apply attempt. Past this
-# point, a confirm/retry rejects with StalePlanError and the row is
-# terminalised by the cleanup sweep. Default: 30 minutes.
+# ── ApplyAttempt lifecycle (Phase Node-9a, #359) ────────────────
+# Execution deadline for a non-terminal apply attempt. Past
+# this point, a confirm/retry rejects with StalePlanError and
+# the row is terminalised by the cleanup sweep. Default: 30
+# minutes.
 APPLY_ATTEMPT_TTL_MS=1800000
-# Retention horizon for a terminal apply attempt. Past this point,
-# the row is hard-deleted by the cleanup sweep. Default: 7 days.
+# Retention horizon for a terminal apply attempt. Past this
+# point, the row is hard-deleted by the cleanup sweep.
+# Default: 7 days.
 APPLY_ATTEMPT_RETENTION_MS=604800000
 # Stale-lock recovery threshold. An `executing` row whose
 # `claim_started_at` has aged past this is flipped to
-# `failed_terminal` by the recovery phase of the cleanup sweep.
-# Default: 2.5 hours.
+# `failed_terminal` by the recovery phase of the cleanup
+# sweep. Default: 2.5 hours.
 APPLY_EXECUTING_STALE_MS=9000000
-# Per-dispatch retry cap. Once `attemptCount` reaches this value the
-# dispatch is hard-locked into `failed_terminal` regardless of the
-# row TTL. Default: 3.
+# Per-dispatch retry cap. Once `attemptCount` reaches this
+# value the dispatch is hard-locked into `failed_terminal`
+# regardless of the row TTL. Default: 3.
 APPLY_DISPATCH_MAX_ATTEMPTS=3
 # Shared secret for the internal cleanup route handler at
-# POST /api/internal/apply-attempts/cleanup. The deployment scheduler
-# must include `Authorization: Bearer <token>` matching this value.
-# If unset, the route refuses every request.
+# POST /api/internal/apply-attempts/cleanup. The deployment
+# scheduler must include `Authorization: Bearer <token>`
+# matching this value. If unset, the route refuses every
+# request.
 APPLY_INTERNAL_CLEANUP_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -75,15 +75,22 @@ JWT_EXPIRATION_MINUTES=15
 # is the public origin browsers use to reach the app and must
 # match what the browser sends in the WebAuthn ceremony.
 #
-# In the prod profile, set both to match the public HTTPS origin
-# (the same value as EXPECTED_ORIGIN above). The two env vars
-# guard different code paths — the CSRF/Origin guard and the
-# WebAuthn ceremony — but share the same value in this
-# deployment, so set them together. Leaving WEBAUTHN_RP_ORIGIN
-# at its dev fallback (BASE_URL or http://localhost:3000)
-# silently breaks MFA enrollment on the prod profile —
-# verifyRegistrationResponse rejects the assertion with a
-# non-obvious error.
+# The two env vars guard different code paths — the CSRF/Origin
+# guard and the WebAuthn ceremony — and they take *different*
+# value shapes, so do not copy one into the other:
+#
+#   EXPECTED_ORIGIN=https://app.example.com
+#   WEBAUTHN_RP_ORIGIN=https://app.example.com   # full origin
+#   WEBAUTHN_RP_ID=app.example.com               # host only
+#
+# WEBAUTHN_RP_ID is read verbatim by the WebAuthn server
+# (src/lib/auth/webauthn.ts); setting it to a URL such as
+# `https://app.example.com` makes it an invalid relying-party id
+# and MFA enrollment/authentication will fail. Leaving
+# WEBAUTHN_RP_ORIGIN at its dev fallback (BASE_URL or
+# http://localhost:3000) silently breaks MFA enrollment on the
+# prod profile — verifyRegistrationResponse rejects the
+# assertion with a non-obvious error.
 WEBAUTHN_RP_ID=
 WEBAUTHN_RP_NAME=AICE
 WEBAUTHN_RP_ORIGIN=
@@ -122,8 +129,8 @@ WEBAUTHN_RP_ORIGIN=
 #    would mint its own key and inter-replica session
 #    validation would fail.
 # 2. The upstream FQDN must resolve to the right address inside
-#    the cluster (CoreDNS rewrite or a `Service` whose name
-#    matches the SAN). See README → "Upstream FQDN resolution".
+#    the cluster via a CoreDNS `rewrite` rule. See README →
+#    "Upstream FQDN resolution".
 
 # ════════════════════════════════════════════════════════════════
 # Tunables — apply to all profiles

--- a/README.md
+++ b/README.md
@@ -418,6 +418,125 @@ If autogen is requested but `DATA_DIR` is not writable by the
 container user (uid 1001), the app fails fast at startup with a
 clear error message instead of crash-looping mid-boot.
 
+#### mTLS upstream certificate mount
+
+`review-web`, Giganto, and Tivan are all reached over mutual TLS.
+The `next-app` container reads the client cert/key/CA from
+`MTLS_CERT_PATH`, `MTLS_KEY_PATH`, and `MTLS_CA_PATH` (see
+`src/lib/mtls.ts`); operators provide them by bind-mounting the
+files into the container. The same shape is what the integration
+test harness uses (`src/__integration__/global-setup.ts`).
+
+Place the bind mount in a local `docker-compose.override.yml` —
+**this file is not shipped** because operators typically already
+keep their own override file, and committing a sample would
+either collide with theirs or get accidentally tracked. Use the
+shape below as a starting point:
+
+```yaml
+# docker-compose.override.yml (local; do NOT commit)
+services:
+  next-app:
+    volumes:
+      - /etc/aice/certs:/certs:ro
+    environment:
+      MTLS_CERT_PATH: /certs/client-cert.pem
+      MTLS_KEY_PATH: /certs/client-key.pem
+      MTLS_CA_PATH: /certs/ca.pem
+```
+
+The runtime user inside the container is `nextjs` (uid `1001`)
+with primary group `nodejs` (gid `1001`) — see `Dockerfile`.
+Files mounted into `/certs` must be readable by uid `1001`. For
+the private key, recommend `0640` with group ownership matching
+gid `1001`, or a POSIX ACL granting uid `1001` read access:
+
+```bash
+# Group-ownership variant
+sudo chown root:1001 /etc/aice/certs/client-key.pem
+sudo chmod 0640      /etc/aice/certs/client-key.pem
+
+# ACL variant (preserves the host user's ownership)
+sudo setfacl -m u:1001:r /etc/aice/certs/client-key.pem
+```
+
+Do **not** chmod the private key to `0644` (world-readable) just
+to satisfy the container user — that exposes the key to every
+other local account on the host. The cert and CA can be `0644`,
+but the key must not be.
+
+The mTLS hot-reload path re-reads all three files on `SIGHUP`
+(`docs/en/operations/mtls-rotation.md`); the bind mount lets the
+operator rotate the on-host file in place without rebuilding the
+image.
+
+#### Upstream FQDN resolution
+
+The FQDN aice-web-next dials for each upstream **must match a
+SAN on that upstream's server certificate**. REview's bootroot
+service-add issues server certs whose SAN follows the
+`<instance-id>.<service-name>.<hostname>.<domain>` shape; if the
+hostname the app resolves disagrees with the SAN, the mTLS
+handshake fails before any GraphQL request is sent. The same
+FQDN must therefore be set as the host portion of
+`REVIEW_GRAPHQL_ENDPOINT`, `GIGANTO_GRAPHQL_ENDPOINT`, and
+`TIVAN_GRAPHQL_ENDPOINT`, and must resolve to the right address
+in whichever environment the app runs.
+
+Three deployment shapes:
+
+- **Docker Desktop / Compose.** When the upstream lives on the
+  Docker host (the common single-host bootroot case), add the
+  SAN-matching FQDN to `extra_hosts` so the container resolves it
+  to the host gateway:
+
+  ```yaml
+  # docker-compose.override.yml
+  services:
+    next-app:
+      extra_hosts:
+        - "review.<instance-id>.<hostname>.<domain>:host-gateway"
+  ```
+
+- **Kubernetes.** Either rewrite the name in CoreDNS so it
+  resolves to the upstream's `Service` ClusterIP:
+
+  ```yaml
+  # CoreDNS Corefile snippet
+  rewrite name review.<instance-id>.<hostname>.<domain> review-web.aice.svc.cluster.local
+  ```
+
+  …or stand up a `Service` whose name (plus
+  `.<namespace>.svc.cluster.local`) is exactly the SAN. The
+  CoreDNS-rewrite path is usually less disruptive when the SAN
+  was minted before the cluster existed.
+
+- **Bare-metal.** Add an `/etc/hosts` entry:
+
+  ```text
+  10.0.0.20  review.<instance-id>.<hostname>.<domain>
+  ```
+
+If the SAN and the resolved hostname disagree, you will see a
+TLS handshake error in the Next.js logs (`certificate name does
+not match`) and no GraphQL traffic will leave the app. Verify
+both ends with `openssl s_client -connect ...` against the
+upstream and `getent hosts ...` from inside the `next-app`
+container.
+
+#### Trusted-proxy CIDR
+
+Single-origin deployments (one TLS-terminating nginx in front of
+one `next-app`) do not need a trusted-proxy allow-list — the
+CSRF/Origin guard is keyed off `EXPECTED_ORIGIN`, not the
+client's transport address, so an attacker who cannot also forge
+the browser's `Origin` header cannot bypass it. There is
+deliberately no `TRUSTED_PROXIES` env var to set; if you go
+looking for one, you won't find it. A separate trusted-proxy
+allow-list (for forwarded-header trust at the BFF, distinct from
+nginx's own `set_real_ip_from`) remains explicitly out of scope
+for v1.
+
 ### Development with Docker Compose
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -498,18 +498,22 @@ Three deployment shapes:
         - "review.<instance-id>.<hostname>.<domain>:host-gateway"
   ```
 
-- **Kubernetes.** Either rewrite the name in CoreDNS so it
-  resolves to the upstream's `Service` ClusterIP:
+- **Kubernetes.** Use a CoreDNS `rewrite` rule that maps the
+  bootroot-issued external FQDN onto the upstream's in-cluster
+  `Service` DNS name:
 
   ```yaml
   # CoreDNS Corefile snippet
   rewrite name review.<instance-id>.<hostname>.<domain> review-web.aice.svc.cluster.local
   ```
 
-  …or stand up a `Service` whose name (plus
-  `.<namespace>.svc.cluster.local`) is exactly the SAN. The
-  CoreDNS-rewrite path is usually less disruptive when the SAN
-  was minted before the cluster existed.
+  An alternative — naming a `Service` so its in-cluster DNS
+  name equals the SAN — is **not** workable for the bootroot
+  SAN shape: Kubernetes Service names are a single DNS label
+  (no dots), while the bootroot SAN
+  `<instance-id>.<service-name>.<hostname>.<domain>` is
+  multi-label. CoreDNS rewrite is the supported path for
+  bootroot-issued external FQDNs.
 
 - **Bare-metal.** Add an `/etc/hosts` entry:
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -99,6 +99,8 @@ pnpm build
 pnpm start
 ```
 
+For Docker Compose production deployments, see the [Production deployment](../../README.md#production) section of the README — that is the authoritative first-boot checklist.
+
 Open `http://localhost:3000` (or the configured address) in your
 browser. You should see the sign-in page:
 

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -100,6 +100,8 @@ pnpm build
 pnpm start
 ```
 
+Docker Compose 기반 프로덕션 배포는 README의 [Production deployment](../../README.md#production) 섹션을 참고하세요 — 첫 부팅 체크리스트의 정식 출처입니다.
+
 브라우저에서 `http://localhost:3000`(또는 설정된 주소)을
 엽니다. 로그인 페이지가 표시됩니다:
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to PR #414, completing the production-deployment guide deferred from #406 §F. With #404 / PR #408 merged and the env-var names finalized, this PR adds the four items from the original F scope that are not yet in `main`:

- **mTLS upstream certificate mount.** README adds a `docker-compose.override.yml` example block (kept as a fenced block, not a committed file) showing the bind-mount plus `MTLS_CERT_PATH` / `MTLS_KEY_PATH` / `MTLS_CA_PATH`, mirroring what the integration-test harness uses. Permission guidance calls out uid `1001` / gid `1001` and recommends `0640` with group ownership or a POSIX ACL — explicitly **not** `0644` for the private key.
- **Upstream FQDN resolution — three shapes.** Docker Compose (`extra_hosts: host-gateway`), Kubernetes (CoreDNS `rewrite` rule mapping the bootroot SAN onto the upstream's in-cluster `Service` DNS name), and bare-metal `/etc/hosts`. The README states the invariant up front: the FQDN the app dials must match the SAN on the upstream cert, otherwise the mTLS handshake fails before any GraphQL traffic is sent. The Kubernetes subsection also explains why the "name a Service after the SAN" alternative is not workable for the bootroot multi-label SAN shape.
- **Trusted-proxy CIDR note.** Single-origin deployments are guarded by `EXPECTED_ORIGIN`, not by client transport address, so there is deliberately no `TRUSTED_PROXIES` env var. The note prevents operators from going looking for one.
- **`.env.example` profile split.** The previous inline prod-override comment block is promoted to clearly delimited Common / DEV / PROD / K8S / Tunables sections. No new default values — existing comment content is regrouped only. The WebAuthn block in PROD spells out that `WEBAUTHN_RP_ID` is the host-only relying-party id (read verbatim by `src/lib/auth/webauthn.ts`) while `WEBAUTHN_RP_ORIGIN` is the full origin, so the two values must not be copied into each other.

EN/KR `getting-started.md` each gain a single-sentence pointer to the new README prod section, keeping the manual aligned with the EN/KR sync rule without duplicating README content.

The items already in `main` (JWT signing key, `WEBAUTHN_RP_ORIGIN` paired with `EXPECTED_ORIGIN`, Postgres host port + dev/prod address split, nginx `X-Request-ID` forward) are not re-added — the diff was reviewed against `main` to confirm no duplication.

Closes #417
Closes #406

## Test plan

- [x] Render README on GitHub and confirm the new mTLS, Upstream FQDN, and Trusted-proxy CIDR subsections appear under `### Production`, with anchors that resolve from the EN/KR getting-started pointer links.
- [x] mTLS section: example block uses `MTLS_CERT_PATH` / `MTLS_KEY_PATH` / `MTLS_CA_PATH` (matches `src/lib/mtls.ts`) and recommends `0640` + uid/gid `1001` ownership or ACL — no `0644` recommendation for the private key.
- [x] Upstream FQDN section: three shapes present (Compose, Kubernetes, bare-metal), and the SAN-must-match-resolved-name invariant is stated as the failure mode. Kubernetes subsection recommends only the CoreDNS rewrite path for bootroot-issued external FQDNs and explains why the Service-name alternative is not workable for the bootroot multi-label SAN shape.
- [x] `.env.example` is restructured into Common / DEV / PROD / K8S / Tunables sections with no new operational default values introduced; existing values (`localhost:5434`, `JWT_EXPIRATION_MINUTES=15`, `DEFAULT_LOCALE=en`, etc.) are unchanged.
- [x] `.env.example` WebAuthn block: example values show `WEBAUTHN_RP_ID=app.example.com` (host only) distinct from `WEBAUTHN_RP_ORIGIN=https://app.example.com` (full origin), with an explicit warning that copying the URL form into `WEBAUTHN_RP_ID` breaks MFA.
- [x] Copy the PROD section into a fresh `.env`, run `docker compose --profile prod up -d`, and confirm the same boot path the integration-test harness uses, with no `docker exec` workarounds, DB SQL hacks, or undocumented env vars.
- [x] Diff check: PR adds **no** non-docs files (no `.ts` / `.tsx` / `.sql` / `docker-compose.override.yml`), and **no** lines duplicating content already in `main`'s README checklist or `.env.example` (JWT key, WebAuthn, Postgres host port, X-Request-ID).
- [x] EN/KR getting-started pages each gain exactly one pointer sentence to the new README section, with the same structural placement.
- [x] `test-clumit/integration-test-plan.md` is unchanged.
- [x] Cross-references resolve: `#404`, `#406`, `#408`, `#410`, `#412`, `#414`.