### PR TITLE
Add TriagePolicy storage and CRUD UI (#459)

### DIFF
--- a/migrations/customer/0002_triage_policy.sql
+++ b/migrations/customer/0002_triage_policy.sql
@@ -1,0 +1,29 @@
+-- Triage policy CRUD storage (1B-5 / discussion #447 §2.1).
+--
+-- Lives in the per-customer tenant DB so a single policy row never
+-- needs a `customer_id` column — the database itself is the scope.
+-- Rule lists are stored as JSONB; their structural validation is done
+-- at the application layer (see src/lib/triage/policy/validation.ts).
+--
+-- Per the deprecatability seam in §6 of #447, this migration owns the
+-- entire policy schema in one file. A future deprecation of the
+-- corpus-B / TriagePolicy feature drops the table and removes this
+-- file in one step, leaving the rest of the tenant schema untouched.
+
+-- `id` is INTEGER (not BIGINT) so node-postgres returns it as a JS
+-- number rather than a string — matches the `TriagePolicyRow.id:
+-- number` contract in src/lib/triage/policy/types.ts and lines up
+-- with the GraphQL `Int` path described in #447 §2.1 for the
+-- inline-policy id surface.
+CREATE TABLE IF NOT EXISTS triage_policy (
+  id           SERIAL PRIMARY KEY,
+  name         TEXT        NOT NULL,
+  packet_attr  JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  confidence   JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  response     JSONB       NOT NULL DEFAULT '[]'::jsonb,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS triage_policy_name_key
+  ON triage_policy (name);

--- a/src/__tests__/app/api/triage/policies/[id]/route.test.ts
+++ b/src/__tests__/app/api/triage/policies/[id]/route.test.ts
@@ -1,0 +1,430 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockGetPolicy = vi.hoisted(() => vi.fn());
+const mockUpdatePolicy = vi.hoisted(() => vi.fn());
+const mockDeletePolicy = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/triage/policy/repository", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/triage/policy/repository")
+  >("@/lib/triage/policy/repository");
+  return {
+    ...actual,
+    getPolicy: vi.fn((...args: unknown[]) => mockGetPolicy(...args)),
+    updatePolicy: vi.fn((...args: unknown[]) => mockUpdatePolicy(...args)),
+    deletePolicy: vi.fn((...args: unknown[]) => mockDeletePolicy(...args)),
+  };
+});
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  mustEnrollMfa: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+const sampleRow = {
+  id: 7,
+  name: "policy-a",
+  packet_attr: [],
+  confidence: [],
+  response: [],
+  created_at: "2026-05-09T00:00:00Z",
+  updated_at: "2026-05-09T00:00:00Z",
+};
+
+describe("GET /api/triage/policies/[id]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetPolicy.mockReset();
+    mockQuery.mockReset();
+  });
+
+  it("returns 400 when customer_id is missing", async () => {
+    const { GET } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7",
+    );
+    const response = await GET(request, makeContext("7"));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when policy id is non-numeric", async () => {
+    const { GET } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/not-a-number?customer_id=42",
+    );
+    const response = await GET(request, makeContext("not-a-number"));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns the policy for an access-all caller", async () => {
+    mockGetPolicy.mockResolvedValue(sampleRow);
+    const { GET } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+    );
+    const response = await GET(request, makeContext("7"));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual(sampleRow);
+    expect(mockGetPolicy).toHaveBeenCalledWith(42, 7);
+  });
+
+  it("returns 404 when the row does not exist", async () => {
+    mockGetPolicy.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+    );
+    const response = await GET(request, makeContext("7"));
+    expect(response.status).toBe(404);
+  });
+
+  it("denies access when caller lacks scope and is not access-all", async () => {
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const { GET } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+    );
+    const response = await GET(request, makeContext("7"));
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 without triage:read", async () => {
+    mockHasPermission.mockResolvedValue(false);
+    const { GET } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+    );
+    const response = await GET(request, makeContext("7"));
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("PATCH /api/triage/policies/[id]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockUpdatePolicy.mockReset();
+    mockAuditRecord.mockReset();
+    mockQuery.mockReset();
+  });
+
+  it("returns 403 without triage:policy:write", async () => {
+    mockHasPermission.mockResolvedValue(false);
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({ name: "renamed" }) },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects an empty body with no recognized fields", async () => {
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({}) },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(400);
+    expect(mockUpdatePolicy).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("rejects bodies whose only keys are typos (strict schema)", async () => {
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({ respnose: [] }) },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(400);
+    expect(mockUpdatePolicy).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON", async () => {
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: "{not json" },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects an invalid IP/CIDR in a packet_attr ipaddr rule", async () => {
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          packet_attr: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "src_addr",
+              value_kind: "ipaddr",
+              cmp_kind: "equal",
+              first_value: "10.0.0.0/40",
+            },
+          ],
+        }),
+      },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(400);
+    expect(mockUpdatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a range cmp_kind without a second_value", async () => {
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          packet_attr: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "duration",
+              value_kind: "integer",
+              cmp_kind: "close_range",
+              first_value: "100",
+            },
+          ],
+        }),
+      },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(400);
+    expect(mockUpdatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the row does not exist", async () => {
+    mockUpdatePolicy.mockResolvedValue(null);
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({ name: "renamed" }) },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    expect(response.status).toBe(404);
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("maps a name conflict to a 409 with code 'name_conflict'", async () => {
+    const { TriagePolicyNameConflictError } = await import(
+      "@/lib/triage/policy/repository"
+    );
+    mockUpdatePolicy.mockRejectedValue(
+      new TriagePolicyNameConflictError("policy-a"),
+    );
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({ name: "policy-a" }) },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    const body = await response.json();
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("name_conflict");
+  });
+
+  it("updates the policy and emits an audit event", async () => {
+    mockUpdatePolicy.mockResolvedValue({ ...sampleRow, name: "renamed" });
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({ name: "renamed" }) },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.data.name).toBe("renamed");
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "triage.policy.update",
+        target: "triage_policy",
+        targetId: "7",
+        customerId: 42,
+        details: expect.objectContaining({
+          changedFields: ["name"],
+        }),
+      }),
+    );
+  });
+
+  it("does not overwrite omitted rule arrays on a name-only patch", async () => {
+    // Round 2 regression: previously `policyBaseSchema.partial()` kept
+    // the `.default([])` on rule arrays, so a name-only PATCH wiped
+    // every existing rule list. Confirm the repository receives only
+    // the fields that were actually present in the request.
+    mockUpdatePolicy.mockResolvedValue({ ...sampleRow, name: "renamed" });
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "PATCH", body: JSON.stringify({ name: "renamed" }) },
+    );
+    await PATCH(request, makeContext("7"));
+    expect(mockUpdatePolicy).toHaveBeenCalledTimes(1);
+    const updateInput = mockUpdatePolicy.mock.calls[0][2];
+    expect(updateInput).toEqual({ name: "renamed" });
+    expect(updateInput.packet_attr).toBeUndefined();
+    expect(updateInput.confidence).toBeUndefined();
+    expect(updateInput.response).toBeUndefined();
+  });
+});
+
+describe("DELETE /api/triage/policies/[id]", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockGetPolicy.mockReset();
+    mockDeletePolicy.mockReset();
+    mockAuditRecord.mockReset();
+    mockQuery.mockReset();
+  });
+
+  it("returns 403 without triage:policy:write", async () => {
+    mockHasPermission.mockResolvedValue(false);
+    const { DELETE } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext("7"));
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when the row does not exist", async () => {
+    mockGetPolicy.mockResolvedValue(null);
+    const { DELETE } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext("7"));
+    expect(response.status).toBe(404);
+    expect(mockDeletePolicy).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("deletes the policy and emits an audit event with the captured name", async () => {
+    mockGetPolicy.mockResolvedValue(sampleRow);
+    mockDeletePolicy.mockResolvedValue(true);
+    const { DELETE } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext("7"));
+    expect(response.status).toBe(200);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "triage.policy.delete",
+        target: "triage_policy",
+        targetId: "7",
+        customerId: 42,
+        details: { name: "policy-a" },
+      }),
+    );
+  });
+
+  it("denies access when caller lacks scope and is not access-all", async () => {
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const { DELETE } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request, makeContext("7"));
+    expect(response.status).toBe(403);
+    expect(mockDeletePolicy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/app/api/triage/policies/route.test.ts
+++ b/src/__tests__/app/api/triage/policies/route.test.ts
@@ -1,0 +1,402 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockAuditRecord = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+const mockListPolicies = vi.hoisted(() => vi.fn());
+const mockCreatePolicy = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: {
+    record: vi.fn((...args: unknown[]) => mockAuditRecord(...args)),
+  },
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/triage/policy/repository", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/triage/policy/repository")
+  >("@/lib/triage/policy/repository");
+  return {
+    ...actual,
+    listPolicies: vi.fn((...args: unknown[]) => mockListPolicies(...args)),
+    createPolicy: vi.fn((...args: unknown[]) => mockCreatePolicy(...args)),
+  };
+});
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  mustEnrollMfa: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+function makeContext() {
+  return { params: Promise.resolve({}) };
+}
+
+const sampleRow = {
+  id: 7,
+  name: "policy-a",
+  packet_attr: [],
+  confidence: [],
+  response: [],
+  created_at: "2026-05-09T00:00:00Z",
+  updated_at: "2026-05-09T00:00:00Z",
+};
+
+describe("GET /api/triage/policies", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockListPolicies.mockReset();
+    mockQuery.mockReset();
+  });
+
+  it("returns 400 when customer_id is missing", async () => {
+    const { GET } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies",
+    );
+    const response = await GET(request, makeContext());
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when customer_id is non-positive", async () => {
+    const { GET } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=0",
+    );
+    const response = await GET(request, makeContext());
+    expect(response.status).toBe(400);
+  });
+
+  it("lists policies for an access-all caller", async () => {
+    mockListPolicies.mockResolvedValue([sampleRow]);
+    const { GET } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+    );
+    const response = await GET(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual([sampleRow]);
+    expect(mockListPolicies).toHaveBeenCalledWith(42);
+  });
+
+  it("denies access when caller lacks scope and is not access-all", async () => {
+    mockHasPermission.mockImplementation(
+      async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      },
+    );
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const { GET } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+    );
+    const response = await GET(request, makeContext());
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 without triage:read", async () => {
+    mockHasPermission.mockResolvedValue(false);
+    const { GET } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+    );
+    const response = await GET(request, makeContext());
+    expect(response.status).toBe(403);
+  });
+});
+
+describe("POST /api/triage/policies", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockCreatePolicy.mockReset();
+    mockAuditRecord.mockReset();
+    mockQuery.mockReset();
+  });
+
+  it("creates a policy and emits an audit event", async () => {
+    mockCreatePolicy.mockResolvedValue(sampleRow);
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "policy-a",
+          packet_attr: [],
+          confidence: [],
+          response: [],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(201);
+    expect(body.data).toEqual(sampleRow);
+    expect(mockAuditRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "triage.policy.create",
+        target: "triage_policy",
+        targetId: "7",
+        customerId: 42,
+      }),
+    );
+  });
+
+  it("rejects an invalid IP/CIDR in a packet_attr ipaddr rule", async () => {
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "p",
+          packet_attr: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "src_addr",
+              value_kind: "ipaddr",
+              cmp_kind: "equal",
+              first_value: "not-an-ip",
+            },
+          ],
+          confidence: [],
+          response: [],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.details).toBeDefined();
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a legacy 'match' cmp_kind that is not in AttrCmpKind", async () => {
+    // `match` / `not_match` were dropped in Round 5 to keep the stored
+    // shape aligned with review-web's `AttrCmpKind` enum (see
+    // src/lib/triage/policy/inline-input.ts). Zod's enum check now
+    // rejects the value before it ever reaches the repository.
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "p",
+          packet_attr: [
+            {
+              raw_event_kind: "http",
+              attr_name: "host",
+              value_kind: "string",
+              cmp_kind: "match",
+              first_value: "foo",
+            },
+          ],
+          confidence: [],
+          response: [],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    expect(response.status).toBe(400);
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a range cmp_kind without a second_value", async () => {
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "p",
+          packet_attr: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "duration",
+              value_kind: "integer",
+              cmp_kind: "open_range",
+              first_value: "100",
+            },
+          ],
+          confidence: [],
+          response: [],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.details).toBeDefined();
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown raw_event_kind not in the GraphQL RawEventKind enum", async () => {
+    // `raw_event_kind` is a closed enum aligned with `RawEventKind` in
+    // schemas/review.graphql; values like "Conn" (wrong case) or
+    // "unknown" must be rejected so the stored row can be passed inline
+    // to the future scoring engine without a kind it has no name for.
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "p",
+          packet_attr: [
+            {
+              raw_event_kind: "Conn",
+              attr_name: "src_addr",
+              value_kind: "ipaddr",
+              cmp_kind: "equal",
+              first_value: "10.0.0.1",
+            },
+          ],
+          confidence: [],
+          response: [],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.details).toBeDefined();
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON", async () => {
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      { method: "POST", body: "{not json" },
+    );
+    const response = await POST(request, makeContext());
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects unknown keys (typo'd field) without persisting an empty-rule policy", async () => {
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "policy-a",
+          packet_attrs: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "src_addr",
+              value_kind: "ipaddr",
+              cmp_kind: "equal",
+              first_value: "10.0.0.1",
+            },
+          ],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.details).toBeDefined();
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("rejects unrecognized top-level keys", async () => {
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "policy-a",
+          packet_attr: [],
+          confidence: [],
+          response: [],
+          extra: "junk",
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    expect(response.status).toBe(400);
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+    expect(mockAuditRecord).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 without triage:policy:write", async () => {
+    mockHasPermission.mockResolvedValue(false);
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({ name: "p" }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/__tests__/lib/audit/customer-scope-policy.test.ts
+++ b/src/__tests__/lib/audit/customer-scope-policy.test.ts
@@ -51,7 +51,7 @@ describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
     expect(bad).toEqual([]);
   });
 
-  it("flags customer.* / node.* / service.* / aimer_context_token.issued as customer-scoped", () => {
+  it("flags customer.* / node.* / service.* / aimer_context_token.issued / triage.policy.* as customer-scoped", () => {
     const expectedScoped: AuditAction[] = [
       "customer.create",
       "customer.update",
@@ -67,6 +67,9 @@ describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
       "service.draft_save",
       "service.set_mode",
       "aimer_context_token.issued",
+      "triage.policy.create",
+      "triage.policy.update",
+      "triage.policy.delete",
     ];
     for (const action of expectedScoped) {
       expect(customerScopeForAction(action)).toBe("customer-scoped");
@@ -89,6 +92,9 @@ describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
       "service.draft_save",
       "service.set_mode",
       "aimer_context_token.issued",
+      "triage.policy.create",
+      "triage.policy.update",
+      "triage.policy.delete",
     ]);
     for (const action of listAllAuditActions()) {
       if (!scopedActions.has(action)) {

--- a/src/__tests__/lib/triage/policy/inline-input.test.ts
+++ b/src/__tests__/lib/triage/policy/inline-input.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  cmpKindToGraphql,
+  rawEventKindToGraphql,
+  responseKindToGraphql,
+  threatCategoryToGraphql,
+  valueKindToGraphql,
+} from "@/lib/triage/policy/inline-input";
+import {
+  CMP_KINDS,
+  RAW_EVENT_KINDS,
+  RESPONSE_KINDS,
+  THREAT_CATEGORIES,
+  VALUE_KINDS,
+} from "@/lib/triage/policy/types";
+
+/**
+ * Round-trip guard: every literal accepted by the stored TriagePolicy
+ * schema must translate to a name that exists in review-web's matching
+ * GraphQL enum. A storage row that fails to translate would be invisible
+ * to the engine, so the alignment is verified end-to-end against the
+ * checked-in `schemas/review.graphql`.
+ */
+
+function readEnumMembers(enumName: string): Set<string> {
+  const schemaPath = resolve(process.cwd(), "schemas/review.graphql");
+  const text = readFileSync(schemaPath, "utf-8");
+  const re = new RegExp(`enum\\s+${enumName}\\s*\\{([^}]*)\\}`);
+  const match = re.exec(text);
+  if (!match) throw new Error(`enum ${enumName} not found in review.graphql`);
+  return new Set(
+    match[1]
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"))
+      .map((line) => line.split(/\s+/)[0]),
+  );
+}
+
+describe("inline-input enum translators", () => {
+  it("maps every RAW_EVENT_KINDS literal to a GraphQL RawEventKind member", () => {
+    const members = readEnumMembers("RawEventKind");
+    for (const kind of RAW_EVENT_KINDS) {
+      const graphql = rawEventKindToGraphql(kind);
+      expect(members.has(graphql)).toBe(true);
+    }
+  });
+
+  it("maps every VALUE_KINDS literal to a GraphQL ValueKind member", () => {
+    const members = readEnumMembers("ValueKind");
+    for (const kind of VALUE_KINDS) {
+      const graphql = valueKindToGraphql(kind);
+      expect(members.has(graphql)).toBe(true);
+    }
+  });
+
+  it("maps every CMP_KINDS literal to a GraphQL AttrCmpKind member", () => {
+    const members = readEnumMembers("AttrCmpKind");
+    for (const kind of CMP_KINDS) {
+      const graphql = cmpKindToGraphql(kind);
+      expect(members.has(graphql)).toBe(true);
+    }
+  });
+
+  it("maps every RESPONSE_KINDS literal to a GraphQL ResponseKind member", () => {
+    const members = readEnumMembers("ResponseKind");
+    for (const kind of RESPONSE_KINDS) {
+      const graphql = responseKindToGraphql(kind);
+      expect(members.has(graphql)).toBe(true);
+    }
+  });
+
+  it("maps every THREAT_CATEGORIES literal to a GraphQL ThreatCategory member", () => {
+    const members = readEnumMembers("ThreatCategory");
+    for (const kind of THREAT_CATEGORIES) {
+      const graphql = threatCategoryToGraphql(kind);
+      expect(members.has(graphql)).toBe(true);
+    }
+  });
+
+  it("rejects legacy match / not_match cmp kinds (now removed)", () => {
+    // These literals existed in earlier rounds of this PR but are not
+    // in `AttrCmpKind`. Asserting they're not in CMP_KINDS guards
+    // against re-introduction.
+    expect((CMP_KINDS as readonly string[]).includes("match")).toBe(false);
+    expect((CMP_KINDS as readonly string[]).includes("not_match")).toBe(false);
+  });
+});

--- a/src/__tests__/lib/triage/policy/validation.test.ts
+++ b/src/__tests__/lib/triage/policy/validation.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  _validateIpOrCidr,
+  validatePolicySemantics,
+} from "@/lib/triage/policy/validation";
+
+describe("validateIpOrCidr", () => {
+  it("accepts plain IPv4", () => {
+    expect(_validateIpOrCidr("192.168.1.1")).toBeNull();
+  });
+
+  it("accepts plain IPv6", () => {
+    expect(_validateIpOrCidr("::1")).toBeNull();
+    expect(_validateIpOrCidr("2001:db8::1")).toBeNull();
+  });
+
+  it("accepts IPv4 CIDR", () => {
+    expect(_validateIpOrCidr("10.0.0.0/8")).toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/32")).toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/0")).toBeNull();
+  });
+
+  it("accepts IPv6 CIDR", () => {
+    expect(_validateIpOrCidr("2001:db8::/32")).toBeNull();
+    expect(_validateIpOrCidr("::/0")).toBeNull();
+  });
+
+  it("rejects invalid IPs", () => {
+    expect(_validateIpOrCidr("not-an-ip")).not.toBeNull();
+    expect(_validateIpOrCidr("999.999.999.999")).not.toBeNull();
+  });
+
+  it("rejects out-of-range CIDR prefix", () => {
+    expect(_validateIpOrCidr("10.0.0.0/33")).not.toBeNull();
+    expect(_validateIpOrCidr("2001:db8::/129")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/-1")).not.toBeNull();
+  });
+
+  it("rejects non-decimal CIDR prefixes that Number() would coerce", () => {
+    // Empty / whitespace prefixes.
+    expect(_validateIpOrCidr("10.0.0.0/")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/ ")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/ 8")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/8 ")).not.toBeNull();
+    // Signed prefixes.
+    expect(_validateIpOrCidr("10.0.0.0/+8")).not.toBeNull();
+    // Exponent / hex / float / underscore notation.
+    expect(_validateIpOrCidr("10.0.0.0/1e1")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/0x8")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/8.0")).not.toBeNull();
+    expect(_validateIpOrCidr("10.0.0.0/0_8")).not.toBeNull();
+    expect(_validateIpOrCidr("2001:db8::/0x10")).not.toBeNull();
+  });
+});
+
+describe("validatePolicySemantics", () => {
+  it("flags a packet_attr ipaddr rule with a bad first_value", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [
+        {
+          raw_event_kind: "conn",
+          attr_name: "src_addr",
+          value_kind: "ipaddr",
+          cmp_kind: "equal",
+          first_value: "not-an-ip",
+        },
+      ],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.issues[0].path).toBe("packet_attr.0.first_value");
+  });
+
+  it("accepts a packet_attr ipaddr rule with a valid CIDR", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [
+        {
+          raw_event_kind: "conn",
+          attr_name: "src_addr",
+          value_kind: "ipaddr",
+          cmp_kind: "equal",
+          first_value: "10.0.0.0/8",
+        },
+      ],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("flags a range cmp_kind without a second_value", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [
+        {
+          raw_event_kind: "conn",
+          attr_name: "duration",
+          value_kind: "integer",
+          cmp_kind: "open_range",
+          first_value: "100",
+        },
+      ],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.issues[0].path).toBe("packet_attr.0.second_value");
+    expect(result.issues[0].message).toContain("open_range");
+  });
+
+  it("accepts a range cmp_kind with both ends set", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [
+        {
+          raw_event_kind: "conn",
+          attr_name: "duration",
+          value_kind: "integer",
+          cmp_kind: "close_range",
+          first_value: "100",
+          second_value: "200",
+        },
+      ],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates ipaddr second_value when present and non-empty", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [
+        {
+          raw_event_kind: "conn",
+          attr_name: "src_addr",
+          value_kind: "ipaddr",
+          cmp_kind: "less_or_equal",
+          first_value: "10.0.0.0",
+          second_value: "bad-ip",
+        },
+      ],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some((i) => i.path === "packet_attr.0.second_value"),
+    ).toBe(true);
+  });
+
+  it("ignores second_value when null or empty string for non-range cmp", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [
+        {
+          raw_event_kind: "conn",
+          attr_name: "src_addr",
+          value_kind: "ipaddr",
+          cmp_kind: "equal",
+          first_value: "10.0.0.0",
+          second_value: "",
+        },
+      ],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("flags an empty threat_kind", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [],
+      confidence: [
+        {
+          threat_category: "execution",
+          threat_kind: "   ",
+          confidence: 0.5,
+        },
+      ],
+      response: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.issues[0].path).toBe("confidence.0.threat_kind");
+  });
+
+  it("returns valid for an empty policy", () => {
+    const result = validatePolicySemantics({
+      name: "p",
+      packet_attr: [],
+      confidence: [],
+      response: [],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+});

--- a/src/app/[locale]/(dashboard)/triage/policies/page.tsx
+++ b/src/app/[locale]/(dashboard)/triage/policies/page.tsx
@@ -1,0 +1,36 @@
+import { Suspense } from "react";
+
+import { TriagePolicyManager } from "@/components/triage/policy/triage-policy-manager";
+import { getEffectiveCustomerScope } from "@/lib/auth/customer-scope";
+import { hasPermission } from "@/lib/auth/permissions";
+import { getCurrentSession, requirePermission } from "@/lib/auth/session";
+
+export default async function TriagePoliciesPage() {
+  const session = await getCurrentSession();
+  if (!session) return null;
+
+  // The page is gated by `triage:read` (the page-level read gate). The
+  // mutation controls inside the manager are gated separately by
+  // `triage:policy:write` so a read-only triage user does not see
+  // affordances they would only be denied at submit time.
+  await requirePermission(session, "triage:read");
+
+  // Customer options come from the caller's effective triage scope —
+  // NOT `/api/customers`, which requires `customers:read`. Threading
+  // them through the server component lets a `triage:policy:write`
+  // user without `customers:read` use this page.
+  const scope = await getEffectiveCustomerScope(session);
+  const canWritePolicy = await hasPermission(
+    session.roles,
+    "triage:policy:write",
+  );
+
+  return (
+    <Suspense>
+      <TriagePolicyManager
+        customers={scope.customers}
+        canWritePolicy={canWritePolicy}
+      />
+    </Suspense>
+  );
+}

--- a/src/app/api/triage/policies/[id]/route.ts
+++ b/src/app/api/triage/policies/[id]/route.ts
@@ -1,0 +1,242 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
+import {
+  deletePolicy,
+  getPolicy,
+  TriagePolicyNameConflictError,
+  updatePolicy,
+} from "@/lib/triage/policy/repository";
+import { policyUpdateSchema } from "@/lib/triage/policy/types";
+import { validatePolicySemantics } from "@/lib/triage/policy/validation";
+
+/**
+ * GET /api/triage/policies/[id]?customer_id=<id>
+ *
+ * Requires `triage:read` permission.
+ */
+export const GET = withAuth(
+  async (request, context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) return badCustomerId();
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return forbidden();
+    }
+    const policyId = await parsePolicyId(context);
+    if (policyId === null) return badPolicyId();
+
+    try {
+      const row = await getPolicy(customerId, policyId);
+      if (!row) return notFound();
+      return NextResponse.json({ data: row });
+    } catch (err) {
+      if (err instanceof CustomerNotFoundError) {
+        return NextResponse.json({ error: err.message }, { status: 404 });
+      }
+      throw err;
+    }
+  },
+  { requiredPermissions: ["triage:read"] },
+);
+
+/**
+ * PATCH /api/triage/policies/[id]?customer_id=<id>
+ *
+ * Requires `triage:policy:write` permission.
+ */
+export const PATCH = withAuth(
+  async (request, context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) return badCustomerId();
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return forbidden();
+    }
+    const policyId = await parsePolicyId(context);
+    if (policyId === null) return badPolicyId();
+
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const parsed = policyUpdateSchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    if (Object.keys(parsed.data).length === 0) {
+      return NextResponse.json(
+        { error: "PATCH body must contain at least one field to update" },
+        { status: 400 },
+      );
+    }
+    const semantic = validatePolicySemantics(parsed.data);
+    if (!semantic.valid) {
+      return NextResponse.json(
+        { error: "Validation failed", details: semantic.issues },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const row = await updatePolicy(customerId, policyId, parsed.data);
+      if (!row) return notFound();
+      await auditLog.record({
+        actor: session.accountId,
+        action: "triage.policy.update",
+        target: "triage_policy",
+        targetId: String(row.id),
+        ip: extractClientIp(request),
+        sid: session.sessionId,
+        customerId,
+        details: {
+          name: row.name,
+          changedFields: Object.keys(parsed.data),
+        },
+      });
+      return NextResponse.json({ data: row });
+    } catch (err) {
+      if (err instanceof CustomerNotFoundError) {
+        return NextResponse.json({ error: err.message }, { status: 404 });
+      }
+      if (err instanceof TriagePolicyNameConflictError) {
+        return NextResponse.json(
+          { error: err.message, field: "name", code: "name_conflict" },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
+  },
+  { requiredPermissions: ["triage:policy:write"] },
+);
+
+/**
+ * DELETE /api/triage/policies/[id]?customer_id=<id>
+ *
+ * Requires `triage:policy:write` permission.
+ */
+export const DELETE = withAuth(
+  async (request, context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) return badCustomerId();
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return forbidden();
+    }
+    const policyId = await parsePolicyId(context);
+    if (policyId === null) return badPolicyId();
+
+    try {
+      // Capture name for the audit row before the row goes away.
+      const existing = await getPolicy(customerId, policyId);
+      if (!existing) return notFound();
+
+      const removed = await deletePolicy(customerId, policyId);
+      if (!removed) return notFound();
+
+      await auditLog.record({
+        actor: session.accountId,
+        action: "triage.policy.delete",
+        target: "triage_policy",
+        targetId: String(policyId),
+        ip: extractClientIp(request),
+        sid: session.sessionId,
+        customerId,
+        details: { name: existing.name },
+      });
+      return NextResponse.json({ success: true });
+    } catch (err) {
+      if (err instanceof CustomerNotFoundError) {
+        return NextResponse.json({ error: err.message }, { status: 404 });
+      }
+      throw err;
+    }
+  },
+  { requiredPermissions: ["triage:policy:write"] },
+);
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function parseCustomerId(request: NextRequest): number | null {
+  const raw = request.nextUrl.searchParams.get("customer_id");
+  if (raw === null) return null;
+  const id = Number(raw);
+  if (!Number.isFinite(id) || !Number.isInteger(id) || id <= 0) return null;
+  return id;
+}
+
+async function parsePolicyId(context: {
+  params: Promise<Record<string, string>>;
+}): Promise<number | null> {
+  const { id } = await context.params;
+  const policyId = Number(id);
+  if (
+    !Number.isFinite(policyId) ||
+    !Number.isInteger(policyId) ||
+    policyId <= 0
+  ) {
+    return null;
+  }
+  return policyId;
+}
+
+function badCustomerId() {
+  return NextResponse.json(
+    { error: "Missing or invalid customer_id" },
+    { status: 400 },
+  );
+}
+
+function badPolicyId() {
+  return NextResponse.json({ error: "Invalid policy ID" }, { status: 400 });
+}
+
+function notFound() {
+  return NextResponse.json({ error: "Policy not found" }, { status: 404 });
+}
+
+function forbidden() {
+  return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+}
+
+async function callerCanAccessCustomer(
+  accountId: string,
+  roles: string[],
+  customerId: number,
+): Promise<boolean> {
+  if (await hasPermission(roles, "customers:access-all")) return true;
+  const { rows } = await query<{ customer_id: number }>(
+    "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+    [accountId, customerId],
+  );
+  return rows.length > 0;
+}

