### PR TITLE
Add customers.external_key column and registration UI field (#438)

### DIFF
--- a/docs/en/settings.md
+++ b/docs/en/settings.md
@@ -200,9 +200,62 @@ Fields:
 
 - **Name** — customer display name (required).
 - **Description** — optional description.
+- **External Key** — optional cross-system bridge identifier paired
+  with the matching customer on aimer-web. Globally unique. Leave
+  blank if the customer is not yet onboarded for *Send to Aimer*.
+  See [External Key](#external-key) below for the agreement and
+  validation rules.
 
 When a customer is created, the system provisions a dedicated
 database automatically.
+
+<!-- TODO: screenshot - aimer-bridge batch -->
+
+### Editing a Customer
+
+Open the row's kebab menu and choose **Edit** to update the name,
+description, or external key. Editing the **external key** to a
+different value (or clearing it back to blank) opens a non-dismissable
+confirmation dialog before the change is saved — see
+[External Key](#external-key) below for why the warning matters.
+
+<!-- TODO: screenshot - aimer-bridge batch -->
+
+### External Key
+
+The external key is the operator-supplied identifier that pairs an
+AICE customer with the matching customer on aimer-web. The value is
+the same string both sides carry, so the cross-system bridge can map
+audit and event traffic back to a single business entity.
+
+- **When to set it.** Only after the value has been agreed with the
+  aimer-web System Administrator over an out-of-band secure channel
+  (in-house SSO messenger, in person, etc.). The recommended
+  identifiers are a domain (e.g. `acmecorp.com`), a business
+  registration number, or a contract code.
+- **Validation.** Trimmed before storage. Empty / whitespace-only
+  inputs clear the value back to blank. Non-empty values are limited
+  to 256 characters and may not contain control characters. The
+  external key is globally unique — submitting a value already in use
+  by another customer returns a typed conflict.
+- **Effect of a change.** Setting or changing the external key
+  rewrites the cross-system mapping; the matching customer on
+  aimer-web must be updated to keep the mapping intact, and a single
+  bridge test is recommended right after.
+- **Effect of clearing.** Clearing the external key disables
+  *Send to Aimer* for the customer until a value is set again. Any
+  existing mapping with the aimer-web side is no longer reachable
+  from this side.
+- **Customers without an external key.** Edits and queries continue
+  to work normally; only the *Send to Aimer* button is disabled per
+  customer until a value is populated.
+
+For the full operator playbook (agreement workflow, recovery from
+mismatches, audit forensics) see the canonical
+[Cross-system customer identification](https://github.com/aicers/aimer-web/blob/main/docs/operations/cross-system-customer-identification.md)
+guide on aimer-web.
+
+<!-- TODO: screenshot - aimer-bridge batch -->
 
 ### Deleting a Customer
 

--- a/docs/ko/settings.md
+++ b/docs/ko/settings.md
@@ -197,9 +197,60 @@ Administrator 역할은 기본적으로 MFA가 필수입니다.
 
 - **이름** — 고객 표시 이름(필수).
 - **설명** — 선택적 설명.
+- **External Key** — aimer-web의 일치하는 고객과 페어링하는
+  교차 시스템 브리지 식별자(선택). 전 시스템에서 globally unique
+  합니다. 해당 고객이 *Send to Aimer*에 아직 온보딩되지 않은 경우
+  비워둡니다. 합의 및 검증 규칙은 아래
+  [External Key](#external-key) 섹션을 참고하세요.
 
 고객이 생성되면 시스템이 전용 데이터베이스를 자동으로
 프로비저닝합니다.
+
+<!-- TODO: screenshot - aimer-bridge batch -->
+
+### 고객 편집
+
+행의 케밥 메뉴에서 **수정**을 선택하여 이름, 설명 또는 external
+key를 업데이트합니다. **external key**를 다른 값으로 변경하거나
+공란으로 되돌릴 때는 저장 전에 닫을 수 없는 확인 대화상자가
+표시됩니다 — 경고가 중요한 이유는 아래
+[External Key](#external-key) 섹션에 정리되어 있습니다.
+
+<!-- TODO: screenshot - aimer-bridge batch -->
+
+### External Key
+
+External key는 AICE 고객과 aimer-web 측의 일치하는 고객을
+페어링하는 운영자 지정 식별자입니다. 양쪽 시스템이 동일한 값을
+보유하므로 교차 시스템 브리지가 감사 / 이벤트 트래픽을 단일
+비즈니스 엔티티로 매핑할 수 있습니다.
+
+- **언제 설정하나요?** aimer-web System Administrator와 out-of-band
+  secure channel(사내 SSO 메신저, 직접 대면 등)로 값을 사전 합의한
+  후에만 설정합니다. 권장 식별자는 도메인(예: `acmecorp.com`),
+  사업자등록번호 또는 계약 코드입니다.
+- **검증 규칙.** 저장 전에 trim 됩니다. 빈 값 또는 공백만 있는
+  입력은 값을 비움으로 처리합니다. 비어 있지 않은 값은 256자
+  이하이며 제어 문자를 포함할 수 없습니다. External key는
+  globally unique 하므로 다른 고객이 이미 사용 중인 값을 제출하면
+  충돌(typed conflict)을 반환합니다.
+- **변경의 영향.** External key를 설정하거나 변경하면 교차 시스템
+  매핑이 재설정됩니다. 매핑을 유지하려면 aimer-web 측의 일치하는
+  고객 정보도 함께 업데이트해야 하며, 직후에 단일 bridge 테스트로
+  매핑을 검증하는 것을 권장합니다.
+- **해제의 영향.** External key를 해제하면 다시 설정할 때까지
+  해당 고객의 *Send to Aimer*가 비활성화됩니다. aimer-web 측과의
+  기존 매핑은 이 측에서는 더 이상 도달할 수 없습니다.
+- **External key가 없는 고객.** 일반적인 편집 및 조회는 그대로
+  동작하며, 고객별로 *Send to Aimer* 버튼만 값이 채워질 때까지
+  비활성화됩니다.
+
+전체 운영자 플레이북(합의 절차, 불일치 복구, 감사 포렌식)은
+aimer-web의 표준 가이드인
+[Cross-system customer identification](https://github.com/aicers/aimer-web/blob/main/docs/operations/cross-system-customer-identification.md)
+를 참고하세요.
+
+<!-- TODO: screenshot - aimer-bridge batch -->
 
 ### 고객 삭제
 

--- a/e2e/customers.spec.ts
+++ b/e2e/customers.spec.ts
@@ -83,6 +83,102 @@ test.describe("Customer management — UI", () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
+  test("warns and persists when setting external_key on edit (#438)", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+    await page.goto("/settings/customers");
+
+    const rowName = `${TEST_PREFIX}UITest-Edited`;
+    await expect(page.getByRole("cell", { name: rowName })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const row = page.getByRole("row").filter({ hasText: rowName });
+    await row.getByRole("button").first().click();
+    await page.getByRole("menuitem", { name: "Edit" }).click();
+
+    const externalKey = `${TEST_PREFIX.toLowerCase()}.example.com`;
+    await page.getByLabel("External Key").fill(externalKey);
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    // Effect-warning modal must appear (set / change copy) and require
+    // explicit confirmation — Escape must not dismiss it.
+    const warning = page.getByRole("alertdialog");
+    await expect(warning).toBeVisible();
+    await expect(
+      warning.getByText(/aimer-web's matching customer/i),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(warning).toBeVisible();
+
+    await warning.getByRole("button", { name: "Continue" }).click();
+
+    // After confirm, the row persists with the new external_key value.
+    const updatedRow = page.getByRole("row").filter({ hasText: rowName });
+    await expect(updatedRow.getByText(externalKey)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("warning does not fire on a name-only edit or no-op (#438)", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+    await page.goto("/settings/customers");
+
+    const rowName = `${TEST_PREFIX}UITest-Edited`;
+    await expect(page.getByRole("cell", { name: rowName })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const row = page.getByRole("row").filter({ hasText: rowName });
+    await row.getByRole("button").first().click();
+    await page.getByRole("menuitem", { name: "Edit" }).click();
+
+    // Description-only edit: leave external_key untouched.
+    await page.getByLabel("Description").fill("Edited description only");
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    // The form dialog closes directly; no warning alertdialog appears.
+    await expect(page.getByRole("alertdialog")).toHaveCount(0);
+    await expect(page.getByRole("cell", { name: rowName })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("warns and persists when clearing external_key (#438)", async ({
+    page,
+    workerUsername,
+    workerPassword,
+  }) => {
+    await signInAndWait(page, workerUsername, workerPassword);
+    await page.goto("/settings/customers");
+
+    const rowName = `${TEST_PREFIX}UITest-Edited`;
+    const row = page.getByRole("row").filter({ hasText: rowName });
+    await row.getByRole("button").first().click();
+    await page.getByRole("menuitem", { name: "Edit" }).click();
+
+    const externalKeyInput = page.getByLabel("External Key");
+    await externalKeyInput.clear();
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    const warning = page.getByRole("alertdialog");
+    await expect(warning).toBeVisible();
+    await expect(warning.getByText(/disables Send to Aimer/i)).toBeVisible();
+    await warning.getByRole("button", { name: "Continue" }).click();
+
+    // Row persists; the external_key cell renders the empty placeholder.
+    await expect(page.getByRole("cell", { name: rowName })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
   test("deletes a customer via UI", async ({
     page,
     workerUsername,

--- a/migrations/auth/0028_customers_external_key.sql
+++ b/migrations/auth/0028_customers_external_key.sql
@@ -1,0 +1,40 @@
+-- Aimer-bridge customer mapping (#438): add `external_key` to the
+-- `customers` table so an aice-web-next customer can be paired with the
+-- matching customer on the aimer-web side via a globally unique
+-- operator-agreed identifier.
+--
+-- Background. aimer-web's `auth_db.customers` already carries
+-- `external_key TEXT NOT NULL UNIQUE` (its
+-- `migrations/auth/0002_customers.sql`). aice-web-next previously had
+-- no equivalent column, so the Send to Aimer flow had no value to put
+-- into the context token's `customer_ids` claim that aimer-web could
+-- map back to a customer UUID.
+--
+-- The constraint is global UNIQUE to mirror aimer-web. A single
+-- billing / unified-management business entity may be linked to
+-- multiple AICE environments via aimer-web's
+-- `aice_environment_customers`, so the key is one-to-many in that
+-- direction but unique per repo.
+--
+-- For the first cycle, `external_key` is NULL-allowed: operators
+-- populate it on a per-customer basis at their own pace, and customers
+-- without it are non-eligible for Send to Aimer (the per-customer gate
+-- in #440 disables the action). A future migration may tighten this
+-- to NOT NULL once the rollout is complete.
+--
+-- Idempotent: safe to re-run.
+
+ALTER TABLE customers
+  ADD COLUMN IF NOT EXISTS external_key TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'customers_external_key_key'
+      AND conrelid = 'customers'::regclass
+  ) THEN
+    ALTER TABLE customers
+      ADD CONSTRAINT customers_external_key_key UNIQUE (external_key);
+  END IF;
+END$$;

--- a/src/__tests__/app/api/customers/[id]/route.test.ts
+++ b/src/__tests__/app/api/customers/[id]/route.test.ts
@@ -84,6 +84,7 @@ const sampleCustomer = {
   id: 1,
   name: "Acme Corp",
   description: "A test customer",
+  external_key: null as string | null,
   database_name: "customer_acme_corp_abc123",
   status: "active",
   created_at: "2026-01-01T00:00:00Z",
@@ -258,6 +259,153 @@ describe("PATCH /api/customers/[id]", () => {
 
     expect(response.status).toBe(200);
     expect(body.data.name).toBe("Acme Corp");
+  });
+
+  it("emits changedFields/previous/next audit detail on a name-only edit (#438)", async () => {
+    const updated = { ...sampleCustomer, name: "Renamed Corp" };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [updated], rowCount: 1 });
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Renamed Corp" }),
+    });
+    await PATCH(request, makeContext());
+
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.update",
+        details: expect.objectContaining({
+          changedFields: ["name"],
+          previous: { name: "Acme Corp" },
+          next: { name: "Renamed Corp" },
+          customerId: 1,
+          customerName: "Renamed Corp",
+        }),
+      }),
+    );
+    // A name-only edit must not include external_key keys.
+    const call = mockAuditRecord.mock.calls[0]?.[0] as
+      | {
+          details: {
+            previous: Record<string, unknown>;
+            next: Record<string, unknown>;
+          };
+        }
+      | undefined;
+    expect(call?.details.previous).not.toHaveProperty("external_key");
+    expect(call?.details.next).not.toHaveProperty("external_key");
+  });
+
+  it("sets external_key from NULL → value with audit changedFields (#438)", async () => {
+    const updated = { ...sampleCustomer, external_key: "acmecorp.com" };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [updated], rowCount: 1 });
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ external_key: "  acmecorp.com  " }),
+    });
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.external_key).toBe("acmecorp.com");
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "customer.update",
+        details: expect.objectContaining({
+          changedFields: ["external_key"],
+          previous: { external_key: null },
+          next: { external_key: "acmecorp.com" },
+        }),
+      }),
+    );
+  });
+
+  it("clears external_key from value → NULL on explicit null (#438)", async () => {
+    const previous = { ...sampleCustomer, external_key: "acmecorp.com" };
+    const cleared = { ...previous, external_key: null };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [previous], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [cleared], rowCount: 1 });
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ external_key: null }),
+    });
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.external_key).toBeNull();
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          changedFields: ["external_key"],
+          previous: { external_key: "acmecorp.com" },
+          next: { external_key: null },
+        }),
+      }),
+    );
+  });
+
+  it("treats empty external_key on already-NULL row as a no-op (#438)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 });
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ external_key: "   " }),
+    });
+    const response = await PATCH(request, makeContext());
+
+    expect(response.status).toBe(200);
+    // No UPDATE query was issued, so only the existence SELECT ran.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with field=external_key on invalid value (#438)", async () => {
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ external_key: "a".repeat(257) }),
+    });
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.field).toBe("external_key");
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 on external_key UNIQUE conflict (#438)", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [sampleCustomer], rowCount: 1 })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("dup"), {
+          code: "23505",
+          constraint: "customers_external_key_key",
+        }),
+      );
+
+    const { PATCH } = await import("@/app/api/customers/[id]/route");
+    const request = new NextRequest("http://localhost:3000/api/customers/1", {
+      method: "PATCH",
+      body: JSON.stringify({ external_key: "acmecorp.com" }),
+    });
+    const response = await PATCH(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.field).toBe("external_key");
+    expect(body.code).toBe("external_key_conflict");
   });
 });
 

