### PR TITLE
Bump pnpm to 10.33.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "aice-web-next",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@10.33.3+sha512.a19744364a7e248b92657a4ca5973f9354d21caf982579674b1c539f32c7420c47138ad8b1254df07aba9bc782d9b3029e3db34d5dbff974326eb74dac8ff489",
   "engines": {
     "node": ">=24.0.0 <25.0.0"
   },


### PR DESCRIPTION
## Summary

Update the `packageManager` field from `pnpm@10.29.3` to `pnpm@10.33.3` (latest patch in the v10 line).

This is a same-major patch update — bug fixes only, no breaking changes. Migration to v11 is intentionally deferred until the new major has stabilized in the ecosystem.

## Test plan

- [x] CI passes (lint, type check, tests, build)
- [x] `pnpm install` runs cleanly with the new version

Closes #433