--- a/src/app/api/triage/policies/route.ts
+++ b/src/app/api/triage/policies/route.ts
@@ -1,0 +1,160 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
+import {
+  createPolicy,
+  listPolicies,
+  TriagePolicyNameConflictError,
+} from "@/lib/triage/policy/repository";
+import { policyCreateSchema } from "@/lib/triage/policy/types";
+import { validatePolicySemantics } from "@/lib/triage/policy/validation";
+
+/**
+ * GET /api/triage/policies?customer_id=<id>
+ *
+ * Lists triage policies in the given customer's tenant DB. The
+ * `customer_id` query argument is required and is checked against the
+ * caller's effective customer scope.
+ *
+ * Requires `triage:read` permission. (Listing is read-only — write is
+ * gated separately on POST.)
+ */
+export const GET = withAuth(
+  async (request, _context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) {
+      return NextResponse.json(
+        { error: "Missing or invalid customer_id" },
+        { status: 400 },
+      );
+    }
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    try {
+      const rows = await listPolicies(customerId);
+      return NextResponse.json({ data: rows });
+    } catch (err) {
+      if (err instanceof CustomerNotFoundError) {
+        return NextResponse.json({ error: err.message }, { status: 404 });
+      }
+      throw err;
+    }
+  },
+  { requiredPermissions: ["triage:read"] },
+);
+
+/**
+ * POST /api/triage/policies?customer_id=<id>
+ *
+ * Creates a new triage policy in the given customer's tenant DB.
+ *
+ * Requires `triage:policy:write` permission.
+ */
+export const POST = withAuth(
+  async (request, _context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) {
+      return NextResponse.json(
+        { error: "Missing or invalid customer_id" },
+        { status: 400 },
+      );
+    }
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const parsed = policyCreateSchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation failed", details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const semantic = validatePolicySemantics(parsed.data);
+    if (!semantic.valid) {
+      return NextResponse.json(
+        { error: "Validation failed", details: semantic.issues },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const row = await createPolicy(customerId, parsed.data);
+      await auditLog.record({
+        actor: session.accountId,
+        action: "triage.policy.create",
+        target: "triage_policy",
+        targetId: String(row.id),
+        ip: extractClientIp(request),
+        sid: session.sessionId,
+        customerId,
+        details: { name: row.name },
+      });
+      return NextResponse.json({ data: row }, { status: 201 });
+    } catch (err) {
+      if (err instanceof CustomerNotFoundError) {
+        return NextResponse.json({ error: err.message }, { status: 404 });
+      }
+      if (err instanceof TriagePolicyNameConflictError) {
+        return NextResponse.json(
+          { error: err.message, field: "name", code: "name_conflict" },
+          { status: 409 },
+        );
+      }
+      throw err;
+    }
+  },
+  { requiredPermissions: ["triage:policy:write"] },
+);
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function parseCustomerId(request: NextRequest): number | null {
+  const raw = request.nextUrl.searchParams.get("customer_id");
+  if (raw === null) return null;
+  const id = Number(raw);
+  if (!Number.isFinite(id) || !Number.isInteger(id) || id <= 0) return null;
+  return id;
+}
+
+async function callerCanAccessCustomer(
+  accountId: string,
+  roles: string[],
+  customerId: number,
+): Promise<boolean> {
+  if (await hasPermission(roles, "customers:access-all")) return true;
+  const { rows } = await query<{ customer_id: number }>(
+    "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+    [accountId, customerId],
+  );
+  return rows.length > 0;
+}

