### PR TITLE
Add automated CSP nonce-coverage check (#418)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,12 @@ The CSP nonce flow requires dynamic rendering — `app/[locale]/layout.tsx`,
 per-request nonce.  Any new page added under `app/` must do the same
 (or have no `<script>` tags at all): a statically rendered HTML
 response carries no per-request nonce and would be blocked once CSP
-promotes from Report-Only to enforcing.  Verify with `pnpm build` —
-the route map should mark every HTML route as `ƒ` (dynamic).
+promotes from Report-Only to enforcing.  `pnpm build` chains
+`scripts/assert-no-static-html-routes.mjs`, which fails the build if
+any HTML route is statically prerendered (the route map should mark
+every HTML route as `ƒ` (dynamic)).  The Playwright suite at
+`e2e/csp-nonce.spec.ts` is the matching regression net for the
+nonce-on-every-`<script>` invariant under `pnpm dev`.
 
 The `__Host-csrf` cookie and `Secure` flag on the access token cookie
 are automatically enabled when `NODE_ENV=production` (set by the

--- a/e2e/csp-nonce.spec.ts
+++ b/e2e/csp-nonce.spec.ts
@@ -1,0 +1,182 @@
+import type { Page, Response } from "@playwright/test";
+
+import { expect, test } from "./fixtures";
+import { resetRateLimits, signInAndWait } from "./helpers/auth";
+
+/**
+ * Automated nonce-coverage check (issue #418 §1).
+ *
+ * Today the proxy emits `Content-Security-Policy-Report-Only` with a
+ * per-request `'nonce-…'` value, and the renderer is responsible for
+ * stamping that nonce onto every `<script>` it emits. PR #413 closed
+ * the static-boundary gap manually, but only eyeballing
+ * "view-source → does every script have the right nonce?" verified it.
+ * Promoting CSP from Report-Only to enforcing (#418 §2) without an
+ * automated check creates a window where a regression breaks every
+ * page in production and only surfaces in user reports — this spec
+ * is the regression net.
+ *
+ * Coverage matches the floor stated in #418 §1:
+ *   • a public route (`/sign-in`)
+ *   • a `[locale]` dashboard page (default + non-default locale)
+ *   • the root `/missing` not-found backstop (PR #413's `app/not-found.tsx`)
+ *   • the `[locale]` not-found locale boundary
+ *     (`/ko/missing`, `/en/missing`, `/xx/missing`)
+ *
+ * Notes on what this spec can and cannot validate, per #418 §1:
+ *   • The Playwright harness boots `pnpm dev` (see
+ *     `e2e/playwright.config.ts` `webServer.command`), so this run does
+ *     **not** validate the nginx hop or prod build's static-vs-dynamic
+ *     decisions. The `static-vs-dynamic` failure mode (#418 §1 (e)) is
+ *     enforced separately by `scripts/assert-no-static-html-routes.mjs`
+ *     against the prod build output.
+ *   • Assertions read `HTMLScriptElement.nonce` (the IDL attribute),
+ *     not `getAttribute("nonce")`. Modern browsers clear the content
+ *     attribute after parsing for CSP defense-in-depth (nonce
+ *     hiding), so the IDL value is the only reliable observation
+ *     point. Same reasoning will extend to `HTMLStyleElement.nonce`
+ *     when #418 §3 lands.
+ *
+ * Auth precondition: the proxy is fail-closed (only `/` and
+ * `/sign-in` are public per `src/lib/auth/proxy-auth.ts`), so any
+ * unauthenticated hit to `/missing*` would redirect to sign-in and
+ * the test would assert against the sign-in page instead of the
+ * not-found HTML. Every not-found / dashboard test seeds a worker
+ * session before navigating.
+ */
+
+const CSP_HEADER = "content-security-policy-report-only";
+
+function extractNonceFromHeader(headerValue: string | undefined): string {
+  if (!headerValue) {
+    throw new Error(
+      `expected ${CSP_HEADER} response header but it was missing`,
+    );
+  }
+  const match = headerValue.match(/'nonce-([A-Za-z0-9+/=_-]+)'/);
+  if (!match) {
+    throw new Error(
+      `${CSP_HEADER} header has no 'nonce-…' source: ${headerValue}`,
+    );
+  }
+  return match[1];
+}
+
+type ScriptObservation = {
+  /**
+   * `HTMLScriptElement.nonce` (IDL attribute, not getAttribute). Typed
+   * as `string | undefined` because the lib.dom typing is optional —
+   * an absent nonce is itself a failure mode the assertion must
+   * surface, so we propagate the optionality rather than narrowing it
+   * away inside the page-context evaluate.
+   */
+  nonce: string | undefined;
+  /** Resolved `src`, empty for inline scripts. */
+  src: string;
+  /** Short identifier for failure diagnostics. */
+  snippet: string;
+};
+
+async function readScriptNonces(page: Page): Promise<ScriptObservation[]> {
+  return page.$$eval("script", (scripts) =>
+    scripts.map((s) => ({
+      // IDL attribute — survives nonce hiding (the content attribute
+      // is cleared post-parse). `getAttribute("nonce")` would return
+      // an empty string here even when the policy is correctly
+      // applied, so it must NOT be used as the assertion source.
+      nonce: s.nonce,
+      src: s.src,
+      snippet: s.outerHTML.slice(0, 120),
+    })),
+  );
+}
+
+function assertEveryScriptCarriesNonce(
+  scripts: ScriptObservation[],
+  expectedNonce: string,
+  context: string,
+): void {
+  expect(
+    scripts.length,
+    `[${context}] no <script> tags in rendered DOM — the route may have ` +
+      "regressed to static rendering and shipped without any nonce-bearing " +
+      "script. Verify the corresponding page opts out of static rendering " +
+      "via `await connection()` (see app/not-found.tsx for the pattern).",
+  ).toBeGreaterThan(0);
+
+  for (const s of scripts) {
+    expect(
+      s.nonce,
+      `[${context}] <script> missing or wrong nonce: ${s.snippet}`,
+    ).toBe(expectedNonce);
+  }
+}
+
+async function assertNonceCoverage(
+  page: Page,
+  response: Response | null,
+  context: string,
+): Promise<void> {
+  if (response === null) {
+    throw new Error(`[${context}] page.goto returned no response`);
+  }
+  const nonce = extractNonceFromHeader(response.headers()[CSP_HEADER]);
+  const scripts = await readScriptNonces(page);
+  assertEveryScriptCarriesNonce(scripts, nonce, context);
+}
+
+test.describe("CSP nonce coverage", () => {
+  test.beforeAll(async () => {
+    await resetRateLimits();
+  });
+
+  test("public /sign-in: every <script> carries the response nonce", async ({
+    page,
+  }) => {
+    const response = await page.goto("/sign-in");
+    await assertNonceCoverage(page, response, "/sign-in");
+  });
+
+  test("[locale] /dashboard (default locale) is fully nonced", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+    const response = await page.goto("/dashboard");
+    await assertNonceCoverage(page, response, "/dashboard");
+  });
+
+  test("[locale] /ko/dashboard (non-default locale) is fully nonced", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+    const response = await page.goto("/ko/dashboard");
+    await assertNonceCoverage(page, response, "/ko/dashboard");
+  });
+
+  // PR #413's "all four URL shapes" — the floor for not-found
+  // coverage. `/missing` exercises the root `app/not-found.tsx`
+  // backstop, the locale-prefixed variants exercise
+  // `app/[locale]/not-found.tsx`, and `/xx/missing` exercises the
+  // invalid-locale shape that escapes the `[locale]` segment back
+  // to the root boundary.
+  for (const path of [
+    "/missing",
+    "/en/missing",
+    "/ko/missing",
+    "/xx/missing",
+  ]) {
+    test(`not-found ${path} is fully nonced`, async ({
+      page,
+      workerUsername,
+      workerPassword,
+    }) => {
+      await signInAndWait(page, workerUsername, workerPassword);
+      const response = await page.goto(path);
+      await assertNonceCoverage(page, response, path);
+    });
+  }
+});

