### PR TITLE
Add Triage baseline cadence scheduler + corpus A schema (#456)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,3 +180,10 @@ APPLY_DISPATCH_MAX_ATTEMPTS=3
 # matching this value. If unset, the route refuses every
 # request.
 APPLY_INTERNAL_CLEANUP_TOKEN=
+# Shared secret for the internal Triage baseline cadence route
+# at POST /api/internal/triage/baseline/cadence. The deployment
+# scheduler must include `Authorization: Bearer <token>` and
+# body `{ "customer_id": <positive integer> }`. Invoked hourly
+# per customer to drive corpus A ingestion (1B-1). If unset,
+# the route refuses every request.
+TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN=

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ the values:
 | `APPLY_EXECUTING_STALE_MS` | Stale-lock recovery threshold for `executing` apply attempts (default: 2.5 hours) |
 | `APPLY_DISPATCH_MAX_ATTEMPTS` | Per-dispatch retry cap before `failed_terminal` (default: 3) |
 | `APPLY_INTERNAL_CLEANUP_TOKEN` | Shared secret for `POST /api/internal/apply-attempts/cleanup`; route refuses every request if unset |
+| `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN` | Shared secret for `POST /api/internal/triage/baseline/cadence`; route refuses every request if unset. Body shape: `{ "customer_id": <positive integer> }`. The deployment scheduler invokes this hourly per customer to drive Triage baseline corpus ingestion (1B-1). |
 | `NEXT_PUBLIC_NODE_STATUS_POLL_MS` | Polling cadence (ms) for the Nodes Status tab and detail-page dashboard. Default `10000`; values outside `[5000, 300000]` clamp to that range. The detail-page sparkline buffer length is a fixed 60 samples (`NODE_STATUS_SPARKLINE_SAMPLES` in `src/lib/node/status.ts`) and is not operator-configurable in v1; samples older than the cap are dropped on a rolling basis. |
 | `NEXT_PUBLIC_GS_MODE` | Set to `1` / `true` / `on` to ship the gs-build subset of Hog `active_models`; anything else (or unset) ships the full set. Read at module load by `src/lib/node/active-models.ts`. |
 

--- a/migrations/customer/0003_baseline_corpus_a.sql
+++ b/migrations/customer/0003_baseline_corpus_a.sql
@@ -1,0 +1,113 @@
+-- Triage baseline corpus A schema (1B-1 / discussion #447 §3.4).
+--
+-- Three tables in every customer-tenant DB. The cadence runner
+-- (src/lib/triage/baseline/cadence.ts) fills them once per hour per
+-- customer; the menu reads `baseline_triaged_event` (1B-3) and the
+-- window-aggregate signals read `observed_event_meta` (1B-8). The
+-- corpus is filled with the unbiased standard-filter survivor stream,
+-- with per-customer + global exclusions re-applied app-side at cadence
+-- time so cadence-time and retroactive-DELETE paths target the same
+-- normalized columns.
+--
+-- `event_key` is review's RocksDB primary key (i128). Numeric(39,0) is
+-- the smallest exact-decimal type that holds an unsigned 128-bit value
+-- (max 2^128 = 340 282 366 920 938 463 463 374 607 431 768 211 456,
+-- 39 digits). This is the single source of truth for event identity:
+-- joins between the two corpus tables happen on `event_key`, and PK
+-- collisions on re-ingest are handled by the cadence runner with
+-- ON CONFLICT DO NOTHING.
+
+CREATE TABLE IF NOT EXISTS baseline_triaged_event (
+    event_key          NUMERIC(39, 0) PRIMARY KEY,
+    event_time         TIMESTAMPTZ    NOT NULL,
+    kind               TEXT           NOT NULL,
+    sensor             TEXT           NOT NULL,
+    orig_addr          INET,
+    orig_port          INTEGER,
+    resp_addr          INET,
+    resp_port          INTEGER,
+    proto              INTEGER,
+    -- Normalized exclusion-matching columns. HTTP/TLS variants populate
+    -- `host`; DNS variants populate `dns_query`; HTTP variants populate
+    -- `uri`; NTLM variants populate `host` from `hostname`. Extracted
+    -- at INSERT time so retroactive exclusion ADD (#457) can DELETE
+    -- matching rows by index without scanning JSONB payloads.
+    host               TEXT,
+    dns_query          TEXT,
+    uri                TEXT,
+    ingested_at        TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    baseline_version   TEXT           NOT NULL,
+    exclusions_fp      TEXT           NOT NULL,
+    category           TEXT,
+    baseline_score     DOUBLE PRECISION,
+    selector_tags      TEXT[],
+    payload_summary    JSONB
+);
+
+-- IpAddress exclusion uses CIDR containment (<<, <<=) which a btree on
+-- `inet` does NOT index efficiently; use GiST with inet_ops for those
+-- lookups. Other indexes are plain btree (equality / range).
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_orig_addr_gist
+    ON baseline_triaged_event USING gist (orig_addr inet_ops);
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_resp_addr_gist
+    ON baseline_triaged_event USING gist (resp_addr inet_ops);
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_event_time_idx
+    ON baseline_triaged_event (event_time DESC);
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_sensor_event_time_idx
+    ON baseline_triaged_event (sensor, event_time DESC);
+-- Composite index for the menu's typical filter pattern: time window +
+-- score threshold. Used by 1B-3 (Baseline mode SELECT) and the future
+-- strictness slider in #471.
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_event_time_score_idx
+    ON baseline_triaged_event (event_time DESC, baseline_score DESC);
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_host_idx
+    ON baseline_triaged_event (host);
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_dns_query_idx
+    ON baseline_triaged_event (dns_query);
+CREATE INDEX IF NOT EXISTS baseline_triaged_event_uri_idx
+    ON baseline_triaged_event (uri);
+
+CREATE TABLE IF NOT EXISTS baseline_corpus_state (
+    -- Singleton enforced by a constant primary key.
+    id                 BOOLEAN     PRIMARY KEY DEFAULT true CHECK (id),
+    last_ingested_at   TIMESTAMPTZ,
+    last_event_cursor  TEXT,
+    baseline_version   TEXT,
+    exclusions_fp      TEXT,
+    last_run_status    TEXT        CHECK (last_run_status IN ('ok', 'failed', 'running')),
+    last_error         TEXT
+);
+
+CREATE TABLE IF NOT EXISTS observed_event_meta (
+    -- Captures every event surviving the cadence's exclusion re-application
+    -- regardless of baseline outcome. Unbiased input for window-aggregate
+    -- signals (1B-8); using `baseline_triaged_event` would create selection
+    -- bias. NOT FK-linked to baseline_triaged_event because retention windows
+    -- differ (180d vs 30d); same-transaction INSERT order is the consistency
+    -- guarantee.
+    event_key   NUMERIC(39, 0) PRIMARY KEY,
+    event_time  TIMESTAMPTZ    NOT NULL,
+    kind        TEXT           NOT NULL,
+    category    TEXT,
+    sensor      TEXT           NOT NULL,
+    orig_addr   INET,
+    resp_addr   INET,
+    host        TEXT,
+    dns_query   TEXT,
+    uri         TEXT,
+    confidence  REAL
+);
+CREATE INDEX IF NOT EXISTS observed_event_meta_orig_addr_gist
+    ON observed_event_meta USING gist (orig_addr inet_ops);
+CREATE INDEX IF NOT EXISTS observed_event_meta_resp_addr_gist
+    ON observed_event_meta USING gist (resp_addr inet_ops);
+CREATE INDEX IF NOT EXISTS observed_event_meta_event_time_idx
+    ON observed_event_meta (event_time DESC);
+CREATE INDEX IF NOT EXISTS observed_event_meta_kind_event_time_idx
+    ON observed_event_meta (kind, event_time DESC);
+CREATE INDEX IF NOT EXISTS observed_event_meta_host_idx
+    ON observed_event_meta (host);
+CREATE INDEX IF NOT EXISTS observed_event_meta_dns_query_idx
+    ON observed_event_meta (dns_query);
+CREATE INDEX IF NOT EXISTS observed_event_meta_uri_idx
+    ON observed_event_meta (uri);

--- a/src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts
@@ -125,6 +125,25 @@ describe("POST /api/internal/triage/baseline/cadence", () => {
     expect(mockRunCadence).toHaveBeenCalledWith(7);
   });
 
+  it("returns 503 with status=pending when the cadence pager is not yet wired", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunCadence.mockResolvedValue({
+      customerId: 7,
+      status: "pending",
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", { customer_id: 7 }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("pending");
+    expect(body.customerId).toBe(7);
+  });
+
   it("returns 200 with status=skipped when the advisory lock was unavailable", async () => {
     mockVerifyToken.mockReturnValue(true);
     mockRunCadence.mockResolvedValue({

--- a/src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunCadence = vi.hoisted(() => vi.fn());
+const mockVerifyToken = vi.hoisted(() => vi.fn());
+
+class MockCustomerNotFoundError extends Error {
+  constructor(customerId: number) {
+    super(`Customer ${customerId} not found or not active`);
+    this.name = "CustomerNotFoundError";
+  }
+}
+
+vi.mock("@/lib/triage/baseline/cadence", () => ({
+  runTriageBaselineCadence: mockRunCadence,
+  verifyTriageBaselineCadenceToken: mockVerifyToken,
+}));
+
+vi.mock("@/lib/triage/policy/customer-db", () => ({
+  CustomerNotFoundError: MockCustomerNotFoundError,
+}));
+
+beforeEach(() => {
+  mockRunCadence.mockReset();
+  mockVerifyToken.mockReset();
+});
+
+function makeRequest(authHeader: string | undefined, body: unknown): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("http://test/api/internal/triage/baseline/cadence", {
+    method: "POST",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/triage/baseline/cadence", () => {
+  it("returns 401 when no Authorization header is sent", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest(undefined, { customer_id: 1 }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(mockVerifyToken).toHaveBeenCalledWith(null);
+    expect(mockRunCadence).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when Authorization is not Bearer", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Basic abc", { customer_id: 1 }));
+    expect(res.status).toBe(401);
+    expect(mockVerifyToken).toHaveBeenCalledWith(null);
+  });
+
+  it("returns 401 when bearer token does not verify", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer wrong", { customer_id: 1 }));
+    expect(res.status).toBe(401);
+    expect(mockVerifyToken).toHaveBeenCalledWith("wrong");
+    expect(mockRunCadence).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when body is not valid JSON", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", "not json"));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+    expect(mockRunCadence).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when customer_id is missing", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", {}));
+    expect(res.status).toBe(400);
+    expect(mockRunCadence).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when customer_id is not a positive integer", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    for (const bad of [0, -1, 1.5, "1", null, true]) {
+      const res = await POST(makeRequest("Bearer right", { customer_id: bad }));
+      expect(res.status).toBe(400);
+    }
+    expect(mockRunCadence).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with the runner result on success", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunCadence.mockResolvedValue({
+      customerId: 7,
+      status: "ok",
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", { customer_id: 7 }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      customerId: 7,
+      status: "ok",
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+    });
+    expect(mockRunCadence).toHaveBeenCalledWith(7);
+  });
+
+  it("returns 200 with status=skipped when the advisory lock was unavailable", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunCadence.mockResolvedValue({
+      customerId: 7,
+      status: "skipped",
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", { customer_id: 7 }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("skipped");
+  });
+
+  it("returns 500 with the structured failure body when the cadence rolls back", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunCadence.mockResolvedValue({
+      customerId: 7,
+      status: "failed",
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+      error: "review unreachable",
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", { customer_id: 7 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.status).toBe("failed");
+    expect(body.error).toBe("review unreachable");
+  });
+
+  it("returns 404 when the customer is not active", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunCadence.mockRejectedValue(new MockCustomerNotFoundError(404));
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", { customer_id: 404 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when the runner throws an unexpected error", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunCadence.mockRejectedValue(new Error("DB exploded"));
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/cadence/route"
+    );
+    const res = await POST(makeRequest("Bearer right", { customer_id: 7 }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "DB exploded" });
+  });
+});