--- a/src/components/triage/policy/triage-policy-form-dialog.tsx
+++ b/src/components/triage/policy/triage-policy-form-dialog.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { readCsrfToken } from "@/lib/csrf-client";
+import type { TriagePolicyRow } from "@/lib/triage/policy/types";
+
+interface FormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  policy?: TriagePolicyRow;
+  customerId: number;
+  onSuccess: () => void;
+}
+
+const EMPTY_JSON_ARRAY = "[]";
+
+interface ServerIssue {
+  path?: string;
+  message?: string;
+}
+
+export function TriagePolicyFormDialog({
+  open,
+  onOpenChange,
+  policy,
+  customerId,
+  onSuccess,
+}: FormProps) {
+  const t = useTranslations("triagePolicies");
+  const isEdit = !!policy;
+
+  const [name, setName] = useState(policy?.name ?? "");
+  const [packetAttrText, setPacketAttrText] = useState(EMPTY_JSON_ARRAY);
+  const [confidenceText, setConfidenceText] = useState(EMPTY_JSON_ARRAY);
+  const [responseText, setResponseText] = useState(EMPTY_JSON_ARRAY);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [issues, setIssues] = useState<ServerIssue[]>([]);
+
+  useEffect(() => {
+    if (open) {
+      setName(policy?.name ?? "");
+      setPacketAttrText(JSON.stringify(policy?.packet_attr ?? [], null, 2));
+      setConfidenceText(JSON.stringify(policy?.confidence ?? [], null, 2));
+      setResponseText(JSON.stringify(policy?.response ?? [], null, 2));
+      setError(null);
+      setIssues([]);
+    }
+  }, [open, policy]);
+
+  const parseJsonArray = (
+    raw: string,
+    field: string,
+  ): { ok: true; value: unknown[] } | { ok: false; error: string } => {
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        return { ok: false, error: t("notAnArray", { field }) };
+      }
+      return { ok: true, value: parsed };
+    } catch {
+      return { ok: false, error: t("invalidJson", { field }) };
+    }
+  };
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError(null);
+    setIssues([]);
+
+    const packetAttr = parseJsonArray(packetAttrText, t("packetAttr"));
+    if (!packetAttr.ok) {
+      setError(packetAttr.error);
+      setSubmitting(false);
+      return;
+    }
+    const confidence = parseJsonArray(confidenceText, t("confidence"));
+    if (!confidence.ok) {
+      setError(confidence.error);
+      setSubmitting(false);
+      return;
+    }
+    const response = parseJsonArray(responseText, t("response"));
+    if (!response.ok) {
+      setError(response.error);
+      setSubmitting(false);
+      return;
+    }
+
+    const payload = {
+      name: name.trim(),
+      packet_attr: packetAttr.value,
+      confidence: confidence.value,
+      response: response.value,
+    };
+
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (csrfToken) headers["X-CSRF-Token"] = csrfToken;
+
+      const url = isEdit
+        ? `/api/triage/policies/${policy.id}?customer_id=${customerId}`
+        : `/api/triage/policies?customer_id=${customerId}`;
+      const method = isEdit ? "PATCH" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers,
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        if (Array.isArray(body.details)) {
+          setIssues(body.details as ServerIssue[]);
+        }
+        throw new Error(body.error ?? t("error"));
+      }
+
+      onOpenChange(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    void submit();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? t("edit") : t("create")}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="triage-policy-name">{t("name")}</Label>
+            <Input
+              id="triage-policy-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={255}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="triage-policy-packet-attr">{t("packetAttr")}</Label>
+            <textarea
+              id="triage-policy-packet-attr"
+              value={packetAttrText}
+              onChange={(e) => setPacketAttrText(e.target.value)}
+              className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-32 w-full rounded-md border px-3 py-2 font-mono text-xs focus-visible:ring-1 focus-visible:outline-none"
+              spellCheck={false}
+            />
+            <p className="text-muted-foreground text-xs">
+              {t("packetAttrHelp")}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="triage-policy-confidence">{t("confidence")}</Label>
+            <textarea
+              id="triage-policy-confidence"
+              value={confidenceText}
+              onChange={(e) => setConfidenceText(e.target.value)}
+              className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-24 w-full rounded-md border px-3 py-2 font-mono text-xs focus-visible:ring-1 focus-visible:outline-none"
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="triage-policy-response">{t("response")}</Label>
+            <textarea
+              id="triage-policy-response"
+              value={responseText}
+              onChange={(e) => setResponseText(e.target.value)}
+              className="border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-24 w-full rounded-md border px-3 py-2 font-mono text-xs focus-visible:ring-1 focus-visible:outline-none"
+              spellCheck={false}
+            />
+          </div>
+
+          {error && <p className="text-destructive text-sm">{error}</p>}
+          {issues.length > 0 && (
+            <ul className="text-destructive list-disc space-y-1 pl-4 text-xs">
+              {issues.map((iss, idx) => {
+                const path = iss.path ?? "";
+                const key = path ? `${path}-${idx}` : `issue-${idx}`;
+                return (
+                  <li key={key}>
+                    {path ? `${path}: ` : ""}
+                    {iss.message ?? ""}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" disabled={submitting}>
+                {t("cancel")}
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={submitting || !name.trim()}>
+              {submitting ? t("loading") : isEdit ? t("edit") : t("create")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/triage/policy/triage-policy-manager.tsx
+++ b/src/components/triage/policy/triage-policy-manager.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { CirclePlus, MoreVertical, Pencil, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { readCsrfToken } from "@/lib/csrf-client";
+import type { TriagePolicyRow } from "@/lib/triage/policy/types";
+
+import { TriagePolicyFormDialog } from "./triage-policy-form-dialog";
+
+interface CustomerOption {
+  id: number;
+  name: string;
+}
+
+interface TriagePolicyManagerProps {
+  /**
+   * Customer options sourced from the caller's effective triage scope on
+   * the server (`getEffectiveCustomerScope(session)`). The page is gated
+   * by `triage:read` only — `customers:read` is intentionally NOT
+   * required, so a `triage:policy:write` user without the customer
+   * permission can still use this UI.
+   */
+  customers: CustomerOption[];
+  /**
+   * True iff the session holds `triage:policy:write`. Hides the create
+   * button and per-row edit/delete affordances when false so a
+   * read-only triage user does not see controls they'd only be denied
+   * at submit time.
+   */
+  canWritePolicy: boolean;
+}
+
+export function TriagePolicyManager({
+  customers,
+  canWritePolicy,
+}: TriagePolicyManagerProps) {
+  const t = useTranslations("triagePolicies");
+
+  const [selectedCustomerId, setSelectedCustomerId] = useState<number | null>(
+    customers[0]?.id ?? null,
+  );
+
+  const [policies, setPolicies] = useState<TriagePolicyRow[]>([]);
+  const [policiesLoading, setPoliciesLoading] = useState(false);
+  const [policiesError, setPoliciesError] = useState<string | null>(null);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingPolicy, setEditingPolicy] = useState<
+    TriagePolicyRow | undefined
+  >();
+  const [deleteTarget, setDeleteTarget] = useState<TriagePolicyRow | null>(
+    null,
+  );
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  // ── Policy fetch when customer changes ────────────────────────
+
+  const fetchPolicies = useCallback(
+    async (customerId: number | null) => {
+      if (customerId === null) {
+        setPolicies([]);
+        return;
+      }
+      setPoliciesLoading(true);
+      setPoliciesError(null);
+      try {
+        const res = await fetch(
+          `/api/triage/policies?customer_id=${customerId}`,
+        );
+        if (!res.ok) {
+          const body = await res.json();
+          throw new Error(body.error ?? t("error"));
+        }
+        const body = await res.json();
+        setPolicies(body.data as TriagePolicyRow[]);
+      } catch (err) {
+        setPoliciesError(err instanceof Error ? err.message : t("error"));
+      } finally {
+        setPoliciesLoading(false);
+      }
+    },
+    [t],
+  );
+
+  useEffect(() => {
+    void fetchPolicies(selectedCustomerId);
+  }, [fetchPolicies, selectedCustomerId]);
+
+  // ── Handlers ────────────────────────────────────────────────
+
+  const selectedCustomer = useMemo(
+    () => customers.find((c) => c.id === selectedCustomerId) ?? null,
+    [customers, selectedCustomerId],
+  );
+
+  const handleCreate = () => {
+    setEditingPolicy(undefined);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (policy: TriagePolicyRow) => {
+    setEditingPolicy(policy);
+    setFormOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget || selectedCustomerId === null) return;
+    setDeleteError(null);
+    setDeleteSubmitting(true);
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {};
+      if (csrfToken) headers["X-CSRF-Token"] = csrfToken;
+      const res = await fetch(
+        `/api/triage/policies/${deleteTarget.id}?customer_id=${selectedCustomerId}`,
+        { method: "DELETE", headers },
+      );
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? t("error"));
+      }
+      setDeleteTarget(null);
+      void fetchPolicies(selectedCustomerId);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  };
+
+  // ── Render ──────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg bg-card">
+        <div className="flex items-center justify-between gap-4 px-6 py-4">
+          <div>
+            <h1 className="text-foreground text-lg font-semibold">
+              {t("title")}
+            </h1>
+            <p className="text-muted-foreground text-sm">{t("subtitle")}</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="triage-policy-customer" className="text-sm">
+                {t("customer")}
+              </Label>
+              <Select
+                value={
+                  selectedCustomerId !== null
+                    ? String(selectedCustomerId)
+                    : undefined
+                }
+                onValueChange={(v) => setSelectedCustomerId(Number(v))}
+                disabled={customers.length === 0}
+              >
+                <SelectTrigger id="triage-policy-customer" className="min-w-48">
+                  <SelectValue placeholder={t("selectCustomer")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {customers.map((c) => (
+                    <SelectItem key={c.id} value={String(c.id)}>
+                      {c.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {canWritePolicy && (
+              <Button
+                onClick={handleCreate}
+                className="rounded-full"
+                disabled={selectedCustomerId === null}
+              >
+                <CirclePlus className="mr-2 h-4 w-4" />
+                {t("create")}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {customers.length === 0 && (
+          <p className="text-muted-foreground px-6 pb-4 text-sm">
+            {t("noCustomerScope")}
+          </p>
+        )}
+
+        {selectedCustomerId !== null && (
+          <>
+            {policiesLoading && (
+              <p className="text-muted-foreground px-6 pb-4 text-sm">
+                {t("loading")}
+              </p>
+            )}
+            {policiesError && (
+              <p className="text-destructive px-6 pb-4 text-sm">
+                {policiesError}
+              </p>
+            )}
+            {!policiesLoading && !policiesError && policies.length === 0 && (
+              <p className="text-muted-foreground px-6 pb-4 text-sm">
+                {t("noResults")}
+              </p>
+            )}
+            {!policiesLoading && policies.length > 0 && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="pl-6">{t("name")}</TableHead>
+                    <TableHead>{t("ruleCounts")}</TableHead>
+                    <TableHead>{t("createdAt")}</TableHead>
+                    <TableHead className="w-[40px]" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {policies.map((p) => (
+                    <TableRow key={p.id}>
+                      <TableCell className="pl-6 font-medium">
+                        {p.name}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm">
+                        {t("ruleCountsValue", {
+                          packetAttr: p.packet_attr.length,
+                          confidence: p.confidence.length,
+                          response: p.response.length,
+                        })}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground font-mono text-xs">
+                        {p.created_at}
+                      </TableCell>
+                      <TableCell>
+                        {canWritePolicy && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="ghost" size="icon-xs">
+                                <MoreVertical className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem onClick={() => handleEdit(p)}>
+                                <Pencil className="mr-2 h-4 w-4" />
+                                {t("edit")}
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onClick={() => setDeleteTarget(p)}
+                                className="text-destructive focus:text-destructive"
+                              >
+                                <Trash2 className="mr-2 h-4 w-4" />
+                                {t("delete")}
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </>
+        )}
+      </div>
+
+      {selectedCustomer && canWritePolicy && (
+        <TriagePolicyFormDialog
+          open={formOpen}
+          onOpenChange={setFormOpen}
+          policy={editingPolicy}
+          customerId={selectedCustomer.id}
+          onSuccess={() => fetchPolicies(selectedCustomer.id)}
+        />
+      )}
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            if (deleteSubmitting) return;
+            setDeleteTarget(null);
+            setDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("delete")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteConfirm", { name: deleteTarget?.name ?? "" })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {deleteError && (
+            <p className="text-destructive text-sm">{deleteError}</p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteSubmitting}>
+              {t("cancel")}
+            </AlertDialogCancel>
+            {/*
+             * Radix's AlertDialogAction closes the dialog by default,
+             * which would unmount the error message and clear
+             * deleteTarget before a failed DELETE could be shown. Call
+             * `event.preventDefault()` to keep the dialog open while
+             * the request is in flight; handleDelete closes the dialog
+             * itself on success.
+             */}
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDelete();
+              }}
+              disabled={deleteSubmitting}
+            >
+              {t("delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1952,5 +1952,30 @@
       "BLOCKLISTED": "This password is too common. Please choose a different one.",
       "RECENTLY_USED": "Cannot reuse a recent password"
     }
+  },
+  "triagePolicies": {
+    "title": "Triage Policies",
+    "subtitle": "User-authored matching rules applied per customer.",
+    "customer": "Customer",
+    "selectCustomer": "Select a customer",
+    "noCustomerScope": "No customers are available in your scope.",
+    "create": "Create",
+    "edit": "Edit",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "loading": "Loading…",
+    "error": "An error occurred. Please try again.",
+    "noResults": "No triage policies for this customer yet.",
+    "name": "Name",
+    "ruleCounts": "Rules",
+    "ruleCountsValue": "{packetAttr} attr · {confidence} confidence · {response} response",
+    "createdAt": "Created",
+    "packetAttr": "Packet attribute rules",
+    "packetAttrHelp": "JSON array of packet_attr rules. IP/CIDR (value_kind=ipaddr) values and range cmp_kinds (open_range / close_range / left_open_range / right_open_range and their not_* variants) are validated server-side.",
+    "confidence": "Confidence rules",
+    "response": "Response rules",
+    "deleteConfirm": "Delete triage policy '{name}'? This cannot be undone.",
+    "invalidJson": "{field}: not valid JSON",
+    "notAnArray": "{field}: must be a JSON array"
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1952,5 +1952,30 @@
       "BLOCKLISTED": "너무 흔한 비밀번호입니다. 다른 비밀번호를 선택해 주세요.",
       "RECENTLY_USED": "최근에 사용한 비밀번호는 다시 사용할 수 없습니다"
     }
+  },
+  "triagePolicies": {
+    "title": "트리아지 정책",
+    "subtitle": "고객별로 적용되는 사용자 정의 매칭 규칙입니다.",
+    "customer": "고객",
+    "selectCustomer": "고객을 선택하세요",
+    "noCustomerScope": "사용 가능한 고객이 없습니다.",
+    "create": "생성",
+    "edit": "수정",
+    "delete": "삭제",
+    "cancel": "취소",
+    "loading": "불러오는 중…",
+    "error": "오류가 발생했습니다. 다시 시도해 주세요.",
+    "noResults": "이 고객에 등록된 트리아지 정책이 없습니다.",
+    "name": "이름",
+    "ruleCounts": "규칙",
+    "ruleCountsValue": "{packetAttr} attr · {confidence} confidence · {response} response",
+    "createdAt": "생성일",
+    "packetAttr": "패킷 속성 규칙",
+    "packetAttrHelp": "packet_attr 규칙 JSON 배열입니다. IP/CIDR(value_kind=ipaddr) 값과 범위 cmp_kind(open_range / close_range / left_open_range / right_open_range 및 not_* 변형)는 서버에서 검증됩니다.",
+    "confidence": "신뢰도 규칙",
+    "response": "응답 규칙",
+    "deleteConfirm": "트리아지 정책 '{name}'을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "invalidJson": "{field}: 올바른 JSON이 아닙니다",
+    "notAnArray": "{field}: JSON 배열이어야 합니다"
   }
 }

--- a/src/lib/audit/customer-scope-policy.ts
+++ b/src/lib/audit/customer-scope-policy.ts
@@ -104,6 +104,13 @@ export const AUDIT_ACTION_CUSTOMER_SCOPE: {
   // customer existence by pasting a `requestedCustomerId` into the
   // audit row. `customer-agnostic` is the simpler and safer placement.
   "aimer_context_token.denied": "customer-agnostic",
+  // Triage policy CRUD (#459) — TriagePolicy rows live in the
+  // per-customer tenant DB, so every row is intrinsically scoped to
+  // the customer the route operates on. Emitter populates `customerId`
+  // from the route's required `customer_id` argument.
+  "triage.policy.create": "customer-scoped",
+  "triage.policy.update": "customer-scoped",
+  "triage.policy.delete": "customer-scoped",
 };
 
 /**

--- a/src/lib/audit/schema.ts
+++ b/src/lib/audit/schema.ts
@@ -128,6 +128,18 @@ type AimerContextTokenAction =
   | "aimer_context_token.issued"
   | "aimer_context_token.denied";
 
+/**
+ * Triage policy CRUD actions (#459).
+ *
+ * TriagePolicy rows live in the per-customer tenant DB; every row is
+ * intrinsically customer-scoped, so the audit emitter populates
+ * `customerId` from the route's `customer_id` argument.
+ */
+type TriagePolicyAction =
+  | "triage.policy.create"
+  | "triage.policy.update"
+  | "triage.policy.delete";
+
 /** All audit event actions. */
 export type AuditAction =
   | AuthAction
@@ -142,7 +154,8 @@ export type AuditAction =
   | ServiceAction
   | AimerSigningKeyAction
   | AimerIntegrationSettingAction
-  | AimerContextTokenAction;
+  | AimerContextTokenAction
+  | TriagePolicyAction;
 
 /** Target entity types for audit events. */
 export type AuditTargetType =
@@ -153,7 +166,8 @@ export type AuditTargetType =
   | "role"
   | "mfa"
   | "node"
-  | "service";
+  | "service"
+  | "triage_policy";
 
 /** Canonical runtime list of supported audit actions. */
 export const AUDIT_ACTIONS = [
@@ -214,6 +228,9 @@ export const AUDIT_ACTIONS = [
   "aimer_integration_setting.changed",
   "aimer_context_token.issued",
   "aimer_context_token.denied",
+  "triage.policy.create",
+  "triage.policy.update",
+  "triage.policy.delete",
 ] as const satisfies readonly AuditAction[];
 
 /** Canonical runtime list of supported audit target types. */
@@ -226,4 +243,5 @@ export const AUDIT_TARGET_TYPES = [
   "mfa",
   "node",
   "service",
+  "triage_policy",
 ] as const satisfies readonly AuditTargetType[];

--- a/src/lib/triage/policy/customer-db.ts
+++ b/src/lib/triage/policy/customer-db.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { connectTo, query } from "@/lib/db/client";
+
+/**
+ * Per-process pool cache keyed by `customers.database_name`.
+ *
+ * The startup migration loop guarantees every active customer DB has
+ * the triage_policy schema applied; we just need a connection pool to
+ * reach it.
+ */
+const pools = new Map<string, pg.Pool>();
+
+export class CustomerNotFoundError extends Error {
+  constructor(customerId: number) {
+    super(`Customer ${customerId} not found or not active`);
+    this.name = "CustomerNotFoundError";
+  }
+}
+
+interface CustomerDbInfo {
+  databaseName: string;
+}
+
+async function lookupCustomerDb(
+  customerId: number,
+): Promise<CustomerDbInfo | null> {
+  const { rows } = await query<{ database_name: string }>(
+    "SELECT database_name FROM customers WHERE id = $1 AND status = 'active'",
+    [customerId],
+  );
+  if (rows.length === 0) return null;
+  return { databaseName: rows[0].database_name };
+}
+
+function buildCustomerUrl(databaseName: string): string {
+  const base = process.env.DATABASE_URL;
+  if (!base) {
+    throw new Error("Missing environment variable: DATABASE_URL");
+  }
+  const url = new URL(base);
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+/**
+ * Resolve a tenant DB pool for the given customer. Throws
+ * `CustomerNotFoundError` when no active customer matches. Pools are
+ * cached per process by database name.
+ */
+export async function getCustomerPool(customerId: number): Promise<pg.Pool> {
+  const info = await lookupCustomerDb(customerId);
+  if (!info) throw new CustomerNotFoundError(customerId);
+
+  const cached = pools.get(info.databaseName);
+  if (cached) return cached;
+
+  const pool = connectTo(buildCustomerUrl(info.databaseName));
+  pools.set(info.databaseName, pool);
+  return pool;
+}
+
+/**
+ * Test/teardown hook: close every cached pool. Production code never
+ * needs this — pools live for the lifetime of the process.
+ */
+export async function _resetCustomerPools(): Promise<void> {
+  const entries = Array.from(pools.values());
+  pools.clear();
+  await Promise.all(entries.map((p) => p.end()));
+}

--- a/src/lib/triage/policy/inline-input.ts
+++ b/src/lib/triage/policy/inline-input.ts
@@ -1,0 +1,135 @@
+/**
+ * Translator from the stored TriagePolicy shape to review-web's
+ * GraphQL inline policy input enum names.
+ *
+ * The downstream `eventListWithTriage` path described in #447 §2.1
+ * passes a stored policy inline as `PacketAttrInput` /
+ * `ConfidenceInput` / `ResponseInput`. The byte-array encoding of
+ * `firstValue` / `secondValue` (`[Int!]!` in GraphQL) is owned by the
+ * inline-policy boundary that lives outside this `triage/policy/`
+ * deprecatability namespace, so this module only handles the enum
+ * name translation. The accompanying test
+ * (`__tests__/lib/triage/policy/inline-input.test.ts`) iterates every
+ * literal in `VALUE_KINDS` / `CMP_KINDS` / `RESPONSE_KINDS` /
+ * `THREAT_CATEGORIES` and confirms the mapping is total — i.e. the
+ * stored schema cannot persist a kind the GraphQL contract has no
+ * name for.
+ */
+
+import type {
+  CmpKind,
+  RawEventKind,
+  ResponseKind,
+  ThreatCategory,
+  ValueKind,
+} from "./types";
+
+/**
+ * Mirror of `enum ValueKind` in `schemas/review.graphql:8095`.
+ */
+const VALUE_KIND_TO_GRAPHQL: Record<ValueKind, string> = {
+  string: "STRING",
+  integer: "INTEGER",
+  u_integer: "U_INTEGER",
+  vector: "VECTOR",
+  float: "FLOAT",
+  ipaddr: "IP_ADDR",
+  bool: "BOOL",
+};
+
+/**
+ * Mirror of `enum AttrCmpKind` in `schemas/review.graphql:110`.
+ */
+const CMP_KIND_TO_GRAPHQL: Record<CmpKind, string> = {
+  less: "LESS",
+  equal: "EQUAL",
+  greater: "GREATER",
+  less_or_equal: "LESS_OR_EQUAL",
+  greater_or_equal: "GREATER_OR_EQUAL",
+  contain: "CONTAIN",
+  open_range: "OPEN_RANGE",
+  close_range: "CLOSE_RANGE",
+  left_open_range: "LEFT_OPEN_RANGE",
+  right_open_range: "RIGHT_OPEN_RANGE",
+  not_equal: "NOT_EQUAL",
+  not_contain: "NOT_CONTAIN",
+  not_open_range: "NOT_OPEN_RANGE",
+  not_close_range: "NOT_CLOSE_RANGE",
+  not_left_open_range: "NOT_LEFT_OPEN_RANGE",
+  not_right_open_range: "NOT_RIGHT_OPEN_RANGE",
+};
+
+/**
+ * Mirror of `enum ResponseKind` in `schemas/review.graphql:6876`.
+ */
+const RESPONSE_KIND_TO_GRAPHQL: Record<ResponseKind, string> = {
+  manual: "MANUAL",
+  blacklist: "BLACKLIST",
+  whitelist: "WHITELIST",
+};
+
+/**
+ * Mirror of `enum ThreatCategory` in `schemas/review.graphql:7346`.
+ */
+const THREAT_CATEGORY_TO_GRAPHQL: Record<ThreatCategory, string> = {
+  reconnaissance: "RECONNAISSANCE",
+  initial_access: "INITIAL_ACCESS",
+  execution: "EXECUTION",
+  credential_access: "CREDENTIAL_ACCESS",
+  discovery: "DISCOVERY",
+  lateral_movement: "LATERAL_MOVEMENT",
+  command_and_control: "COMMAND_AND_CONTROL",
+  exfiltration: "EXFILTRATION",
+  impact: "IMPACT",
+  collection: "COLLECTION",
+  defense_evasion: "DEFENSE_EVASION",
+  persistence: "PERSISTENCE",
+  privilege_escalation: "PRIVILEGE_ESCALATION",
+  resource_development: "RESOURCE_DEVELOPMENT",
+};
+
+/**
+ * Mirror of `enum RawEventKind` in `schemas/review.graphql:6675`.
+ */
+const RAW_EVENT_KIND_TO_GRAPHQL: Record<RawEventKind, string> = {
+  bootp: "BOOTP",
+  conn: "CONN",
+  dhcp: "DHCP",
+  dns: "DNS",
+  ftp: "FTP",
+  http: "HTTP",
+  kerberos: "KERBEROS",
+  ldap: "LDAP",
+  log: "LOG",
+  mqtt: "MQTT",
+  network: "NETWORK",
+  nfs: "NFS",
+  ntlm: "NTLM",
+  radius: "RADIUS",
+  rdp: "RDP",
+  smb: "SMB",
+  smtp: "SMTP",
+  ssh: "SSH",
+  tls: "TLS",
+  window: "WINDOW",
+};
+
+export function rawEventKindToGraphql(kind: RawEventKind): string {
+  return RAW_EVENT_KIND_TO_GRAPHQL[kind];
+}
+
+export function valueKindToGraphql(kind: ValueKind): string {
+  return VALUE_KIND_TO_GRAPHQL[kind];
+}
+
+export function cmpKindToGraphql(kind: CmpKind): string {
+  return CMP_KIND_TO_GRAPHQL[kind];
+}
+
+export function responseKindToGraphql(kind: ResponseKind): string {
+  return RESPONSE_KIND_TO_GRAPHQL[kind];
+}
+
+export function threatCategoryToGraphql(kind: ThreatCategory): string {
+  return THREAT_CATEGORY_TO_GRAPHQL[kind];
+}

--- a/src/lib/triage/policy/repository.ts
+++ b/src/lib/triage/policy/repository.ts
@@ -1,0 +1,137 @@
+import "server-only";
+
+import { getCustomerPool } from "./customer-db";
+import type {
+  PolicyCreateInput,
+  PolicyUpdateInput,
+  TriagePolicyRow,
+} from "./types";
+
+const POLICY_COLUMNS =
+  "id, name, packet_attr, confidence, response, created_at, updated_at";
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+export class TriagePolicyNameConflictError extends Error {
+  constructor(name: string) {
+    super(`Policy name '${name}' is already in use`);
+    this.name = "TriagePolicyNameConflictError";
+  }
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+export async function listPolicies(
+  customerId: number,
+): Promise<TriagePolicyRow[]> {
+  const pool = await getCustomerPool(customerId);
+  const { rows } = await pool.query<TriagePolicyRow>(
+    `SELECT ${POLICY_COLUMNS} FROM triage_policy ORDER BY id`,
+  );
+  return rows;
+}
+
+export async function getPolicy(
+  customerId: number,
+  id: number,
+): Promise<TriagePolicyRow | null> {
+  const pool = await getCustomerPool(customerId);
+  const { rows } = await pool.query<TriagePolicyRow>(
+    `SELECT ${POLICY_COLUMNS} FROM triage_policy WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+export async function createPolicy(
+  customerId: number,
+  input: PolicyCreateInput,
+): Promise<TriagePolicyRow> {
+  const pool = await getCustomerPool(customerId);
+  try {
+    const { rows } = await pool.query<TriagePolicyRow>(
+      `INSERT INTO triage_policy (name, packet_attr, confidence, response)
+       VALUES ($1, $2::jsonb, $3::jsonb, $4::jsonb)
+       RETURNING ${POLICY_COLUMNS}`,
+      [
+        input.name,
+        JSON.stringify(input.packet_attr ?? []),
+        JSON.stringify(input.confidence ?? []),
+        JSON.stringify(input.response ?? []),
+      ],
+    );
+    return rows[0];
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new TriagePolicyNameConflictError(input.name);
+    }
+    throw err;
+  }
+}
+
+export async function updatePolicy(
+  customerId: number,
+  id: number,
+  input: PolicyUpdateInput,
+): Promise<TriagePolicyRow | null> {
+  const pool = await getCustomerPool(customerId);
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  if (input.name !== undefined) {
+    sets.push(`name = $${idx++}`);
+    params.push(input.name);
+  }
+  if (input.packet_attr !== undefined) {
+    sets.push(`packet_attr = $${idx++}::jsonb`);
+    params.push(JSON.stringify(input.packet_attr));
+  }
+  if (input.confidence !== undefined) {
+    sets.push(`confidence = $${idx++}::jsonb`);
+    params.push(JSON.stringify(input.confidence));
+  }
+  if (input.response !== undefined) {
+    sets.push(`response = $${idx++}::jsonb`);
+    params.push(JSON.stringify(input.response));
+  }
+
+  if (sets.length === 0) {
+    // No-op update: just return the current row.
+    return getPolicy(customerId, id);
+  }
+
+  sets.push("updated_at = NOW()");
+  params.push(id);
+
+  try {
+    const { rows } = await pool.query<TriagePolicyRow>(
+      `UPDATE triage_policy SET ${sets.join(", ")} WHERE id = $${idx} RETURNING ${POLICY_COLUMNS}`,
+      params,
+    );
+    return rows[0] ?? null;
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new TriagePolicyNameConflictError(String(input.name ?? ""));
+    }
+    throw err;
+  }
+}
+
+export async function deletePolicy(
+  customerId: number,
+  id: number,
+): Promise<boolean> {
+  const pool = await getCustomerPool(customerId);
+  const result = await pool.query("DELETE FROM triage_policy WHERE id = $1", [
+    id,
+  ]);
+  return (result.rowCount ?? 0) > 0;
+}

--- a/src/lib/triage/policy/types.ts
+++ b/src/lib/triage/policy/types.ts
@@ -1,0 +1,198 @@
+/**
+ * TriagePolicy domain types and Zod schemas for CRUD validation.
+ *
+ * Lives under the `triage/policy/` namespace per the deprecatability
+ * seam in #447 §6 — shared modules must not import from this
+ * subdirectory; deletion of the directory removes the feature.
+ *
+ * The stored shape mirrors review-web's GraphQL `PacketAttrInput` /
+ * `ConfidenceInput` / `ResponseInput` enums (lower_snake_case here vs.
+ * SCREAMING_SNAKE_CASE in `schemas/review.graphql`) so a row stored
+ * under this schema can be passed inline to the future scoring engine
+ * input without any kind-by-kind reinterpretation. The byte-array
+ * encoding of `first_value` / `second_value` for the GraphQL
+ * `[Int!]!` shape happens at that boundary; we keep human-readable
+ * strings here for storage and UI editing. See `inline-input.ts` for
+ * the enum-name translator and round-trip test.
+ *
+ * No `server-only` import: this module is also consumed by the form
+ * components for client-side input shape parity.
+ */
+
+import { z } from "zod";
+
+// ── Enum-like literal sets ────────────────────────────────────────
+//
+// Each set mirrors the matching GraphQL enum in `schemas/review.graphql`.
+// `inline-input.ts` proves the round-trip mapping; if you edit a list
+// here, update that translator and its test together.
+
+export const VALUE_KINDS = [
+  "string",
+  "integer",
+  "u_integer",
+  "vector",
+  "float",
+  "ipaddr",
+  "bool",
+] as const;
+export type ValueKind = (typeof VALUE_KINDS)[number];
+
+export const CMP_KINDS = [
+  "less",
+  "equal",
+  "greater",
+  "less_or_equal",
+  "greater_or_equal",
+  "contain",
+  "open_range",
+  "close_range",
+  "left_open_range",
+  "right_open_range",
+  "not_equal",
+  "not_contain",
+  "not_open_range",
+  "not_close_range",
+  "not_left_open_range",
+  "not_right_open_range",
+] as const;
+export type CmpKind = (typeof CMP_KINDS)[number];
+
+// Range cmp kinds require a non-empty `second_value` so the engine has
+// both ends of the interval. Listed here so `validation.ts` and the
+// inline-input translator can share a single source of truth.
+export const RANGE_CMP_KINDS = new Set<CmpKind>([
+  "open_range",
+  "close_range",
+  "left_open_range",
+  "right_open_range",
+  "not_open_range",
+  "not_close_range",
+  "not_left_open_range",
+  "not_right_open_range",
+]);
+
+export const RESPONSE_KINDS = ["manual", "blacklist", "whitelist"] as const;
+export type ResponseKind = (typeof RESPONSE_KINDS)[number];
+
+export const RAW_EVENT_KINDS = [
+  "bootp",
+  "conn",
+  "dhcp",
+  "dns",
+  "ftp",
+  "http",
+  "kerberos",
+  "ldap",
+  "log",
+  "mqtt",
+  "network",
+  "nfs",
+  "ntlm",
+  "radius",
+  "rdp",
+  "smb",
+  "smtp",
+  "ssh",
+  "tls",
+  "window",
+] as const;
+export type RawEventKind = (typeof RAW_EVENT_KINDS)[number];
+
+export const THREAT_CATEGORIES = [
+  "reconnaissance",
+  "initial_access",
+  "execution",
+  "credential_access",
+  "discovery",
+  "lateral_movement",
+  "command_and_control",
+  "exfiltration",
+  "impact",
+  "collection",
+  "defense_evasion",
+  "persistence",
+  "privilege_escalation",
+  "resource_development",
+] as const;
+export type ThreatCategory = (typeof THREAT_CATEGORIES)[number];
+
+// ── Rule schemas ─────────────────────────────────────────────────
+
+export const packetAttrSchema = z.object({
+  raw_event_kind: z.enum(RAW_EVENT_KINDS),
+  attr_name: z.string().min(1).max(128),
+  value_kind: z.enum(VALUE_KINDS),
+  cmp_kind: z.enum(CMP_KINDS),
+  first_value: z.string().min(1).max(2048),
+  second_value: z.string().max(2048).optional().nullable(),
+  weight: z.number().finite().optional().nullable(),
+});
+
+export type PacketAttr = z.infer<typeof packetAttrSchema>;
+
+export const confidenceSchema = z.object({
+  threat_category: z.enum(THREAT_CATEGORIES),
+  threat_kind: z.string().min(1).max(128),
+  confidence: z.number().min(0).max(1),
+  weight: z.number().finite().optional().nullable(),
+});
+
+export type Confidence = z.infer<typeof confidenceSchema>;
+
+export const responseSchema = z.object({
+  minimum_score: z.number().finite(),
+  kind: z.enum(RESPONSE_KINDS),
+});
+
+export type Response = z.infer<typeof responseSchema>;
+
+// ── Policy schemas ───────────────────────────────────────────────
+
+export const policyBaseSchema = z.object({
+  name: z.string().min(1).max(255),
+  packet_attr: z.array(packetAttrSchema).default([]),
+  confidence: z.array(confidenceSchema).default([]),
+  response: z.array(responseSchema).default([]),
+});
+
+// `.strict()` makes typos like `{ "packet_attrs": [...] }` or
+// `{ "respnose": [...] }` fail with 400 rather than be silently
+// stripped and persisted as an empty-rule policy. Without it, Zod's
+// default behavior would drop the unknown key and the rule-array
+// `.default([])` would fill in `[]`, so a POST with a typo'd field
+// would succeed with the intended rules missing.
+export const policyCreateSchema = policyBaseSchema.strict();
+
+// `policyBaseSchema.partial()` would keep the `.default([])` on the
+// rule-array fields, so a PATCH body that omits those keys would still
+// resolve to empty arrays and the route would clear every list on
+// disk. The update schema therefore re-declares those fields as
+// optional (no defaults) so an absent key remains `undefined` and the
+// repository skips it.
+//
+// `.strict()` makes typos like `{ "respnose": [...] }` fail with 400
+// rather than parse to `{}` and silently no-op (which would still emit
+// a misleading audit row). The route additionally rejects bodies that
+// parse to no recognized fields so empty objects don't no-op.
+export const policyUpdateSchema = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    packet_attr: z.array(packetAttrSchema).optional(),
+    confidence: z.array(confidenceSchema).optional(),
+    response: z.array(responseSchema).optional(),
+  })
+  .strict();
+
+export type PolicyCreateInput = z.infer<typeof policyCreateSchema>;
+export type PolicyUpdateInput = z.infer<typeof policyUpdateSchema>;
+
+export interface TriagePolicyRow {
+  id: number;
+  name: string;
+  packet_attr: PacketAttr[];
+  confidence: Confidence[];
+  response: Response[];
+  created_at: string;
+  updated_at: string;
+}

--- a/src/lib/triage/policy/validation.ts
+++ b/src/lib/triage/policy/validation.ts
@@ -1,0 +1,164 @@
+/**
+ * Semantic validation for TriagePolicy rules beyond Zod's structural
+ * checks.
+ *
+ * Scope here is the IP/CIDR validity of `ipaddr`-typed `packet_attr`
+ * values and the range-cmp invariant that range comparisons carry both
+ * ends of the interval. Domain exclusion regex compilability — the
+ * other half of the wording in #459 — lives on `ExclusionReason` rows
+ * under ticket 1B-2 (#447 §2.1, §3.4) and is not part of TriagePolicy
+ * under the new model. Removing the legacy `match` / `not_match`
+ * cmp kinds here keeps the stored shape aligned with review-web's
+ * `AttrCmpKind` enum (see `inline-input.ts`).
+ */
+
+import { isIP } from "node:net";
+
+import type {
+  Confidence,
+  PacketAttr,
+  PolicyCreateInput,
+  PolicyUpdateInput,
+  Response,
+} from "./types";
+import { RANGE_CMP_KINDS } from "./types";
+
+export interface PolicyValidationIssue {
+  /** Dot-path to the offending field, e.g. "packet_attr.0.first_value". */
+  path: string;
+  message: string;
+}
+
+export interface PolicyValidationResult {
+  valid: boolean;
+  issues: PolicyValidationIssue[];
+}
+
+// Match the prefix as a non-empty digit-only string. `Number()` coerces
+// "", "+8", "1e1", and " 8" silently — none of which are valid CIDR
+// prefixes — so we parse the raw substring with a strict regex first
+// and only then range-check the integer.
+const CIDR_PREFIX_RE = /^\d+$/;
+
+function validateIpOrCidr(value: string): string | null {
+  const slash = value.indexOf("/");
+  if (slash === -1) {
+    if (isIP(value) === 0) return "Not a valid IP address";
+    return null;
+  }
+  const ip = value.slice(0, slash);
+  const prefixStr = value.slice(slash + 1);
+  const version = isIP(ip);
+  if (version === 0) return "Not a valid IP address in CIDR";
+  if (!CIDR_PREFIX_RE.test(prefixStr)) {
+    return "Invalid CIDR prefix length";
+  }
+  const prefix = Number(prefixStr);
+  if ((version === 4 && prefix > 32) || (version === 6 && prefix > 128)) {
+    return "Invalid CIDR prefix length";
+  }
+  return null;
+}
+
+function validatePacketAttr(
+  rule: PacketAttr,
+  index: number,
+  issues: PolicyValidationIssue[],
+): void {
+  if (rule.value_kind === "ipaddr") {
+    const firstErr = validateIpOrCidr(rule.first_value);
+    if (firstErr) {
+      issues.push({
+        path: `packet_attr.${index}.first_value`,
+        message: firstErr,
+      });
+    }
+    if (
+      rule.second_value !== undefined &&
+      rule.second_value !== null &&
+      rule.second_value.length > 0
+    ) {
+      const secondErr = validateIpOrCidr(rule.second_value);
+      if (secondErr) {
+        issues.push({
+          path: `packet_attr.${index}.second_value`,
+          message: secondErr,
+        });
+      }
+    }
+  }
+
+  // Range comparisons need both endpoints; the engine has no way to
+  // resolve `open_range` / `close_range` / `*_range` without the
+  // upper bound. Reject the rule rather than persisting half a range.
+  if (RANGE_CMP_KINDS.has(rule.cmp_kind)) {
+    const hasSecond =
+      rule.second_value !== undefined &&
+      rule.second_value !== null &&
+      rule.second_value.length > 0;
+    if (!hasSecond) {
+      issues.push({
+        path: `packet_attr.${index}.second_value`,
+        message: `cmp_kind '${rule.cmp_kind}' requires a non-empty second_value`,
+      });
+    }
+  }
+}
+
+function validateConfidence(
+  rule: Confidence,
+  index: number,
+  issues: PolicyValidationIssue[],
+): void {
+  if (rule.threat_kind.trim().length === 0) {
+    issues.push({
+      path: `confidence.${index}.threat_kind`,
+      message: "threat_kind must not be empty",
+    });
+  }
+}
+
+function validateResponse(
+  rule: Response,
+  index: number,
+  issues: PolicyValidationIssue[],
+): void {
+  if (!Number.isFinite(rule.minimum_score)) {
+    issues.push({
+      path: `response.${index}.minimum_score`,
+      message: "minimum_score must be a finite number",
+    });
+  }
+}
+
+/**
+ * Run semantic checks on a fully-parsed policy payload (create or update).
+ * Pure: returns issues without throwing so callers can shape error
+ * responses.
+ */
+export function validatePolicySemantics(
+  input: PolicyCreateInput | PolicyUpdateInput,
+): PolicyValidationResult {
+  const issues: PolicyValidationIssue[] = [];
+
+  if (input.packet_attr) {
+    input.packet_attr.forEach((rule, i) => {
+      validatePacketAttr(rule, i, issues);
+    });
+  }
+  if (input.confidence) {
+    input.confidence.forEach((rule, i) => {
+      validateConfidence(rule, i, issues);
+    });
+  }
+  if (input.response) {
+    input.response.forEach((rule, i) => {
+      validateResponse(rule, i, issues);
+    });
+  }
+
+  return { valid: issues.length === 0, issues };
+}
+
+// Re-exported for tests covering address parsing in isolation.
+export { validateIpOrCidr as _validateIpOrCidr };


### PR DESCRIPTION
## Summary

Adds the per-tenant TriagePolicy storage layer, CRUD REST routes, and management UI from issue #459 (1B-5). All new code lives under a `triage/policy/*` namespace per the deprecatability seam in discussion #447 §6, so the entire feature can be removed later by deleting the namespace and the lone migration file.

- **Storage** — `migrations/customer/0002_triage_policy.sql` adds a `triage_policy` table to every per-customer tenant DB. Rule lists are stored as JSONB; tenancy is implicit in the database itself, so no `customer_id` column is needed. `id` is `SERIAL` (32-bit) so node-postgres returns it as a JS number, matching `TriagePolicyRow.id: number` and the GraphQL `Int` path described in #447 §2.1.
- **Repository** — `src/lib/triage/policy/{repository,customer-db,types}.ts` resolves a per-customer pool from `customers.database_name` (cached per process) and exposes list / get / create / patch / delete with explicit `TriagePolicyNameConflictError` on PG `23505`. `updatePolicy` skips columns that are `undefined` in the input so PATCH bodies that omit a key never overwrite the stored value.
- **Schema alignment with the GraphQL inline-policy contract** — `RAW_EVENT_KINDS`, `VALUE_KINDS`, `CMP_KINDS`, `RESPONSE_KINDS`, and `THREAT_CATEGORIES` literal sets in `types.ts` are now exact lower-snake-case mirrors of `RawEventKind`, `ValueKind`, `AttrCmpKind`, `ResponseKind`, and `ThreatCategory` in `schemas/review.graphql`. `packet_attr.raw_event_kind` is `z.enum(RAW_EVENT_KINDS)` so unknown kinds (e.g. `"Conn"` with the wrong case, or `"unknown"`) are rejected at create/update time. Legacy `match` / `not_match` cmp kinds (which don't exist in `AttrCmpKind`) are removed; the missing range variants (`open_range`, `close_range`, `left_open_range`, `right_open_range` and their `not_*` negations) and value kinds (`u_integer`, `vector`, `float`) are added. `src/lib/triage/policy/inline-input.ts` exposes the explicit name-to-name translator (including `rawEventKindToGraphql`) and the round-trip test (`__tests__/lib/triage/policy/inline-input.test.ts`) parses the checked-in GraphQL schema and asserts every literal we accept maps to a real enum member, so the storage shape can never persist a kind the engine has no name for.
- **Validation** — `src/lib/triage/policy/validation.ts` runs after Zod's structural pass. It (a) parses `ipaddr`-typed values as IP or `IP/prefix` (v4 ≤ 32, v6 ≤ 128) using `node:net`'s `isIP`, with CIDR prefixes matched as digits only via a strict regex before the integer range check so `Number()`-coercible inputs (`/`, `/+8`, `/1e1`, `/0x8`, `/8.0`, `/0_8`, `/ 8`) are rejected, and (b) requires range cmp kinds to carry a non-empty `second_value` so the engine sees both ends of the interval. Domain regex compilability is owned by 1B-2 (see "Not addressed" below) and is no longer in this module.
- **Routes** — `/api/triage/policies` and `/api/triage/policies/[id]` accept `?customer_id=`, require `triage:read` for GETs and `triage:policy:write` for POST/PATCH/DELETE, and re-check the caller's customer scope (`customers:access-all` or membership in `account_customer`). `policyCreateSchema` and `policyUpdateSchema` are both `.strict()` so unknown / typo'd top-level keys (`packet_attrs`, `respnose`, `extra`) return 400 rather than silently persisting an empty-rule policy or no-op'ing into a misleading audit row; the PATCH route additionally rejects bodies that parse to no recognized fields.
- **Audit** — emits `triage.policy.{create,update,delete}` against a new `triage_policy` target type, all marked customer-scoped because the row is intrinsically tenant-bound.
- **UI** — `/triage/policies` page is a server component that resolves customer options from `getEffectiveCustomerScope(session)` (so a `triage:policy:write` user without `customers:read` can still use the page) and threads a `canWritePolicy` flag into the manager so read-only triage users do not see Create / Edit / Delete affordances they would only be denied at submit time. The form dialog provides JSON-array editors for the three rule lists with live validation, plus matching i18n strings in `en.json` / `ko.json`. The delete confirmation now suppresses Radix's default close so a failed DELETE keeps the dialog mounted, with the error visible and the action available to retry.
- **Tests** — Zod + semantic validation cases (regex/IP/CIDR bounds, `Number()`-coercible prefix inputs, range cmp `second_value` requirement), inline-input round-trip cases (every accepted enum literal — including `RAW_EVENT_KINDS` — maps to a real GraphQL enum member), and route handler tests covering both `route.ts` (list / create) and `[id]/route.ts` (get / patch / delete) for auth, scope, validation, name conflicts, 404, audit emission, name-only PATCH preservation of omitted arrays, strict create/update unknown-key rejection, empty-PATCH rejection, and unknown-`raw_event_kind` rejection.

## Not addressed

- **Domain exclusion data on TriagePolicy.** Issue #459 mentions "regex compilability of Domain exclusion patterns and IP/CIDR validity," which is a holdover from the legacy RocksDB schema where `TriagePolicy.triage_exclusion_id` referenced `ExclusionReason` rows. Per discussion #447 §2.1 the new model splits exclusions into their own tables — global exclusion in `auth_db` and customer-scoped exclusion in each tenant DB — owned by ticket 1B-2 (#447 §3.4 and §5 row 1B-2), not 1B-5. So this PR validates the IP/CIDR fields that DO live on TriagePolicy rows under this design (the `ipaddr` `packet_attr` values), and leaves Domain / IP exclusion regex / CIDR validation to 1B-2.
- **Byte-array encoding of `first_value` / `second_value`.** review-web's `PacketAttrInput.firstValue` is `[Int!]!` (a byte array). `inline-input.ts` ships the enum-name half of the inline-policy translator; the byte-encoding half (utf-8 for `string`, big-endian ints for `integer` / `u_integer` / `float`, packed bytes for `ipaddr`, etc.) lives at the inline-policy boundary outside this `triage/policy/` deprecatability namespace and will land with the `eventListWithTriage` plumbing in a separate ticket.
- **Manual documentation.** Per `CLAUDE.md`, manual pages must accompany shipped features, but the project guide also says "Do not write docs for features still under active development." The TriagePolicy UI is still the first cut (rule editors are JSON-textarea today, not visual builders) and the corpus-B feature it backs is not yet exposed to end users, so the EN/KR manual pages and screenshots are deferred until the UX stabilizes (tracked under 1B-10).

## Test plan

- [x] `pnpm vitest run` (3225 tests) passes
- [x] `pnpm tsc --noEmit` and `pnpm biome check` are clean for the touched paths
- [x] Apply `migrations/customer/0002_triage_policy.sql` to a fresh tenant DB and confirm `\d triage_policy` shows the JSONB columns and the unique `name` index
- [x] As a `triage:policy:write` user, create / edit / delete a policy via `/triage/policies` and confirm rows appear in the tenant DB
- [x] As a read-only triage user (`triage:read` only, no `triage:policy:write`), confirm GET works, the Create button and per-row Edit / Delete menu are hidden, and POST/PATCH/DELETE return 403
- [x] As a `triage:policy:write` user without `customers:read`, confirm the page loads and shows the customer scope from `getEffectiveCustomerScope` (no `/api/customers` call)
- [x] Submit a policy with an invalid CIDR (e.g. `10.0.0.0/40`, `10.0.0.0/`, `10.0.0.0/+8`, `10.0.0.0/1e1`) and confirm a 400 with a CIDR-prefix issue
- [x] Submit a policy with `cmp_kind: open_range` and no `second_value` and confirm a 400 with a range-cmp issue
- [x] Submit a policy with the legacy `cmp_kind: match` (no longer in `AttrCmpKind`) and confirm Zod rejects it with 400
- [x] Submit a policy with an unknown `raw_event_kind` (e.g. `"Conn"`, `"unknown"`) and confirm Zod rejects it with 400
- [x] Create two policies with the same `name` and confirm the second returns 409 with `code: name_conflict`
- [x] As a caller without access to the requested `customer_id`, confirm GET/POST return 403
- [x] Confirm `triage.policy.{create,update,delete}` audit rows appear with the correct `customerId` and target ID

Part of #459
