### PR TITLE
Widen Triage corpus for pivot dimensions (#476)

### DIFF
--- a/src/__tests__/lib/triage/aggregate.test.ts
+++ b/src/__tests__/lib/triage/aggregate.test.ts
@@ -25,6 +25,7 @@ describe("aggregateTriageEvents", () => {
     expect(result.assets).toEqual([]);
     expect(result.truncated).toBe(false);
     expect(result.loadedEventCount).toBe(0);
+    expect(result.events).toEqual([]);
   });
 
   it("computes funnel stats and pass-through rate", () => {
@@ -177,5 +178,102 @@ describe("aggregateTriageEvents", () => {
     expect(asset.score).toBeGreaterThan(0);
     expect(asset.events).toHaveLength(1);
     expect(asset.events[0].category).toBe("EXFILTRATION");
+  });
+
+  describe("scored events corpus", () => {
+    it("attaches per-event score on the top-level events array", () => {
+      const triaged = ev({
+        origAddr: "10.0.0.1",
+        category: "COMMAND_AND_CONTROL",
+        time: "2026-05-09T10:00:00.000Z",
+      });
+      const httpClusterNone = ev({
+        __typename: "HttpThreat",
+        origAddr: "10.0.0.1",
+        category: "INITIAL_ACCESS",
+        clusterId: "",
+        time: "2026-05-09T11:00:00.000Z",
+      });
+      const noise = ev({
+        origAddr: "10.0.0.1",
+        category: "DISCOVERY",
+        time: "2026-05-09T12:00:00.000Z",
+      });
+      const result = aggregateTriageEvents(
+        [triaged, httpClusterNone, noise],
+        false,
+      );
+      expect(result.events).toHaveLength(3);
+      const byTime = new Map(result.events.map((e) => [e.time, e.score]));
+      expect(byTime.get("2026-05-09T10:00:00.000Z")).toBe(1);
+      expect(byTime.get("2026-05-09T11:00:00.000Z")).toBe(1.5);
+      expect(byTime.get("2026-05-09T12:00:00.000Z")).toBe(0);
+    });
+
+    it("attaches per-event score on assets[*].events", () => {
+      const events: TriageEvent[] = [
+        ev({ origAddr: "10.0.0.1", category: "EXFILTRATION" }),
+        ev({
+          __typename: "HttpThreat",
+          origAddr: "10.0.0.1",
+          category: "INITIAL_ACCESS",
+          clusterId: "none",
+        }),
+      ];
+      const result = aggregateTriageEvents(events, false);
+      const [asset] = result.assets;
+      expect(asset.events).toHaveLength(2);
+      const scores = asset.events.map((e) => e.score).sort();
+      expect(scores).toEqual([1, 1.5]);
+    });
+
+    it("the top-level events length equals loadedEventCount", () => {
+      const events: TriageEvent[] = Array.from({ length: 17 }, (_, i) =>
+        ev({
+          origAddr: i % 2 === 0 ? "10.0.0.1" : undefined,
+          category: i % 3 === 0 ? "EXFILTRATION" : "RECONNAISSANCE",
+          time: `2026-05-09T${String(i % 24).padStart(2, "0")}:00:00.000Z`,
+        }),
+      );
+      const result = aggregateTriageEvents(events, false);
+      expect(result.events).toHaveLength(result.loadedEventCount);
+      expect(result.events).toHaveLength(17);
+    });
+
+    it("includes non-baseline events in the top-level corpus with score 0", () => {
+      // #452 builds its pivot index over the full corpus and filters
+      // to triaged events at index time, so non-baseline events MUST
+      // be present in `events` (with score 0) even though they are
+      // absent from the per-asset detail list.
+      const events: TriageEvent[] = [
+        ev({ origAddr: "10.0.0.1", category: "RECONNAISSANCE" }),
+        ev({ origAddr: "10.0.0.2", category: "EXFILTRATION" }),
+      ];
+      const result = aggregateTriageEvents(events, false);
+      expect(result.events).toHaveLength(2);
+      const recon = result.events.find((e) => e.category === "RECONNAISSANCE");
+      const exfil = result.events.find((e) => e.category === "EXFILTRATION");
+      expect(recon?.score).toBe(0);
+      expect(exfil?.score).toBe(1);
+    });
+
+    it("keeps the 50-cap on assets[*].events while events corpus is uncapped", () => {
+      // Generate 60 baseline-passing events for one asset. The asset
+      // detail list must stay capped at 50, but the top-level scored
+      // corpus must contain all 60 so #452 can pivot over the full
+      // loaded slice.
+      const events: TriageEvent[] = Array.from({ length: 60 }, (_, i) => {
+        const hour = String(i % 24).padStart(2, "0");
+        const minute = String(Math.floor(i / 24)).padStart(2, "0");
+        return ev({
+          origAddr: "10.0.0.1",
+          category: "EXFILTRATION",
+          time: `2026-05-09T${hour}:${minute}:00.000Z`,
+        });
+      });
+      const result = aggregateTriageEvents(events, false);
+      expect(result.events).toHaveLength(60);
+      expect(result.assets[0].events).toHaveLength(50);
+    });
   });
 });

--- a/src/__tests__/lib/triage/classify.test.ts
+++ b/src/__tests__/lib/triage/classify.test.ts
@@ -1,0 +1,219 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyTriageEndpoint,
+  type TriageEvent,
+  type TriageHostNetworkGroup,
+} from "@/lib/triage";
+
+function ev(overrides: Partial<TriageEvent>): TriageEvent {
+  return {
+    __typename: "NetworkThreat",
+    time: "2026-05-09T12:00:00.000Z",
+    sensor: "sensor-a",
+    category: "EXFILTRATION",
+    level: "MEDIUM",
+    ...overrides,
+  };
+}
+
+function group(
+  overrides: Partial<TriageHostNetworkGroup> = {},
+): TriageHostNetworkGroup {
+  return {
+    hosts: [],
+    networks: [],
+    ranges: [],
+    ...overrides,
+  };
+}
+
+describe("classifyTriageEndpoint", () => {
+  describe("customer-network-membership wins on the requested side", () => {
+    it("classifies as internal when origAddr falls inside origNetwork CIDR", () => {
+      const event = ev({
+        origAddr: "203.0.113.5",
+        origNetwork: { networks: group({ networks: ["203.0.113.0/24"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "orig")).toBe("internal");
+    });
+
+    it("classifies as internal when origAddr matches an exact host", () => {
+      const event = ev({
+        origAddr: "8.8.8.8",
+        origNetwork: { networks: group({ hosts: ["8.8.8.8"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "orig")).toBe("internal");
+    });
+
+    it("classifies as internal when origAddr falls inside a range", () => {
+      const event = ev({
+        origAddr: "8.8.8.4",
+        origNetwork: {
+          networks: group({ ranges: [{ start: "8.8.8.1", end: "8.8.8.10" }] }),
+        },
+      });
+      expect(classifyTriageEndpoint(event, "orig")).toBe("internal");
+    });
+
+    it("classifies as external when origAddr is a public IP outside the customer network", () => {
+      // Without metadata it would be external by RFC1918 fallback as
+      // well, but the customer-metadata branch must reach the same
+      // answer authoritatively rather than falling through.
+      const event = ev({
+        origAddr: "8.8.8.8",
+        origNetwork: { networks: group({ networks: ["203.0.113.0/24"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "orig")).toBe("external");
+    });
+
+    it("classifies an RFC1918 address as external when customer metadata excludes it", () => {
+      // Customer metadata is authoritative — so a 10.x address that
+      // is NOT in the customer's defined network is external, even
+      // though the RFC1918 fallback would have said internal.
+      const event = ev({
+        origAddr: "10.0.0.5",
+        origNetwork: { networks: group({ networks: ["192.168.0.0/16"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "orig")).toBe("external");
+    });
+  });
+
+  describe("RFC1918 / IPv6 fallback when no customer metadata is present", () => {
+    it.each([
+      ["10.0.0.1"],
+      ["10.255.255.254"],
+      ["172.16.0.1"],
+      ["172.31.255.254"],
+      ["192.168.1.1"],
+      ["127.0.0.1"],
+      ["169.254.10.10"],
+      ["100.64.0.1"],
+      ["100.127.255.254"],
+    ])("classifies %s as internal", (addr) => {
+      expect(classifyTriageEndpoint(ev({ origAddr: addr }), "orig")).toBe(
+        "internal",
+      );
+    });
+
+    it.each([
+      ["::1"],
+      ["fc00::1"],
+      ["fd12:3456::1"],
+      ["fe80::1"],
+      ["fe80::abcd:1234"],
+    ])("classifies IPv6 %s as internal", (addr) => {
+      expect(classifyTriageEndpoint(ev({ origAddr: addr }), "orig")).toBe(
+        "internal",
+      );
+    });
+
+    it.each([
+      ["8.8.8.8"],
+      ["1.1.1.1"],
+      ["172.32.0.1"],
+      ["192.169.0.1"],
+      ["100.128.0.1"],
+      ["2001:db8::1"],
+      ["2606:4700:4700::1111"],
+    ])("classifies %s as external", (addr) => {
+      expect(classifyTriageEndpoint(ev({ origAddr: addr }), "orig")).toBe(
+        "external",
+      );
+    });
+  });
+
+  describe("unparseable addresses return unknown", () => {
+    it.each([
+      ["nonsense"],
+      ["999.999.999.999"],
+      ["10.0.0"],
+      ["10.0.0.0.0"],
+      ["10.0.0.-1"],
+      [":::1"],
+      ["g123::1"],
+      [""],
+    ])("classifies %s as unknown", (addr) => {
+      expect(classifyTriageEndpoint(ev({ origAddr: addr }), "orig")).toBe(
+        "unknown",
+      );
+    });
+
+    it("classifies a missing origAddr as unknown", () => {
+      expect(classifyTriageEndpoint(ev({ origAddr: undefined }), "orig")).toBe(
+        "unknown",
+      );
+    });
+
+    it("classifies a null origAddr as unknown", () => {
+      expect(classifyTriageEndpoint(ev({ origAddr: null }), "orig")).toBe(
+        "unknown",
+      );
+    });
+  });
+
+  describe("orig vs resp side selection cannot leak metadata across sides", () => {
+    it("ignores respNetwork when classifying orig", () => {
+      // origAddr is a public address that would be 'external' under
+      // RFC1918 fallback. respNetwork lists it but origNetwork is
+      // absent, so the orig side must NOT use respNetwork.
+      const event = ev({
+        origAddr: "8.8.8.8",
+        respAddr: "10.0.0.1",
+        respNetwork: { networks: group({ hosts: ["8.8.8.8"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "orig")).toBe("external");
+    });
+
+    it("ignores origNetwork when classifying resp", () => {
+      const event = ev({
+        origAddr: "10.0.0.1",
+        respAddr: "8.8.8.8",
+        origNetwork: { networks: group({ hosts: ["8.8.8.8"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "resp")).toBe("external");
+    });
+
+    it("classifies the resp side using respAddr + respNetwork", () => {
+      const event = ev({
+        origAddr: "8.8.8.8",
+        respAddr: "203.0.113.5",
+        respNetwork: { networks: group({ networks: ["203.0.113.0/24"] }) },
+      });
+      expect(classifyTriageEndpoint(event, "resp")).toBe("internal");
+    });
+
+    it("returns unknown for the resp side when respAddr is missing", () => {
+      // RdpBruteForce / MultiHostPortScan etc. expose no respAddr.
+      const event = ev({
+        origAddr: "10.0.0.1",
+        respAddr: undefined,
+      });
+      expect(classifyTriageEndpoint(event, "resp")).toBe("unknown");
+    });
+  });
+});
+
+describe("classifier import boundary", () => {
+  // Guard rail for #476 §2: the classifier must be importable from
+  // the client bundle. `src/lib/auth/cidr.ts` is `server-only` and
+  // depends on `node:net`; if the classifier transitively pulled in
+  // either, this would fail.
+  it("does not declare a server-only side-effect or import node:net", () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      "../../../lib/triage/classify.ts",
+    );
+    const source = readFileSync(sourcePath, "utf8");
+    expect(source).not.toMatch(/from\s+["']server-only["']/);
+    expect(source).not.toMatch(/import\s+["']server-only["']/);
+    expect(source).not.toMatch(/from\s+["']node:net["']/);
+    expect(source).not.toMatch(/from\s+["']node:/);
+    // Reusing src/lib/auth/cidr.ts directly is forbidden — the whole
+    // point of the fork is to avoid dragging the server-only boundary
+    // into the client bundle.
+    expect(source).not.toMatch(/from\s+["']@\/lib\/auth\/cidr["']/);
+  });
+});

--- a/src/__tests__/lib/triage/queries.test.ts
+++ b/src/__tests__/lib/triage/queries.test.ts
@@ -1,13 +1,26 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import {
+  buildSchema,
   type DocumentNode,
   type FieldNode,
+  type GraphQLObjectType,
+  type GraphQLSchema,
   type InlineFragmentNode,
+  isObjectType,
   Kind,
   type SelectionSetNode,
 } from "graphql";
 import { describe, expect, it } from "vitest";
 
 import { TRIAGE_EVENT_LIST_QUERY } from "@/lib/triage/queries";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const SCHEMA_PATH = path.join(REPO_ROOT, "schemas/review.graphql");
+
+function loadSchema(): GraphQLSchema {
+  return buildSchema(readFileSync(SCHEMA_PATH, "utf8"));
+}
 
 function findEventListSelectionSet(doc: DocumentNode): SelectionSetNode {
   for (const def of doc.definitions) {
@@ -50,7 +63,20 @@ function selectsField(node: InlineFragmentNode, fieldName: string): boolean {
   );
 }
 
+function objectType(schema: GraphQLSchema, name: string): GraphQLObjectType {
+  const t = schema.getType(name);
+  if (!t || !isObjectType(t)) {
+    throw new Error(`schema does not define object type ${name}`);
+  }
+  return t;
+}
+
+function exposesField(t: GraphQLObjectType, fieldName: string): boolean {
+  return Object.hasOwn(t.getFields(), fieldName);
+}
+
 describe("TRIAGE_EVENT_LIST_QUERY", () => {
+  const schema = loadSchema();
   const nodesSelectionSet = findEventListSelectionSet(TRIAGE_EVENT_LIST_QUERY);
 
   // Subtypes that expose `origAddr` and whose category falls inside the
@@ -100,6 +126,52 @@ describe("TRIAGE_EVENT_LIST_QUERY", () => {
     "TorConnectionConn",
   ] as const;
 
+  // Pivot dimensions defined in #476 §1: per-subtype the query must
+  // select every one of these that the schema actually defines on
+  // that subtype. Coverage is uneven (RdpBruteForce has no resp side
+  // at all; MultiHostPortScan / PortScan / FtpBruteForce /
+  // LdapBruteForce are missing one or more of origPort / respAddr /
+  // respCountry), so the test consults the schema to decide what
+  // each fragment must select rather than asserting a uniform list.
+  const NETWORK_DIMENSION_FIELDS = [
+    "respAddr",
+    "origPort",
+    "respPort",
+    "origCountry",
+    "respCountry",
+    "origNetwork",
+    "respNetwork",
+  ] as const;
+
+  // HTTP-shaped subtypes: only these four get host/uri/userAgent in
+  // 1A-1.1, even though the schema may expose those fields on other
+  // subtypes (e.g. TorConnection). RepeatedHttpSessions is the
+  // intentionally-skipped HTTP subtype — see issue.
+  const HTTP_ALLOWLIST = [
+    "BlocklistHttp",
+    "HttpThreat",
+    "NonBrowser",
+    "DomainGenerationAlgorithm",
+  ] as const;
+  const HTTP_FIELDS = ["host", "uri", "userAgent"] as const;
+
+  const DNS_ALLOWLIST = [
+    "BlocklistDns",
+    "DnsCovertChannel",
+    "CryptocurrencyMiningPool",
+    "LockyRansomware",
+  ] as const;
+  const DNS_FIELDS = ["query", "answer"] as const;
+
+  const TLS_ALLOWLIST = ["BlocklistTls", "SuspiciousTlsTraffic"] as const;
+  const TLS_FIELDS = [
+    "ja3",
+    "ja3S",
+    "serverName",
+    "serial",
+    "subjectCommonName",
+  ] as const;
+
   it.each(
     REQUIRED_WHITELIST_SUBTYPES,
   )("selects origAddr on the %s inline fragment", (typeName) => {
@@ -115,5 +187,80 @@ describe("TRIAGE_EVENT_LIST_QUERY", () => {
     const fragment = inlineFragmentFor(nodesSelectionSet, "HttpThreat");
     expect(fragment).toBeDefined();
     expect(fragment && selectsField(fragment, "clusterId")).toBe(true);
+  });
+
+  describe("network pivot dimensions", () => {
+    for (const subtype of REQUIRED_WHITELIST_SUBTYPES) {
+      describe(subtype, () => {
+        const obj = objectType(schema, subtype);
+        const fragment = inlineFragmentFor(nodesSelectionSet, subtype);
+        for (const field of NETWORK_DIMENSION_FIELDS) {
+          const exposes = exposesField(obj, field);
+          if (exposes) {
+            it(`selects ${field} (schema exposes it)`, () => {
+              expect(fragment).toBeDefined();
+              expect(fragment && selectsField(fragment, field)).toBe(true);
+            });
+          } else {
+            it(`does not select ${field} (schema does not expose it)`, () => {
+              expect(fragment).toBeDefined();
+              expect(fragment && selectsField(fragment, field)).toBe(false);
+            });
+          }
+        }
+      });
+    }
+  });
+
+  describe("HTTP-shaped pivot fields", () => {
+    for (const subtype of HTTP_ALLOWLIST) {
+      it.each(HTTP_FIELDS)(`selects %s on ${subtype}`, (field) => {
+        const fragment = inlineFragmentFor(nodesSelectionSet, subtype);
+        expect(fragment).toBeDefined();
+        expect(fragment && selectsField(fragment, field)).toBe(true);
+      });
+    }
+
+    it.each(
+      HTTP_FIELDS,
+    )("does not select %s on RepeatedHttpSessions (intentionally skipped)", (field) => {
+      const fragment = inlineFragmentFor(
+        nodesSelectionSet,
+        "RepeatedHttpSessions",
+      );
+      expect(fragment).toBeDefined();
+      expect(fragment && selectsField(fragment, field)).toBe(false);
+    });
+  });
+
+  describe("DNS-shaped pivot fields", () => {
+    for (const subtype of DNS_ALLOWLIST) {
+      it.each(DNS_FIELDS)(`selects %s on ${subtype}`, (field) => {
+        const fragment = inlineFragmentFor(nodesSelectionSet, subtype);
+        expect(fragment).toBeDefined();
+        expect(fragment && selectsField(fragment, field)).toBe(true);
+      });
+    }
+
+    it.each(
+      DNS_FIELDS,
+    )("does not select %s on BlocklistMalformedDns (no payload)", (field) => {
+      const fragment = inlineFragmentFor(
+        nodesSelectionSet,
+        "BlocklistMalformedDns",
+      );
+      expect(fragment).toBeDefined();
+      expect(fragment && selectsField(fragment, field)).toBe(false);
+    });
+  });
+
+  describe("TLS-shaped pivot fields", () => {
+    for (const subtype of TLS_ALLOWLIST) {
+      it.each(TLS_FIELDS)(`selects %s on ${subtype}`, (field) => {
+        const fragment = inlineFragmentFor(nodesSelectionSet, subtype);
+        expect(fragment).toBeDefined();
+        expect(fragment && selectsField(fragment, field)).toBe(true);
+      });
+    }
   });
 });

--- a/src/lib/triage/aggregate.ts
+++ b/src/lib/triage/aggregate.ts
@@ -1,5 +1,6 @@
 /**
- * Pure aggregation of Triage events into the funnel + asset list.
+ * Pure aggregation of Triage events into the funnel + asset list +
+ * scored corpus.
  *
  * Kept separate from the server-action layer so the scoring +
  * grouping logic is unit-testable without mocking the GraphQL
@@ -8,6 +9,7 @@
 
 import { baselineScore } from "./scoring";
 import type {
+  ScoredTriageEvent,
   TriageAsset,
   TriageEvent,
   TriageFunnel,
@@ -22,7 +24,7 @@ interface AssetAccumulator {
   detectedCount: number;
   triagedCount: number;
   score: number;
-  events: TriageEvent[];
+  events: ScoredTriageEvent[];
 }
 
 function emptyAccumulator(address: string): AssetAccumulator {
@@ -35,7 +37,10 @@ function emptyAccumulator(address: string): AssetAccumulator {
   };
 }
 
-function compareEventsNewestFirst(a: TriageEvent, b: TriageEvent): number {
+function compareEventsNewestFirst(
+  a: ScoredTriageEvent,
+  b: ScoredTriageEvent,
+): number {
   // ISO-8601 strings sort lexicographically in calendar order.
   if (a.time < b.time) return 1;
   if (a.time > b.time) return -1;
@@ -58,9 +63,10 @@ function compareAssets(a: TriageAsset, b: TriageAsset): number {
  *
  * Events without a usable originator IP (e.g., aggregate threat
  * subtypes that emit `origAddrs` plural) are still counted in the
- * funnel denominator but do not contribute to any asset row — Phase
- * 1.A's asset key is a single originator address and the issue is
- * explicit that the asset list is sorted by score.
+ * funnel denominator and surface in the top-level scored `events`
+ * list, but do not contribute to any asset row — Phase 1.A's asset
+ * key is a single originator address and the issue is explicit that
+ * the asset list is sorted by score.
  */
 export function aggregateTriageEvents(
   events: TriageEvent[],
@@ -72,11 +78,14 @@ export function aggregateTriageEvents(
     passThroughRate: 0,
   };
   const byAddress = new Map<string, AssetAccumulator>();
+  const scoredEvents: ScoredTriageEvent[] = [];
 
   for (const event of events) {
     const score = baselineScore(event);
     const triaged = score > 0;
     if (triaged) funnel.triaged += 1;
+    const scored: ScoredTriageEvent = { ...event, score };
+    scoredEvents.push(scored);
 
     const address = typeof event.origAddr === "string" ? event.origAddr : null;
     if (!address) continue;
@@ -91,7 +100,7 @@ export function aggregateTriageEvents(
       // both whitelisted and non-whitelisted events must not surface
       // score-0 noise that could push the actual scored events out of
       // the 50-event detail window.
-      acc.events.push(event);
+      acc.events.push(scored);
     }
     byAddress.set(address, acc);
   }
@@ -132,5 +141,6 @@ export function aggregateTriageEvents(
     assets,
     truncated,
     loadedEventCount: events.length,
+    events: scoredEvents,
   };
 }

--- a/src/lib/triage/classify.ts
+++ b/src/lib/triage/classify.ts
@@ -1,0 +1,245 @@
+/**
+ * Browser-safe asset endpoint classifier for the Triage menu.
+ *
+ * Side-specific by design: the caller picks `"orig"` or `"resp"` and
+ * the helper looks up only that side's address and network metadata,
+ * so it is impossible to accidentally compare `origAddr` against
+ * `respNetwork` membership (or vice versa).
+ *
+ * The IP parsing / CIDR matching is reimplemented locally rather
+ * than imported from `src/lib/auth/cidr.ts` because that module is
+ * `server-only` and depends on `node:net`. This file must stay
+ * importable from React client components — see the unit test that
+ * asserts the import boundary.
+ */
+
+import type {
+  TriageEvent,
+  TriageHostNetworkGroup,
+  TriageNetwork,
+} from "./types";
+
+type IpVersion = 4 | 6;
+
+interface ParsedIp {
+  version: IpVersion;
+  bytes: Uint8Array;
+}
+
+const IPV4_OCTET = /^\d+$/;
+const IPV6_GROUP = /^[0-9a-fA-F]{1,4}$/;
+
+function parseIpv4(ip: string): Uint8Array | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  const bytes = new Uint8Array(4);
+  for (let i = 0; i < 4; i += 1) {
+    const part = parts[i];
+    if (!IPV4_OCTET.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    bytes[i] = n;
+  }
+  return bytes;
+}
+
+function parseIpv6(ip: string): Uint8Array | null {
+  // Strip optional zone identifier (e.g. "fe80::1%eth0").
+  const stripped = ip.split("%")[0];
+
+  // Expand a trailing dotted-quad (e.g. "::ffff:1.2.3.4") into two
+  // hex groups so the rest of the parser can stay v6-only.
+  let preprocessed = stripped;
+  const lastColon = stripped.lastIndexOf(":");
+  if (lastColon !== -1) {
+    const tail = stripped.slice(lastColon + 1);
+    if (tail.includes(".")) {
+      const v4 = parseIpv4(tail);
+      if (!v4) return null;
+      const head = stripped.slice(0, lastColon + 1);
+      const a = ((v4[0] << 8) | v4[1]).toString(16);
+      const b = ((v4[2] << 8) | v4[3]).toString(16);
+      preprocessed = `${head}${a}:${b}`;
+    }
+  }
+
+  const halves = preprocessed.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  if (halves.length === 2 && missing < 0) return null;
+  if (halves.length === 1 && left.length !== 8) return null;
+
+  const groups = [
+    ...left,
+    ...Array.from({ length: halves.length === 2 ? missing : 0 }, () => "0"),
+    ...right,
+  ];
+  if (groups.length !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 8; i += 1) {
+    if (!IPV6_GROUP.test(groups[i])) return null;
+    const value = Number.parseInt(groups[i], 16);
+    bytes[i * 2] = (value >> 8) & 0xff;
+    bytes[i * 2 + 1] = value & 0xff;
+  }
+  return bytes;
+}
+
+function parseIp(ip: string): ParsedIp | null {
+  if (ip.includes(":")) {
+    const bytes = parseIpv6(ip);
+    return bytes ? { version: 6, bytes } : null;
+  }
+  const bytes = parseIpv4(ip);
+  return bytes ? { version: 4, bytes } : null;
+}
+
+function compareBytes(a: Uint8Array, b: Uint8Array): number {
+  if (a.length !== b.length) return a.length - b.length;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+function matchesCidrBytes(
+  clientBytes: Uint8Array,
+  networkBytes: Uint8Array,
+  prefixLen: number,
+): boolean {
+  if (clientBytes.length !== networkBytes.length) return false;
+  const fullBytes = Math.floor(prefixLen / 8);
+  const remainderBits = prefixLen % 8;
+  for (let i = 0; i < fullBytes; i += 1) {
+    if (clientBytes[i] !== networkBytes[i]) return false;
+  }
+  if (remainderBits > 0 && fullBytes < clientBytes.length) {
+    const mask = 0xff << (8 - remainderBits);
+    if ((clientBytes[fullBytes] & mask) !== (networkBytes[fullBytes] & mask)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function inCidrString(client: ParsedIp, cidr: string): boolean {
+  const slashIndex = cidr.indexOf("/");
+  let networkIp: string;
+  let prefixLen: number;
+  if (slashIndex === -1) {
+    networkIp = cidr;
+    prefixLen = client.version === 4 ? 32 : 128;
+  } else {
+    networkIp = cidr.slice(0, slashIndex);
+    prefixLen = Number(cidr.slice(slashIndex + 1));
+    if (Number.isNaN(prefixLen) || prefixLen < 0) return false;
+  }
+  const network = parseIp(networkIp);
+  if (!network || network.version !== client.version) return false;
+  const max = client.version === 4 ? 32 : 128;
+  if (prefixLen > max) return false;
+  return matchesCidrBytes(client.bytes, network.bytes, prefixLen);
+}
+
+function inRange(client: ParsedIp, start: string, end: string): boolean {
+  const s = parseIp(start);
+  const e = parseIp(end);
+  if (
+    !s ||
+    !e ||
+    s.version !== client.version ||
+    e.version !== client.version
+  ) {
+    return false;
+  }
+  return (
+    compareBytes(client.bytes, s.bytes) >= 0 &&
+    compareBytes(client.bytes, e.bytes) <= 0
+  );
+}
+
+function inAnyCidr(client: ParsedIp, cidrs: readonly string[]): boolean {
+  for (const cidr of cidrs) {
+    if (inCidrString(client, cidr)) return true;
+  }
+  return false;
+}
+
+function inHostNetworkGroup(
+  client: ParsedIp,
+  group: TriageHostNetworkGroup,
+): boolean {
+  for (const host of group.hosts ?? []) {
+    const parsed = parseIp(host);
+    if (!parsed) continue;
+    if (
+      parsed.version === client.version &&
+      compareBytes(parsed.bytes, client.bytes) === 0
+    ) {
+      return true;
+    }
+  }
+  if (inAnyCidr(client, group.networks ?? [])) return true;
+  for (const range of group.ranges ?? []) {
+    if (inRange(client, range.start, range.end)) return true;
+  }
+  return false;
+}
+
+/**
+ * RFC1918 / loopback / link-local / CGNAT (IPv4) and loopback / ULA
+ * / link-local (IPv6). Used only when the side has no customer
+ * network metadata to consult.
+ */
+const PRIVATE_CIDRS_V4: readonly string[] = [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "127.0.0.0/8",
+  "169.254.0.0/16",
+  "100.64.0.0/10",
+];
+const PRIVATE_CIDRS_V6: readonly string[] = [
+  "::1/128",
+  "fc00::/7",
+  "fe80::/10",
+];
+
+export type TriageEndpointClassification = "external" | "internal" | "unknown";
+
+/**
+ * Classify one side of an event as `internal` / `external` /
+ * `unknown` for the asset pivot.
+ *
+ * Two-step rule (#476 §2):
+ *   1. If the requested side carries customer network metadata
+ *      (`origNetwork` / `respNetwork`), it is authoritative —
+ *      addresses inside the customer-defined network are
+ *      `internal`, everything else `external`.
+ *   2. Otherwise fall back to RFC1918 + IPv6 special-use ranges.
+ *   3. Unparseable addresses (or absent / non-string addresses)
+ *      return `unknown`; the caller decides whether to pivot.
+ */
+export function classifyTriageEndpoint(
+  event: TriageEvent,
+  side: "orig" | "resp",
+): TriageEndpointClassification {
+  const addr = side === "orig" ? event.origAddr : event.respAddr;
+  if (typeof addr !== "string" || addr.length === 0) return "unknown";
+  const parsed = parseIp(addr);
+  if (!parsed) return "unknown";
+
+  const network: TriageNetwork | null | undefined =
+    side === "orig" ? event.origNetwork : event.respNetwork;
+  if (network?.networks) {
+    return inHostNetworkGroup(parsed, network.networks)
+      ? "internal"
+      : "external";
+  }
+
+  const fallback = parsed.version === 4 ? PRIVATE_CIDRS_V4 : PRIVATE_CIDRS_V6;
+  return inAnyCidr(parsed, fallback) ? "internal" : "external";
+}

--- a/src/lib/triage/index.ts
+++ b/src/lib/triage/index.ts
@@ -1,4 +1,8 @@
 export { aggregateTriageEvents } from "./aggregate";
+export {
+  classifyTriageEndpoint,
+  type TriageEndpointClassification,
+} from "./classify";
 export { TriageForbiddenError, TriageUnauthorizedError } from "./errors";
 export {
   defaultTriagePeriod,
@@ -14,11 +18,14 @@ export {
   TRIAGE_BASELINE_WHITELIST,
 } from "./scoring";
 export {
+  type ScoredTriageEvent,
   TRIAGE_HARD_EVENT_CAP,
   type TriageAsset,
   type TriageEvent,
   type TriageEventListPage,
   type TriageEventListResult,
   type TriageFunnel,
+  type TriageHostNetworkGroup,
   type TriageLoadResult,
+  type TriageNetwork,
 } from "./types";

--- a/src/lib/triage/queries.ts
+++ b/src/lib/triage/queries.ts
@@ -3,12 +3,28 @@ import "server-only";
 import { parse } from "graphql";
 
 /**
- * Triage `eventList` query — Phase 1.A baseline (discussion #447 §3.2).
+ * Triage `eventList` query — Phase 1.A baseline (discussion #447 §3.2,
+ * §3.3, §3.4).
  *
- * The selection is the minimum the baseline scoring rule and asset
- * list need: time/sensor/category/level (interface fields), origAddr
- * for the asset key, plus `clusterId` on `HttpThreat` to support the
- * "cluster_id-None bonus" branch of the baseline rule.
+ * The selection includes the minimum the baseline scoring rule and
+ * asset list need (interface fields plus `origAddr` and HttpThreat
+ * `clusterId`) and the pivot-dimension fields enumerated in #476 §1
+ * so #452 / #453 can do client-side pivot without re-fetching:
+ *   - Network fields (`respAddr`, `origPort`, `respPort`,
+ *     `origCountry`, `respCountry`, `origNetwork`, `respNetwork`) on
+ *     every subtype that exposes them.
+ *   - HTTP-shaped fields (`host`, `uri`, `userAgent`) on the four
+ *     HTTP-shaped subtypes.
+ *   - DNS-shaped fields (`query`, `answer`) on the four DNS-shaped
+ *     subtypes (BlocklistMalformedDns is omitted — it carries only
+ *     question/answer counts, no payload).
+ *   - TLS-shaped fields (`ja3`, `ja3S`, `serverName`, `serial`,
+ *     `subjectCommonName`) on the two TLS-shaped subtypes.
+ *
+ * `origNetwork` / `respNetwork` select the membership shape
+ * (`HostNetworkGroup`) needed by the customer-network classifier so
+ * the client side can answer "is this address inside the customer's
+ * defined network?" without an extra round-trip.
  *
  * The query is validated against `schemas/review.graphql` by the
  * inline-parse() walk in
@@ -38,115 +54,830 @@ export const TRIAGE_EVENT_LIST_QUERY = parse(`
         level
         ... on BlocklistBootp {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistConn {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistDceRpc {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistDhcp {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistDns {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          query
+          answer
         }
         ... on BlocklistFtp {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistHttp {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          host
+          uri
+          userAgent
         }
         ... on BlocklistKerberos {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistLdap {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistMalformedDns {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistMqtt {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistNfs {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistNtlm {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistRadius {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistRdp {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistSmb {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistSmtp {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistSsh {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on BlocklistTls {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          ja3
+          ja3S
+          serverName
+          serial
+          subjectCommonName
         }
         ... on CryptocurrencyMiningPool {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          query
+          answer
         }
         ... on DnsCovertChannel {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          query
+          answer
         }
         ... on DomainGenerationAlgorithm {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          host
+          uri
+          userAgent
         }
         ... on FtpBruteForce {
           origAddr
+          respAddr
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on FtpPlainText {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on HttpThreat {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
           clusterId
+          host
+          uri
+          userAgent
         }
         ... on LdapBruteForce {
           origAddr
+          respAddr
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on LdapPlainText {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on LockyRansomware {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          query
+          answer
         }
         ... on MultiHostPortScan {
           origAddr
+          respPort
+          origCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on NetworkThreat {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on NonBrowser {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          host
+          uri
+          userAgent
         }
         ... on PortScan {
           origAddr
+          respAddr
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on RdpBruteForce {
           origAddr
+          origCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on RepeatedHttpSessions {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on SuspiciousTlsTraffic {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          ja3
+          ja3S
+          serverName
+          serial
+          subjectCommonName
         }
         ... on TorConnection {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
         ... on TorConnectionConn {
           origAddr
+          respAddr
+          origPort
+          respPort
+          origCountry
+          respCountry
+          origNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
+          respNetwork {
+            networks {
+              hosts
+              networks
+              ranges { start end }
+            }
+          }
         }
       }
     }

--- a/src/lib/triage/types.ts
+++ b/src/lib/triage/types.ts
@@ -12,11 +12,37 @@ import type { ThreatCategory, ThreatLevel } from "@/lib/detection";
 export const TRIAGE_HARD_EVENT_CAP = 5_000;
 
 /**
+ * Membership shape of a customer-defined network. Mirrors REview's
+ * `HostNetworkGroup` — exact hosts, CIDR networks, and inclusive IP
+ * ranges. The triage classifier reads all three fields to decide
+ * whether an address is inside the customer perimeter.
+ */
+export interface TriageHostNetworkGroup {
+  hosts: string[];
+  networks: string[];
+  ranges: { start: string; end: string }[];
+}
+
+/**
+ * Customer network attached to an event side. Only the
+ * `networks` membership shape is selected by the triage query —
+ * other `Network` fields (id, name, …) are not needed for
+ * classification.
+ */
+export interface TriageNetwork {
+  networks: TriageHostNetworkGroup;
+}
+
+/**
  * Slim event shape returned by the Triage `eventList` query.
  *
  * The selection set lives in {@link TRIAGE_EVENT_LIST_QUERY}; this
  * mirror only carries fields the page actually consumes (scoring,
- * asset extraction, asset-detail display).
+ * asset extraction, asset-detail display, and the pivot dimensions
+ * #452 / #453 will index over). Coverage is uneven across subtypes
+ * (e.g. `RdpBruteForce` exposes no resp-side fields), so every
+ * non-required field is optional and consumers must treat absent
+ * fields as `null`.
  */
 export interface TriageEvent {
   __typename: string;
@@ -26,14 +52,47 @@ export interface TriageEvent {
   level: ThreatLevel;
   /** Originator IP — present on every curated subtype the page handles. */
   origAddr?: string | null;
+  /** Responder IP — present on most but not all subtypes. */
+  respAddr?: string | null;
+  origPort?: number | null;
+  respPort?: number | null;
+  origCountry?: string | null;
+  respCountry?: string | null;
+  /** Customer-defined originator network membership. */
+  origNetwork?: TriageNetwork | null;
+  /** Customer-defined responder network membership. */
+  respNetwork?: TriageNetwork | null;
   /** Cluster ID; only `HttpThreat` selects it in the query. */
   clusterId?: string | null;
+  // HTTP-shaped subtypes only.
+  host?: string | null;
+  uri?: string | null;
+  userAgent?: string | null;
+  // DNS-shaped subtypes only.
+  query?: string | null;
+  answer?: string | null;
+  // TLS-shaped subtypes only.
+  ja3?: string | null;
+  ja3S?: string | null;
+  serverName?: string | null;
+  serial?: string | null;
+  subjectCommonName?: string | null;
   /**
    * Stable per-render React key for the asset detail panel. Populated
    * by {@link aggregateTriageEvents} so the list rows have a unique
    * identity even when several events share `time` + `__typename`.
    */
   rowKey?: string;
+}
+
+/**
+ * Post-aggregation event shape with the locally-computed baseline
+ * score attached. `score === 0` for events that do not pass the
+ * baseline rule. Carries `score` separately from `TriageEvent` so
+ * the GraphQL-mapping type stays free of computed fields.
+ */
+export interface ScoredTriageEvent extends TriageEvent {
+  score: number;
 }
 
 /** Result of one `eventList` page in the triage query. */
@@ -65,8 +124,12 @@ export interface TriageAsset {
   triagedCount: number;
   /** Sum of per-event baseline scores. Sort key for the asset list. */
   score: number;
-  /** Up to 50 events for the asset detail panel; ordered newest first. */
-  events: TriageEvent[];
+  /**
+   * Up to 50 baseline-passing events for the asset detail panel;
+   * ordered newest first. Each event carries its per-event `score`
+   * so the detail panel can render score per row.
+   */
+  events: ScoredTriageEvent[];
 }
 
 /** Funnel summary for the Triage page. */
@@ -84,6 +147,13 @@ export interface TriageLoadResult {
   truncated: boolean;
   /** Number of events actually loaded (≤ {@link TRIAGE_HARD_EVENT_CAP}). */
   loadedEventCount: number;
+  /**
+   * Every loaded event with its baseline score attached
+   * (`score === 0` for non-baseline-passing rows). #452 builds its
+   * pivot index over this full list — not over `assets[*].events`,
+   * which is capped at 50 and filters out non-baseline events.
+   */
+  events: ScoredTriageEvent[];
 }
 
 export interface TriageError {


### PR DESCRIPTION
## Summary

Phase 1.A follow-up to #451. The first-cut Triage menu loads only the fields its own acceptance criteria required (`__typename`, `time`, `sensor`, `category`, `level`, `origAddr`, and `HttpThreat.clusterId`). That minimum is correct for #451 but is not enough for the pivot work in #452 (1A-2) and #453 (1A-3), which both index on dimensions extracted from the loaded corpus. This PR widens the corpus shape so #452 / #453 can do client-side pivot without re-fetching, without touching scope #451 already closed.

### What changed

- **Selection set expansion in `TRIAGE_EVENT_LIST_QUERY`** (`src/lib/triage/queries.ts`):
  - Network fields (`respAddr`, `origPort`, `respPort`, `origCountry`, `respCountry`, plus `origNetwork`/`respNetwork` membership) on every subtype that exposes them.
  - HTTP-shaped fields (`host`, `uri`, `userAgent`) on `BlocklistHttp`, `HttpThreat`, `NonBrowser`, and `DomainGenerationAlgorithm`.
  - DNS-shaped fields (`query`, `answer`) on `BlocklistDns`, `DnsCovertChannel`, `CryptocurrencyMiningPool`, and `LockyRansomware`.
  - TLS-shaped fields (`ja3`, `ja3S`, `serverName`, `serial`, `subjectCommonName`) on `BlocklistTls` and `SuspiciousTlsTraffic`.
  - `BlocklistMalformedDns` and `RepeatedHttpSessions` are deliberately not extended (they have no payload / session-content fields).
  - The AST regression test in `src/__tests__/lib/triage/queries.test.ts` is extended to assert presence per subtype against the schema (not via a blanket rule) and to assert that the deliberately-skipped subtypes are not erroneously selected.

- **`classifyTriageEndpoint(event, side)`** (`src/lib/triage/classify.ts`):
  - Side-specific pure helper returning `"external" | "internal" | "unknown"`.
  - Customer-network membership (`origNetwork` / `respNetwork`) is authoritative when present; otherwise falls back to RFC1918 / loopback / link-local / CGNAT (IPv4) and loopback / ULA / link-local (IPv6).
  - Browser-safe: IP parsing and CIDR matching are reimplemented locally rather than reused from `src/lib/auth/cidr.ts` (which is `server-only` and pulls `node:net`). An import-boundary test guards the client-bundle constraint.

- **Per-event score and a full scored corpus** (`src/lib/triage/types.ts`, `src/lib/triage/aggregate.ts`):
  - New `ScoredTriageEvent extends TriageEvent { score: number }` keeps the GraphQL-mapping `TriageEvent` free of computed fields.
  - `TriageLoadResult.events: ScoredTriageEvent[]` carries every loaded event (including non-baseline ones with `score === 0`) so #452 can build its pivot index over the full corpus and #453's Tier 2 can read the same array without an extra fetch.
  - `assets[*].events` is now `ScoredTriageEvent[]` too, but its 50-cap and baseline-passing filter are unchanged.

### Out of scope (per issue)

The pivot index, panel UI, breadcrumb (#452); Tier 2 expansion and weak-signal rendering (#453); per-protocol identifiers (SSH/SMB/FTP/LDAP/MQTT); `confidence` selection; revision of `ASSET_DETAIL_EVENT_LIMIT = 50`; destination-side asset keys; persistence / corpus tables (Phase 1.B); new GraphQL filters or resolvers in `review-web` (Phase 1.B).

Closes #476

## Test plan

- [x] AST regression: every whitelisted subtype carries the dimension fields it exposes, and `BlocklistMalformedDns` / `RepeatedHttpSessions` are not erroneously selected.
- [x] Classifier: customer-network-membership wins on the requested side; RFC1918 / IPv6 fallback covers all listed ranges; unparseable / absent / null input returns `unknown`; `orig` vs `resp` selection cannot leak metadata across sides.
- [x] Browser-safe import boundary: `src/lib/triage/classify.ts` does not import `server-only` or `node:net` and does not reuse `src/lib/auth/cidr.ts`.
- [x] `aggregateTriageEvents`: per-event `score` is populated on `assets[*].events` and on the new top-level `events`; `events` length equals `loadedEventCount`; the existing 50-cap / baseline-passing invariants on `TriageAsset.events` still hold.
- [x] Schema validation (`src/__tests__/lib/graphql/schema-validation.test.ts`) still passes with the widened query.
- [x] Full local test suite passes (`pnpm vitest run`).
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm biome check` clean for changed files.