### PR TITLE
Use 9443:443 for nginx-prod default port mapping (#449)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,8 +66,11 @@ JWT_EXPIRATION_MINUTES=15
 # guard would reject every POST/PUT/PATCH/DELETE.
 #
 # Canonicalized at parse time: trailing slash stripped; scheme
-# and host lowercased. Set to the public HTTPS origin.
-# EXPECTED_ORIGIN=https://app.example.com
+# and host lowercased. Set to the public HTTPS origin. The
+# default `nginx-prod` host-port mapping is `9443:443`, so a
+# fresh prod-profile install on the host itself should use
+# `https://localhost:9443`.
+# EXPECTED_ORIGIN=https://localhost:9443
 
 # ── WebAuthn relying-party identity ─────────────────────────────
 # WEBAUTHN_RP_ID is the eTLD+1-aligned domain the authenticator
@@ -79,9 +82,9 @@ JWT_EXPIRATION_MINUTES=15
 # guard and the WebAuthn ceremony — and they take *different*
 # value shapes, so do not copy one into the other:
 #
-#   EXPECTED_ORIGIN=https://app.example.com
-#   WEBAUTHN_RP_ORIGIN=https://app.example.com   # full origin
-#   WEBAUTHN_RP_ID=app.example.com               # host only
+#   EXPECTED_ORIGIN=https://localhost:9443
+#   WEBAUTHN_RP_ORIGIN=https://localhost:9443    # full origin
+#   WEBAUTHN_RP_ID=localhost                     # host only
 #
 # WEBAUTHN_RP_ID is read verbatim by the WebAuthn server
 # (src/lib/auth/webauthn.ts); setting it to a URL such as

--- a/README.md
+++ b/README.md
@@ -281,16 +281,33 @@ the `decisions/` directory for detailed design records.
 ## HTTPS
 
 Production deployments must be served over HTTPS. The nginx reverse
-proxy handles TLS termination and redirects all HTTP traffic to HTTPS.
+proxy handles TLS termination; the prod profile only publishes the
+HTTPS listener on the host (see "Production" below).
 
 ### Production
 
 The production nginx config (`infra/nginx/nginx.prod.conf`) enables:
 
-- HTTP → HTTPS redirect (port 80 → 443)
 - HSTS with a 1-year `max-age` and `includeSubDomains`
 - Security headers: `X-Frame-Options`, `X-Content-Type-Options`,
   `Referrer-Policy`
+
+The `nginx-prod` compose service publishes the container's TLS
+listener (`:443`) on host port `9443` by default — i.e. the app is
+reachable at `https://<host>:9443`. The non-standard port leaves
+host `:443` free for an internet-facing peer (e.g. `aimer-web` in
+the bridge handoff) on the same machine and avoids collisions on
+host OSes that already bind `:80`. Operators who want the standard
+`:443` (or to publish `:80` for an HTTP→HTTPS redirect handled by
+the container's internal `listen 80` block) can re-publish via a
+local `docker-compose.override.yml`. Note that the internal redirect
+emits `https://$host$request_uri`, so reopening host `:80` without
+also publishing host `:443` will land the redirect on a closed port.
+
+**Migration note.** This default changed from `80:80, 443:443` to
+`9443:443`. Operators relying on the previous default need to
+update bookmarks and any reverse-proxy upstream from `:443` to
+`:9443`, or pin the old mapping in their override.
 
 `Content-Security-Policy-Report-Only` is emitted by the Next.js app
 (per-request nonce — nginx leaves the header untouched). Enforcement

--- a/README.md
+++ b/README.md
@@ -410,14 +410,21 @@ audit table.
    (e.g. `.env.local`) is the natural place to keep them.
 
    At minimum also set `CSRF_SECRET`, the GraphQL endpoints, and:
-   - `EXPECTED_ORIGIN=https://your.public.host` so the CSRF/Origin
-     guard accepts mutation requests through the HTTPS proxy. For
-     the prod profile, also set `WEBAUTHN_RP_ORIGIN` to the same
-     public HTTPS origin and `WEBAUTHN_RP_ID` to its host
+   - `EXPECTED_ORIGIN=https://your.public.host:9443` so the
+     CSRF/Origin guard accepts mutation requests through the HTTPS
+     proxy. The `:9443` suffix matches the default `nginx-prod`
+     host-port mapping (`9443:443`) — the browser sends the port in
+     the `Origin` header, and any mismatch with `EXPECTED_ORIGIN`
+     causes every state-changing request to be rejected. Drop the
+     port suffix only when an external reverse proxy terminates TLS
+     on standard `:443` (in which case the operator typically also
+     publishes nginx-prod on host `:443` via override). The prod
+     profile also needs `WEBAUTHN_RP_ORIGIN` set to that same full
+     origin and `WEBAUTHN_RP_ID` set to its host
      (e.g. `WEBAUTHN_RP_ID=your.public.host`,
-     `WEBAUTHN_RP_ORIGIN=https://your.public.host`). The two env
-     vars guard different code paths — the CSRF/Origin guard and
-     the WebAuthn ceremony — but share the same value in this
+     `WEBAUTHN_RP_ORIGIN=https://your.public.host:9443`). The two
+     env vars guard different code paths — the CSRF/Origin guard
+     and the WebAuthn ceremony — but share the same value in this
      deployment. Leaving `WEBAUTHN_RP_ORIGIN` at its dev fallback
      silently breaks MFA enrollment on the prod profile.
    - One of `JWT_SIGNING_KEY_FILE=<path>` (recommended — a Secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,7 @@ services:
     image: nginx:alpine
     profiles: [prod]
     ports:
-      - "80:80"
-      - "443:443"
+      - "9443:443"
     volumes:
       - ./infra/nginx/nginx.prod.conf:/etc/nginx/conf.d/default.conf:ro
       - ./infra/certs:/etc/nginx/certs:ro

--- a/infra/nginx/nginx.prod.conf
+++ b/infra/nginx/nginx.prod.conf
@@ -38,7 +38,15 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
 
-        proxy_set_header Host $host;
+        # Forward the original Host header verbatim (including the
+        # client-visible port) so Next.js sees the same authority the
+        # browser used. With the default `9443:443` host mapping the
+        # client sends `Host: localhost:9443`; using `$host` here would
+        # strip the port and Next would build `request.url` (and any
+        # absolute redirect derived from it — see `redirectToSignIn`
+        # in src/proxy.ts) against `https://localhost`, breaking the
+        # redirect chain. `$http_host` preserves the port.
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/src/__tests__/nginx-prod-config.test.ts
+++ b/src/__tests__/nginx-prod-config.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression coverage for the nginx-side half of the `9443:443` host
+// mapping change. The proxy.test.ts suite drives `NextRequest` directly
+// with an authority that already carries `:9443`, which exercises the
+// app's behavior but cannot fail when the prod nginx config is reverted
+// to `proxy_set_header Host $host` — the bug surfaces only because
+// `$host` strips the port nginx received from the browser. These tests
+// pin the directive at the config layer so that a future edit to
+// `infra/nginx/nginx.prod.conf` cannot silently re-introduce the
+// regression.
+const PROD_CONF_PATH = path.resolve(
+  __dirname,
+  "../../infra/nginx/nginx.prod.conf",
+);
+
+const prodConf = readFileSync(PROD_CONF_PATH, "utf8");
+
+describe("infra/nginx/nginx.prod.conf", () => {
+  it("forwards the original Host header verbatim with $http_host", () => {
+    // `$http_host` echoes whatever authority the browser sent (including
+    // the non-standard `:9443` port); `$host` would normalize it and
+    // strip the port, breaking absolute redirects derived from
+    // `request.url` (e.g. `redirectToSignIn` in src/proxy.ts).
+    expect(prodConf).toMatch(/proxy_set_header\s+Host\s+\$http_host\s*;/);
+  });
+
+  it("does not forward Host as $host (port-stripping variant)", () => {
+    expect(prodConf).not.toMatch(/proxy_set_header\s+Host\s+\$host\s*;/);
+  });
+});

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -88,6 +88,21 @@ describe("proxy", () => {
       // "en" is the default locale — redirect has no locale prefix
       expect(getRedirectPathname(response)).toBe("/sign-in");
     });
+
+    // Regression: with the default `nginx-prod` host mapping of
+    // `9443:443`, the browser sends `Host: localhost:9443`. Nginx
+    // must forward that authority verbatim (`proxy_set_header Host
+    // $http_host`) so Next builds `request.url` against it; otherwise
+    // the sign-in redirect lands on the unpublished `:443`.
+    it("preserves the inbound host:port authority on the sign-in redirect", async () => {
+      const request = new NextRequest("https://localhost:9443/audit-logs");
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      const location = new URL(response.headers.get("location") ?? "");
+      expect(location.origin).toBe("https://localhost:9443");
+      expect(location.pathname).toBe("/sign-in");
+    });
   });
 
   describe("protected routes — invalid JWT", () => {


### PR DESCRIPTION
## Summary

- Change `nginx-prod` host-port mapping from `80:80, 443:443` to `9443:443`. This frees host `:443` for an internet-facing peer (e.g. `aimer-web` in the bridge handoff) on the same machine, fixes the same-host collision in the integration-test plan (`bootroot` + `aice-web-next` + `aimer-web`), and avoids startup failures on host OSes that already bind `:80`.
- Drop the `:80` publish entirely. The product mandates HTTPS, so plain-HTTP exposure on the host has no use. The internal `listen 80` redirect in `infra/nginx/nginx.prod.conf` stays as a no-op for operators who republish `:80` via override.
- Switch the prod nginx upstream `Host` header from `$host` to `$http_host`. With a non-standard host port the browser sends `Host: localhost:9443`; `$host` strips the port, so Next would derive `request.url` against `https://localhost` and the sign-in redirect would land on the unpublished `:443`. Pinned this directive at the config layer with a new `nginx-prod-config.test.ts` (a `proxy.test.ts` case alone cannot fail when the nginx config regresses, since the test constructs `NextRequest` directly with `:9443`).
- Update `.env.example` so `EXPECTED_ORIGIN`, `WEBAUTHN_RP_ORIGIN`, and `WEBAUTHN_RP_ID` all agree with the new default (`https://localhost:9443` / `localhost`). Updating only `EXPECTED_ORIGIN` would leave WebAuthn/MFA broken on a fresh prod install.
- Update `README.md` HTTPS / Production section and first-boot deployment checklist to describe the new default, rationale, override path, and migration note. The checklist now shows `EXPECTED_ORIGIN=https://your.public.host:9443` (and the same for `WEBAUTHN_RP_ORIGIN`) for default compose deployments, with a note that the port suffix is dropped only when an external reverse proxy terminates TLS on standard `:443`. Dev-profile section is intentionally untouched (nginx-dev unchanged).

`8443` was considered first but is conventionally taken by `step-ca` and is occupied in this project's integration-test environment by the host-side `review` daemon's `graphql_srv_addr`. `9443` is the next conventional HTTPS-alt port.

## Migration note

Operators relying on the default need to update bookmarks and reverse-proxy upstreams from `:443` to `:9443`, or pin the old mapping via `docker-compose.override.yml`. Operators who already had a local override are unaffected.

Closes #449

## Test plan

- [x] `docker compose --profile prod up` with no `.env` overrides binds host `:9443` and does not bind host `:443` or `:80`.
- [x] `docker compose -f docker-compose.yml --profile prod config` shows `nginx-prod` with a single published port `9443 -> 443` and no `80` publish.
- [x] `https://localhost:9443/...` reaches the app; `https://localhost/...` does not.
- [x] An unauthenticated request to a protected route via `https://localhost:9443/...` redirects to `https://localhost:9443/sign-in` (port preserved through the nginx hop). Application-side coverage in `src/__tests__/proxy.test.ts`; the actual nginx-side regression — the directive choice in `infra/nginx/nginx.prod.conf` — is now pinned by the new `src/__tests__/nginx-prod-config.test.ts`, which fails if the directive is reverted to `\$host`.
- [x] Sign-in + WebAuthn/MFA happy paths pass with `EXPECTED_ORIGIN=https://localhost:9443` and `WEBAUTHN_RP_ORIGIN=https://localhost:9443`.
- [x] `nginx-dev` (dev profile) still serves on `https://localhost` — README dev-profile examples remain valid.
- [x] README / `docs/` examples that mention the prod URL show `:9443`; dev-profile examples still show `https://localhost`.