### PR TITLE
Add Triage permissions and seed migration (#454)

### DIFF
--- a/docs/en/settings.md
+++ b/docs/en/settings.md
@@ -153,6 +153,7 @@ resource:
 |-------|-------------|
 | Dashboard | `dashboard:read`, `dashboard:write` |
 | Detection | `detection:read` |
+| Triage | `triage:read`, `triage:policy:write`, `triage:exclusion:write`, `triage:exclusion:global:write` |
 | Accounts | `accounts:read`, `accounts:write`, `accounts:delete` |
 | Roles | `roles:read`, `roles:write`, `roles:delete` |
 | Customers | `customers:read`, `customers:write`, `customers:delete`, `customers:access-all` |

--- a/docs/ko/settings.md
+++ b/docs/ko/settings.md
@@ -149,6 +149,7 @@ rm "$DATA_DIR/.emergency_mfa_reset_consumed_<username>"
 |------|------|
 | 대시보드 | `dashboard:read`, `dashboard:write` |
 | 탐지 | `detection:read` |
+| 분류 | `triage:read`, `triage:policy:write`, `triage:exclusion:write`, `triage:exclusion:global:write` |
 | 계정 | `accounts:read`, `accounts:write`, `accounts:delete` |
 | 역할 | `roles:read`, `roles:write`, `roles:delete` |
 | 고객 | `customers:read`, `customers:write`, `customers:delete`, `customers:access-all` |

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { exportJWK, generateKeyPair } from "jose";
+import { VALID_PERMISSIONS } from "../src/lib/auth/permission-defs";
 import {
   readAllFixtureManifests,
   runAllFixturePreflights,
@@ -71,29 +72,9 @@ const MAX_WORKERS = 8;
 
 // All permissions — same as System Administrator, but with a different
 // role name so worker accounts don't count toward the System Admin limit.
-const ALL_PERMISSIONS = [
-  "accounts:read",
-  "accounts:write",
-  "accounts:delete",
-  "roles:read",
-  "roles:write",
-  "roles:delete",
-  "customers:read",
-  "customers:write",
-  "customers:delete",
-  "customers:access-all",
-  "audit-logs:read",
-  "system-settings:read",
-  "system-settings:write",
-  "dashboard:read",
-  "dashboard:write",
-  "detection:read",
-  "nodes:read",
-  "nodes:write",
-  "nodes:delete",
-  "services:read",
-  "services:write",
-];
+// Derived from VALID_PERMISSIONS so new permissions added to the shared
+// definition are automatically granted to E2E workers.
+const ALL_PERMISSIONS = [...VALID_PERMISSIONS];
 
 async function ensureWorkerAccounts(): Promise<void> {
   await createTestRole(WORKER_ROLE, ALL_PERMISSIONS, "E2E worker role");

--- a/e2e/roles.spec.ts
+++ b/e2e/roles.spec.ts
@@ -184,7 +184,7 @@ test.describe("Role management — UI", () => {
 
     const clonedRow = roleRow(page, `${TEST_PREFIX}ui-clone`);
     await expect(clonedRow).toBeVisible({ timeout: 15_000 });
-    await expect(clonedRow).toContainText("21");
+    await expect(clonedRow).toContainText("25");
   });
 
   test("built-in roles have no edit or delete buttons", async ({

--- a/migrations/auth/0030_triage_permissions.sql
+++ b/migrations/auth/0030_triage_permissions.sql
@@ -1,0 +1,49 @@
+-- Seed Triage permissions onto the three built-in roles per the design
+-- in discussion #447 §5 (Phase 1.A). Phase 1.A only enforces
+-- `triage:read` (it gates the menu); the three `triage:*:write`
+-- permissions are placeholders that 1B-2 / 1B-5 will start enforcing,
+-- but admins can pre-grant/revoke them now.
+--
+-- Each permission is its own INSERT to honor the deprecatability seam
+-- (§6 of #447): future deprecation of `triage:policy:write` removes
+-- exactly one row without disturbing the other three.
+--
+-- Idempotent: safe to re-run (#454).
+
+-- triage:read → System Administrator + Tenant Administrator + Security Monitor
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, 'triage:read'
+FROM roles r
+WHERE r.name IN (
+  'System Administrator',
+  'Tenant Administrator',
+  'Security Monitor'
+)
+ON CONFLICT DO NOTHING;
+
+-- triage:policy:write → System Administrator + Tenant Administrator
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, 'triage:policy:write'
+FROM roles r
+WHERE r.name IN (
+  'System Administrator',
+  'Tenant Administrator'
+)
+ON CONFLICT DO NOTHING;
+
+-- triage:exclusion:write → System Administrator + Tenant Administrator
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, 'triage:exclusion:write'
+FROM roles r
+WHERE r.name IN (
+  'System Administrator',
+  'Tenant Administrator'
+)
+ON CONFLICT DO NOTHING;
+
+-- triage:exclusion:global:write → System Administrator only
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, 'triage:exclusion:global:write'
+FROM roles r
+WHERE r.name = 'System Administrator'
+ON CONFLICT DO NOTHING;

--- a/src/__tests__/components/roles/role-form-dialog.test.tsx
+++ b/src/__tests__/components/roles/role-form-dialog.test.tsx
@@ -140,6 +140,34 @@ describe("RoleFormDialog rendering", () => {
     }
   });
 
+  it("renders the triage group and labels each triage permission by its full key (#454)", () => {
+    // Phase 1.A-4 introduces three triple-segment permissions
+    // (`triage:policy:write`, `triage:exclusion:write`,
+    // `triage:exclusion:global:write`) whose action segment alone
+    // (`policy` / `exclusion`) is not unique. The dialog therefore
+    // looks up `permissionLabels.<full-permission-key>` instead of the
+    // old action-only `permissionActions.<action>` lookup. A regression
+    // that reverted the lookup would collapse "Manage policies" /
+    // "Manage exclusions" / "Manage global exclusions" into a single
+    // ambiguous "Write" label and reintroduce duplicate-id collisions
+    // on the two `:exclusion:` permissions.
+    const html = renderToStaticMarkup(
+      <RoleFormDialog open onOpenChange={noop} onSuccess={noop} />,
+    );
+
+    expect(html).toContain("permissionGroups.triage");
+
+    for (const perm of [
+      "triage:read",
+      "triage:policy:write",
+      "triage:exclusion:write",
+      "triage:exclusion:global:write",
+    ]) {
+      expect(html).toContain(`id="perm-${perm}"`);
+      expect(html).toContain(`permissionLabels.${perm}`);
+    }
+  });
+
   it("seeds initial selected permissions from the edited role on the very first render", () => {
     const role = {
       id: 99,

--- a/src/__tests__/lib/auth/account-role-policy.test.ts
+++ b/src/__tests__/lib/auth/account-role-policy.test.ts
@@ -79,6 +79,43 @@ describe("account-role-policy", () => {
     expect(policy.maxCustomerAssignments).toBe(1);
   });
 
+  it("treats triage:read as Security Monitor-equivalent", () => {
+    // Migration 0030 (#454) seeds `triage:read` onto Security Monitor.
+    // Without this in the allow-list, Security Monitor accounts would
+    // silently lose `tenantManageable: true` after the migration runs
+    // and Tenant Administrators could no longer create or manage them.
+    const policy = deriveAccountRolePolicy({
+      id: 12,
+      name: "Security Monitor",
+      permissions: [
+        "audit-logs:read",
+        "dashboard:read",
+        "detection:read",
+        "nodes:read",
+        "services:read",
+        "triage:read",
+      ],
+    });
+
+    expect(policy.isSecurityMonitorEquivalent).toBe(true);
+    expect(policy.tenantManageable).toBe(true);
+    expect(policy.maxCustomerAssignments).toBe(1);
+  });
+
+  it("does not treat triage:policy:write as Security Monitor-equivalent", () => {
+    // The three `triage:*:write` permissions are placeholders in
+    // Phase 1.A but are intentionally NOT in the allow-list — granting
+    // any of them must disqualify the role from monitor equivalence.
+    const policy = deriveAccountRolePolicy({
+      id: 13,
+      name: "Custom Triage Editor",
+      permissions: ["triage:read", "triage:policy:write"],
+    });
+
+    expect(policy.isSecurityMonitorEquivalent).toBe(false);
+    expect(policy.tenantManageable).toBe(false);
+  });
+
   it("does not treat nodes:write as Security Monitor-equivalent", () => {
     const policy = deriveAccountRolePolicy({
       id: 10,

--- a/src/components/roles/role-form-dialog.tsx
+++ b/src/components/roles/role-form-dialog.tsx
@@ -290,8 +290,6 @@ export function RoleFormDialog({
                   <div className="flex flex-wrap gap-x-6 gap-y-2">
                     {perms.map((perm) => {
                       const checkboxId = `perm-${perm}`;
-                      // Extract action part: "accounts:read" → "read"
-                      const action = perm.split(":")[1];
                       return (
                         <div
                           key={perm}
@@ -303,7 +301,7 @@ export function RoleFormDialog({
                             onCheckedChange={() => form.togglePermission(perm)}
                           />
                           <label htmlFor={checkboxId}>
-                            {t(`permissionActions.${action}`)}
+                            {t(`permissionLabels.${perm}`)}
                           </label>
                         </div>
                       );

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1047,13 +1047,35 @@
       "detection": "Detection",
       "nodes": "Nodes",
       "services": "Services",
-      "system-settings": "System Settings"
+      "system-settings": "System Settings",
+      "triage": "Triage"
     },
-    "permissionActions": {
-      "read": "Read",
-      "write": "Write",
-      "delete": "Delete",
-      "access-all": "Access All"
+    "permissionLabels": {
+      "accounts:read": "Read",
+      "accounts:write": "Write",
+      "accounts:delete": "Delete",
+      "roles:read": "Read",
+      "roles:write": "Write",
+      "roles:delete": "Delete",
+      "customers:read": "Read",
+      "customers:write": "Write",
+      "customers:delete": "Delete",
+      "customers:access-all": "Access All",
+      "audit-logs:read": "Read",
+      "dashboard:read": "Read",
+      "dashboard:write": "Write",
+      "detection:read": "Read",
+      "nodes:read": "Read",
+      "nodes:write": "Write",
+      "nodes:delete": "Delete",
+      "services:read": "Read",
+      "services:write": "Write",
+      "system-settings:read": "Read",
+      "system-settings:write": "Write",
+      "triage:read": "Read",
+      "triage:policy:write": "Manage policies",
+      "triage:exclusion:write": "Manage exclusions",
+      "triage:exclusion:global:write": "Manage global exclusions"
     }
   },
   "dashboard": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1047,13 +1047,35 @@
       "detection": "탐지",
       "nodes": "노드",
       "services": "서비스",
-      "system-settings": "시스템 설정"
+      "system-settings": "시스템 설정",
+      "triage": "분류"
     },
-    "permissionActions": {
-      "read": "읽기",
-      "write": "쓰기",
-      "delete": "삭제",
-      "access-all": "전체 접근"
+    "permissionLabels": {
+      "accounts:read": "읽기",
+      "accounts:write": "쓰기",
+      "accounts:delete": "삭제",
+      "roles:read": "읽기",
+      "roles:write": "쓰기",
+      "roles:delete": "삭제",
+      "customers:read": "읽기",
+      "customers:write": "쓰기",
+      "customers:delete": "삭제",
+      "customers:access-all": "전체 접근",
+      "audit-logs:read": "읽기",
+      "dashboard:read": "읽기",
+      "dashboard:write": "쓰기",
+      "detection:read": "읽기",
+      "nodes:read": "읽기",
+      "nodes:write": "쓰기",
+      "nodes:delete": "삭제",
+      "services:read": "읽기",
+      "services:write": "쓰기",
+      "system-settings:read": "읽기",
+      "system-settings:write": "쓰기",
+      "triage:read": "읽기",
+      "triage:policy:write": "정책 관리",
+      "triage:exclusion:write": "제외 규칙 관리",
+      "triage:exclusion:global:write": "전역 제외 규칙 관리"
     }
   },
   "dashboard": {

--- a/src/lib/auth/account-role-policy.ts
+++ b/src/lib/auth/account-role-policy.ts
@@ -56,6 +56,7 @@ const SECURITY_MONITOR_EQUIVALENT_PERMISSIONS: ReadonlySet<string> = new Set([
   "detection:read",
   "nodes:read",
   "services:read",
+  "triage:read",
 ]);
 
 function hasNonMonitorPermission(permissions: string[]): boolean {

--- a/src/lib/auth/permission-defs.ts
+++ b/src/lib/auth/permission-defs.ts
@@ -22,6 +22,12 @@ export const ALL_PERMISSIONS = {
   nodes: ["nodes:read", "nodes:write", "nodes:delete"],
   services: ["services:read", "services:write"],
   "system-settings": ["system-settings:read", "system-settings:write"],
+  triage: [
+    "triage:read",
+    "triage:policy:write",
+    "triage:exclusion:write",
+    "triage:exclusion:global:write",
+  ],
 } as const;
 
 /** Flat set of all valid permission strings. */


### PR DESCRIPTION
## Summary

- Add the four Phase 1.A `triage:*` permissions to `ALL_PERMISSIONS`. `triage:read` gates the Triage menu; the three `:*:write` entries are placeholders that 1B-2 / 1B-5 will begin enforcing but admins can pre-grant/revoke today.
- Add migration `0030_triage_permissions.sql` that idempotently seeds the matrix from discussion #447 §5 onto the existing built-in roles by name (System Administrator, Tenant Administrator, Security Monitor). Each permission is its own `INSERT … ON CONFLICT DO NOTHING` to honor the deprecatability seam (§6), so a future removal of `triage:policy:write` is exactly one row.
- Add `triage:read` to `SECURITY_MONITOR_EQUIVALENT_PERMISSIONS` so Security Monitor accounts retain monitor-equivalence (and remain manageable by Tenant Administrators) once the migration lands. The three `triage:*:write` permissions are intentionally NOT added there.
- Replace the role-edit grid's `perm.split(":")[1]` → `permissionActions.<action>` lookup with `permissionLabels.<full-permission-key>`. The old scheme would collapse `triage:policy:write` / `triage:exclusion:write` / `triage:exclusion:global:write` into ambiguous duplicates and collide on `id="perm-..."`. EN/KR i18n updated for all existing permissions plus the new `triage` group and four labels.
- Update `docs/{en,ko}/settings.md` permission-matrix tables with the new Triage row.
- Derive the E2E worker role's permission list in `e2e/global-setup.ts` from `VALID_PERMISSIONS` instead of a hard-coded array, so newly added permissions (starting with `triage:*`) flow through to E2E coverage automatically.

Closes #454.

## Test plan

- [x] `ALL_PERMISSIONS.triage` lists all four new permissions and `VALID_PERMISSIONS` accepts them.
- [x] `SECURITY_MONITOR_EQUIVALENT_PERMISSIONS` contains `triage:read` only — not the three `:*:write` permissions.
- [x] `pnpm vitest run src/__tests__/lib/auth/account-role-policy.test.ts` — Security Monitor with `triage:read` stays monitor-equivalent and `tenantManageable`; a custom role granted `triage:policy:write` is NOT monitor-equivalent.
- [x] `pnpm vitest run src/__tests__/components/roles/role-form-dialog.test.tsx` — the role-edit dialog renders the `triage` group and labels each permission via `permissionLabels.<full-key>` (no duplicate `id="perm-..."`).
- [x] `pnpm biome check` and `pnpm tsc --noEmit` are clean for the changed files.
- [x] Apply migration `0030_triage_permissions.sql` against a freshly migrated DB; re-running it is a no-op. Verified against the dev `auth_db` at version 0029: first run inserted 3+2+2+1=8 rows matching the design matrix; second run inserted 0 rows (`INSERT 0 0` for each statement).
- [x] Open the role-edit dialog: the Triage group shows `Read`, `Manage policies`, `Manage exclusions`, `Manage global exclusions` (EN) and the KR equivalents (`읽기` / `정책 관리` / `제외 규칙 관리` / `전역 제외 규칙 관리`). Verified via `role-form-dialog.test.tsx` (asserts `permissionGroups.triage` + `permissionLabels.<full-key>` for each), the EN/KR i18n JSON, and the passing CI E2E `roles.spec.ts` suite that exercises the dialog.
- [x] Custom (non-built-in) roles created before the migration are unchanged afterward. Verified by inserting a `Custom Test Role` with `dashboard:read` + `detection:read` before applying 0030; after the migration its permission set was still exactly those two rows (the migration's `WHERE r.name IN (...)` filter excludes any role whose name is not one of the three built-ins).
- [x] E2E worker role grants every entry in `VALID_PERMISSIONS` (now including the four `triage:*` permissions) so Playwright fixtures running as the worker admin retain access once `triage:read` gates the Triage menu.