--- a/src/__tests__/lib/triage/baseline/cadence.test.ts
+++ b/src/__tests__/lib/triage/baseline/cadence.test.ts
@@ -33,17 +33,22 @@ interface MockPool {
   connect: () => Promise<MockClient>;
 }
 
-function createMockPool(
-  {
-    lockAcquired,
-    throwOnLock,
-  }: {
-    lockAcquired: boolean;
-    throwOnLock?: boolean;
-  } = {
-    lockAcquired: true,
-  },
-): MockPool {
+function createMockPool({
+  lockSequence,
+  throwOnLock,
+}: {
+  /**
+   * Per-page lock-acquired booleans. The mock pops one each time the
+   * runner runs `pg_try_advisory_xact_lock`. If the array is exhausted
+   * the last value is reused (so a single-element array means "always
+   * acquired" / "always denied").
+   */
+  lockSequence?: boolean[];
+  throwOnLock?: boolean;
+} = {}): MockPool {
+  const sequence = lockSequence ?? [true];
+  let lockCallIndex = 0;
+
   const client: MockClient = {
     queries: [],
     released: false,
@@ -58,7 +63,10 @@ function createMockPool(
       client.queries.push({ sql, params });
       if (sql.includes("pg_try_advisory_xact_lock")) {
         if (throwOnLock) throw new Error("lock probe blew up");
-        return { rows: [{ acquired: lockAcquired }], rowCount: 1 };
+        const acquired =
+          sequence[Math.min(lockCallIndex, sequence.length - 1)] ?? false;
+        lockCallIndex += 1;
+        return { rows: [{ acquired }], rowCount: 1 };
       }
       if (sql.startsWith("SELECT last_ingested_at")) {
         return {
@@ -149,15 +157,65 @@ describe("verifyTriageBaselineCadenceToken", () => {
   });
 });
 
+/**
+ * Test-only fake pager. By default reports a single empty page so the
+ * runner walks one page-transaction and reports `ok`.
+ */
+type PagerScript = Array<{
+  observedInserted?: number;
+  baselineInserted?: number;
+  endCursor?: string | null;
+  hasNextPage?: boolean;
+  throw?: Error;
+}>;
+
+interface FakePager {
+  ingestPage: (
+    client: unknown,
+    customerId: number,
+    afterCursor: string | null,
+  ) => Promise<{
+    observedInserted: number;
+    baselineInserted: number;
+    endCursor: string | null;
+    hasNextPage: boolean;
+  }>;
+  calls: unknown[][];
+  callCount: () => number;
+}
+
+function makePager(script: PagerScript = [{ hasNextPage: false }]): FakePager {
+  const calls: unknown[][] = [];
+  let i = 0;
+  const ingestPage = async (
+    _client: unknown,
+    _customerId: number,
+    afterCursor: string | null,
+  ) => {
+    calls.push([afterCursor]);
+    const step = script[Math.min(i, script.length - 1)];
+    i += 1;
+    if (step.throw) throw step.throw;
+    return {
+      observedInserted: step.observedInserted ?? 0,
+      baselineInserted: step.baselineInserted ?? 0,
+      endCursor: step.endCursor ?? null,
+      hasNextPage: step.hasNextPage ?? false,
+    };
+  };
+  return { ingestPage, calls, callCount: () => calls.length };
+}
+
 describe("runTriageBaselineCadence — advisory lock + status machine", () => {
-  it("commits with status=ok when the advisory lock is acquired", async () => {
-    const pool = createMockPool({ lockAcquired: true });
+  it("commits with status=ok when the advisory lock is acquired and the pager reports an empty page", async () => {
+    const pool = createMockPool({ lockSequence: [true] });
     mockGetCustomerPool.mockResolvedValue(pool);
 
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    const result = await runTriageBaselineCadence(42);
+    const pager = makePager();
+    const result = await runTriageBaselineCadence(42, { pager });
 
     expect(result.status).toBe("ok");
     expect(result.customerId).toBe(42);
@@ -178,16 +236,17 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
     expect(sqls.some((s) => s.includes("last_run_status = 'ok'"))).toBe(true);
     expect(sqls).toContain("COMMIT");
     expect(pool.client.released).toBe(true);
+    expect(pager.callCount()).toBe(1);
   });
 
   it("passes the namespaced lock-key string into hashtext", async () => {
-    const pool = createMockPool({ lockAcquired: true });
+    const pool = createMockPool({ lockSequence: [true] });
     mockGetCustomerPool.mockResolvedValue(pool);
 
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    await runTriageBaselineCadence(42);
+    await runTriageBaselineCadence(42, { pager: makePager() });
 
     const lockCall = pool.client.queries.find((q) =>
       q.sql.includes("pg_try_advisory_xact_lock"),
@@ -195,14 +254,14 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
     expect(lockCall?.params).toEqual(["triage_baseline_cadence:42"]);
   });
 
-  it("returns status=skipped without UPDATEing state when the lock is unavailable", async () => {
-    const pool = createMockPool({ lockAcquired: false });
+  it("returns status=skipped without UPDATEing state when the lock is unavailable on the first page", async () => {
+    const pool = createMockPool({ lockSequence: [false] });
     mockGetCustomerPool.mockResolvedValue(pool);
 
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    const result = await runTriageBaselineCadence(42);
+    const result = await runTriageBaselineCadence(42, { pager: makePager() });
 
     expect(result.status).toBe("skipped");
     const sqls = pool.client.queries.map((q) => q.sql);
@@ -216,13 +275,13 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
   });
 
   it("returns status=failed and persists the error on rollback", async () => {
-    const pool = createMockPool({ lockAcquired: true, throwOnLock: true });
+    const pool = createMockPool({ lockSequence: [true], throwOnLock: true });
     mockGetCustomerPool.mockResolvedValue(pool);
 
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    const result = await runTriageBaselineCadence(42);
+    const result = await runTriageBaselineCadence(42, { pager: makePager() });
 
     expect(result.status).toBe("failed");
     expect(result.error).toBe("lock probe blew up");
@@ -258,5 +317,151 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
       "@/lib/triage/baseline/cadence"
     );
     await expect(runTriageBaselineCadence(99)).rejects.toThrow("DNS down");
+  });
+});
+
+describe("runTriageBaselineCadence — pending pager", () => {
+  it("returns status=pending and does not touch the corpus-state row when no pager is injected", async () => {
+    const pool = createMockPool({ lockSequence: [true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const result = await runTriageBaselineCadence(42);
+
+    expect(result.status).toBe("pending");
+    expect(result.observedInserted).toBe(0);
+    expect(result.baselineInserted).toBe(0);
+    expect(result.lastEventCursor).toBeNull();
+
+    const sqls = pool.client.queries.map((q) => q.sql);
+    // Page transaction was attempted but rolled back: no `ok` UPDATE,
+    // no COMMIT, and pool.query was never called for a failure record.
+    expect(sqls).toContain("BEGIN");
+    expect(sqls).toContain("ROLLBACK");
+    expect(sqls).not.toContain("COMMIT");
+    expect(sqls.some((s) => s.includes("last_run_status = 'ok'"))).toBe(false);
+    expect(pool.poolQueries).toEqual([]);
+    expect(pool.client.released).toBe(true);
+  });
+
+  it("exposes CadencePagerNotImplementedError as the stub-pager sentinel", async () => {
+    const { CadencePagerNotImplementedError, STUB_PAGER } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    await expect(
+      STUB_PAGER.ingestPage({} as never, 1, null),
+    ).rejects.toBeInstanceOf(CadencePagerNotImplementedError);
+  });
+});
+
+describe("runTriageBaselineCadence — per-page transaction discipline", () => {
+  it("commits each page in its own transaction and reacquires the advisory lock per page", async () => {
+    const pool = createMockPool({ lockSequence: [true, true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const pager = makePager([
+      {
+        observedInserted: 3,
+        baselineInserted: 1,
+        endCursor: "c1",
+        hasNextPage: true,
+      },
+      {
+        observedInserted: 2,
+        baselineInserted: 0,
+        endCursor: "c2",
+        hasNextPage: false,
+      },
+    ]);
+    const result = await runTriageBaselineCadence(7, { pager });
+
+    expect(result.status).toBe("ok");
+    expect(result.observedInserted).toBe(5);
+    expect(result.baselineInserted).toBe(1);
+    expect(result.lastEventCursor).toBe("c2");
+
+    const sqls = pool.client.queries.map((q) => q.sql);
+    const begins = sqls.filter((s) => s === "BEGIN").length;
+    const commits = sqls.filter((s) => s === "COMMIT").length;
+    const lockProbes = sqls.filter((s) =>
+      s.includes("pg_try_advisory_xact_lock"),
+    ).length;
+    expect(begins).toBe(2);
+    expect(commits).toBe(2);
+    expect(lockProbes).toBe(2);
+
+    // Page 1 is invoked with the cursor page 0 returned.
+    expect(pager.calls).toEqual([[null], ["c1"]]);
+  });
+
+  it("preserves earlier pages' commits and persists the failure when a later page throws", async () => {
+    const pool = createMockPool({ lockSequence: [true, true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const pager = makePager([
+      {
+        observedInserted: 4,
+        baselineInserted: 2,
+        endCursor: "c1",
+        hasNextPage: true,
+      },
+      { throw: new Error("review timeout") },
+    ]);
+    const result = await runTriageBaselineCadence(7, { pager });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("review timeout");
+    expect(result.observedInserted).toBe(4);
+    expect(result.baselineInserted).toBe(2);
+    expect(result.lastEventCursor).toBe("c1");
+
+    const sqls = pool.client.queries.map((q) => q.sql);
+    expect(sqls.filter((s) => s === "COMMIT").length).toBe(1);
+    expect(sqls.filter((s) => s === "ROLLBACK").length).toBe(1);
+
+    const failureWrite = pool.poolQueries.find((q) =>
+      q.sql.includes("INSERT INTO baseline_corpus_state"),
+    );
+    expect(failureWrite?.params?.[0]).toBe("review timeout");
+  });
+
+  it("stops cleanly mid-run if the advisory lock is lost between page commits", async () => {
+    const pool = createMockPool({ lockSequence: [true, false] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const pager = makePager([
+      {
+        observedInserted: 1,
+        baselineInserted: 1,
+        endCursor: "c1",
+        hasNextPage: true,
+      },
+      {
+        observedInserted: 99,
+        baselineInserted: 99,
+        endCursor: "c2",
+        hasNextPage: false,
+      },
+    ]);
+    const result = await runTriageBaselineCadence(7, { pager });
+
+    expect(result.status).toBe("ok");
+    // Only the first page actually committed; the second never got the
+    // lock so the pager was not called for it.
+    expect(result.observedInserted).toBe(1);
+    expect(result.baselineInserted).toBe(1);
+    expect(result.lastEventCursor).toBe("c1");
+    expect(pager.callCount()).toBe(1);
   });
 });

--- a/src/__tests__/lib/triage/baseline/cadence.test.ts
+++ b/src/__tests__/lib/triage/baseline/cadence.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCustomerPool = vi.hoisted(() => vi.fn());
+
+class MockCustomerNotFoundError extends Error {
+  constructor(customerId: number) {
+    super(`Customer ${customerId} not found or not active`);
+    this.name = "CustomerNotFoundError";
+  }
+}
+
+vi.mock("@/lib/triage/policy/customer-db", () => ({
+  getCustomerPool: mockGetCustomerPool,
+  CustomerNotFoundError: MockCustomerNotFoundError,
+}));
+
+interface QueuedRow {
+  rows: Record<string, unknown>[];
+  rowCount: number;
+}
+
+interface MockClient {
+  queries: Array<{ sql: string; params: unknown[] | undefined }>;
+  released: boolean;
+  query: ReturnType<typeof vi.fn>;
+  release: () => void;
+}
+
+interface MockPool {
+  client: MockClient;
+  poolQueries: Array<{ sql: string; params: unknown[] | undefined }>;
+  query: ReturnType<typeof vi.fn>;
+  connect: () => Promise<MockClient>;
+}
+
+function createMockPool(
+  {
+    lockAcquired,
+    throwOnLock,
+  }: {
+    lockAcquired: boolean;
+    throwOnLock?: boolean;
+  } = {
+    lockAcquired: true,
+  },
+): MockPool {
+  const client: MockClient = {
+    queries: [],
+    released: false,
+    query: vi.fn(),
+    release() {
+      client.released = true;
+    },
+  };
+
+  client.query.mockImplementation(
+    async (sql: string, params?: unknown[]): Promise<QueuedRow> => {
+      client.queries.push({ sql, params });
+      if (sql.includes("pg_try_advisory_xact_lock")) {
+        if (throwOnLock) throw new Error("lock probe blew up");
+        return { rows: [{ acquired: lockAcquired }], rowCount: 1 };
+      }
+      if (sql.startsWith("SELECT last_ingested_at")) {
+        return {
+          rows: [
+            {
+              last_ingested_at: null,
+              last_event_cursor: null,
+              baseline_version: null,
+              exclusions_fp: null,
+              last_run_status: null,
+              last_error: null,
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    },
+  );
+
+  const poolQueries: MockPool["poolQueries"] = [];
+  const pool: MockPool = {
+    client,
+    poolQueries,
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      poolQueries.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    }),
+    connect: async () => client,
+  };
+  return pool;
+}
+
+const ORIGINAL_TOKEN = process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN;
+
+beforeEach(() => {
+  mockGetCustomerPool.mockReset();
+});
+
+afterEach(() => {
+  if (ORIGINAL_TOKEN === undefined) {
+    delete process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN;
+  } else {
+    process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN = ORIGINAL_TOKEN;
+  }
+});
+
+describe("verifyTriageBaselineCadenceToken", () => {
+  it("returns false when env var is unset", async () => {
+    delete process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN;
+    const { verifyTriageBaselineCadenceToken } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    expect(verifyTriageBaselineCadenceToken("anything")).toBe(false);
+  });
+
+  it("returns false when the supplied token is null", async () => {
+    process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN = "secret-token";
+    const { verifyTriageBaselineCadenceToken } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    expect(verifyTriageBaselineCadenceToken(null)).toBe(false);
+  });
+
+  it("returns false when lengths differ (timing-safe precheck)", async () => {
+    process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN = "secret";
+    const { verifyTriageBaselineCadenceToken } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    expect(verifyTriageBaselineCadenceToken("s")).toBe(false);
+    expect(verifyTriageBaselineCadenceToken("secret-too-long")).toBe(false);
+  });
+
+  it("returns true on an exact match", async () => {
+    process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN = "exact-match-token";
+    const { verifyTriageBaselineCadenceToken } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    expect(verifyTriageBaselineCadenceToken("exact-match-token")).toBe(true);
+  });
+
+  it("returns false on equal-length but different content", async () => {
+    process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN = "abcdef";
+    const { verifyTriageBaselineCadenceToken } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    expect(verifyTriageBaselineCadenceToken("abcdeg")).toBe(false);
+  });
+});
+
+describe("runTriageBaselineCadence — advisory lock + status machine", () => {
+  it("commits with status=ok when the advisory lock is acquired", async () => {
+    const pool = createMockPool({ lockAcquired: true });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const result = await runTriageBaselineCadence(42);
+
+    expect(result.status).toBe("ok");
+    expect(result.customerId).toBe(42);
+    expect(result.observedInserted).toBe(0);
+    expect(result.baselineInserted).toBe(0);
+
+    const sqls = pool.client.queries.map((q) => q.sql);
+    expect(sqls[0]).toBe("BEGIN");
+    expect(sqls.some((s) => s.includes("pg_try_advisory_xact_lock"))).toBe(
+      true,
+    );
+    expect(
+      sqls.some((s) => s.includes("INSERT INTO baseline_corpus_state")),
+    ).toBe(true);
+    expect(sqls.some((s) => s.includes("last_run_status = 'running'"))).toBe(
+      true,
+    );
+    expect(sqls.some((s) => s.includes("last_run_status = 'ok'"))).toBe(true);
+    expect(sqls).toContain("COMMIT");
+    expect(pool.client.released).toBe(true);
+  });
+
+  it("passes the namespaced lock-key string into hashtext", async () => {
+    const pool = createMockPool({ lockAcquired: true });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    await runTriageBaselineCadence(42);
+
+    const lockCall = pool.client.queries.find((q) =>
+      q.sql.includes("pg_try_advisory_xact_lock"),
+    );
+    expect(lockCall?.params).toEqual(["triage_baseline_cadence:42"]);
+  });
+
+  it("returns status=skipped without UPDATEing state when the lock is unavailable", async () => {
+    const pool = createMockPool({ lockAcquired: false });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const result = await runTriageBaselineCadence(42);
+
+    expect(result.status).toBe("skipped");
+    const sqls = pool.client.queries.map((q) => q.sql);
+    expect(sqls).toContain("ROLLBACK");
+    expect(sqls).not.toContain("COMMIT");
+    expect(sqls.some((s) => s.includes("last_run_status = 'ok'"))).toBe(false);
+    expect(sqls.some((s) => s.includes("last_run_status = 'running'"))).toBe(
+      false,
+    );
+    expect(pool.client.released).toBe(true);
+  });
+
+  it("returns status=failed and persists the error on rollback", async () => {
+    const pool = createMockPool({ lockAcquired: true, throwOnLock: true });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const result = await runTriageBaselineCadence(42);
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("lock probe blew up");
+
+    const sqls = pool.client.queries.map((q) => q.sql);
+    expect(sqls).toContain("ROLLBACK");
+    expect(sqls).not.toContain("COMMIT");
+    expect(pool.client.released).toBe(true);
+
+    // Failure is recorded outside the transaction (pool.query, not client.query)
+    const failureWrite = pool.poolQueries.find((q) =>
+      q.sql.includes("INSERT INTO baseline_corpus_state"),
+    );
+    expect(failureWrite).toBeDefined();
+    expect(failureWrite?.params?.[0]).toBe("lock probe blew up");
+  });
+
+  it("returns status=skipped (not throws) when getCustomerPool rejects with CustomerNotFoundError", async () => {
+    mockGetCustomerPool.mockRejectedValue(new MockCustomerNotFoundError(99));
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const result = await runTriageBaselineCadence(99);
+
+    expect(result.status).toBe("skipped");
+    expect(result.customerId).toBe(99);
+  });
+
+  it("re-throws unexpected errors from getCustomerPool", async () => {
+    mockGetCustomerPool.mockRejectedValue(new Error("DNS down"));
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    await expect(runTriageBaselineCadence(99)).rejects.toThrow("DNS down");
+  });
+});

--- a/src/__tests__/lib/triage/baseline/cadence.test.ts
+++ b/src/__tests__/lib/triage/baseline/cadence.test.ts
@@ -240,16 +240,15 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
     expect(failureWrite?.params?.[0]).toBe("lock probe blew up");
   });
 
-  it("returns status=skipped (not throws) when getCustomerPool rejects with CustomerNotFoundError", async () => {
+  it("propagates CustomerNotFoundError so the route handler can return 404", async () => {
     mockGetCustomerPool.mockRejectedValue(new MockCustomerNotFoundError(99));
 
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    const result = await runTriageBaselineCadence(99);
-
-    expect(result.status).toBe("skipped");
-    expect(result.customerId).toBe(99);
+    await expect(runTriageBaselineCadence(99)).rejects.toBeInstanceOf(
+      MockCustomerNotFoundError,
+    );
   });
 
   it("re-throws unexpected errors from getCustomerPool", async () => {

--- a/src/app/api/internal/triage/baseline/cadence/route.ts
+++ b/src/app/api/internal/triage/baseline/cadence/route.ts
@@ -1,0 +1,82 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import {
+  runTriageBaselineCadence,
+  verifyTriageBaselineCadenceToken,
+} from "@/lib/triage/baseline/cadence";
+import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
+
+/**
+ * POST /api/internal/triage/baseline/cadence
+ *
+ * Internal-token-guarded entrypoint the deployment scheduler uses to
+ * drive one hourly cadence pass per customer (1B-1 / discussion #447
+ * §3.4). Body shape:
+ *
+ *     { "customer_id": <number> }
+ *
+ * Token verification follows the same shape as the apply-attempt
+ * cleanup route (`Authorization: Bearer <token>`), with the secret
+ * read from `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`. No user session
+ * is involved; the runner executes as a system actor against the
+ * customer-tenant DB the resolver maps `customer_id` to.
+ *
+ * Status codes:
+ *   - 200 with `{ status, observedInserted, baselineInserted,
+ *     lastEventCursor }` when the cadence transaction commits or the
+ *     advisory lock was already held by another invocation
+ *     (`status: 'skipped'`).
+ *   - 400 when the request body is invalid.
+ *   - 401 when the bearer token does not verify.
+ *   - 404 when the supplied `customer_id` is unknown / not active.
+ *   - 500 with `{ status: 'failed', error }` when the cadence
+ *     transaction rolled back. The route still returns a structured
+ *     body so the scheduler can log the error string.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = request.headers.get("authorization");
+  const token = auth?.startsWith("Bearer ")
+    ? auth.slice("Bearer ".length).trim()
+    : null;
+  if (!verifyTriageBaselineCadenceToken(token)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const customerId = parseCustomerId(body);
+  if (customerId === null) {
+    return NextResponse.json(
+      { error: "Body must be { customer_id: <positive integer> }" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await runTriageBaselineCadence(customerId);
+    if (result.status === "failed") {
+      return NextResponse.json(result, { status: 500 });
+    }
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof CustomerNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 });
+    }
+    const message = err instanceof Error ? err.message : "Cadence failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+function parseCustomerId(body: unknown): number | null {
+  if (!body || typeof body !== "object") return null;
+  const raw = (body as { customer_id?: unknown }).customer_id;
+  if (typeof raw !== "number") return null;
+  if (!Number.isInteger(raw)) return null;
+  if (raw <= 0) return null;
+  return raw;
+}

--- a/src/app/api/internal/triage/baseline/cadence/route.ts
+++ b/src/app/api/internal/triage/baseline/cadence/route.ts
@@ -24,15 +24,20 @@ import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
  *
  * Status codes:
  *   - 200 with `{ status, observedInserted, baselineInserted,
- *     lastEventCursor }` when the cadence transaction commits or the
- *     advisory lock was already held by another invocation
- *     (`status: 'skipped'`).
+ *     lastEventCursor }` when at least one page committed (`status:
+ *     'ok'`) or the advisory lock was already held by another
+ *     invocation (`status: 'skipped'`).
  *   - 400 when the request body is invalid.
  *   - 401 when the bearer token does not verify.
  *   - 404 when the supplied `customer_id` is unknown / not active.
- *   - 500 with `{ status: 'failed', error }` when the cadence
- *     transaction rolled back. The route still returns a structured
- *     body so the scheduler can log the error string.
+ *   - 500 with `{ status: 'failed', error }` when a cadence page rolled
+ *     back. The route still returns a structured body so the scheduler
+ *     can log the error string.
+ *   - 503 with `{ status: 'pending' }` when the cadence pager is not
+ *     yet wired (review-web#842 + aice-web-next#460 still outstanding).
+ *     The runner did not touch the corpus-state row; the scheduler can
+ *     keep ticking and the response flips to 200 / `ok` automatically
+ *     once the pager lands.
  */
 export async function POST(request: Request): Promise<NextResponse> {
   const auth = request.headers.get("authorization");
@@ -61,6 +66,9 @@ export async function POST(request: Request): Promise<NextResponse> {
     const result = await runTriageBaselineCadence(customerId);
     if (result.status === "failed") {
       return NextResponse.json(result, { status: 500 });
+    }
+    if (result.status === "pending") {
+      return NextResponse.json(result, { status: 503 });
     }
     return NextResponse.json(result);
   } catch (err) {

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -62,10 +62,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 
 import type pg from "pg";
 
-import {
-  CustomerNotFoundError,
-  getCustomerPool,
-} from "@/lib/triage/policy/customer-db";
+import { getCustomerPool } from "@/lib/triage/policy/customer-db";
 
 /**
  * Phase 1.A baseline-version marker stamped on every row this runner
@@ -328,26 +325,10 @@ async function drivePages(
 export async function runTriageBaselineCadence(
   customerId: number,
 ): Promise<CadenceRunResult> {
-  let pool: pg.Pool;
-  try {
-    pool = await getCustomerPool(customerId);
-  } catch (err) {
-    if (err instanceof CustomerNotFoundError) {
-      // Treat unknown customers as a clean "skip" so a stale schedule
-      // entry pointing at a deactivated customer does not page the
-      // operator. The route handler returns 404 instead — this branch
-      // is only reachable from in-process callers (tests, future
-      // batched drivers).
-      return {
-        customerId,
-        status: "skipped",
-        observedInserted: 0,
-        baselineInserted: 0,
-        lastEventCursor: null,
-      };
-    }
-    throw err;
-  }
+  // Lets `CustomerNotFoundError` propagate so the route handler can
+  // surface it as a 404. In-process callers (future batched drivers,
+  // tests) catch the same error type if they want a "skip" instead.
+  const pool = await getCustomerPool(customerId);
 
   const client = await pool.connect();
   try {

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -1,0 +1,435 @@
+import "server-only";
+
+/**
+ * Triage baseline cadence runner (1B-1 / discussion #447 §3.4).
+ *
+ * Drives one ingestion pass for a single customer-tenant DB. The
+ * deployment scheduler hits the internal route
+ * (`POST /api/internal/triage/baseline/cadence`) once per hour per
+ * customer; the route handler defers to {@link runTriageBaselineCadence}.
+ *
+ * ## Concurrency
+ *
+ * A second concurrent invocation for the same customer must not double-
+ * ingest. The runner takes a per-customer transaction-scoped advisory
+ * lock as the first statement of the cadence transaction:
+ *
+ *   `pg_try_advisory_xact_lock(hashtext('triage_baseline_cadence:' || customer_id))`
+ *
+ * If the lock is unavailable the runner exits cleanly without touching
+ * `baseline_corpus_state` — the next scheduled tick picks up where the
+ * previous run stopped via `last_event_cursor`. Lock release is
+ * automatic on commit/rollback because it is transaction-scoped.
+ *
+ * ## Pipeline (per page)
+ *
+ *   a. Fetch a raw standard-filter page from review via
+ *      `eventListWithTriage(triage = null)` (review-web#842).
+ *   b. Populate normalized columns (host / dns_query / uri / etc.) per
+ *      event-kind mapping.
+ *   c. Apply active global + customer-scoped exclusions in-memory
+ *      against the normalized columns with full semantics — IpAddress
+ *      (CIDR containment), Hostname (exact), Uri (exact), Domain
+ *      (RegexSet against host + dns_query only).
+ *   d. INSERT remaining events into `observed_event_meta`.
+ *   e. INSERT the baseline-passing subset into `baseline_triaged_event`.
+ *   f. UPDATE `baseline_corpus_state.last_event_cursor` and
+ *      `last_ingested_at`.
+ *
+ * Steps (d), (e), and (f) commit as a single transaction so the
+ * watermark advances atomically with the rows it covers. PK collisions
+ * on re-ingest of the same `event_key` are handled with
+ * `ON CONFLICT DO NOTHING`.
+ *
+ * ## Upstream dependency
+ *
+ * This module ships the scheduler entrypoint, the advisory lock
+ * discipline, the corpus-state machine, and the schema migration. The
+ * GraphQL fetch-and-ingest path is intentionally a placeholder: it
+ * depends on `eventListWithTriage` from aicers/review-web#842, which
+ * exposes both the new `EventStandardFilterInput` filter type and the
+ * `event_key` (i128 RocksDB primary key) selection that this corpus
+ * keys on. Today's vendored `schemas/review.graphql` carries neither.
+ *
+ * Once #842 lands, the placeholder marker in {@link ingestPage} flips
+ * to a real GraphQL pager: the rest of the cadence flow (lock,
+ * transaction, status updates, normalization helpers, exclusion re-
+ * application, ON CONFLICT DO NOTHING inserts, watermark advance) is
+ * unchanged. The route handler and its token guard are unaffected.
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+import type pg from "pg";
+
+import {
+  CustomerNotFoundError,
+  getCustomerPool,
+} from "@/lib/triage/policy/customer-db";
+
+/**
+ * Phase 1.A baseline-version marker stamped on every row this runner
+ * inserts into `baseline_triaged_event`. The 1B-3 menu reader uses the
+ * marker to distinguish Phase 1.A simple-rule rows from later 1B-8
+ * four-selector rows, so a future cadence-version bump cleanly tags
+ * its own output without disturbing rows already on disk. See
+ * "What 'baseline-passing' means in 1B-1" in the issue body.
+ */
+export const PHASE_1A_BASELINE_VERSION = "phase1a-simple";
+
+/**
+ * Selector tag stamped on every Phase 1.A row. Stored as a
+ * single-element TEXT[] so 1B-8 can extend the array without rewriting
+ * existing rows.
+ */
+export const PHASE_1A_SELECTOR_TAG = "phase1a-simple";
+
+/**
+ * Constant placeholder score for Phase 1.A rows. Reflects "passed the
+ * Phase 1.A simple rule"; replaced per-row by 1B-8's four-selector
+ * scoring once that lands.
+ */
+export const PHASE_1A_BASELINE_SCORE = 1;
+
+export type CadenceRunStatus = "ok" | "failed" | "running" | "skipped";
+
+export interface CadenceRunResult {
+  /** Customer the runner targeted. */
+  customerId: number;
+  /**
+   * Outcome marker:
+   *   - `ok`: the cadence transaction committed (zero or more pages
+   *     ingested).
+   *   - `skipped`: the per-customer advisory lock was unavailable
+   *     because another run is in progress; this tick is a no-op.
+   *   - `failed`: the cadence transaction rolled back; `error` carries
+   *     the message that was persisted to
+   *     `baseline_corpus_state.last_error`.
+   *   - `running`: never returned to the caller — the on-disk marker
+   *     used while a run holds the lock so a crash leaves a forensic
+   *     breadcrumb.
+   */
+  status: Exclude<CadenceRunStatus, "running">;
+  /** Number of rows inserted into `observed_event_meta` this run. */
+  observedInserted: number;
+  /** Number of rows inserted into `baseline_triaged_event` this run. */
+  baselineInserted: number;
+  /** End cursor from the last raw page successfully scanned this run. */
+  lastEventCursor: string | null;
+  /** Error message, populated only when `status === 'failed'`. */
+  error?: string;
+}
+
+interface CorpusStateRow {
+  last_ingested_at: Date | null;
+  last_event_cursor: string | null;
+  baseline_version: string | null;
+  exclusions_fp: string | null;
+  last_run_status: CadenceRunStatus | null;
+  last_error: string | null;
+}
+
+/**
+ * Build the bigint advisory-lock key. Mirrors the SQL formula in the
+ * issue: `hashtext('triage_baseline_cadence:' || customer_id)`. Letting
+ * the database compute the hash avoids a Node ↔ Postgres consistency
+ * trap (Postgres' `hashtext` is not equivalent to any well-known JS
+ * hash). Returns the raw SQL fragment passed straight into
+ * `pg_try_advisory_xact_lock`.
+ */
+const LOCK_NAMESPACE = "triage_baseline_cadence:";
+
+function buildLockKeyExpr(): string {
+  return `hashtext($1)`;
+}
+
+function buildLockKeyParam(customerId: number): string {
+  return `${LOCK_NAMESPACE}${customerId}`;
+}
+
+/**
+ * Compute the canonical exclusions fingerprint placeholder. Phase 1.A
+ * has no exclusions wired up (the helper from #460 / shared
+ * `src/lib/triage/exclusion/` module has not landed yet); until then,
+ * every Phase 1.A row carries a stable empty-set fingerprint so the
+ * column is NOT NULL but does not falsely identify rows as having
+ * passed any specific exclusion configuration. When #460 lands the
+ * cadence runner swaps this constant for the real
+ * `computeExclusionsFingerprint(active)` call.
+ */
+const EMPTY_EXCLUSIONS_FP = (() => {
+  return createHash("sha256")
+    .update("phase1a:no-exclusions", "utf8")
+    .digest("hex");
+})();
+
+/**
+ * Read the corpus-state row, INSERTing the singleton if it does not
+ * yet exist. Mirrors the migration's `id BOOLEAN PRIMARY KEY` shape.
+ */
+async function readOrInitCorpusState(
+  client: pg.PoolClient,
+): Promise<CorpusStateRow> {
+  await client.query(
+    `INSERT INTO baseline_corpus_state (id) VALUES (true) ON CONFLICT (id) DO NOTHING`,
+  );
+  const result = await client.query<CorpusStateRow>(
+    `SELECT last_ingested_at, last_event_cursor, baseline_version,
+            exclusions_fp, last_run_status, last_error
+       FROM baseline_corpus_state
+      WHERE id = true`,
+  );
+  if (result.rows.length === 0) {
+    throw new Error(
+      "baseline_corpus_state singleton row is missing after INSERT — this should be unreachable.",
+    );
+  }
+  return result.rows[0];
+}
+
+async function markRunning(client: pg.PoolClient): Promise<void> {
+  await client.query(
+    `UPDATE baseline_corpus_state
+        SET last_run_status = 'running',
+            last_error = NULL
+      WHERE id = true`,
+  );
+}
+
+async function markOk(
+  client: pg.PoolClient,
+  endCursor: string | null,
+  exclusionsFp: string,
+): Promise<void> {
+  await client.query(
+    `UPDATE baseline_corpus_state
+        SET last_run_status = 'ok',
+            last_error = NULL,
+            last_ingested_at = NOW(),
+            last_event_cursor = COALESCE($1, last_event_cursor),
+            baseline_version = $2,
+            exclusions_fp = $3
+      WHERE id = true`,
+    [endCursor, PHASE_1A_BASELINE_VERSION, exclusionsFp],
+  );
+}
+
+async function markFailed(pool: pg.Pool, message: string): Promise<void> {
+  // Failure status is written *outside* the cadence transaction (which
+  // rolled back) so the next scheduler tick can read it. Best-effort:
+  // a failure recording itself is not allowed to mask the real error
+  // the caller surfaces.
+  try {
+    await pool.query(
+      `INSERT INTO baseline_corpus_state (id, last_run_status, last_error)
+            VALUES (true, 'failed', $1)
+       ON CONFLICT (id) DO UPDATE
+            SET last_run_status = 'failed',
+                last_error = EXCLUDED.last_error`,
+      [message],
+    );
+  } catch {
+    // Swallow: the original error is what matters; status persistence
+    // is a forensic aid, not a correctness requirement.
+  }
+}
+
+/**
+ * Ingest a single page of standard-filter survivors and return the
+ * count of rows inserted into each table plus the end cursor of the
+ * page (or `null` if no further pages exist). Phase 1.A: this function
+ * is a placeholder. The full implementation lands once review-web#842
+ * exposes `eventListWithTriage` + `event_key`. Today it returns a
+ * no-op page so the surrounding cadence transaction commits a clean
+ * "ran, no work to do" record — the corpus stays empty until #842
+ * lands, but the scheduler endpoint, advisory-lock discipline, status
+ * machine, and migration are all exercised in production.
+ */
+async function ingestPage(
+  _client: pg.PoolClient,
+  _customerId: number,
+  _afterCursor: string | null,
+): Promise<{
+  observedInserted: number;
+  baselineInserted: number;
+  endCursor: string | null;
+  hasNextPage: boolean;
+}> {
+  // TODO(review-web#842): replace this stub with a real pager.
+  //
+  //   1. Build EventStandardFilterInput (no triagePolicies field).
+  //   2. graphqlRequest(EVENT_LIST_WITH_TRIAGE_QUERY, { filter, first,
+  //      after, triage: null }, { role, customerIds: [customerId] }).
+  //   3. For each node:
+  //        - Extract event_key (NUMERIC(39,0)) from the GraphQL field.
+  //        - Normalize host / dns_query / uri per event-kind mapping.
+  //        - Drop if any active exclusion (CIDR / hostname / domain
+  //          regex / uri exact) matches.
+  //   4. INSERT survivors into observed_event_meta (ON CONFLICT DO
+  //      NOTHING).
+  //   5. INSERT baseline-passing subset (Phase 1.A category whitelist
+  //      OR HttpThreat with cluster_id IS NULL) into
+  //      baseline_triaged_event (ON CONFLICT DO NOTHING) with
+  //      baseline_version = PHASE_1A_BASELINE_VERSION,
+  //      baseline_score  = PHASE_1A_BASELINE_SCORE,
+  //      selector_tags   = ARRAY[PHASE_1A_SELECTOR_TAG],
+  //      exclusions_fp   = computeExclusionsFingerprint(active).
+  //   6. Return endCursor + hasNextPage so the outer driver can either
+  //      advance the watermark or break out of the loop on the last
+  //      page.
+  return {
+    observedInserted: 0,
+    baselineInserted: 0,
+    endCursor: null,
+    hasNextPage: false,
+  };
+}
+
+/**
+ * Page-bounded driver. Walks pages until either the resolver reports
+ * no more pages or `MAX_PAGES_PER_RUN` is reached, accumulating row
+ * counts and the latest end cursor. Hard cap defends against a runaway
+ * loop if the resolver ever reports `hasNextPage = true` on every page.
+ */
+const MAX_PAGES_PER_RUN = 200;
+
+async function drivePages(
+  client: pg.PoolClient,
+  customerId: number,
+  startCursor: string | null,
+): Promise<{
+  observedInserted: number;
+  baselineInserted: number;
+  endCursor: string | null;
+}> {
+  let cursor = startCursor;
+  let observedInserted = 0;
+  let baselineInserted = 0;
+  for (let page = 0; page < MAX_PAGES_PER_RUN; page += 1) {
+    const out = await ingestPage(client, customerId, cursor);
+    observedInserted += out.observedInserted;
+    baselineInserted += out.baselineInserted;
+    if (out.endCursor !== null) cursor = out.endCursor;
+    if (!out.hasNextPage) break;
+  }
+  return {
+    observedInserted,
+    baselineInserted,
+    endCursor: cursor,
+  };
+}
+
+/**
+ * Run one cadence pass for a single customer. Resolves the customer's
+ * tenant pool, opens a single transaction, takes the per-customer
+ * advisory lock, and either drives pages to completion + commits or
+ * exits without touching state.
+ */
+export async function runTriageBaselineCadence(
+  customerId: number,
+): Promise<CadenceRunResult> {
+  let pool: pg.Pool;
+  try {
+    pool = await getCustomerPool(customerId);
+  } catch (err) {
+    if (err instanceof CustomerNotFoundError) {
+      // Treat unknown customers as a clean "skip" so a stale schedule
+      // entry pointing at a deactivated customer does not page the
+      // operator. The route handler returns 404 instead — this branch
+      // is only reachable from in-process callers (tests, future
+      // batched drivers).
+      return {
+        customerId,
+        status: "skipped",
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+      };
+    }
+    throw err;
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    try {
+      const lockResult = await client.query<{ acquired: boolean }>(
+        `SELECT pg_try_advisory_xact_lock(${buildLockKeyExpr()}) AS acquired`,
+        [buildLockKeyParam(customerId)],
+      );
+      const acquired = lockResult.rows[0]?.acquired === true;
+      if (!acquired) {
+        // Concurrent run holds the lock. Roll back so we leave the row
+        // alone — the active runner will write the watermark.
+        await client.query("ROLLBACK");
+        return {
+          customerId,
+          status: "skipped",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+        };
+      }
+
+      const state = await readOrInitCorpusState(client);
+      await markRunning(client);
+
+      const driven = await drivePages(
+        client,
+        customerId,
+        state.last_event_cursor,
+      );
+
+      await markOk(client, driven.endCursor, EMPTY_EXCLUSIONS_FP);
+      await client.query("COMMIT");
+      return {
+        customerId,
+        status: "ok",
+        observedInserted: driven.observedInserted,
+        baselineInserted: driven.baselineInserted,
+        lastEventCursor: driven.endCursor,
+      };
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {
+        // Already rolled back or connection broken; nothing to do.
+      });
+      const message = err instanceof Error ? err.message : "Cadence failed";
+      await markFailed(pool, message);
+      return {
+        customerId,
+        status: "failed",
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+        error: message,
+      };
+    }
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Internal-token guard for the cadence route handler. Reads the
+ * shared secret from `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`. Mirrors
+ * the apply-attempt cleanup token check: constant-time comparison via
+ * `timingSafeEqual` after a length precheck so unequal-length probes
+ * do not leak through the early-return.
+ */
+export function verifyTriageBaselineCadenceToken(
+  provided: string | null,
+): boolean {
+  const expected = process.env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN;
+  if (!expected) return false;
+  if (!provided) return false;
+  if (provided.length !== expected.length) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export const _testing = {
+  buildLockKeyParam,
+  EMPTY_EXCLUSIONS_FP,
+};

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -11,15 +11,18 @@ import "server-only";
  * ## Concurrency
  *
  * A second concurrent invocation for the same customer must not double-
- * ingest. The runner takes a per-customer transaction-scoped advisory
- * lock as the first statement of the cadence transaction:
+ * ingest. Every per-page transaction starts by taking a per-customer
+ * transaction-scoped advisory lock:
  *
  *   `pg_try_advisory_xact_lock(hashtext('triage_baseline_cadence:' || customer_id))`
  *
- * If the lock is unavailable the runner exits cleanly without touching
- * `baseline_corpus_state` — the next scheduled tick picks up where the
- * previous run stopped via `last_event_cursor`. Lock release is
- * automatic on commit/rollback because it is transaction-scoped.
+ * If the lock is unavailable on the first page, the runner exits cleanly
+ * without touching `baseline_corpus_state` — the next scheduled tick
+ * picks up where the previous run stopped via `last_event_cursor`. Lock
+ * release is automatic on commit/rollback because it is transaction-
+ * scoped. A run holds the lock only across one page transaction at a
+ * time, so multiple cadence pages do not stretch a long-lived database
+ * transaction.
  *
  * ## Pipeline (per page)
  *
@@ -36,26 +39,33 @@ import "server-only";
  *   f. UPDATE `baseline_corpus_state.last_event_cursor` and
  *      `last_ingested_at`.
  *
- * Steps (d), (e), and (f) commit as a single transaction so the
- * watermark advances atomically with the rows it covers. PK collisions
- * on re-ingest of the same `event_key` are handled with
+ * Steps (a)–(f) for a single page commit as one DB transaction. PK
+ * collisions on re-ingest of the same `event_key` are handled with
  * `ON CONFLICT DO NOTHING`.
  *
- * ## Upstream dependency
+ * ## Upstream dependency and the `pending` status
  *
- * This module ships the scheduler entrypoint, the advisory lock
- * discipline, the corpus-state machine, and the schema migration. The
- * GraphQL fetch-and-ingest path is intentionally a placeholder: it
- * depends on `eventListWithTriage` from aicers/review-web#842, which
- * exposes both the new `EventStandardFilterInput` filter type and the
- * `event_key` (i128 RocksDB primary key) selection that this corpus
- * keys on. Today's vendored `schemas/review.graphql` carries neither.
+ * This module ships the scheduler entrypoint, the per-page advisory-
+ * lock discipline, the corpus-state machine, and the schema migration.
+ * The actual GraphQL pager — steps (a)–(e) — is injected via the
+ * {@link CadencePager} interface and depends on two pieces that are not
+ * yet in this repo: review-web#842 (`eventListWithTriage` resolver +
+ * `EventStandardFilterInput` type + `event_key` field selection) needs
+ * to be vendored into `schemas/review.graphql`, and aice-web-next#460
+ * (the shared `src/lib/triage/exclusion/` helper) must land so cadence-
+ * time and retroactive-DELETE paths share one normalization +
+ * `exclusions_fp` source of truth.
  *
- * Once #842 lands, the placeholder marker in {@link ingestPage} flips
- * to a real GraphQL pager: the rest of the cadence flow (lock,
- * transaction, status updates, normalization helpers, exclusion re-
- * application, ON CONFLICT DO NOTHING inserts, watermark advance) is
- * unchanged. The route handler and its token guard are unaffected.
+ * Until those land, `runTriageBaselineCadence` defaults to
+ * {@link STUB_PAGER}, which throws {@link CadencePagerNotImplementedError}
+ * on the first page. The runner catches that error specifically, rolls
+ * back the page transaction (so the corpus-state row stays untouched),
+ * and returns `status: 'pending'`. The scheduler can wire the route up
+ * today — it will see `pending` responses and the corpus stays empty —
+ * without any risk that a no-op run advertises success or advances
+ * `last_ingested_at`. When the real pager lands, the same module just
+ * swaps `STUB_PAGER` for the production pager and the surrounding
+ * lock / transaction / status-machine plumbing is unchanged.
  */
 
 import { createHash, timingSafeEqual } from "node:crypto";
@@ -88,20 +98,28 @@ export const PHASE_1A_SELECTOR_TAG = "phase1a-simple";
  */
 export const PHASE_1A_BASELINE_SCORE = 1;
 
-export type CadenceRunStatus = "ok" | "failed" | "running" | "skipped";
+export type CadenceRunStatus =
+  | "ok"
+  | "failed"
+  | "running"
+  | "skipped"
+  | "pending";
 
 export interface CadenceRunResult {
   /** Customer the runner targeted. */
   customerId: number;
   /**
    * Outcome marker:
-   *   - `ok`: the cadence transaction committed (zero or more pages
-   *     ingested).
-   *   - `skipped`: the per-customer advisory lock was unavailable
-   *     because another run is in progress; this tick is a no-op.
-   *   - `failed`: the cadence transaction rolled back; `error` carries
-   *     the message that was persisted to
-   *     `baseline_corpus_state.last_error`.
+   *   - `ok`: at least one page committed cleanly.
+   *   - `skipped`: the per-customer advisory lock was unavailable on
+   *     the very first page; this tick is a no-op.
+   *   - `failed`: a page rolled back; `error` carries the message that
+   *     was persisted to `baseline_corpus_state.last_error`.
+   *   - `pending`: the cadence pager is not yet wired (see module
+   *     docstring). The runner started a page transaction, observed the
+   *     stub, rolled back, and returned without touching the corpus-
+   *     state row. The scheduler can keep ticking; runs flip to `ok`
+   *     automatically once the pager lands.
    *   - `running`: never returned to the caller — the on-disk marker
    *     used while a run holds the lock so a crash leaves a forensic
    *     breadcrumb.
@@ -126,16 +144,68 @@ interface CorpusStateRow {
   last_error: string | null;
 }
 
+export interface CadencePageResult {
+  /** Rows inserted into `observed_event_meta` for this page. */
+  observedInserted: number;
+  /** Rows inserted into `baseline_triaged_event` for this page. */
+  baselineInserted: number;
+  /**
+   * End cursor of the page as reported by the resolver, or `null` if
+   * the resolver returned no edges. Used to advance
+   * `baseline_corpus_state.last_event_cursor`.
+   */
+  endCursor: string | null;
+  /** Whether the resolver indicates more pages are available. */
+  hasNextPage: boolean;
+}
+
 /**
- * Build the bigint advisory-lock key. Mirrors the SQL formula in the
- * issue: `hashtext('triage_baseline_cadence:' || customer_id)`. Letting
- * the database compute the hash avoids a Node ↔ Postgres consistency
- * trap (Postgres' `hashtext` is not equivalent to any well-known JS
- * hash). Returns the raw SQL fragment passed straight into
- * `pg_try_advisory_xact_lock`.
+ * Fetch + insert one page of standard-filter survivors. The runner
+ * threads `afterCursor` from the previous page's `endCursor` (or
+ * `baseline_corpus_state.last_event_cursor` on the first page) and
+ * runs every call inside an open page transaction with the per-customer
+ * advisory lock already held.
  */
+export interface CadencePager {
+  ingestPage(
+    client: pg.PoolClient,
+    customerId: number,
+    afterCursor: string | null,
+  ): Promise<CadencePageResult>;
+}
+
+/**
+ * Sentinel raised by {@link STUB_PAGER}. The runner catches this error
+ * specifically and returns `status: 'pending'` so the scheduler does
+ * not see a fake-success response while the real pager is unavailable.
+ */
+export class CadencePagerNotImplementedError extends Error {
+  constructor() {
+    super(
+      "Triage cadence pager is not yet implemented (pending review-web#842 schema vendor and aicers/aice-web-next#460 shared exclusion helper).",
+    );
+    this.name = "CadencePagerNotImplementedError";
+  }
+}
+
+/**
+ * Default pager. Throws {@link CadencePagerNotImplementedError} on
+ * every call. Replace at the {@link runTriageBaselineCadence} call site
+ * once the real pager lands.
+ */
+export const STUB_PAGER: CadencePager = {
+  async ingestPage() {
+    throw new CadencePagerNotImplementedError();
+  },
+};
+
 const LOCK_NAMESPACE = "triage_baseline_cadence:";
 
+/**
+ * Letting the database compute the hash avoids a Node ↔ Postgres
+ * consistency trap (Postgres' `hashtext` is not equivalent to any
+ * well-known JS hash).
+ */
 function buildLockKeyExpr(): string {
   return `hashtext($1)`;
 }
@@ -232,159 +302,129 @@ async function markFailed(pool: pg.Pool, message: string): Promise<void> {
 }
 
 /**
- * Ingest a single page of standard-filter survivors and return the
- * count of rows inserted into each table plus the end cursor of the
- * page (or `null` if no further pages exist). Phase 1.A: this function
- * is a placeholder. The full implementation lands once review-web#842
- * exposes `eventListWithTriage` + `event_key`. Today it returns a
- * no-op page so the surrounding cadence transaction commits a clean
- * "ran, no work to do" record — the corpus stays empty until #842
- * lands, but the scheduler endpoint, advisory-lock discipline, status
- * machine, and migration are all exercised in production.
- */
-async function ingestPage(
-  _client: pg.PoolClient,
-  _customerId: number,
-  _afterCursor: string | null,
-): Promise<{
-  observedInserted: number;
-  baselineInserted: number;
-  endCursor: string | null;
-  hasNextPage: boolean;
-}> {
-  // TODO(review-web#842): replace this stub with a real pager.
-  //
-  //   1. Build EventStandardFilterInput (no triagePolicies field).
-  //   2. graphqlRequest(EVENT_LIST_WITH_TRIAGE_QUERY, { filter, first,
-  //      after, triage: null }, { role, customerIds: [customerId] }).
-  //   3. For each node:
-  //        - Extract event_key (NUMERIC(39,0)) from the GraphQL field.
-  //        - Normalize host / dns_query / uri per event-kind mapping.
-  //        - Drop if any active exclusion (CIDR / hostname / domain
-  //          regex / uri exact) matches.
-  //   4. INSERT survivors into observed_event_meta (ON CONFLICT DO
-  //      NOTHING).
-  //   5. INSERT baseline-passing subset (Phase 1.A category whitelist
-  //      OR HttpThreat with cluster_id IS NULL) into
-  //      baseline_triaged_event (ON CONFLICT DO NOTHING) with
-  //      baseline_version = PHASE_1A_BASELINE_VERSION,
-  //      baseline_score  = PHASE_1A_BASELINE_SCORE,
-  //      selector_tags   = ARRAY[PHASE_1A_SELECTOR_TAG],
-  //      exclusions_fp   = computeExclusionsFingerprint(active).
-  //   6. Return endCursor + hasNextPage so the outer driver can either
-  //      advance the watermark or break out of the loop on the last
-  //      page.
-  return {
-    observedInserted: 0,
-    baselineInserted: 0,
-    endCursor: null,
-    hasNextPage: false,
-  };
-}
-
-/**
- * Page-bounded driver. Walks pages until either the resolver reports
- * no more pages or `MAX_PAGES_PER_RUN` is reached, accumulating row
- * counts and the latest end cursor. Hard cap defends against a runaway
- * loop if the resolver ever reports `hasNextPage = true` on every page.
+ * Hard cap on pages per cadence run. Defends against a runaway loop if
+ * the resolver ever reports `hasNextPage = true` indefinitely. With
+ * per-page transactions, the cap also bounds how long a single cadence
+ * tick can hold the connection.
  */
 const MAX_PAGES_PER_RUN = 200;
 
-async function drivePages(
-  client: pg.PoolClient,
-  customerId: number,
-  startCursor: string | null,
-): Promise<{
-  observedInserted: number;
-  baselineInserted: number;
-  endCursor: string | null;
-}> {
-  let cursor = startCursor;
-  let observedInserted = 0;
-  let baselineInserted = 0;
-  for (let page = 0; page < MAX_PAGES_PER_RUN; page += 1) {
-    const out = await ingestPage(client, customerId, cursor);
-    observedInserted += out.observedInserted;
-    baselineInserted += out.baselineInserted;
-    if (out.endCursor !== null) cursor = out.endCursor;
-    if (!out.hasNextPage) break;
-  }
-  return {
-    observedInserted,
-    baselineInserted,
-    endCursor: cursor,
-  };
-}
-
 /**
- * Run one cadence pass for a single customer. Resolves the customer's
- * tenant pool, opens a single transaction, takes the per-customer
- * advisory lock, and either drives pages to completion + commits or
- * exits without touching state.
+ * Run one cadence pass for a single customer. Walks pages until either
+ * the resolver reports `hasNextPage = false` or `MAX_PAGES_PER_RUN` is
+ * reached, committing each page's INSERTs + watermark UPDATE in its own
+ * transaction so progress is preserved if a later page fails.
  */
 export async function runTriageBaselineCadence(
   customerId: number,
+  options: { pager?: CadencePager } = {},
 ): Promise<CadenceRunResult> {
+  const pager = options.pager ?? STUB_PAGER;
+
   // Lets `CustomerNotFoundError` propagate so the route handler can
   // surface it as a 404. In-process callers (future batched drivers,
   // tests) catch the same error type if they want a "skip" instead.
   const pool = await getCustomerPool(customerId);
 
   const client = await pool.connect();
+  let totalObserved = 0;
+  let totalBaseline = 0;
+  let lastCommittedCursor: string | null = null;
+  let nextStartCursor: string | null = null;
+  let isFirstPage = true;
+
   try {
-    await client.query("BEGIN");
-    try {
-      const lockResult = await client.query<{ acquired: boolean }>(
-        `SELECT pg_try_advisory_xact_lock(${buildLockKeyExpr()}) AS acquired`,
-        [buildLockKeyParam(customerId)],
-      );
-      const acquired = lockResult.rows[0]?.acquired === true;
-      if (!acquired) {
-        // Concurrent run holds the lock. Roll back so we leave the row
-        // alone — the active runner will write the watermark.
-        await client.query("ROLLBACK");
+    for (let page = 0; page < MAX_PAGES_PER_RUN; page += 1) {
+      let pageCommitted = false;
+      try {
+        await client.query("BEGIN");
+
+        const lockResult = await client.query<{ acquired: boolean }>(
+          `SELECT pg_try_advisory_xact_lock(${buildLockKeyExpr()}) AS acquired`,
+          [buildLockKeyParam(customerId)],
+        );
+        const acquired = lockResult.rows[0]?.acquired === true;
+        if (!acquired) {
+          await client.query("ROLLBACK");
+          if (isFirstPage) {
+            return {
+              customerId,
+              status: "skipped",
+              observedInserted: 0,
+              baselineInserted: 0,
+              lastEventCursor: null,
+            };
+          }
+          // Mid-run lock loss (rare: a competing scheduler tick grabbed
+          // the lock between two of our page commits). Stop cleanly at
+          // the watermark we already committed; the competing run will
+          // continue from there.
+          break;
+        }
+
+        if (isFirstPage) {
+          const state = await readOrInitCorpusState(client);
+          await markRunning(client);
+          nextStartCursor = state.last_event_cursor;
+        }
+
+        const ingest = await pager.ingestPage(
+          client,
+          customerId,
+          nextStartCursor,
+        );
+
+        await markOk(client, ingest.endCursor, EMPTY_EXCLUSIONS_FP);
+        await client.query("COMMIT");
+        pageCommitted = true;
+
+        totalObserved += ingest.observedInserted;
+        totalBaseline += ingest.baselineInserted;
+        if (ingest.endCursor !== null) {
+          nextStartCursor = ingest.endCursor;
+          lastCommittedCursor = ingest.endCursor;
+        }
+        isFirstPage = false;
+        if (!ingest.hasNextPage) break;
+      } catch (err) {
+        if (!pageCommitted) {
+          await client.query("ROLLBACK").catch(() => {
+            // Already rolled back or connection broken; nothing to do.
+          });
+        }
+        if (err instanceof CadencePagerNotImplementedError) {
+          // Stub pager: do not advertise success and do not write
+          // failure. The corpus is intentionally idle until the real
+          // pager lands; the scheduler can keep ticking and observe
+          // `pending` until then.
+          return {
+            customerId,
+            status: "pending",
+            observedInserted: totalObserved,
+            baselineInserted: totalBaseline,
+            lastEventCursor: lastCommittedCursor,
+          };
+        }
+        const message = err instanceof Error ? err.message : "Cadence failed";
+        await markFailed(pool, message);
         return {
           customerId,
-          status: "skipped",
-          observedInserted: 0,
-          baselineInserted: 0,
-          lastEventCursor: null,
+          status: "failed",
+          observedInserted: totalObserved,
+          baselineInserted: totalBaseline,
+          lastEventCursor: lastCommittedCursor,
+          error: message,
         };
       }
-
-      const state = await readOrInitCorpusState(client);
-      await markRunning(client);
-
-      const driven = await drivePages(
-        client,
-        customerId,
-        state.last_event_cursor,
-      );
-
-      await markOk(client, driven.endCursor, EMPTY_EXCLUSIONS_FP);
-      await client.query("COMMIT");
-      return {
-        customerId,
-        status: "ok",
-        observedInserted: driven.observedInserted,
-        baselineInserted: driven.baselineInserted,
-        lastEventCursor: driven.endCursor,
-      };
-    } catch (err) {
-      await client.query("ROLLBACK").catch(() => {
-        // Already rolled back or connection broken; nothing to do.
-      });
-      const message = err instanceof Error ? err.message : "Cadence failed";
-      await markFailed(pool, message);
-      return {
-        customerId,
-        status: "failed",
-        observedInserted: 0,
-        baselineInserted: 0,
-        lastEventCursor: null,
-        error: message,
-      };
     }
+
+    return {
+      customerId,
+      status: "ok",
+      observedInserted: totalObserved,
+      baselineInserted: totalBaseline,
+      lastEventCursor: lastCommittedCursor,
+    };
   } finally {
     client.release();
   }


### PR DESCRIPTION
## Summary

Lands the scheduler entrypoint, per-page advisory-lock discipline, status machine, and customer-tenant DB schema for Triage baseline corpus A (1B-1 / discussion #447 §3.4):

- New migration `migrations/customer/0003_baseline_corpus_a.sql` adds `baseline_triaged_event` (180d retention, menu-facing), `baseline_corpus_state` (cadence watermark singleton), and `observed_event_meta` (30d retention, unbiased input for 1B-8 window-aggregate stats). GiST + `inet_ops` indexes for CIDR-containment columns, plain btree elsewhere; composite `(event_time DESC, baseline_score DESC)` index for the Baseline-mode SELECT in 1B-3.
- New route `POST /api/internal/triage/baseline/cadence` accepting `{ customer_id }`, guarded by `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN` (same Bearer-token shape as the apply-attempts cleanup route).
- New runner `src/lib/triage/baseline/cadence.ts` taking a per-customer transaction-scoped advisory lock (`hashtext('triage_baseline_cadence:' || customer_id)`) **at the start of each page transaction**, running the corpus-state machine (`running` → `ok` / `skipped` / `failed` / `pending`), and committing each page's row inserts + watermark UPDATE in its own transaction. A failure on a later page therefore preserves earlier pages' commits and persists the failure record outside the rolled-back page; a competing scheduler tick that grabs the lock between two of our page commits causes a clean stop at the last committed watermark. `CustomerNotFoundError` propagates out of the runner so the route maps it to a 404.
- The cadence pager itself is dependency-injected via the new `CadencePager` interface. Until review-web#842 is vendored into `schemas/review.graphql` and aice-web-next#460's shared `src/lib/triage/exclusion/` helper lands, the runner uses `STUB_PAGER` which throws `CadencePagerNotImplementedError`. The runner catches that sentinel specifically, rolls back the page transaction (so `baseline_corpus_state` stays untouched), and returns `status: 'pending'`. The route surfaces that as **HTTP 503** so the scheduler cannot mistake a no-op tick for a successful ingest. Once the real pager lands the same module just swaps `STUB_PAGER` and the lock / transaction / status-machine plumbing is unchanged.
- Phase 1.A baseline-passing constants (`PHASE_1A_BASELINE_VERSION`, `PHASE_1A_BASELINE_SCORE`, `PHASE_1A_SELECTOR_TAG`) and an empty-set `exclusions_fp` placeholder are exported so 1B-8 / #460 can swap them in without rewriting on-disk rows.
- `.env.example` and `README.md` document the new internal token.

## Not addressed

This PR ships the scheduler/lock/state-machine plumbing and schema migration, but several issue requirements are intentionally left for follow-up PRs. The runner returns `status: 'pending'` (HTTP 503) until they all land, so the scheduler can be wired up safely today without risking false-success ingests.

- **Cadence pipeline steps (a)–(e)** — fetching raw standard-filter survivors via `eventListWithTriage(triage = null)`, populating normalized columns (`host` / `dns_query` / `uri` per event-kind mapping), applying global + customer-scoped exclusions in-memory with full IpAddress / Hostname / Uri / Domain semantics, and INSERTing into `observed_event_meta` + `baseline_triaged_event` (with the Phase 1.A simple `category ∈ {CommandAndControl, Exfiltration, Impact, InitialAccess, CredentialAccess}` ∪ unlabeled `HttpThreat` baseline-passing rule). Why: the resolver-side dependency `eventListWithTriage` is merged in upstream review-web#842 but not yet vendored into this repo's `schemas/review.graphql` (still pinned at 0.47.0, with neither `eventListWithTriage` nor `EventStandardFilterInput` nor the `event_key` i128 selection exposed). Schema vendoring is a documented multi-step process — see `README.md` §"Sync vendored schemas" — and is intentionally a separate PR because it touches the codegen pipeline and many downstream tests. The pager is stubbed via the dependency-injected `CadencePager` interface so the swap is mechanical when the schema lands.
- **Shared `exclusions_fp` canonicalization** — the issue requires the cadence runner, the corpus B runner (#460), and the retroactive-DELETE planner (#457) to derive `exclusions_fp` from one shared `src/lib/triage/exclusion/` helper. Why: aice-web-next#460 (the helper itself) is still OPEN. Until then the runner stamps a stable empty-set placeholder fingerprint so the column is NOT NULL but does not falsely identify rows as having passed any specific exclusion configuration; the swap to `computeExclusionsFingerprint(active)` is a single line.
- **Hourly scheduler registration** — the issue's "Hourly cadence per customer. … registered with the existing external deployment scheduler" wiring is not done in this PR. Why: while the pager is stubbed, registering the route would only generate hourly 503s; the wiring will go in alongside the follow-up that swaps `STUB_PAGER` for the real pager and closes #456.

Both upstream dependencies are tracked under #456 — the follow-up that wires `STUB_PAGER` to the real pager and registers the scheduler will be the one that closes this issue.

## Test plan

- [x] `pnpm biome check` clean
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run` — 3672 tests pass, including 28 new tests under `src/__tests__/app/api/internal/triage` and `src/__tests__/lib/triage/baseline`
- [x] `pnpm build` succeeds
- [x] Run `migrations/customer/0003_baseline_corpus_a.sql` against a customer-tenant DB and verify all three tables + indexes are created (GiST `inet_ops` for `*_addr`, btree elsewhere)
- [x] `POST /api/internal/triage/baseline/cadence` returns 401 when `Authorization: Bearer …` is missing or wrong
- [x] `POST /api/internal/triage/baseline/cadence` returns 400 when body is missing `customer_id` or it is not a positive integer
- [x] `POST /api/internal/triage/baseline/cadence` returns 404 when `customer_id` does not match an active customer
- [x] `POST /api/internal/triage/baseline/cadence` returns **503 with `status: 'pending'`** today (stub pager) and does not touch `baseline_corpus_state`
- [x] Two concurrent invocations for the same `customer_id`: one returns `status: 'ok'`, the other returns `status: 'skipped'` and does not modify `baseline_corpus_state`
- [x] An invocation that fails inside a cadence page transaction leaves `baseline_corpus_state.last_run_status='failed'` and `last_error` populated, with the row visible to the next tick; earlier successfully-committed pages are preserved
- [x] Each cadence page commits its own transaction and reacquires the advisory lock per page (covered by `per-page transaction discipline` test group)
- [ ] Wire the route into the deployment scheduler with hourly cadence per customer once the pager lands; today scheduler ticks see `503 / pending` and the corpus stays empty by design

Part of #456