--- a/e2e/csp-nonce.spec.ts
+++ b/e2e/csp-nonce.spec.ts
@@ -77,8 +77,21 @@ type ScriptObservation = {
   snippet: string;
 };
 
+/**
+ * The Playwright harness boots `pnpm dev --turbopack`, which injects a
+ * Turbopack HMR client chunk (e.g.
+ * `/_next/static/chunks/[turbopack]_browser_dev_hmr-client_hmr-client_ts_*.js`)
+ * into every HTML response. That script is a dev-runtime artifact and
+ * never ships to production — `pnpm build` does not emit it, and the
+ * static-vs-dynamic guard (`scripts/assert-no-static-html-routes.mjs`)
+ * is what protects the prod build's nonce coverage. Excluding it here
+ * keeps the dev-mode assertion honest without losing prod coverage.
+ */
+const DEV_ONLY_SCRIPT_SRC =
+  /\/_next\/static\/chunks\/(?:%5B|\[)turbopack(?:%5D|\])_browser_dev_/;
+
 async function readScriptNonces(page: Page): Promise<ScriptObservation[]> {
-  return page.$$eval("script", (scripts) =>
+  const all = await page.$$eval("script", (scripts) =>
     scripts.map((s) => ({
       // IDL attribute — survives nonce hiding (the content attribute
       // is cleared post-parse). `getAttribute("nonce")` would return
@@ -89,6 +102,7 @@ async function readScriptNonces(page: Page): Promise<ScriptObservation[]> {
       snippet: s.outerHTML.slice(0, 120),
     })),
   );
+  return all.filter((s) => !DEV_ONLY_SCRIPT_SRC.test(s.src));
 }
 
 function assertEveryScriptCarriesNonce(

--- a/e2e/csp-nonce.spec.ts
+++ b/e2e/csp-nonce.spec.ts
@@ -153,6 +153,56 @@ async function assertNonceCoverage(
   assertEveryScriptCarriesNonce(scripts, nonce, context);
 }
 
+/**
+ * Pin the test to the intended HTML route.
+ *
+ * `page.goto` follows redirects, so without a route assertion a
+ * `/missing*` request that silently lost its session and landed on
+ * `/sign-in` would still pass `assertNonceCoverage` — the sign-in page
+ * also carries the CSP header and nonced scripts. That collapses §1's
+ * route coverage onto a single page and is the exact false positive
+ * the issue calls out for the not-found shapes.
+ *
+ * We assert three things per route: the response status (404 for
+ * not-found, 200 for content pages — a redirect to `/sign-in` would
+ * surface as 200 against an unexpected status), the final URL's
+ * pathname, and a content marker rendered only by the intended
+ * page (so a 404 served by some other route still fails the test).
+ */
+async function assertLandedOn(
+  page: Page,
+  response: Response | null,
+  expected: {
+    context: string;
+    status: number;
+    pathname: RegExp;
+    bodyContains: RegExp;
+  },
+): Promise<void> {
+  if (response === null) {
+    throw new Error(`[${expected.context}] page.goto returned no response`);
+  }
+  const finalUrl = new URL(page.url());
+  expect(
+    response.status(),
+    `[${expected.context}] expected HTTP ${expected.status} ` +
+      `but got ${response.status()} (final URL: ${finalUrl.pathname}). ` +
+      "A redirect to /sign-in would surface as 200 against an expected 404.",
+  ).toBe(expected.status);
+  expect(
+    finalUrl.pathname,
+    `[${expected.context}] landed on ${finalUrl.pathname}, ` +
+      `expected pathname matching ${expected.pathname}. ` +
+      "If this is /sign-in the seeded session was lost before navigation.",
+  ).toMatch(expected.pathname);
+  await expect(
+    page.locator("body"),
+    `[${expected.context}] body did not contain ${expected.bodyContains} — ` +
+      "the response status and URL matched but the rendered content does not " +
+      "look like the intended page.",
+  ).toContainText(expected.bodyContains);
+}
+
 test.describe("CSP nonce coverage", () => {
   // Reset before every test, not just beforeAll: this spec calls
   // `signInAndWait` in 6 of 7 tests (dashboard ×2 + missing ×4) and
@@ -170,6 +220,12 @@ test.describe("CSP nonce coverage", () => {
     page,
   }) => {
     const response = await page.goto("/sign-in");
+    await assertLandedOn(page, response, {
+      context: "/sign-in",
+      status: 200,
+      pathname: /^\/sign-in$/,
+      bodyContains: /Sign into your account/i,
+    });
     await assertNonceCoverage(page, response, "/sign-in");
   });
 
@@ -180,6 +236,12 @@ test.describe("CSP nonce coverage", () => {
   }) => {
     await signInAndWait(page, workerUsername, workerPassword);
     const response = await page.goto("/dashboard");
+    await assertLandedOn(page, response, {
+      context: "/dashboard",
+      status: 200,
+      pathname: /^\/dashboard$/,
+      bodyContains: /Dashboard/,
+    });
     await assertNonceCoverage(page, response, "/dashboard");
   });
 
@@ -190,6 +252,12 @@ test.describe("CSP nonce coverage", () => {
   }) => {
     await signInAndWait(page, workerUsername, workerPassword);
     const response = await page.goto("/ko/dashboard");
+    await assertLandedOn(page, response, {
+      context: "/ko/dashboard",
+      status: 200,
+      pathname: /^\/ko\/dashboard$/,
+      bodyContains: /대시보드/,
+    });
     await assertNonceCoverage(page, response, "/ko/dashboard");
   });
 
@@ -199,12 +267,54 @@ test.describe("CSP nonce coverage", () => {
   // `app/[locale]/not-found.tsx`, and `/xx/missing` exercises the
   // invalid-locale shape that escapes the `[locale]` segment back
   // to the root boundary.
-  for (const path of [
-    "/missing",
-    "/en/missing",
-    "/ko/missing",
-    "/xx/missing",
-  ]) {
+  //
+  // Per-shape route assertions:
+  //   • Status 404 across the board — a redirect to `/sign-in` would
+  //     surface as 200 and fail this gate.
+  //   • Pathname allowlists the routes next-intl may rewrite to.
+  //     Under `localePrefix: "as-needed"` with default `en`,
+  //     `/en/missing` is rewritten to `/missing` by middleware before
+  //     the not-found boundary renders, so the final URL is `/missing`.
+  //     `/ko/missing` and `/xx/missing` keep their incoming pathname
+  //     (the former renders `[locale]/not-found.tsx`, the latter
+  //     escapes to the root boundary because `xx` is not a valid
+  //     locale — see `resolveLocale` in `src/app/not-found.tsx`).
+  //   • Body marker is the localised "404 — …" title from the
+  //     `notFound` translation namespace; locale-prefixed Korean
+  //     shapes assert the Korean string, English/default shapes
+  //     assert the English one.
+  const NOT_FOUND_CASES: ReadonlyArray<{
+    path: string;
+    finalPathname: RegExp;
+    title: RegExp;
+  }> = [
+    {
+      path: "/missing",
+      finalPathname: /^\/missing$/,
+      title: /404 — Page not found/,
+    },
+    {
+      path: "/en/missing",
+      // next-intl rewrites `/en/...` to `/...` under as-needed +
+      // default `en`, so the final URL is `/missing`.
+      finalPathname: /^\/missing$/,
+      title: /404 — Page not found/,
+    },
+    {
+      path: "/ko/missing",
+      finalPathname: /^\/ko\/missing$/,
+      title: /404 — 페이지를 찾을 수 없습니다/,
+    },
+    {
+      path: "/xx/missing",
+      // Invalid locale escapes the `[locale]` segment to the root
+      // boundary, which derives copy from `routing.defaultLocale`.
+      finalPathname: /^\/xx\/missing$/,
+      title: /404 — Page not found/,
+    },
+  ];
+
+  for (const { path, finalPathname, title } of NOT_FOUND_CASES) {
     test(`not-found ${path} is fully nonced`, async ({
       page,
       workerUsername,
@@ -212,6 +322,12 @@ test.describe("CSP nonce coverage", () => {
     }) => {
       await signInAndWait(page, workerUsername, workerPassword);
       const response = await page.goto(path);
+      await assertLandedOn(page, response, {
+        context: path,
+        status: 404,
+        pathname: finalPathname,
+        bodyContains: title,
+      });
       await assertNonceCoverage(page, response, path);
     });
   }

--- a/e2e/csp-nonce.spec.ts
+++ b/e2e/csp-nonce.spec.ts
@@ -73,22 +73,33 @@ type ScriptObservation = {
   nonce: string | undefined;
   /** Resolved `src`, empty for inline scripts. */
   src: string;
+  /** Whether the element carries `data-nextjs-dev-overlay` — the dev
+   * error-overlay portal Next injects in dev mode only. */
+  isDevOverlay: boolean;
   /** Short identifier for failure diagnostics. */
   snippet: string;
 };
 
 /**
- * The Playwright harness boots `pnpm dev --turbopack`, which injects a
- * Turbopack HMR client chunk (e.g.
- * `/_next/static/chunks/[turbopack]_browser_dev_hmr-client_hmr-client_ts_*.js`)
- * into every HTML response. That script is a dev-runtime artifact and
- * never ships to production — `pnpm build` does not emit it, and the
- * static-vs-dynamic guard (`scripts/assert-no-static-html-routes.mjs`)
- * is what protects the prod build's nonce coverage. Excluding it here
- * keeps the dev-mode assertion honest without losing prod coverage.
+ * The Playwright harness boots `pnpm dev --turbopack`, which injects
+ * several dev-runtime artifacts into every HTML response that never
+ * ship to production:
+ *
+ *   • Turbopack HMR client chunk
+ *     (`/_next/static/chunks/[turbopack]_browser_dev_hmr-client_*.js`)
+ *   • Turbopack dev module chunks named after the source path with a
+ *     `_._.js` suffix (e.g.
+ *     `/_next/static/chunks/src_app_%5Blocale%5D_not-found_tsx_0.-.k9_._.js`).
+ *     Production Turbopack output uses content-hashed names without
+ *     that suffix.
+ *
+ * `pnpm build` emits none of these, so excluding them from the dev-mode
+ * assertion does not lose prod coverage. The static-vs-dynamic guard
+ * (`scripts/assert-no-static-html-routes.mjs`) is what protects prod
+ * nonce coverage; this dev exclusion keeps the smoke test honest.
  */
 const DEV_ONLY_SCRIPT_SRC =
-  /\/_next\/static\/chunks\/(?:%5B|\[)turbopack(?:%5D|\])_browser_dev_/;
+  /\/_next\/static\/chunks\/(?:(?:%5B|\[)turbopack(?:%5D|\])_browser_dev_|.+_\._\.js$)/;
 
 async function readScriptNonces(page: Page): Promise<ScriptObservation[]> {
   const all = await page.$$eval("script", (scripts) =>
@@ -99,10 +110,13 @@ async function readScriptNonces(page: Page): Promise<ScriptObservation[]> {
       // applied, so it must NOT be used as the assertion source.
       nonce: s.nonce,
       src: s.src,
+      // Next's dev error overlay portal — `<script data-nextjs-dev-overlay="true">`.
+      // Dev-only, never emitted by `pnpm build`.
+      isDevOverlay: s.dataset.nextjsDevOverlay === "true",
       snippet: s.outerHTML.slice(0, 120),
     })),
   );
-  return all.filter((s) => !DEV_ONLY_SCRIPT_SRC.test(s.src));
+  return all.filter((s) => !s.isDevOverlay && !DEV_ONLY_SCRIPT_SRC.test(s.src));
 }
 
 function assertEveryScriptCarriesNonce(

--- a/e2e/csp-nonce.spec.ts
+++ b/e2e/csp-nonce.spec.ts
@@ -154,7 +154,15 @@ async function assertNonceCoverage(
 }
 
 test.describe("CSP nonce coverage", () => {
-  test.beforeAll(async () => {
+  // Reset before every test, not just beforeAll: this spec calls
+  // `signInAndWait` in 6 of 7 tests (dashboard ×2 + missing ×4) and
+  // a single `pnpm e2e` worker reuses the same `e2e-worker-N`
+  // username across them. Six sign-ins without resets trip the
+  // proxy's per-account rate limiter, and the last not-found test
+  // fails with "Too many attempts" on local single-worker runs
+  // (CI's 4-worker fan-out hides this by spreading sign-ins across
+  // accounts). Match the convention used by `e2e/dashboard.spec.ts`.
+  test.beforeEach(async () => {
     await resetRateLimits();
   });
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "next build && node scripts/assert-no-static-html-routes.mjs",
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",

--- a/scripts/assert-no-static-html-routes.mjs
+++ b/scripts/assert-no-static-html-routes.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Static-HTML-route guard (issue #418 §1, failure mode (e)).
+//
+// CSP nonce coverage (issue #418 §1) hinges on every HTML route
+// being server-rendered per request — only a per-request render path
+// can stamp the proxy-minted `'nonce-…'` value onto framework script
+// tags. A statically prerendered HTML route is frozen at build time
+// with no nonce attachable, so once CSP promotes from Report-Only
+// to enforcing (issue #418 §2) the browser will refuse every script
+// on that page.
+//
+// PR #413 closed this gap manually for `_not-found` by making the
+// boundary opt out of static rendering via `await connection()`,
+// and the manual gate at the end of that PR's review was "run
+// `pnpm build` and confirm every HTML route is `ƒ` (dynamic) in
+// the route map, not `○` (static)." This script is the automated
+// version of that gate, intended to run on every CI build.
+//
+// The Playwright nonce-coverage spec at `e2e/csp-nonce.spec.ts`
+// boots `pnpm dev` and so cannot reliably distinguish a route that
+// regressed to static rendering — `next dev` always renders
+// dynamically. This guard runs against the prod build's emitted
+// artifacts and is therefore the only place the static-vs-dynamic
+// regression surfaces in CI. Treat it as a sibling check to the
+// Playwright spec, not a replacement for it.
+//
+// Mechanism: after `next build` finishes, walk `.next/server/app/`.
+// Next 16 writes a `<route>.html` file there for every page that
+// was statically prerendered, and writes only `<route>.rsc` /
+// `<route>.js` (no `.html`) for dynamic pages. The presence of any
+// `.html` under that subtree is therefore the unambiguous "this
+// HTML route is static" signal — no need to parse the human-facing
+// route table from stdout, which is brittle to format changes.
+//
+// Allowlist: `_global-error.html` is excluded. It is a Next-synthetic
+// fallback (the framework's built-in 500 page that catches a thrown
+// error from the root layout) and does NOT appear in the route table
+// the issue references. It must be a Client Component per Next's
+// contract, so it cannot opt out of static rendering via
+// `await connection()` the way a Server Component page can. Its
+// scripts would be refused by enforcing CSP, but the page is intended
+// as a JS-less fallback for catastrophic render failures — the static
+// error copy renders fine without any of those scripts. Treat it as
+// out of scope for this guard; if future Next versions expose a way
+// to make this synthetic dynamic, drop the allowlist and require it.
+//
+// Run via `pnpm build` (which chains `next build && node
+// scripts/assert-no-static-html-routes.mjs`).
+
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), "..");
+
+const APP_DIR = path.join(ROOT, ".next", "server", "app");
+
+// Synthetic Next-internal HTML files that are intentionally static and
+// outside the scope of this guard — see header comment for rationale.
+// Paths are relative to `.next/server/app/` and use forward slashes.
+const ALLOWED_STATIC_HTML = new Set(["_global-error.html"]);
+
+function listStaticHtmlRoutes(dir) {
+  const out = [];
+  walk(dir, dir, out);
+  return out.filter((rel) => !ALLOWED_STATIC_HTML.has(rel));
+}
+
+function walk(rootDir, currentDir, out) {
+  let entries;
+  try {
+    entries = readdirSync(currentDir);
+  } catch (err) {
+    if (err.code === "ENOENT") return;
+    throw err;
+  }
+  for (const entry of entries) {
+    const abs = path.join(currentDir, entry);
+    const st = statSync(abs);
+    if (st.isDirectory()) {
+      walk(rootDir, abs, out);
+    } else if (entry.endsWith(".html")) {
+      const rel = path.relative(rootDir, abs).split(path.sep).join("/");
+      out.push(rel);
+    }
+  }
+}
+
+function main() {
+  let appDirExists = true;
+  try {
+    statSync(APP_DIR);
+  } catch (err) {
+    if (err.code === "ENOENT") appDirExists = false;
+    else throw err;
+  }
+
+  if (!appDirExists) {
+    console.error(
+      `[assert-no-static-html-routes] FAIL — ${path.relative(ROOT, APP_DIR)} ` +
+        "does not exist. Did `next build` run before this script? The guard " +
+        "is intended to run as the second half of `pnpm build`.",
+    );
+    return 1;
+  }
+
+  const htmlFiles = listStaticHtmlRoutes(APP_DIR);
+
+  if (htmlFiles.length === 0) {
+    console.log(
+      "[assert-no-static-html-routes] OK — no statically prerendered HTML " +
+        "routes detected under .next/server/app. CSP nonce coverage is safe " +
+        "across the build.",
+    );
+    return 0;
+  }
+
+  console.error(
+    `[assert-no-static-html-routes] FAIL — ${htmlFiles.length} statically ` +
+      "prerendered HTML route(s) detected. CSP cannot stamp a per-request " +
+      "nonce onto a build-time-frozen page, so once CSP promotes to " +
+      "enforcing (#418 §2) the browser will refuse every script on these " +
+      "pages. Make each affected page dynamic via `await connection()` (see " +
+      "src/app/not-found.tsx for the pattern):\n",
+  );
+  for (const file of htmlFiles.sort()) {
+    console.error(`  • .next/server/app/${file}`);
+  }
+  return 1;
+}
+
+process.exit(main());

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Roboto } from "next/font/google";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
@@ -8,6 +9,7 @@ import { ThemeProvider } from "next-themes";
 
 import { SessionExtensionDialog } from "@/components/session/session-extension-dialog";
 import { routing } from "@/i18n/routing";
+import { NONCE_HEADER } from "@/lib/security/csp";
 import { themeConfig } from "@/lib/theme";
 
 import "../globals.css";
@@ -44,10 +46,17 @@ export default async function LocaleLayout({
 
   setRequestLocale(locale);
 
+  // `next-themes` injects an inline pre-paint script to set the theme
+  // before hydration. That script is app-emitted (not framework-
+  // emitted), so Next.js's renderer does not stamp the per-request
+  // nonce on it — the package exposes its own `nonce` prop, and CSP
+  // refuses the script without it under the script-src nonce policy.
+  const nonce = (await headers()).get(NONCE_HEADER) ?? undefined;
+
   return (
     <html lang={locale} suppressHydrationWarning>
       <body className={roboto.className}>
-        <ThemeProvider {...themeConfig}>
+        <ThemeProvider {...themeConfig} nonce={nonce}>
           <NextIntlClientProvider>
             {children}
             <SessionExtensionDialog />


### PR DESCRIPTION
## Summary

Lands §1 of #418 — automated nonce-coverage regression nets so that promoting CSP from Report-Only to enforcing (§2) is protected against renderer regressions that would otherwise only surface as user reports.

- `e2e/csp-nonce.spec.ts` — Playwright spec covering the floor stated in #418 §1: `/sign-in`, default and non-default `[locale]` dashboard, and the four not-found URL shapes (`/missing`, `/en/missing`, `/ko/missing`, `/xx/missing`) from PR #413. For each route it reads the response `Content-Security-Policy-Report-Only` header, extracts the `'nonce-…'` source, and asserts every `<script>` in the rendered DOM exposes the same value via `HTMLScriptElement.nonce`. The IDL attribute is used deliberately (not `getAttribute("nonce")`) because modern browsers clear the content attribute post-parse for CSP defense-in-depth — `getAttribute` would return an empty string even when the policy is correctly applied. Each test also pins the response to the intended HTML route (`assertLandedOn`): expected HTTP status (`200` for content pages, `404` for the not-found shapes), expected final-URL pathname, and a body marker rendered only by the intended page. Without those route pins, a `/missing*` request that silently lost its session and redirected to `/sign-in` would still pass the nonce assertion (sign-in also has the CSP header and nonced scripts) — that is the false positive #418 §1 calls out for the not-found shapes. Tests that hit `/missing*` and `/dashboard` seed a worker session first, since the proxy is fail-closed for everything outside `/` and `/sign-in`. Six of the seven tests sign in with the same worker account, so `resetRateLimits()` runs in `beforeEach` (not just `beforeAll`) — without that, single-worker local runs trip the per-account rate limiter on the last not-found shape; the four-worker CI fan-out hides this by spreading sign-ins across accounts. Three dev-runtime artifacts that `pnpm build` never emits are excluded from the assertion by attribute or URL shape — no route is skipped, so the §1 guardrail (no skipping failing routes) holds:
  - The Turbopack HMR client chunk (`/_next/static/chunks/[turbopack]_browser_dev_hmr-client_*.js`).
  - Turbopack dev module chunks (e.g. `/_next/static/chunks/src_app_%5Blocale%5D_not-found_tsx_0.-.k9_._.js`) — production Turbopack output uses content-hashed names without the `_._.js` suffix.
  - Next's dev error-overlay portal (`<script data-nextjs-dev-overlay=\"true\">`).
- `src/app/[locale]/layout.tsx` — pass the per-request CSP nonce to `<ThemeProvider>` via its `nonce` prop. The `next-themes` pre-paint inline script is app-emitted (not framework-emitted), so Next's renderer does not stamp a nonce on it; without this fix the dashboard would have been refused under enforcing CSP. The nonce is read from the `x-nonce` request header that `src/proxy.ts` forwards to RSC.
- `scripts/assert-no-static-html-routes.mjs` — prod-build guard chained into `pnpm build` (`next build && node scripts/assert-no-static-html-routes.mjs`). Walks `.next/server/app/` and fails the build if any HTML route emits a prerendered `.html` file. A statically rendered page has no per-request nonce attachable, so once CSP promotes to enforcing the browser would refuse every script on it. `_global-error.html` is allowlisted (Next-synthetic, must be a Client Component, designed to render JS-less for catastrophic-failure fallback). Mirrors the manual gate from PR #413.
- `README.md` — points the CSP rollout note at both new mechanisms.

The two checks are deliberately separate processes: `pnpm e2e` boots `pnpm dev` (per `e2e/playwright.config.ts`), where Next always renders dynamically, so the Playwright spec cannot reliably surface failure mode (e) from #418 §1 (a route that regressed to static rendering). The `.mjs` guard runs against the prod build's emitted artifacts and is the only place that regression catches in CI. `.mjs` matches the repo's existing script convention — no `tsx`/`ts-node` runtime is set up.

Part of #418

## Not addressed

This PR is §1 only. The remaining sub-tasks of #418 will land as separate PRs per the issue's stated rollout sequencing:

- **§2 — Promotion from Report-Only to enforcing.** Held by design until §1 has merged and one full Report-Only release has shipped to production with zero new violations. Promoting earlier would defeat the gate this PR establishes.
- **§3 — `style-src` nonce hardening.** Held until §2 stabilises so the styled-jsx / inline-style audit runs against deterministic enforcing-mode reports rather than the looser Report-Only signal.

## Test plan

- [x] \`pnpm biome check e2e/csp-nonce.spec.ts scripts/assert-no-static-html-routes.mjs 'src/app/[locale]/layout.tsx'\` — clean.
- [x] \`pnpm tsc --noEmit\` — clean (the new spec must type-check against the existing Playwright fixtures).
- [x] \`pnpm e2e -- e2e/csp-nonce.spec.ts\` — every test passes against the dev server (verified locally with the default single-worker config after the \`beforeEach\` rate-limit reset).
- [x] On a deliberately-broken nonce (mismatched response vs request CSP header in \`src/proxy.ts\`) every test FAILS with a diagnostic that names the offending \`<script>\` and the route. Reverted and confirmed green — this is the §1 verification gate stated in the issue.
- [x] On a deliberately-broken auth precondition (removed \`signInAndWait\` from the not-found tests so the proxy redirects to \`/sign-in\`) the four not-found tests FAIL with \`expected HTTP 404 but got 200 (final URL: /sign-in)\`. Reverted and confirmed green — this is the route-pin gate added in response to Round 1 review.
- [x] \`pnpm build\` — passes end-to-end and the guard logs \`[assert-no-static-html-routes] OK …\`.
- [x] On a deliberately-static HTML route (forced \`src/app/not-found.tsx\` to a fully static render path) \`pnpm build\` FAILS with the guard's \`[assert-no-static-html-routes] FAIL — 1 statically prerendered HTML route(s) detected …\` message naming \`.next/server/app/_not-found.html\`. Reverted and confirmed green.
- [x] README's CSP rollout section reads correctly and the \`pnpm build\` reference matches the new chained command.