### PR TITLE
Widen event locator end bound by +1s

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -99,7 +99,7 @@ pnpm build
 pnpm start
 ```
 
-For Docker Compose production deployments, see the [Production deployment](../../README.md#production) section of the README — that is the authoritative first-boot checklist.
+For Docker Compose production deployments, see the [Production deployment](https://github.com/aicers/aice-web-next/blob/main/README.md#production) section of the README — that is the authoritative first-boot checklist.
 
 Open `http://localhost:3000` (or the configured address) in your
 browser. You should see the sign-in page:

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -100,7 +100,7 @@ pnpm build
 pnpm start
 ```
 
-Docker Compose 기반 프로덕션 배포는 README의 [Production deployment](../../README.md#production) 섹션을 참고하세요 — 첫 부팅 체크리스트의 정식 출처입니다.
+Docker Compose 기반 프로덕션 배포는 README의 [Production deployment](https://github.com/aicers/aice-web-next/blob/main/README.md#production) 섹션을 참고하세요 — 첫 부팅 체크리스트의 정식 출처입니다.
 
 브라우저에서 `http://localhost:3000`(또는 설정된 주소)을
 엽니다. 로그인 페이지가 표시됩니다:

--- a/e2e/detection-manual-dynamic-screenshots.spec.ts
+++ b/e2e/detection-manual-dynamic-screenshots.spec.ts
@@ -49,7 +49,11 @@ test.beforeAll(async () => {
     matchVariables: {
       filter: {
         start: INVESTIGATION_EVENT.time,
-        end: INVESTIGATION_EVENT.time,
+        // #424: `end` is widened by +1 s in `locatorToEventListFilter`
+        // because REview's `eventList` treats `end` as exclusive. The
+        // stub matcher must mirror the widened bound; the value is
+        // produced by `new Date(Date.parse(time) + 1000).toISOString()`.
+        end: "2026-04-22T12:00:01.000Z",
         source: INVESTIGATION_EVENT.origAddr,
         destination: INVESTIGATION_EVENT.respAddr,
         kinds: [INVESTIGATION_EVENT.__typename],

--- a/src/__tests__/lib/detection/event-detail.test.ts
+++ b/src/__tests__/lib/detection/event-detail.test.ts
@@ -109,12 +109,19 @@ describe("fetchEventByLocator", () => {
     const filter = locatorToEventListFilter(LOCATOR);
     expect(filter).toEqual({
       start: LOCATOR.time,
-      end: LOCATOR.time,
+      end: "2026-04-22T10:00:01.000Z",
       source: LOCATOR.origAddr,
       destination: LOCATOR.respAddr,
       kinds: ["HttpThreat"],
       levels: [3],
     });
+    // #424: REview's `eventList` treats `end` as exclusive, so the
+    // half-open interval `[time, time)` is empty. The widening must
+    // produce a strictly larger end and the gap is exactly 1 s.
+    const startMs = Date.parse(filter.start as string);
+    const endMs = Date.parse(filter.end as string);
+    expect(endMs).toBeGreaterThan(startMs);
+    expect(endMs - startMs).toBe(1000);
 
     const result = await fetchEventByLocator(makeSession(), LOCATOR);
 
@@ -192,6 +199,71 @@ describe("fetchEventByLocator", () => {
     const ddos = extractFragmentBody(printed, "ExternalDdos");
     expect(ddos).toContain("origAddrs");
     expect(ddos).toMatch(/\brespAddr\b/);
+  });
+
+  // #424: end-to-end shape — encode a token from a list-returned
+  // event, decode it, and assert `fetchEventByLocator` lands on
+  // `status: "one"`. Guards against regressions where the BFF
+  // re-collapses the half-open interval and the panel reverts to
+  // the "Event no longer available" state.
+  it("resolves a token built from a list-returned event to status:one", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42]);
+
+    const eventTime = "2026-03-12T05:17:40.076967Z";
+    const listEvent = {
+      __typename: "HttpThreat" as const,
+      time: eventTime,
+      sensor: "sensor-1",
+      level: "HIGH" as const,
+      origAddr: "10.0.0.5",
+      respAddr: "203.0.113.45",
+      origPort: 54321,
+      respPort: 80,
+      proto: 6,
+    };
+
+    const { encodeEventLocator, decodeEventLocator } = await import(
+      "@/lib/events/event-locator"
+    );
+    const token = encodeEventLocator(listEvent);
+    expect(token).not.toBeNull();
+    const decoded = decodeEventLocator(token as string);
+    expect(decoded).not.toBeNull();
+
+    mockGraphqlRequest.mockImplementation(async (_doc, variables) => {
+      const { start, end } = (
+        variables as { filter: { start: string; end: string } }
+      ).filter;
+      const eventMs = Date.parse(eventTime);
+      const startMs = Date.parse(start);
+      const endMs = Date.parse(end);
+      // Mimic REview's exclusive-end semantics: the event matches
+      // only when start <= eventTime < end.
+      const matches = startMs <= eventMs && eventMs < endMs;
+      return {
+        eventList: matches
+          ? {
+              totalCount: "1",
+              nodes: [
+                {
+                  ...listEvent,
+                  confidence: 0.9,
+                  category: null,
+                  triageScores: null,
+                },
+              ],
+            }
+          : { totalCount: "0", nodes: [] },
+      };
+    });
+
+    const { fetchEventByLocator } = await import("@/lib/detection");
+    const result = await fetchEventByLocator(
+      makeSession(),
+      decoded as NonNullable<ReturnType<typeof decodeEventLocator>>,
+    );
+    expect(result.status).toBe("one");
   });
 
   it("rejects callers without detection:read before dispatching", async () => {

--- a/src/lib/detection/server-actions.ts
+++ b/src/lib/detection/server-actions.ts
@@ -455,16 +455,37 @@ interface IpLocationVariables extends Record<string, unknown> {
 }
 
 /**
+ * Add one second to an RFC 3339 timestamp, returning a UTC ISO
+ * string with millisecond precision. Used by
+ * {@link locatorToEventListFilter} to widen the end bound; the
+ * 1-second gap is intentionally generous so callers don't need to
+ * preserve nanosecond fractions across the round-trip.
+ */
+function addOneSecond(timestamp: string): string {
+  return new Date(Date.parse(timestamp) + 1000).toISOString();
+}
+
+/**
  * Build the tight `EventListFilterInput` for a decoded locator.
  * Exposed for tests and for the page component, which logs the
  * filter it will dispatch for debuggability.
+ *
+ * `end` is widened by **+1 second** because REview's `eventList`
+ * treats `end` as exclusive: the half-open interval
+ * `[locator.time, locator.time)` is empty and the matching event is
+ * always filtered out (#424). Disambiguation when more than one
+ * event lands inside the 1-second window is handled by the existing
+ * `status: "multiple"` branch in {@link fetchEventByLocator}. This
+ * is a workaround for REview lacking a single-event lookup API
+ * (aicers/review-web#841); when that API ships the widening must be
+ * removed and replaced with the direct lookup.
  */
 export function locatorToEventListFilter(
   locator: EventLocator,
 ): EventListFilterInput {
   return {
     start: locator.time,
-    end: locator.time,
+    end: addOneSecond(locator.time),
     source: locator.origAddr,
     destination: locator.respAddr,
     kinds: [locator.kind],


### PR DESCRIPTION
## Summary

`locatorToEventListFilter` translated an `EventLocator` into an `EventListFilterInput` with `start = end = locator.time`. REview's `eventList` treats `end` as **exclusive**, so the half-open interval `[time, time)` was always empty — every "Open full investigation" Quick peek pivot resolved to `status: "zero"` and rendered the "Event no longer available" panel.

This widens `end` by **+1 second** so the matching event lands inside the window. The 1-second gap is intentionally generous: it absorbs RFC 3339 fractional-digit normalization differences between the encoder and REview's internal comparison without requiring nanosecond-precise arithmetic in the BFF. Disambiguation when more than one event matches is already handled by the existing `status: "multiple"` branch and the `multipleNotice` UI.

Scope per the issue:

- Touches only `locatorToEventListFilter` — locator token shape, route, and page component are untouched.
- `source` / `destination` / `kinds` / `levels` are unchanged; the 5-tuple narrowing keeps results down to (almost always) one event.

## Workaround disclosure

This is a workaround for REview's `eventList` being a range API misused for single-event identification. The proper fix requires REview to expose a single-event lookup API (aicers/review-web#841). Once that API ships, the widening must be removed and replaced with the direct lookup.

## Tests

- Unit assertion in `event-detail.test.ts`: `end > start` and the gap is exactly 1000 ms.
- Integration-style test: encode a token from a list-returned event, decode it, and assert `fetchEventByLocator` returns `status: "one"` against a mock that respects REview's exclusive-end semantics (`start <= eventTime < end`).

## Test plan

- [x] `pnpm test src/__tests__/lib/detection/event-detail.test.ts` — 6/6 pass
- [x] `pnpm test` — 2907/2907 pass
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm check` — clean (info-only Biome version notice)
- [x] `pnpm build` — clean
- [ ] Manual: open a Detection Quick peek against a live REview, click "Open full investigation", verify the page resolves to the event instead of the not-found panel.

Closes #424