--- a/src/__tests__/app/api/customers/route.test.ts
+++ b/src/__tests__/app/api/customers/route.test.ts
@@ -88,6 +88,7 @@ const sampleCustomer = {
   id: 1,
   name: "Acme Corp",
   description: "A test customer",
+  external_key: null as string | null,
   database_name: "customer_acme_corp_abc123",
   status: "active",
   created_at: "2026-01-01T00:00:00Z",
@@ -233,6 +234,100 @@ describe("POST /api/customers", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe("Invalid JSON");
+  });
+
+  it("creates a customer with external_key and persists it (#438)", async () => {
+    const provisioned = {
+      ...sampleCustomer,
+      external_key: "acmecorp.com",
+      status: "provisioning",
+    };
+    const active = {
+      ...sampleCustomer,
+      external_key: "acmecorp.com",
+      status: "active",
+    };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [provisioned], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [active], rowCount: 1 });
+
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Acme Corp",
+        external_key: "  acmecorp.com  ",
+      }),
+    });
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.data.external_key).toBe("acmecorp.com");
+    // INSERT received the trimmed external_key in the right slot.
+    const insertCall = mockQuery.mock.calls[0];
+    expect(insertCall?.[0]).toContain("INSERT INTO customers");
+    expect(insertCall?.[1][2]).toBe("acmecorp.com");
+  });
+
+  it("returns 400 with field=external_key for invalid input (#438)", async () => {
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Acme",
+        external_key: "a".repeat(257),
+      }),
+    });
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.field).toBe("external_key");
+  });
+
+  it("returns 409 on external_key UNIQUE conflict (#438)", async () => {
+    mockQuery.mockRejectedValueOnce(
+      Object.assign(new Error("dup"), {
+        code: "23505",
+        constraint: "customers_external_key_key",
+      }),
+    );
+
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Acme",
+        external_key: "acmecorp.com",
+      }),
+    });
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("external_key_conflict");
+    // Provisioning was never invoked because the INSERT itself failed.
+    expect(mockProvisionCustomerDb).not.toHaveBeenCalled();
+  });
+
+  it("treats empty external_key on create as NULL (#438)", async () => {
+    const provisioned = { ...sampleCustomer, status: "provisioning" };
+    const active = { ...sampleCustomer, status: "active" };
+    mockQuery
+      .mockResolvedValueOnce({ rows: [provisioned], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [active], rowCount: 1 });
+
+    const { POST } = await import("@/app/api/customers/route");
+    const request = new NextRequest("http://localhost:3000/api/customers", {
+      method: "POST",
+      body: JSON.stringify({ name: "Acme", external_key: "  " }),
+    });
+    const response = await POST(request, makeContext());
+
+    expect(response.status).toBe(201);
+    const insertCall = mockQuery.mock.calls[0];
+    expect(insertCall?.[1][2]).toBeNull();
   });
 
   it("cleans up on provisioning failure", async () => {

--- a/src/__tests__/lib/customers/external-key.test.ts
+++ b/src/__tests__/lib/customers/external-key.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXTERNAL_KEY_MAX_LENGTH,
+  ExternalKeyValidationError,
+  isExternalKeyUniqueViolation,
+  isPgUniqueViolation,
+  normalizeExternalKey,
+} from "@/lib/customers/external-key";
+
+describe("normalizeExternalKey", () => {
+  it("returns undefined for an omitted field", () => {
+    expect(normalizeExternalKey(undefined)).toBeUndefined();
+  });
+
+  it("returns null for explicit null", () => {
+    expect(normalizeExternalKey(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(normalizeExternalKey("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(normalizeExternalKey("   \t  \n")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeExternalKey("  acmecorp.com  ")).toBe("acmecorp.com");
+  });
+
+  it("preserves a non-empty value", () => {
+    expect(normalizeExternalKey("acmecorp.com")).toBe("acmecorp.com");
+  });
+
+  it("rejects non-string values", () => {
+    expect(() => normalizeExternalKey(123)).toThrow(ExternalKeyValidationError);
+    expect(() => normalizeExternalKey({})).toThrow(ExternalKeyValidationError);
+    expect(() => normalizeExternalKey([])).toThrow(ExternalKeyValidationError);
+  });
+
+  it(`rejects strings longer than ${EXTERNAL_KEY_MAX_LENGTH} chars`, () => {
+    const tooLong = "a".repeat(EXTERNAL_KEY_MAX_LENGTH + 1);
+    expect(() => normalizeExternalKey(tooLong)).toThrow(
+      ExternalKeyValidationError,
+    );
+  });
+
+  it(`accepts strings exactly ${EXTERNAL_KEY_MAX_LENGTH} chars long`, () => {
+    const exact = "a".repeat(EXTERNAL_KEY_MAX_LENGTH);
+    expect(normalizeExternalKey(exact)).toBe(exact);
+  });
+
+  it("rejects values containing C0 control characters", () => {
+    expect(() =>
+      normalizeExternalKey(`acme${String.fromCharCode(0x01)}corp`),
+    ).toThrow(ExternalKeyValidationError);
+    expect(() => normalizeExternalKey("acme\ncorp")).toThrow(
+      ExternalKeyValidationError,
+    );
+    expect(() => normalizeExternalKey("acme\tcorp")).toThrow(
+      ExternalKeyValidationError,
+    );
+  });
+
+  it("rejects values containing DEL or C1 control characters", () => {
+    expect(() =>
+      normalizeExternalKey(`acme${String.fromCharCode(0x7f)}corp`),
+    ).toThrow(ExternalKeyValidationError);
+    expect(() =>
+      normalizeExternalKey(`acme${String.fromCharCode(0x9f)}corp`),
+    ).toThrow(ExternalKeyValidationError);
+  });
+
+  it("allows non-ASCII printable characters (e.g. Hangul, accents)", () => {
+    expect(normalizeExternalKey("회사-001")).toBe("회사-001");
+    expect(normalizeExternalKey("café-Ω-42")).toBe("café-Ω-42");
+  });
+});
+
+describe("isPgUniqueViolation", () => {
+  it("matches errors with code 23505", () => {
+    expect(isPgUniqueViolation({ code: "23505" })).toBe(true);
+  });
+
+  it("rejects other shapes", () => {
+    expect(isPgUniqueViolation(null)).toBe(false);
+    expect(isPgUniqueViolation(undefined)).toBe(false);
+    expect(isPgUniqueViolation({ code: "23502" })).toBe(false);
+    expect(isPgUniqueViolation(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("isExternalKeyUniqueViolation", () => {
+  it("matches the customers_external_key_key constraint", () => {
+    expect(
+      isExternalKeyUniqueViolation({
+        code: "23505",
+        constraint: "customers_external_key_key",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match other unique violations", () => {
+    expect(
+      isExternalKeyUniqueViolation({
+        code: "23505",
+        constraint: "customers_database_name_key",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match non-unique errors", () => {
+    expect(
+      isExternalKeyUniqueViolation({
+        code: "23502",
+        constraint: "customers_external_key_key",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/app/api/customers/[id]/route.ts
+++ b/src/app/api/customers/[id]/route.ts
@@ -6,6 +6,11 @@ import { auditLog } from "@/lib/audit/logger";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { hasPermission } from "@/lib/auth/permissions";
+import {
+  ExternalKeyValidationError,
+  isExternalKeyUniqueViolation,
+  normalizeExternalKey,
+} from "@/lib/customers/external-key";
 import { query } from "@/lib/db/client";
 import { dropCustomerDb } from "@/lib/db/migrate";
 
@@ -15,6 +20,7 @@ interface CustomerRow {
   id: number;
   name: string;
   description: string | null;
+  external_key: string | null;
   database_name: string;
   status: string;
   created_at: string;
@@ -79,9 +85,16 @@ export const GET = withAuth(
 /**
  * PATCH /api/customers/[id]
  *
- * Update a customer's name and/or description.
+ * Update a customer's name, description, and/or external_key.
  *
- * Body: `{ name?: string, description?: string }`
+ * Body: `{ name?: string, description?: string, external_key?: string | null }`
+ *
+ * `external_key` semantics (#438):
+ *   - omitted from body → no change
+ *   - explicit `null` / empty / whitespace-only → cleared to NULL
+ *   - non-empty string → trimmed, validated (≤256 chars, no control chars)
+ *
+ * UNIQUE conflicts on `external_key` produce a 409.
  *
  * Requires `customers:write` permission.
  */
@@ -99,11 +112,20 @@ export const PATCH = withAuth(
     // Parse body
     let name: string | undefined;
     let description: string | undefined;
+    // `undefined` means "field omitted, do not change".
+    let externalKey: string | null | undefined;
     try {
       const body = await request.json();
       name = body.name;
       description = body.description;
-    } catch {
+      externalKey = normalizeExternalKey(body.external_key);
+    } catch (err) {
+      if (err instanceof ExternalKeyValidationError) {
+        return NextResponse.json(
+          { error: err.message, field: "external_key" },
+          { status: 400 },
+        );
+      }
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
@@ -152,28 +174,73 @@ export const PATCH = withAuth(
     const params: unknown[] = [];
     let idx = 1;
 
-    if (name !== undefined) {
+    const previousRow = existing[0];
+    const trimmedName = name?.trim();
+    const trimmedDescription =
+      description === undefined ? undefined : description?.trim() || null;
+
+    const changedFields: string[] = [];
+    const previous: Record<string, unknown> = {};
+    const next: Record<string, unknown> = {};
+
+    if (trimmedName !== undefined && trimmedName !== previousRow.name) {
       updates.push(`name = $${idx++}`);
-      params.push(name.trim());
+      params.push(trimmedName);
+      changedFields.push("name");
+      previous.name = previousRow.name;
+      next.name = trimmedName;
     }
-    if (description !== undefined) {
+    if (
+      trimmedDescription !== undefined &&
+      trimmedDescription !== previousRow.description
+    ) {
       updates.push(`description = $${idx++}`);
-      params.push(description?.trim() || null);
+      params.push(trimmedDescription);
+      changedFields.push("description");
+      previous.description = previousRow.description;
+      next.description = trimmedDescription;
+    }
+    // external_key: only include in the SET / changedFields when the
+    // effective value actually changes (covers NULL→NULL no-op, e.g.
+    // an empty input on a row that's already NULL).
+    if (externalKey !== undefined && externalKey !== previousRow.external_key) {
+      updates.push(`external_key = $${idx++}`);
+      params.push(externalKey);
+      changedFields.push("external_key");
+      previous.external_key = previousRow.external_key;
+      next.external_key = externalKey;
     }
 
     if (updates.length === 0) {
-      return NextResponse.json({ data: existing[0] });
+      return NextResponse.json({ data: previousRow });
     }
 
     updates.push(`updated_at = NOW()`);
     params.push(customerId);
 
-    const { rows } = await query<CustomerRow>(
-      `UPDATE customers SET ${updates.join(", ")} WHERE id = $${idx} RETURNING *`,
-      params,
-    );
+    let updatedRow: CustomerRow;
+    try {
+      const { rows } = await query<CustomerRow>(
+        `UPDATE customers SET ${updates.join(", ")} WHERE id = $${idx} RETURNING *`,
+        params,
+      );
+      updatedRow = rows[0];
+    } catch (err) {
+      if (isExternalKeyUniqueViolation(err)) {
+        return NextResponse.json(
+          {
+            error: "external_key is already in use by another customer",
+            field: "external_key",
+            code: "external_key_conflict",
+          },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
 
-    // Audit
+    // Audit (aligns with aimer-web #196 `changedFields` detail shape;
+    // we keep the existing `customer.update` action — see #438).
     await auditLog.record({
       actor: session.accountId,
       action: "customer.update",
@@ -185,14 +252,15 @@ export const PATCH = withAuth(
       // surfaces the row to the tenant operator who owns this customer.
       customerId,
       details: {
-        ...(name !== undefined && { name: name.trim() }),
-        ...(description !== undefined && {
-          description: description?.trim() || null,
-        }),
+        changedFields,
+        previous,
+        next,
+        customerId,
+        customerName: updatedRow.name,
       },
     });
 
-    return NextResponse.json({ data: rows[0] });
+    return NextResponse.json({ data: updatedRow });
   },
   { requiredPermissions: ["customers:write"] },
 );

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -8,6 +8,11 @@ import { auditLog } from "@/lib/audit/logger";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { hasPermission } from "@/lib/auth/permissions";
+import {
+  ExternalKeyValidationError,
+  isExternalKeyUniqueViolation,
+  normalizeExternalKey,
+} from "@/lib/customers/external-key";
 import { query } from "@/lib/db/client";
 import { provisionCustomerDb } from "@/lib/db/migrate";
 
@@ -17,6 +22,7 @@ interface CustomerRow {
   id: number;
   name: string;
   description: string | null;
+  external_key: string | null;
   database_name: string;
   status: string;
   created_at: string;
@@ -83,7 +89,7 @@ export const GET = withAuth(
  *
  * Create a new customer and provision its database.
  *
- * Body: `{ name: string, description?: string }`
+ * Body: `{ name: string, description?: string, external_key?: string | null }`
  *
  * Flow:
  *  1. Insert row with `status = 'provisioning'`
@@ -99,6 +105,7 @@ export const POST = withAuth(
     // Step 1: Parse body
     let name: string;
     let description: string | undefined;
+    let externalKey: string | null;
     try {
       const body = await request.json();
       name = body.name;
@@ -110,19 +117,42 @@ export const POST = withAuth(
         );
       }
       name = name.trim();
-    } catch {
+      // omitted / null / empty / whitespace → NULL on create
+      externalKey = normalizeExternalKey(body.external_key) ?? null;
+    } catch (err) {
+      if (err instanceof ExternalKeyValidationError) {
+        return NextResponse.json(
+          { error: err.message, field: "external_key" },
+          { status: 400 },
+        );
+      }
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
     // Step 2: Insert as provisioning
     const databaseName = generateDatabaseName(name);
-    const { rows } = await query<CustomerRow>(
-      `INSERT INTO customers (name, description, database_name, status)
-       VALUES ($1, $2, $3, 'provisioning')
-       RETURNING *`,
-      [name, description?.trim() || null, databaseName],
-    );
-    const customer = rows[0];
+    let customer: CustomerRow;
+    try {
+      const { rows } = await query<CustomerRow>(
+        `INSERT INTO customers (name, description, external_key, database_name, status)
+         VALUES ($1, $2, $3, $4, 'provisioning')
+         RETURNING *`,
+        [name, description?.trim() || null, externalKey, databaseName],
+      );
+      customer = rows[0];
+    } catch (err) {
+      if (isExternalKeyUniqueViolation(err)) {
+        return NextResponse.json(
+          {
+            error: "external_key is already in use by another customer",
+            field: "external_key",
+            code: "external_key_conflict",
+          },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
 
     // Step 3: Provision the database
     try {
@@ -154,7 +184,11 @@ export const POST = withAuth(
       // surfaces this create to a tenant operator after the matching
       // `account_customer` link is added.
       customerId: customer.id,
-      details: { name, databaseName },
+      details: {
+        name,
+        databaseName,
+        ...(externalKey !== null && { externalKey }),
+      },
     });
 
     return NextResponse.json({ data: activeRows[0] }, { status: 201 });

--- a/src/components/customers/customer-form-dialog.tsx
+++ b/src/components/customers/customer-form-dialog.tsx
@@ -3,6 +3,16 @@
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { readCsrfToken } from "@/components/session/session-extension-dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -21,6 +31,7 @@ interface Customer {
   id: number;
   name: string;
   description: string | null;
+  external_key: string | null;
 }
 
 interface CustomerFormDialogProps {
@@ -28,6 +39,23 @@ interface CustomerFormDialogProps {
   onOpenChange: (open: boolean) => void;
   customer?: Customer;
   onSuccess: () => void;
+}
+
+// Variants for the effect-warning modal triggered when an edit changes
+// the effective `external_key` value (#438).
+type ExternalKeyChangeVariant = "set" | "clear";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Normalize an `external_key` form input to the value that would
+ * actually be stored after server-side normalization. Mirrors
+ * `src/lib/customers/external-key.ts` rules: trim, then empty becomes
+ * NULL.
+ */
+function normalizeExternalKeyInput(raw: string): string | null {
+  const trimmed = raw.trim();
+  return trimmed.length === 0 ? null : trimmed;
 }
 
 // ── Component ───────────────────────────────────────────────────
@@ -43,13 +71,13 @@ export function CustomerFormDialog({
 
   const [name, setName] = useState(customer?.name ?? "");
   const [description, setDescription] = useState(customer?.description ?? "");
+  const [externalKey, setExternalKey] = useState(customer?.external_key ?? "");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingWarning, setPendingWarning] =
+    useState<ExternalKeyChangeVariant | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!name.trim()) return;
-
+  const submit = async () => {
     setSubmitting(true);
     setError(null);
 
@@ -65,18 +93,32 @@ export function CustomerFormDialog({
       const url = isEdit ? `/api/customers/${customer.id}` : "/api/customers";
       const method = isEdit ? "PATCH" : "POST";
 
+      // For external_key we send `null` to clear, the trimmed string
+      // when set, or omit the field when it was untouched on edit.
+      const normalizedExternalKey = normalizeExternalKeyInput(externalKey);
+      const externalKeyChanged =
+        !isEdit || normalizedExternalKey !== (customer?.external_key ?? null);
+
+      const body: Record<string, unknown> = {
+        name: name.trim(),
+        description: description.trim() || undefined,
+      };
+      if (externalKeyChanged) {
+        body.external_key = normalizedExternalKey;
+      }
+
       const res = await fetch(url, {
         method,
         headers,
-        body: JSON.stringify({
-          name: name.trim(),
-          description: description.trim() || undefined,
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) {
-        const body = await res.json();
-        throw new Error(body.error ?? t("error"));
+        const responseBody = await res.json();
+        if (res.status === 409 && responseBody.field === "external_key") {
+          throw new Error(t("externalKeyConflict"));
+        }
+        throw new Error(responseBody.error ?? t("error"));
       }
 
       onOpenChange(false);
@@ -85,59 +127,158 @@ export function CustomerFormDialog({
       setError(err instanceof Error ? err.message : t("error"));
     } finally {
       setSubmitting(false);
+      setPendingWarning(null);
     }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    // Determine whether the effective `external_key` is changing on
+    // edit. The warning fires for any change to the effective value:
+    //   - NULL → value (set)
+    //   - value → different value (change)
+    //   - non-NULL → NULL (clear)
+    // A no-op (NULL → NULL via empty input on an already-NULL row)
+    // does not trigger the warning.
+    if (isEdit) {
+      const previous = customer?.external_key ?? null;
+      const next = normalizeExternalKeyInput(externalKey);
+      if (next !== previous) {
+        setPendingWarning(next === null ? "clear" : "set");
+        return;
+      }
+    }
+
+    void submit();
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setName(customer?.name ?? "");
       setDescription(customer?.description ?? "");
+      setExternalKey(customer?.external_key ?? "");
       setError(null);
+      setPendingWarning(null);
     }
     onOpenChange(nextOpen);
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{isEdit ? t("edit") : t("create")}</DialogTitle>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{isEdit ? t("edit") : t("create")}</DialogTitle>
+          </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="customer-name">{t("name")}</Label>
-            <Input
-              id="customer-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-            />
-          </div>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="customer-name">{t("name")}</Label>
+              <Input
+                id="customer-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="customer-description">{t("description")}</Label>
-            <Input
-              id="customer-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </div>
+            <div className="space-y-2">
+              <Label htmlFor="customer-description">{t("description")}</Label>
+              <Input
+                id="customer-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </div>
 
-          {error && <p className="text-destructive text-sm">{error}</p>}
+            <div className="space-y-2">
+              <Label htmlFor="customer-external-key">{t("externalKey")}</Label>
+              <Input
+                id="customer-external-key"
+                value={externalKey}
+                onChange={(e) => setExternalKey(e.target.value)}
+                placeholder={t("externalKeyPlaceholder")}
+                maxLength={256}
+                aria-describedby="customer-external-key-help"
+              />
+              <p
+                id="customer-external-key-help"
+                className="text-muted-foreground text-xs leading-relaxed"
+              >
+                {t("externalKeyHelp")}{" "}
+                <a
+                  href={t("externalKeyHelpLinkUrl")}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="underline"
+                >
+                  {t("externalKeyHelpLink")}
+                </a>
+              </p>
+            </div>
 
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button type="button" variant="outline" disabled={submitting}>
-                {t("cancel")}
+            {error && <p className="text-destructive text-sm">{error}</p>}
+
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline" disabled={submitting}>
+                  {t("cancel")}
+                </Button>
+              </DialogClose>
+              <Button type="submit" disabled={submitting || !name.trim()}>
+                {submitting ? t("loading") : isEdit ? t("edit") : t("create")}
               </Button>
-            </DialogClose>
-            <Button type="submit" disabled={submitting || !name.trim()}>
-              {submitting ? t("loading") : isEdit ? t("edit") : t("create")}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={pendingWarning !== null}
+        // Non-dismissable: the modal is consumed only via Cancel or
+        // Continue, never by an outside click or escape press (#438).
+        // Radix AlertDialog already blocks pointer-down-outside; we
+        // additionally swallow Escape so the operator can't dismiss
+        // the warning without an explicit choice.
+        onOpenChange={() => {}}
+      >
+        <AlertDialogContent
+          onEscapeKeyDown={(event: KeyboardEvent) => {
+            event.preventDefault();
+          }}
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingWarning === "clear"
+                ? t("externalKeyClearTitle")
+                : t("externalKeyChangeTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingWarning === "clear"
+                ? t("externalKeyClearBody")
+                : t("externalKeyChangeBody")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={() => setPendingWarning(null)}
+              disabled={submitting}
+            >
+              {t("cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                void submit();
+              }}
+              disabled={submitting}
+            >
+              {t("confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/components/customers/customer-form-dialog.tsx
+++ b/src/components/customers/customer-form-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { readCsrfToken } from "@/components/session/session-extension-dialog";
 import {
   AlertDialog,
@@ -76,6 +76,21 @@ export function CustomerFormDialog({
   const [error, setError] = useState<string | null>(null);
   const [pendingWarning, setPendingWarning] =
     useState<ExternalKeyChangeVariant | null>(null);
+
+  // Resync form state from the current `customer` prop whenever the
+  // dialog opens. The component is mounted once by the parent table and
+  // reused across opens, so without this effect the initial `useState`
+  // values from the very first render would persist (e.g. an empty
+  // `name` after the first edit), leaving the submit button disabled.
+  useEffect(() => {
+    if (open) {
+      setName(customer?.name ?? "");
+      setDescription(customer?.description ?? "");
+      setExternalKey(customer?.external_key ?? "");
+      setError(null);
+      setPendingWarning(null);
+    }
+  }, [open, customer]);
 
   const submit = async () => {
     setSubmitting(true);

--- a/src/components/customers/customer-table.tsx
+++ b/src/components/customers/customer-table.tsx
@@ -46,6 +46,7 @@ interface Customer {
   id: number;
   name: string;
   description: string | null;
+  external_key: string | null;
   database_name: string;
   status: string;
   created_at: string;
@@ -209,6 +210,7 @@ export function CustomerTable() {
                   </button>
                 </TableHead>
                 <TableHead>{t("description")}</TableHead>
+                <TableHead>{t("externalKey")}</TableHead>
                 <TableHead className="w-[40px]" />
               </TableRow>
             </TableHeader>
@@ -224,6 +226,9 @@ export function CustomerTable() {
                   <TableCell className="font-medium">{customer.name}</TableCell>
                   <TableCell className="text-muted-foreground text-sm">
                     {customer.description ?? "-"}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground font-mono text-xs">
+                    {customer.external_key ?? "-"}
                   </TableCell>
                   <TableCell>
                     <DropdownMenu>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -641,6 +641,11 @@
     "name": "Name",
     "description": "Description",
     "databaseName": "Database Name",
+    "externalKey": "External Key",
+    "externalKeyPlaceholder": "e.g. acmecorp.com",
+    "externalKeyHelp": "Enter a globally unique business identifier pre-agreed with the aimer-web System Administrator. Recommended: a domain (e.g. acmecorp.com), business registration number, or contract code. The agreement must be made over an out-of-band secure channel (in-house SSO messenger, in person, etc.). An incorrect value will be rejected on the first bridge attempt with bridge_customer_mismatch. After entering, ask the operator to run a single bridge test to verify the mapping. Read more:",
+    "externalKeyHelpLink": "Operations guide",
+    "externalKeyHelpLinkUrl": "https://github.com/aicers/aimer-web/blob/main/docs/operations/cross-system-customer-identification.md",
     "status": "Status",
     "active": "Active",
     "provisioning": "Provisioning",
@@ -649,6 +654,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "cancel": "Cancel",
+    "confirm": "Continue",
     "deleteConfirm": "Are you sure you want to delete this customer? This will permanently remove the customer database.",
     "deleteLinked": "Cannot delete customer with active account assignments.",
     "noResults": "No customers found.",
@@ -656,7 +662,12 @@
     "error": "Failed to load customers",
     "created": "Customer created successfully",
     "updated": "Customer updated successfully",
-    "deleted": "Customer deleted successfully"
+    "deleted": "Customer deleted successfully",
+    "externalKeyConflict": "external_key is already in use by another customer.",
+    "externalKeyChangeTitle": "Confirm external_key change",
+    "externalKeyChangeBody": "external_key is the customer mapping identifier with aimer-web. After this change, aimer-web's matching customer must also be updated to keep the mapping intact. A bridge test is recommended right after. Continue?",
+    "externalKeyClearTitle": "Confirm external_key clear",
+    "externalKeyClearBody": "Clearing this customer's external_key disables Send to Aimer for this customer until it is set again, and any existing mapping with aimer-web's matching customer is no longer reachable from this side. Continue?"
   },
   "multitenancy": {
     "scope": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -641,6 +641,11 @@
     "name": "이름",
     "description": "설명",
     "databaseName": "데이터베이스 이름",
+    "externalKey": "외부 키",
+    "externalKeyPlaceholder": "예: acmecorp.com",
+    "externalKeyHelp": "Aimer-web System Administrator와 사전 합의된 globally unique한 비즈니스 식별자를 입력하세요. 권장: 도메인(acmecorp.com), 사업자등록번호, 또는 계약 코드. 합의는 out-of-band secure channel(사내 SSO 메신저, 직접 대면 등)로 이루어져야 합니다. 잘못된 값은 첫 bridge 시도에서 bridge_customer_mismatch로 거부됩니다. 입력 후 운영자에게 한 번 bridge 테스트로 매핑 검증을 권장합니다. 자세한 내용:",
+    "externalKeyHelpLink": "운영 가이드",
+    "externalKeyHelpLinkUrl": "https://github.com/aicers/aimer-web/blob/main/docs/operations/cross-system-customer-identification.md",
     "status": "상태",
     "active": "활성",
     "provisioning": "프로비저닝",
@@ -649,6 +654,7 @@
     "edit": "수정",
     "delete": "삭제",
     "cancel": "취소",
+    "confirm": "계속",
     "deleteConfirm": "이 고객을 삭제하시겠습니까? 고객 데이터베이스가 영구적으로 삭제됩니다.",
     "deleteLinked": "활성 계정이 할당된 고객은 삭제할 수 없습니다.",
     "noResults": "고객이 없습니다.",
@@ -656,7 +662,12 @@
     "error": "고객 목록을 불러오지 못했습니다",
     "created": "고객이 생성되었습니다",
     "updated": "고객이 수정되었습니다",
-    "deleted": "고객이 삭제되었습니다"
+    "deleted": "고객이 삭제되었습니다",
+    "externalKeyConflict": "external_key가 다른 고객에 의해 이미 사용 중입니다.",
+    "externalKeyChangeTitle": "external_key 변경 확인",
+    "externalKeyChangeBody": "external_key는 aimer-web과의 고객 매핑 식별자입니다. 이 변경 후에는 매핑을 유지하기 위해 aimer-web 측의 일치하는 고객 정보도 함께 업데이트해야 합니다. 직후에 bridge 테스트를 권장합니다. 계속하시겠습니까?",
+    "externalKeyClearTitle": "external_key 해제 확인",
+    "externalKeyClearBody": "이 고객의 external_key를 해제하면 다시 설정할 때까지 이 고객에 대한 Send to Aimer가 비활성화되며, aimer-web 측의 일치하는 고객과의 기존 매핑도 이 측에서는 더 이상 도달할 수 없습니다. 계속하시겠습니까?"
   },
   "multitenancy": {
     "scope": {

--- a/src/lib/customers/external-key.ts
+++ b/src/lib/customers/external-key.ts
@@ -1,0 +1,84 @@
+/**
+ * Validation and normalization for `customers.external_key` (#438).
+ *
+ * `external_key` is the cross-system bridge identifier paired with the
+ * matching customer on aimer-web. The value is operator-supplied,
+ * globally unique (DB-enforced), and may be NULL while a customer is
+ * not yet onboarded for Send to Aimer.
+ *
+ * Input rules (see #438 scope):
+ *   - omitted / `null` / empty / whitespace-only → stored as NULL.
+ *     Empty/whitespace is treated as "operator chose not to set it"
+ *     so the UI can clear the field by submitting an empty input.
+ *   - non-empty string → `trim()`, max 256 chars, no control chars.
+ *   - UNIQUE conflict from the DB is surfaced separately as a 409.
+ */
+
+export class ExternalKeyValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExternalKeyValidationError";
+  }
+}
+
+export const EXTERNAL_KEY_MAX_LENGTH = 256;
+
+// Matches C0 + DEL + C1 control characters. We reject these so the
+// stored value remains safe to render in operator UIs and embed in the
+// context-token claim that aimer-web reads (see #439).
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching control chars is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f-\x9f]/;
+
+/**
+ * Normalize a raw `external_key` field from a request body.
+ *
+ * Returns one of:
+ *   - `undefined` — key was omitted from the body (caller decides whether
+ *     that means "no change" or "store NULL").
+ *   - `null` — explicit clear (`null`, empty, or whitespace-only).
+ *   - `string` — trimmed, validated, ready to persist.
+ *
+ * Throws {@link ExternalKeyValidationError} for malformed inputs
+ * (wrong type, too long, control characters).
+ */
+export function normalizeExternalKey(raw: unknown): string | null | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+  if (typeof raw !== "string") {
+    throw new ExternalKeyValidationError("external_key must be a string");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length > EXTERNAL_KEY_MAX_LENGTH) {
+    throw new ExternalKeyValidationError(
+      `external_key must be at most ${EXTERNAL_KEY_MAX_LENGTH} characters`,
+    );
+  }
+  if (CONTROL_CHARS.test(trimmed)) {
+    throw new ExternalKeyValidationError(
+      "external_key must not contain control characters",
+    );
+  }
+  return trimmed;
+}
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+export function isPgUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+/**
+ * True when a Postgres unique-violation came from the
+ * `customers.external_key` UNIQUE constraint (rather than e.g.
+ * `database_name`). pg surfaces the constraint name on the error.
+ */
+export function isExternalKeyUniqueViolation(err: unknown): boolean {
+  if (!isPgUniqueViolation(err)) return false;
+  const constraint = (err as { constraint?: unknown }).constraint;
+  return constraint === "customers_external_key_key";
+}


### PR DESCRIPTION
## Summary

- Adds `external_key TEXT UNIQUE NULL` to `customers` (migration 0028) so an aice-web-next customer can be paired with the matching customer on aimer-web. NULL-allowed for the first rollout cycle.
- Extends the existing customer create / edit dialog with an `External Key` input and EN/KO inline help that links to aimer-web's canonical operations guide. List view renders the value in a monospace cell.
- `POST /api/customers` and `PATCH /api/customers/[id]` accept an optional `external_key`. Trim → empty/whitespace/omitted/null = NULL. Non-empty values are capped at 256 chars, reject control characters (typed 400), and surface UNIQUE conflicts as 409 (`code: "external_key_conflict"`). All customer-shaped responses (list / item / create / update) now include `external_key`.
- PATCH audit `details` switches to the `changedFields` / `previous` / `next` shape aligned with aimer-web #196, on the existing `customer.update` action (no closed-union change in `src/lib/audit/schema.ts`).
- Edits that change the effective value open a non-dismissable AlertDialog with two copy variants: *set / change* and *clear* (Escape and outside-click blocked). No-op submissions (empty input on an already-NULL row) skip the warning.
- Manual pages get an `External Key` subsection in EN and KO with `<!-- TODO: screenshot - aimer-bridge batch -->` placeholders per the aimer-bridge batch capture plan.

Closes #438

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass locally.
- [x] Migration 0028 applies cleanly on a fresh and an upgraded auth DB; pre-existing rows have `external_key = NULL`.
- [x] DB UNIQUE: a second insert of the same non-NULL `external_key` fails with 409 (`external_key_conflict`); two rows with `external_key = NULL` coexist.
- [x] `normalizeExternalKey` unit cases: `undefined → undefined`, `null → null`, empty / whitespace → `null`, `>256` chars → 400, control characters → 400, normal value trimmed and returned.
- [x] `GET /api/customers`, `GET /api/customers/[id]`, `POST /api/customers`, `PATCH /api/customers/[id]` return `external_key` (`string | null`) on the customer object.
- [x] e2e: System Administrator creates a customer **without** `external_key` → row saved with `-` in the External Key cell; row remains editable; Send to Aimer is disabled (gate from #440 — verify when that lands).
- [x] e2e: System Administrator creates a customer **with** an `external_key` → value persists, list cell shows the value, row editable.
- [x] e2e: editing `external_key` to a different non-NULL value triggers the *set / change* warning; Escape does not dismiss; Continue persists the change; Cancel reverts.
- [x] e2e: clearing `external_key` (`non-NULL → NULL`) triggers the *clear* warning; Continue persists the row as NULL.
- [x] e2e: a name-only edit and a no-op empty-input edit on an already-NULL row do **not** trigger the warning.
- [x] Audit: a successful `external_key` change emits `customer.update` with `details.changedFields = ["external_key"]`, `details.previous.external_key`, `details.next.external_key`, plus `customerId` and `customerName`. A name-only edit emits `changedFields: ["name"]` with no `external_key` keys in `previous` / `next`.
- [x] No new closed-union member in `src/lib/audit/schema.ts`; taxonomy-completeness tests still pass.
