### PR TITLE
Wire Triage baseline cadence pager and exclusion helper (#481)

### DIFF
--- a/docs/en/operations/triage-baseline-cadence.md
+++ b/docs/en/operations/triage-baseline-cadence.md
@@ -47,9 +47,14 @@ A successful pass returns HTTP 200 with the per-run counters:
   "status": "ok",
   "observedInserted": 142,
   "baselineInserted": 9,
-  "lastEventCursor": "AAAA…"
+  "lastEventCursor": "1234567890123456789"
 }
 ```
+
+`lastEventCursor` is the decimal RocksDB primary key of the last
+event scanned in this run (the upstream resolver builds connection
+edges with `Edge::new(k.to_string(), ev)`, so the cursor is the
+i128 key serialised as a decimal string up to 39 digits).
 
 | Field | Meaning |
 | :-- | :-- |

--- a/docs/en/operations/triage-baseline-cadence.md
+++ b/docs/en/operations/triage-baseline-cadence.md
@@ -1,0 +1,155 @@
+# Triage Baseline Cadence
+
+The Triage menu's Baseline mode reads from a per-customer
+`baseline_triaged_event` corpus that the deployment scheduler
+fills via a recurring HTTP call. The route runs as a system actor
+(no user session) and is gated by a shared internal secret.
+
+## What the cadence does
+
+Each invocation runs one ingestion pass for a single customer-tenant
+DB. The pass walks pages of the upstream `eventListWithTriage`
+resolver in order, applies the active exclusion set in-memory, and
+INSERTs both:
+
+- the **observed-event metadata** for every standard-filter survivor
+  into `observed_event_meta` (30-day retention, used by future
+  window-aggregate signals); and
+- the **baseline-passing subset** into `baseline_triaged_event`
+  (180-day retention, read directly by the Triage menu).
+
+`baseline_corpus_state.last_event_cursor` is advanced atomically
+with the per-page INSERTs so a failure rolls back to the previous
+watermark without losing rows already committed.
+
+## Endpoint
+
+```text
+POST /api/internal/triage/baseline/cadence
+Authorization: Bearer <TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN>
+Content-Type: application/json
+
+{ "customer_id": <positive integer> }
+```
+
+The token is a shared secret read from
+`TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`. The route refuses every
+request when the env var is unset, and it constant-time compares
+the provided value to avoid a timing oracle.
+
+## Response
+
+A successful pass returns HTTP 200 with the per-run counters:
+
+```json
+{
+  "customerId": 7,
+  "status": "ok",
+  "observedInserted": 142,
+  "baselineInserted": 9,
+  "lastEventCursor": "AAAA…"
+}
+```
+
+| Field | Meaning |
+| :-- | :-- |
+| `status` | `ok` if at least one page committed; `skipped` if the per-customer advisory lock was already held by another invocation; `failed` if a page rolled back. |
+| `observedInserted` | Rows added to `observed_event_meta` this run. |
+| `baselineInserted` | Rows added to `baseline_triaged_event` this run. |
+| `lastEventCursor` | End cursor of the last raw page successfully scanned. |
+| `error` | Present only on `failed`; the message that was persisted to `baseline_corpus_state.last_error`. |
+
+Status codes other than 200:
+
+| Status | Meaning |
+| :-- | :-- |
+| 400 | Malformed JSON or missing / non-positive `customer_id`. |
+| 401 | Bearer token missing or does not match. |
+| 404 | The supplied `customer_id` does not map to an active customer. |
+| 500 | The cadence pass rolled back; the structured `failed` body still includes `error` so the scheduler can log it. |
+
+## Concurrency
+
+A second concurrent invocation for the same customer must not
+double-ingest. Every per-page transaction starts by taking a
+per-customer transaction-scoped advisory lock:
+
+```sql
+pg_try_advisory_xact_lock(hashtext('triage_baseline_cadence:' || customer_id))
+```
+
+If the lock is unavailable on the very first page, the runner
+returns `status: 'skipped'` without touching `baseline_corpus_state`
+— the next scheduled tick picks up where the previous run stopped.
+Lock release is automatic on commit/rollback because the lock is
+transaction-scoped, so multiple cadence pages do not stretch a
+long-lived database transaction.
+
+## Failure and retry
+
+When a page rolls back the runner records the error in
+`baseline_corpus_state.last_run_status = 'failed'` /
+`last_error = <message>` and returns 500 with the structured body.
+Subsequent scheduler ticks reattempt from `last_event_cursor`, so
+a transient outage costs at most one missed page; the next pass
+refills it.
+
+The runner recognises one specific recovery shape:
+
+- A competing scheduler tick that grabs the advisory lock between
+  two of our page commits causes a clean stop at the last
+  committed watermark and `status: 'ok'` with the partial counters.
+
+## Runbook entry — schedule the cadence endpoint
+
+Add the cadence route to the deployment scheduler in your release
+runbook. The recommended cadence is **once per hour per customer**
+(per discussion #447 §3.4). Hourly cadence keeps the corpus warm
+without doubling the resolver load — the per-page commit + cursor
+advance lets the next tick pick up from where the previous one
+stopped, so a transient outage of one or two cycles is harmless.
+
+1. Provision a strong random token for
+   `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`. Store it in your
+   secrets manager, rotate on a normal cadence, never check it in.
+2. Set the env var on every BFF instance and on the scheduler that
+   calls the route. The route refuses every request when the env
+   var is unset, so the scheduler must explicitly load it before
+   the first tick.
+3. Wire a recurring caller (cron, Kubernetes `CronJob`, GitHub
+   Actions schedule, etc.) that issues, once per hour per
+   customer:
+
+    ```bash
+    curl -fsS -X POST \
+      -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$BFF_BASE_URL/api/internal/triage/baseline/cadence" \
+      -d '{"customer_id": 1}'
+    ```
+
+    If you operate multiple customer-tenant DBs, fan out one HTTP
+    call per `customer_id` per hour. Per-customer advisory locks
+    let independent customers run concurrently.
+
+4. Verify the first scheduled run by tailing the scheduler logs
+   and confirming the JSON body parses cleanly. A healthy first
+   run on a quiet deployment usually reports modest counters; a
+   `status: 'skipped'` on a first run after an interrupted tick
+   is expected (the previous run is still finishing) and should
+   resolve on the subsequent pass.
+
+## Observability
+
+Every successful pass updates `baseline_corpus_state` with:
+
+- `last_run_status = 'ok'`
+- `last_ingested_at = NOW()`
+- `last_event_cursor = <end-cursor of last page>`
+- `baseline_version = 'phase1a-simple'`
+- `exclusions_fp = <fingerprint of active exclusion set>`
+
+A failed pass leaves `last_run_status = 'failed'` with the error
+text on `last_error`. Operators can sample these columns directly
+to confirm the scheduler is wired up correctly without polling
+the route every tick.

--- a/docs/ko/operations/triage-baseline-cadence.md
+++ b/docs/ko/operations/triage-baseline-cadence.md
@@ -48,9 +48,15 @@ Content-Type: application/json
   "status": "ok",
   "observedInserted": 142,
   "baselineInserted": 9,
-  "lastEventCursor": "AAAA…"
+  "lastEventCursor": "1234567890123456789"
 }
 ```
+
+`lastEventCursor`는 이번 실행에서 마지막으로 스캔한 이벤트의
+RocksDB 기본 키를 10진수로 인코딩한 값입니다. 상위 리졸버가
+`Edge::new(k.to_string(), ev)`로 커넥션 엣지를 만들기 때문에,
+커서는 i128 키를 10진수 문자열(최대 39자리)로 직렬화한 형태
+그대로입니다.
 
 | 필드 | 의미 |
 | :-- | :-- |

--- a/docs/ko/operations/triage-baseline-cadence.md
+++ b/docs/ko/operations/triage-baseline-cadence.md
@@ -1,0 +1,153 @@
+# 트리아지 베이스라인 케이던스
+
+트리아지 메뉴의 베이스라인 모드는 고객별
+`baseline_triaged_event` 코퍼스를 읽으며, 배포 스케줄러가
+주기적인 HTTP 호출로 이 코퍼스를 채웁니다. 라우트는 시스템
+액터로 동작(사용자 세션 없음)하며, 공유 내부 비밀 키로
+보호됩니다.
+
+## 케이던스가 하는 일
+
+호출 한 번이 한 고객 테넌트 DB에 대한 한 번의 인제스션
+패스를 실행합니다. 패스는 상위 `eventListWithTriage`
+리졸버의 페이지를 순서대로 순회하며 활성 제외 셋을
+인메모리에서 적용한 후 두 테이블에 모두 INSERT합니다.
+
+- 표준 필터 통과한 모든 이벤트의 **관측 메타데이터**를
+  `observed_event_meta`(보존 30일, 향후 윈도우 집계 신호용)에
+  저장합니다.
+- **베이스라인 통과 부분집합**을 `baseline_triaged_event`
+  (보존 180일, 트리아지 메뉴가 직접 읽음)에 저장합니다.
+
+`baseline_corpus_state.last_event_cursor`는 페이지별 INSERT와
+원자적으로 진행되므로, 실패 시 이전 워터마크로 롤백되며 이미
+커밋된 행은 손실되지 않습니다.
+
+## 엔드포인트
+
+```text
+POST /api/internal/triage/baseline/cadence
+Authorization: Bearer <TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN>
+Content-Type: application/json
+
+{ "customer_id": <양의 정수> }
+```
+
+토큰은 환경 변수 `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`에서
+읽는 공유 비밀 키입니다. 환경 변수가 미설정이면 라우트는 모든
+요청을 거부하며, 타이밍 오라클 방지를 위해 상수 시간 비교를
+사용합니다.
+
+## 응답
+
+성공한 패스는 HTTP 200과 실행별 카운터를 반환합니다.
+
+```json
+{
+  "customerId": 7,
+  "status": "ok",
+  "observedInserted": 142,
+  "baselineInserted": 9,
+  "lastEventCursor": "AAAA…"
+}
+```
+
+| 필드 | 의미 |
+| :-- | :-- |
+| `status` | 한 페이지 이상 커밋되었으면 `ok`, 다른 호출이 이미 고객별 어드바이저리 락을 보유 중이면 `skipped`, 한 페이지가 롤백되었으면 `failed`. |
+| `observedInserted` | 이번 실행에서 `observed_event_meta`에 추가된 행 수. |
+| `baselineInserted` | 이번 실행에서 `baseline_triaged_event`에 추가된 행 수. |
+| `lastEventCursor` | 이번 실행에서 마지막으로 성공적으로 스캔한 페이지의 종료 커서. |
+| `error` | `failed` 상태에서만 존재하며, `baseline_corpus_state.last_error`에 저장된 메시지. |
+
+200 외 상태 코드:
+
+| 상태 | 의미 |
+| :-- | :-- |
+| 400 | JSON이 잘못되었거나 `customer_id`가 누락/비양수. |
+| 401 | Bearer 토큰 누락 또는 불일치. |
+| 404 | 제공된 `customer_id`가 활성 고객에 매핑되지 않음. |
+| 500 | 케이던스 패스가 롤백되었으며, `failed` 응답 본문의 `error` 필드를 스케줄러가 로그할 수 있도록 구조화됨. |
+
+## 동시성
+
+같은 고객에 대한 동시 호출 두 건이 이중 인제스션되지
+않아야 합니다. 페이지별 트랜잭션은 시작 시 고객별
+트랜잭션 범위 어드바이저리 락을 획득합니다.
+
+```sql
+pg_try_advisory_xact_lock(hashtext('triage_baseline_cadence:' || customer_id))
+```
+
+첫 페이지에서 락을 획득하지 못하면 러너는
+`baseline_corpus_state`를 건드리지 않은 채 `status: 'skipped'`를
+반환합니다. 다음 스케줄 틱이 이전 실행이 멈춘 지점부터 이어
+받습니다. 락은 트랜잭션 범위이므로 커밋/롤백 시 자동 해제되며,
+여러 케이던스 페이지가 장시간 트랜잭션을 점유하지 않습니다.
+
+## 실패와 재시도
+
+페이지가 롤백되면 러너는
+`baseline_corpus_state.last_run_status = 'failed'` /
+`last_error = <메시지>`로 기록하고 구조화된 본문과 함께 500을
+반환합니다. 다음 스케줄 틱은 `last_event_cursor`에서 재시도하므로,
+일시적 장애는 최대 한 페이지만 재처리하면 회복됩니다.
+
+러너는 한 가지 회복 형태를 특별히 인식합니다.
+
+- 우리 페이지 커밋 사이에 경쟁 스케줄러 틱이 어드바이저리 락을
+  획득해 가져가는 경우, 마지막으로 커밋된 워터마크에서 깨끗하게
+  멈추고 부분 카운터와 함께 `status: 'ok'`를 반환합니다.
+
+## 런북 — 케이던스 엔드포인트 등록
+
+릴리스 런북의 배포 스케줄러에 케이던스 라우트를 등록하세요.
+권장 주기는 **고객당 시간당 1회** (논의 #447 §3.4 기준)입니다.
+시간당 주기는 코퍼스를 신선하게 유지하면서 리졸버 부하를
+배가시키지 않습니다. 페이지별 커밋과 커서 진행 덕분에 다음
+틱이 이전이 멈춘 지점에서 이어받아, 1–2 사이클의 일시적 장애는
+무해합니다.
+
+1. `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`에 강한 무작위 토큰을
+   준비합니다. 시크릿 매니저에 저장하고, 일반적인 주기로
+   순환시키며, 절대 체크인하지 않습니다.
+2. 모든 BFF 인스턴스와 라우트를 호출하는 스케줄러에 환경
+   변수를 설정합니다. 환경 변수가 미설정이면 라우트는 모든
+   요청을 거부하므로, 첫 틱 전에 스케줄러가 명시적으로 변수를
+   로드해야 합니다.
+3. 시간당 한 번씩 호출하는 반복 호출자(cron, Kubernetes
+   `CronJob`, GitHub Actions 스케줄 등)를 연결합니다.
+
+    ```bash
+    curl -fsS -X POST \
+      -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$BFF_BASE_URL/api/internal/triage/baseline/cadence" \
+      -d '{"customer_id": 1}'
+    ```
+
+    여러 고객 테넌트 DB를 운영하는 경우, 시간당 `customer_id`별로
+    한 번씩 HTTP 호출을 분기합니다. 고객별 어드바이저리 락
+    덕분에 서로 다른 고객의 패스는 동시 실행이 가능합니다.
+
+4. 첫 스케줄 실행을 스케줄러 로그를 추적하며 검증합니다.
+   조용한 배포에서 정상적인 첫 실행은 보통 보통 수준의 카운터를
+   보고합니다. 중단된 틱 직후 첫 실행에서 `status: 'skipped'`가
+   나오는 것은 정상이며(이전 실행이 아직 마무리 중), 다음
+   패스에서 해소되어야 합니다.
+
+## 관찰성
+
+성공한 패스는 매번 `baseline_corpus_state`를 다음과 같이
+갱신합니다.
+
+- `last_run_status = 'ok'`
+- `last_ingested_at = NOW()`
+- `last_event_cursor = <마지막 페이지의 종료 커서>`
+- `baseline_version = 'phase1a-simple'`
+- `exclusions_fp = <활성 제외 셋의 지문>`
+
+실패한 패스는 `last_run_status = 'failed'`와 `last_error`에 오류
+메시지를 남깁니다. 운영자는 매 틱마다 라우트를 폴링하지 않아도
+이 컬럼들을 직접 샘플링해 스케줄러가 올바르게 연결되어 있는지
+확인할 수 있습니다.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ plugins:
             - Operations:
                 - Node management: operations/node-management.md
                 - mTLS certificate rotation: operations/mtls-rotation.md
+                - Triage baseline cadence: operations/triage-baseline-cadence.md
             - Settings: settings.md
             - Customer Scope: customer-scope.md
         - locale: ko
@@ -45,6 +46,7 @@ plugins:
             - Operations:
                 - Node management: operations/node-management.md
                 - mTLS certificate rotation: operations/mtls-rotation.md
+                - Triage baseline cadence: operations/triage-baseline-cadence.md
             - Settings: settings.md
             - Customer Scope: customer-scope.md
           nav_translations:
@@ -56,6 +58,7 @@ plugins:
             Operations: 운영
             Node management: 노드 관리
             mTLS certificate rotation: mTLS 인증서 교체
+            Triage baseline cadence: 트리아지 베이스라인 케이던스
             Settings: 설정
             Customer Scope: 고객사 범위
 

--- a/src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts
@@ -15,6 +15,13 @@ vi.mock("@/lib/triage/baseline/cadence", () => ({
   verifyTriageBaselineCadenceToken: mockVerifyToken,
 }));
 
+vi.mock("@/lib/triage/baseline/pager", () => ({
+  // The route handler instantiates the production pager once per
+  // process; the mock returns a sentinel so route tests can assert
+  // the pager was forwarded into the runner.
+  createCadencePager: () => ({ ingestPage: vi.fn() }),
+}));
+
 vi.mock("@/lib/triage/policy/customer-db", () => ({
   CustomerNotFoundError: MockCustomerNotFoundError,
 }));
@@ -122,26 +129,10 @@ describe("POST /api/internal/triage/baseline/cadence", () => {
       baselineInserted: 0,
       lastEventCursor: null,
     });
-    expect(mockRunCadence).toHaveBeenCalledWith(7);
-  });
-
-  it("returns 503 with status=pending when the cadence pager is not yet wired", async () => {
-    mockVerifyToken.mockReturnValue(true);
-    mockRunCadence.mockResolvedValue({
-      customerId: 7,
-      status: "pending",
-      observedInserted: 0,
-      baselineInserted: 0,
-      lastEventCursor: null,
-    });
-    const { POST } = await import(
-      "@/app/api/internal/triage/baseline/cadence/route"
+    expect(mockRunCadence).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ pager: expect.any(Object) }),
     );
-    const res = await POST(makeRequest("Bearer right", { customer_id: 7 }));
-    expect(res.status).toBe(503);
-    const body = await res.json();
-    expect(body.status).toBe("pending");
-    expect(body.customerId).toBe(7);
   });
 
   it("returns 200 with status=skipped when the advisory lock was unavailable", async () => {

--- a/src/__tests__/lib/triage/baseline/cadence.test.ts
+++ b/src/__tests__/lib/triage/baseline/cadence.test.ts
@@ -166,6 +166,7 @@ type PagerScript = Array<{
   baselineInserted?: number;
   endCursor?: string | null;
   hasNextPage?: boolean;
+  exclusionsFp?: string;
   throw?: Error;
 }>;
 
@@ -179,10 +180,13 @@ interface FakePager {
     baselineInserted: number;
     endCursor: string | null;
     hasNextPage: boolean;
+    exclusionsFp: string;
   }>;
   calls: unknown[][];
   callCount: () => number;
 }
+
+const TEST_EXCLUSIONS_FP = "test-empty-exclusions-fingerprint";
 
 function makePager(script: PagerScript = [{ hasNextPage: false }]): FakePager {
   const calls: unknown[][] = [];
@@ -201,6 +205,7 @@ function makePager(script: PagerScript = [{ hasNextPage: false }]): FakePager {
       baselineInserted: step.baselineInserted ?? 0,
       endCursor: step.endCursor ?? null,
       hasNextPage: step.hasNextPage ?? false,
+      exclusionsFp: step.exclusionsFp ?? TEST_EXCLUSIONS_FP,
     };
   };
   return { ingestPage, calls, callCount: () => calls.length };
@@ -397,6 +402,36 @@ describe("runTriageBaselineCadence — per-page transaction discipline", () => {
       q.sql.includes("INSERT INTO baseline_corpus_state"),
     );
     expect(failureWrite?.params?.[0]).toBe("review timeout");
+  });
+
+  it("writes the per-page exclusionsFp from the pager to baseline_corpus_state, not a runner-side constant", async () => {
+    const pool = createMockPool({ lockSequence: [true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+    const pager = makePager([
+      {
+        observedInserted: 0,
+        baselineInserted: 0,
+        endCursor: "c1",
+        hasNextPage: false,
+        // The pager is the single source of truth for the active-set
+        // fingerprint of a given page. The runner must propagate this
+        // value as-is, so when #457 swaps in real (non-empty) storage,
+        // the corpus-state row stays in lockstep with the per-row
+        // `exclusions_fp` written into `baseline_triaged_event`.
+        exclusionsFp: "non-empty-fp-from-pager",
+      },
+    ]);
+    const result = await runTriageBaselineCadence(7, { pager });
+
+    expect(result.status).toBe("ok");
+    const okWrite = pool.client.queries.find((q) =>
+      q.sql.includes("last_run_status = 'ok'"),
+    );
+    expect(okWrite?.params?.[2]).toBe("non-empty-fp-from-pager");
   });
 
   it("stops cleanly mid-run if the advisory lock is lost between page commits", async () => {

--- a/src/__tests__/lib/triage/baseline/cadence.test.ts
+++ b/src/__tests__/lib/triage/baseline/cadence.test.ts
@@ -305,9 +305,9 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    await expect(runTriageBaselineCadence(99)).rejects.toBeInstanceOf(
-      MockCustomerNotFoundError,
-    );
+    await expect(
+      runTriageBaselineCadence(99, { pager: makePager() }),
+    ).rejects.toBeInstanceOf(MockCustomerNotFoundError);
   });
 
   it("re-throws unexpected errors from getCustomerPool", async () => {
@@ -316,43 +316,9 @@ describe("runTriageBaselineCadence — advisory lock + status machine", () => {
     const { runTriageBaselineCadence } = await import(
       "@/lib/triage/baseline/cadence"
     );
-    await expect(runTriageBaselineCadence(99)).rejects.toThrow("DNS down");
-  });
-});
-
-describe("runTriageBaselineCadence — pending pager", () => {
-  it("returns status=pending and does not touch the corpus-state row when no pager is injected", async () => {
-    const pool = createMockPool({ lockSequence: [true] });
-    mockGetCustomerPool.mockResolvedValue(pool);
-
-    const { runTriageBaselineCadence } = await import(
-      "@/lib/triage/baseline/cadence"
-    );
-    const result = await runTriageBaselineCadence(42);
-
-    expect(result.status).toBe("pending");
-    expect(result.observedInserted).toBe(0);
-    expect(result.baselineInserted).toBe(0);
-    expect(result.lastEventCursor).toBeNull();
-
-    const sqls = pool.client.queries.map((q) => q.sql);
-    // Page transaction was attempted but rolled back: no `ok` UPDATE,
-    // no COMMIT, and pool.query was never called for a failure record.
-    expect(sqls).toContain("BEGIN");
-    expect(sqls).toContain("ROLLBACK");
-    expect(sqls).not.toContain("COMMIT");
-    expect(sqls.some((s) => s.includes("last_run_status = 'ok'"))).toBe(false);
-    expect(pool.poolQueries).toEqual([]);
-    expect(pool.client.released).toBe(true);
-  });
-
-  it("exposes CadencePagerNotImplementedError as the stub-pager sentinel", async () => {
-    const { CadencePagerNotImplementedError, STUB_PAGER } = await import(
-      "@/lib/triage/baseline/cadence"
-    );
     await expect(
-      STUB_PAGER.ingestPage({} as never, 1, null),
-    ).rejects.toBeInstanceOf(CadencePagerNotImplementedError);
+      runTriageBaselineCadence(99, { pager: makePager() }),
+    ).rejects.toThrow("DNS down");
   });
 });
 

--- a/src/__tests__/lib/triage/baseline/pager.test.ts
+++ b/src/__tests__/lib/triage/baseline/pager.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CADENCE_PAGE_SIZE,
+  type CadencePagerOptions,
+  createCadencePager,
+  cursorToEventKey,
+} from "@/lib/triage/baseline/pager";
+import {
+  EMPTY_EXCLUSIONS_FINGERPRINT,
+  type ExclusionRule,
+} from "@/lib/triage/exclusion";
+
+interface FakeClient {
+  queries: Array<{ sql: string; params: unknown[] | undefined }>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function makeClient(): FakeClient {
+  const client: FakeClient = {
+    queries: [],
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      client.queries.push({ sql, params });
+      return { rows: [], rowCount: 1 };
+    }),
+  };
+  return client;
+}
+
+function eventKeyToCursor(value: bigint): string {
+  // Big-endian 16-byte encoding; matches `cursorToEventKey`.
+  const bytes = Buffer.alloc(16);
+  let n = value;
+  for (let i = 15; i >= 0; i -= 1) {
+    bytes[i] = Number(n & BigInt(0xff));
+    n = n >> BigInt(8);
+  }
+  return bytes.toString("base64");
+}
+
+describe("cursorToEventKey", () => {
+  it("decodes a 16-byte big-endian base64 cursor to a NUMERIC string", () => {
+    expect(cursorToEventKey(eventKeyToCursor(BigInt(1)))).toBe("1");
+    expect(cursorToEventKey(eventKeyToCursor(BigInt(255)))).toBe("255");
+    expect(
+      cursorToEventKey(eventKeyToCursor(BigInt("123456789012345678901"))),
+    ).toBe("123456789012345678901");
+  });
+
+  it("throws on a malformed cursor (length != 16 bytes)", () => {
+    expect(() => cursorToEventKey("AAAA")).toThrow(/expected 16-byte/);
+  });
+});
+
+describe("createCadencePager — full pipeline (a)–(e)", () => {
+  it("normalizes, exclusions-filters, INSERTs into both corpus tables, and reports counts", async () => {
+    const cursor1 = eventKeyToCursor(BigInt(1001));
+    const cursor2 = eventKeyToCursor(BigInt(1002));
+    const cursor3 = eventKeyToCursor(BigInt(1003));
+
+    const fetchPage = vi.fn(async () => ({
+      eventListWithTriage: {
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false,
+          startCursor: cursor1,
+          endCursor: cursor3,
+        },
+        edges: [
+          {
+            cursor: cursor1,
+            node: {
+              __typename: "HttpThreat",
+              time: "2026-05-09T12:00:00.000Z",
+              sensor: "sensor-a",
+              category: "COMMAND_AND_CONTROL",
+              level: "MEDIUM",
+              origAddr: "10.0.0.1",
+              respAddr: "1.1.1.1",
+              origPort: 50000,
+              respPort: 443,
+              host: "phish.example",
+              uri: "/login",
+              clusterId: "",
+            },
+          },
+          {
+            cursor: cursor2,
+            // Whitelisted-only path (score 1.0).
+            node: {
+              __typename: "NetworkThreat",
+              time: "2026-05-09T12:01:00.000Z",
+              sensor: "sensor-a",
+              category: "IMPACT",
+              level: "MEDIUM",
+              origAddr: "10.0.0.2",
+              respAddr: "1.1.1.2",
+              origPort: 51000,
+              respPort: 443,
+            },
+          },
+          {
+            cursor: cursor3,
+            // Score 0 — passes (b)/(c)/(d) but is dropped at (e).
+            node: {
+              __typename: "PortScan",
+              time: "2026-05-09T12:02:00.000Z",
+              sensor: "sensor-a",
+              category: "RECONNAISSANCE",
+              level: "LOW",
+              origAddr: "10.0.0.3",
+              respAddr: "1.1.1.3",
+            },
+          },
+        ],
+      },
+    }));
+
+    const pager = createCadencePager({
+      fetchPage: fetchPage as unknown as CadencePagerOptions["fetchPage"],
+    });
+    const client = makeClient();
+    const result = await pager.ingestPage(
+      client as unknown as Parameters<typeof pager.ingestPage>[0],
+      42,
+      null,
+    );
+    expect(result).toEqual({
+      observedInserted: 3,
+      baselineInserted: 2,
+      endCursor: cursor3,
+      hasNextPage: false,
+    });
+
+    // (d) one observed insert per surviving event.
+    const observedInserts = client.queries.filter((q) =>
+      q.sql.includes("INSERT INTO observed_event_meta"),
+    );
+    expect(observedInserts).toHaveLength(3);
+
+    // (e) one baseline insert per baseline-passing event (HttpThreat
+    // whitelisted+unlabeled = 1.5; NetworkThreat whitelisted = 1.0).
+    const baselineInserts = client.queries.filter((q) =>
+      q.sql.includes("INSERT INTO baseline_triaged_event"),
+    );
+    expect(baselineInserts).toHaveLength(2);
+
+    // Each baseline INSERT carries the empty-set exclusions_fp pre-#457.
+    for (const insert of baselineInserts) {
+      const params = insert.params ?? [];
+      expect(params).toContain(EMPTY_EXCLUSIONS_FINGERPRINT);
+    }
+
+    // The first baseline insert (HttpThreat unlabeled-bonus) carries
+    // the unlabeled-bonus selector tag.
+    const httpThreatInsert = baselineInserts[0];
+    const tags = (httpThreatInsert.params ?? []).find((p) =>
+      Array.isArray(p),
+    ) as string[] | undefined;
+    expect(tags).toContain("phase1a-simple");
+    expect(tags).toContain("unlabeled-bonus");
+
+    // The second baseline insert (NetworkThreat whitelisted-only) does
+    // NOT carry the unlabeled-bonus tag.
+    const networkThreatInsert = baselineInserts[1];
+    const networkTags = (networkThreatInsert.params ?? []).find((p) =>
+      Array.isArray(p),
+    ) as string[] | undefined;
+    expect(networkTags).toEqual(["phase1a-simple"]);
+
+    // fetchPage was called with the customer + null cursor on the
+    // first page.
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect((fetchPage.mock.calls[0] as unknown[])[0]).toMatchObject({
+      filter: { customers: ["42"] },
+      triage: null,
+      first: CADENCE_PAGE_SIZE,
+      after: null,
+    });
+  });
+
+  it("drops events that match an active exclusion before INSERTing them anywhere", async () => {
+    const cursor = eventKeyToCursor(BigInt(2001));
+    const fetchPage = vi.fn(async () => ({
+      eventListWithTriage: {
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false,
+          startCursor: cursor,
+          endCursor: cursor,
+        },
+        edges: [
+          {
+            cursor,
+            node: {
+              __typename: "HttpThreat",
+              time: "2026-05-09T12:00:00.000Z",
+              sensor: "sensor-a",
+              category: "COMMAND_AND_CONTROL",
+              level: "MEDIUM",
+              origAddr: "10.0.0.5",
+              host: "ads.example.com",
+              clusterId: "real-cluster",
+            },
+          },
+        ],
+      },
+    }));
+
+    const rule: ExclusionRule = { hostname: ["ads.example.com"] };
+    const resolver = {
+      async resolve() {
+        return { rules: [rule] };
+      },
+    };
+    const pager = createCadencePager({
+      fetchPage: fetchPage as unknown as CadencePagerOptions["fetchPage"],
+      resolver,
+    });
+    const client = makeClient();
+    const result = await pager.ingestPage(
+      client as unknown as Parameters<typeof pager.ingestPage>[0],
+      42,
+      null,
+    );
+
+    expect(result.observedInserted).toBe(0);
+    expect(result.baselineInserted).toBe(0);
+    // No INSERTs at all.
+    expect(client.queries.some((q) => q.sql.startsWith("INSERT INTO"))).toBe(
+      false,
+    );
+  });
+
+  it("threads the after cursor and reports hasNextPage from the resolver", async () => {
+    const startCursor = eventKeyToCursor(BigInt(100));
+    const endCursor = eventKeyToCursor(BigInt(101));
+    const fetchPage = vi.fn(async () => ({
+      eventListWithTriage: {
+        pageInfo: {
+          hasPreviousPage: true,
+          hasNextPage: true,
+          startCursor,
+          endCursor,
+        },
+        edges: [],
+      },
+    }));
+    const pager = createCadencePager({
+      fetchPage: fetchPage as unknown as CadencePagerOptions["fetchPage"],
+    });
+    const client = makeClient();
+    const result = await pager.ingestPage(
+      client as unknown as Parameters<typeof pager.ingestPage>[0],
+      99,
+      "previous-page-cursor",
+    );
+
+    expect(result.endCursor).toBe(endCursor);
+    expect(result.hasNextPage).toBe(true);
+    expect((fetchPage.mock.calls[0] as unknown[])[0]).toMatchObject({
+      after: "previous-page-cursor",
+    });
+  });
+
+  it("reports an empty page (no edges) without any INSERTs", async () => {
+    const fetchPage = vi.fn(async () => ({
+      eventListWithTriage: {
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false,
+          startCursor: null,
+          endCursor: null,
+        },
+        edges: [],
+      },
+    }));
+    const pager = createCadencePager({
+      fetchPage: fetchPage as unknown as CadencePagerOptions["fetchPage"],
+    });
+    const client = makeClient();
+    const result = await pager.ingestPage(
+      client as unknown as Parameters<typeof pager.ingestPage>[0],
+      42,
+      null,
+    );
+    expect(result).toEqual({
+      observedInserted: 0,
+      baselineInserted: 0,
+      endCursor: null,
+      hasNextPage: false,
+    });
+    expect(client.queries.some((q) => q.sql.startsWith("INSERT INTO"))).toBe(
+      false,
+    );
+  });
+
+  it("INSERTs into baseline_triaged_event for the unlabeled-only path (score 0.5)", async () => {
+    const cursor = eventKeyToCursor(BigInt(3001));
+    const fetchPage = vi.fn(async () => ({
+      eventListWithTriage: {
+        pageInfo: {
+          hasPreviousPage: false,
+          hasNextPage: false,
+          startCursor: cursor,
+          endCursor: cursor,
+        },
+        edges: [
+          {
+            cursor,
+            node: {
+              __typename: "HttpThreat",
+              time: "2026-05-09T12:00:00.000Z",
+              sensor: "sensor-a",
+              category: "RECONNAISSANCE", // non-whitelisted
+              level: "LOW",
+              origAddr: "10.0.0.9",
+              host: "novel.example",
+              clusterId: "none",
+            },
+          },
+        ],
+      },
+    }));
+    const pager = createCadencePager({
+      fetchPage: fetchPage as unknown as CadencePagerOptions["fetchPage"],
+    });
+    const client = makeClient();
+    const result = await pager.ingestPage(
+      client as unknown as Parameters<typeof pager.ingestPage>[0],
+      42,
+      null,
+    );
+    expect(result.baselineInserted).toBe(1);
+    const baseInsert = client.queries.find((q) =>
+      q.sql.includes("INSERT INTO baseline_triaged_event"),
+    );
+    expect(baseInsert).toBeDefined();
+    // The score parameter (16th positional arg in our SQL) should be 0.5.
+    expect(baseInsert?.params?.[15]).toBe(0.5);
+  });
+});

--- a/src/__tests__/lib/triage/baseline/pager.test.ts
+++ b/src/__tests__/lib/triage/baseline/pager.test.ts
@@ -27,27 +27,36 @@ function makeClient(): FakeClient {
 }
 
 function eventKeyToCursor(value: bigint): string {
-  // Big-endian 16-byte encoding; matches `cursorToEventKey`.
-  const bytes = Buffer.alloc(16);
-  let n = value;
-  for (let i = 15; i >= 0; i -= 1) {
-    bytes[i] = Number(n & BigInt(0xff));
-    n = n >> BigInt(8);
-  }
-  return bytes.toString("base64");
+  // The vendored review-web resolver builds edges with
+  // `Edge::new(k.to_string(), ev)` where `k` is the i128 RocksDB key,
+  // so the wire cursor is just the decimal string. The cadence's
+  // `cursorToEventKey` validates that shape and forwards it
+  // unchanged.
+  return value.toString();
 }
 
 describe("cursorToEventKey", () => {
-  it("decodes a 16-byte big-endian base64 cursor to a NUMERIC string", () => {
-    expect(cursorToEventKey(eventKeyToCursor(BigInt(1)))).toBe("1");
-    expect(cursorToEventKey(eventKeyToCursor(BigInt(255)))).toBe("255");
-    expect(
-      cursorToEventKey(eventKeyToCursor(BigInt("123456789012345678901"))),
-    ).toBe("123456789012345678901");
+  it("validates and returns the decimal RocksDB-key cursor unchanged", () => {
+    expect(cursorToEventKey("1")).toBe("1");
+    expect(cursorToEventKey("255")).toBe("255");
+    expect(cursorToEventKey("123456789012345678901")).toBe(
+      "123456789012345678901",
+    );
+    // Upper bound of the unsigned i128 range is 39 digits.
+    expect(cursorToEventKey("340282366920938463463374607431768211455")).toBe(
+      "340282366920938463463374607431768211455",
+    );
   });
 
-  it("throws on a malformed cursor (length != 16 bytes)", () => {
-    expect(() => cursorToEventKey("AAAA")).toThrow(/expected 16-byte/);
+  it("throws on a non-decimal cursor (rejects legacy base64 shape too)", () => {
+    expect(() => cursorToEventKey("AAAA")).toThrow(/malformed edge cursor/);
+    expect(() => cursorToEventKey("")).toThrow(/malformed edge cursor/);
+    expect(() => cursorToEventKey("12.0")).toThrow(/malformed edge cursor/);
+    expect(() => cursorToEventKey("-1")).toThrow(/malformed edge cursor/);
+    // 40-digit value falls outside the unsigned-i128 range.
+    expect(() =>
+      cursorToEventKey("1234567890123456789012345678901234567890"),
+    ).toThrow(/malformed edge cursor/);
   });
 });
 
@@ -129,6 +138,7 @@ describe("createCadencePager — full pipeline (a)–(e)", () => {
       baselineInserted: 2,
       endCursor: cursor3,
       hasNextPage: false,
+      exclusionsFp: EMPTY_EXCLUSIONS_FINGERPRINT,
     });
 
     // (d) one observed insert per surviving event.
@@ -168,13 +178,18 @@ describe("createCadencePager — full pipeline (a)–(e)", () => {
     expect(networkTags).toEqual(["phase1a-simple"]);
 
     // fetchPage was called with the customer + null cursor on the
-    // first page.
+    // first page. The customerId is threaded alongside the variables
+    // so the production fetcher can scope the outbound JWT's
+    // `customer_ids` to the same customer.
     expect(fetchPage).toHaveBeenCalledTimes(1);
     expect((fetchPage.mock.calls[0] as unknown[])[0]).toMatchObject({
-      filter: { customers: ["42"] },
-      triage: null,
-      first: CADENCE_PAGE_SIZE,
-      after: null,
+      customerId: 42,
+      variables: {
+        filter: { customers: ["42"] },
+        triage: null,
+        first: CADENCE_PAGE_SIZE,
+        after: null,
+      },
     });
   });
 
@@ -258,7 +273,8 @@ describe("createCadencePager — full pipeline (a)–(e)", () => {
     expect(result.endCursor).toBe(endCursor);
     expect(result.hasNextPage).toBe(true);
     expect((fetchPage.mock.calls[0] as unknown[])[0]).toMatchObject({
-      after: "previous-page-cursor",
+      customerId: 99,
+      variables: { after: "previous-page-cursor" },
     });
   });
 
@@ -288,6 +304,7 @@ describe("createCadencePager — full pipeline (a)–(e)", () => {
       baselineInserted: 0,
       endCursor: null,
       hasNextPage: false,
+      exclusionsFp: EMPTY_EXCLUSIONS_FINGERPRINT,
     });
     expect(client.queries.some((q) => q.sql.startsWith("INSERT INTO"))).toBe(
       false,

--- a/src/__tests__/lib/triage/exclusion/fingerprint.test.ts
+++ b/src/__tests__/lib/triage/exclusion/fingerprint.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeExclusionsFingerprint,
+  EMPTY_EXCLUSIONS_FINGERPRINT,
+  type ExclusionRule,
+} from "@/lib/triage/exclusion";
+
+describe("computeExclusionsFingerprint", () => {
+  it("produces a stable empty-set fingerprint", () => {
+    const fp = computeExclusionsFingerprint([]);
+    expect(fp).toBe(EMPTY_EXCLUSIONS_FINGERPRINT);
+    expect(typeof fp).toBe("string");
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("hashes set-equal inputs identically (rule order and intra-array permutation)", () => {
+    const a: ExclusionRule[] = [
+      { hostname: ["a.example", "b.example"] },
+      { uri: ["/x", "/y"] },
+    ];
+    const b: ExclusionRule[] = [
+      { uri: ["/y", "/x"] },
+      { hostname: ["b.example", "a.example"] },
+    ];
+    expect(computeExclusionsFingerprint(a)).toBe(
+      computeExclusionsFingerprint(b),
+    );
+  });
+
+  it("treats duplicate values as one (de-dup)", () => {
+    const a: ExclusionRule[] = [{ hostname: ["a.example", "a.example"] }];
+    const b: ExclusionRule[] = [{ hostname: ["a.example"] }];
+    expect(computeExclusionsFingerprint(a)).toBe(
+      computeExclusionsFingerprint(b),
+    );
+  });
+
+  it("hashes IpAddressGroup content order-independently", () => {
+    const a: ExclusionRule[] = [
+      {
+        ipAddress: {
+          hosts: ["10.0.0.1", "10.0.0.2"],
+          networks: ["10.0.0.0/24"],
+          ranges: [{ start: "10.0.0.5", end: "10.0.0.10" }],
+        },
+      },
+    ];
+    const b: ExclusionRule[] = [
+      {
+        ipAddress: {
+          hosts: ["10.0.0.2", "10.0.0.1"],
+          networks: ["10.0.0.0/24"],
+          ranges: [{ start: "10.0.0.5", end: "10.0.0.10" }],
+        },
+      },
+    ];
+    expect(computeExclusionsFingerprint(a)).toBe(
+      computeExclusionsFingerprint(b),
+    );
+  });
+
+  it("differs when content differs", () => {
+    const a: ExclusionRule[] = [{ hostname: ["a.example"] }];
+    const b: ExclusionRule[] = [{ hostname: ["b.example"] }];
+    expect(computeExclusionsFingerprint(a)).not.toBe(
+      computeExclusionsFingerprint(b),
+    );
+  });
+
+  it("ignores empty rules (all four fields null/empty) so they do not perturb the fingerprint", () => {
+    const a: ExclusionRule[] = [
+      { hostname: ["a.example"] },
+      { hostname: [] },
+      {},
+    ];
+    const b: ExclusionRule[] = [{ hostname: ["a.example"] }];
+    expect(computeExclusionsFingerprint(a)).toBe(
+      computeExclusionsFingerprint(b),
+    );
+  });
+
+  it("EMPTY_EXCLUSIONS_FINGERPRINT is a 64-char hex string (sha256 hex)", () => {
+    expect(EMPTY_EXCLUSIONS_FINGERPRINT).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/match.test.ts
+++ b/src/__tests__/lib/triage/exclusion/match.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ActiveExclusionSet,
+  NormalizedEventColumns,
+} from "@/lib/triage/exclusion";
+import { isExcluded } from "@/lib/triage/exclusion";
+
+function cols(
+  overrides: Partial<NormalizedEventColumns> = {},
+): NormalizedEventColumns {
+  return {
+    origAddr: null,
+    respAddr: null,
+    host: null,
+    dnsQuery: null,
+    uri: null,
+    ...overrides,
+  };
+}
+
+function active(set: ActiveExclusionSet["rules"]): ActiveExclusionSet {
+  return { rules: set };
+}
+
+describe("isExcluded — IpAddress (CIDR / range / exact host)", () => {
+  it("matches an exact host IP", () => {
+    expect(
+      isExcluded(
+        cols({ origAddr: "10.0.0.5" }),
+        active([
+          { ipAddress: { hosts: ["10.0.0.5"], networks: [], ranges: [] } },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a CIDR network", () => {
+    expect(
+      isExcluded(
+        cols({ origAddr: "10.0.0.42" }),
+        active([
+          { ipAddress: { hosts: [], networks: ["10.0.0.0/24"], ranges: [] } },
+        ]),
+      ),
+    ).toBe(true);
+    expect(
+      isExcluded(
+        cols({ origAddr: "10.0.1.42" }),
+        active([
+          { ipAddress: { hosts: [], networks: ["10.0.0.0/24"], ranges: [] } },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches an inclusive range", () => {
+    expect(
+      isExcluded(
+        cols({ respAddr: "10.0.0.10" }),
+        active([
+          {
+            ipAddress: {
+              hosts: [],
+              networks: [],
+              ranges: [{ start: "10.0.0.5", end: "10.0.0.20" }],
+            },
+          },
+        ]),
+      ),
+    ).toBe(true);
+    expect(
+      isExcluded(
+        cols({ respAddr: "10.0.0.21" }),
+        active([
+          {
+            ipAddress: {
+              hosts: [],
+              networks: [],
+              ranges: [{ start: "10.0.0.5", end: "10.0.0.20" }],
+            },
+          },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("matches IPv6 CIDR", () => {
+    expect(
+      isExcluded(
+        cols({ origAddr: "2001:db8:abcd::1" }),
+        active([
+          { ipAddress: { hosts: [], networks: ["2001:db8::/32"], ranges: [] } },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match across IPv4 / IPv6 families", () => {
+    expect(
+      isExcluded(
+        cols({ origAddr: "10.0.0.5" }),
+        active([{ ipAddress: { hosts: [], networks: ["::/0"], ranges: [] } }]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isExcluded — Hostname / Uri (exact)", () => {
+  it("Hostname matches host column exactly only", () => {
+    expect(
+      isExcluded(
+        cols({ host: "internal.example" }),
+        active([{ hostname: ["internal.example"] }]),
+      ),
+    ).toBe(true);
+    expect(
+      isExcluded(
+        cols({ host: "internal.example.com" }),
+        active([{ hostname: ["internal.example"] }]),
+      ),
+    ).toBe(false);
+  });
+
+  it("Uri matches uri column exactly only", () => {
+    expect(
+      isExcluded(cols({ uri: "/health" }), active([{ uri: ["/health"] }])),
+    ).toBe(true);
+    expect(
+      isExcluded(
+        cols({ uri: "/health/check" }),
+        active([{ uri: ["/health"] }]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isExcluded — Domain (regex on host + dns_query, never uri)", () => {
+  it("matches host via Rust ∩ JS regex", () => {
+    expect(
+      isExcluded(
+        cols({ host: "ads.example.net" }),
+        active([{ domain: ["\\.example\\.net$"] }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches dnsQuery via Rust ∩ JS regex", () => {
+    expect(
+      isExcluded(
+        cols({ dnsQuery: "tracker.example.org" }),
+        active([{ domain: ["^tracker\\."] }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT match uri (Domain → host + dns_query only)", () => {
+    expect(
+      isExcluded(
+        cols({ uri: "https://ads.example.net/path" }),
+        active([{ domain: ["\\.example\\.net"] }]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isExcluded — engine-boundary regex patterns", () => {
+  // The intersection grammar rejects engine-divergent constructs at
+  // INSERT time. The matcher itself throws if asked to compile one,
+  // so the cadence runner cannot silently match different things in
+  // Rust and JS.
+
+  it("rejects (?i) inline modifier", () => {
+    expect(() =>
+      isExcluded(
+        cols({ host: "x.example" }),
+        active([{ domain: ["(?i)example"] }]),
+      ),
+    ).toThrow(/Inline modifier flags/);
+  });
+
+  it("rejects \\A / \\z anchors", () => {
+    expect(() =>
+      isExcluded(
+        cols({ host: "x.example" }),
+        active([{ domain: ["\\Aexample\\z"] }]),
+      ),
+    ).toThrow(/anchors are rejected/);
+  });
+
+  it("rejects lookbehind", () => {
+    expect(() =>
+      isExcluded(
+        cols({ host: "x.example" }),
+        active([{ domain: ["(?<=foo)example"] }]),
+      ),
+    ).toThrow(/Lookbehind/);
+  });
+
+  it("rejects lookahead", () => {
+    expect(() =>
+      isExcluded(
+        cols({ host: "x.example" }),
+        active([{ domain: ["(?=foo)example"] }]),
+      ),
+    ).toThrow(/Lookahead/);
+  });
+
+  it("rejects back-references", () => {
+    expect(() =>
+      isExcluded(
+        cols({ host: "x.example" }),
+        active([{ domain: ["(foo)\\1"] }]),
+      ),
+    ).toThrow(/Back-references/);
+  });
+});
+
+describe("isExcluded — short-circuit / OR semantics", () => {
+  it("matches when ANY rule in the active set matches", () => {
+    expect(
+      isExcluded(
+        cols({ host: "ok.example" }),
+        active([{ hostname: ["other.example"] }, { hostname: ["ok.example"] }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when no rule matches", () => {
+    expect(
+      isExcluded(
+        cols({ host: "neither.example" }),
+        active([{ hostname: ["other.example"] }, { uri: ["/admin"] }]),
+      ),
+    ).toBe(false);
+  });
+
+  it("empty rule set is a pass-through (every event survives)", () => {
+    expect(
+      isExcluded(cols({ origAddr: "10.0.0.1", host: "x" }), active([])),
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/normalize.test.ts
+++ b/src/__tests__/lib/triage/exclusion/normalize.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEventColumns } from "@/lib/triage/exclusion";
+import type { TriageEvent } from "@/lib/triage/types";
+
+function ev(overrides: Partial<TriageEvent>): TriageEvent {
+  return {
+    __typename: "PortScan",
+    time: "2026-05-09T12:00:00.000Z",
+    sensor: "sensor-a",
+    category: null,
+    level: "MEDIUM",
+    ...overrides,
+  };
+}
+
+describe("normalizeEventColumns — event-kind to column mapping", () => {
+  it("populates host and uri for HTTP-shaped subtypes", () => {
+    const cols = normalizeEventColumns(
+      ev({
+        __typename: "HttpThreat",
+        origAddr: "10.0.0.1",
+        respAddr: "10.0.0.2",
+        host: "example.com",
+        uri: "/path/to/resource",
+      }),
+    );
+    expect(cols).toEqual({
+      origAddr: "10.0.0.1",
+      respAddr: "10.0.0.2",
+      host: "example.com",
+      dnsQuery: null,
+      uri: "/path/to/resource",
+    });
+  });
+
+  it("populates host from serverName for TLS-shaped subtypes (no uri / dns_query)", () => {
+    const cols = normalizeEventColumns(
+      ev({
+        __typename: "BlocklistTls",
+        origAddr: "10.0.0.3",
+        serverName: "internal.tls.example",
+      }),
+    );
+    expect(cols.host).toBe("internal.tls.example");
+    expect(cols.dnsQuery).toBeNull();
+    expect(cols.uri).toBeNull();
+  });
+
+  it("populates dnsQuery from query for DNS-shaped subtypes (no host / uri)", () => {
+    const cols = normalizeEventColumns(
+      ev({
+        __typename: "DnsCovertChannel",
+        origAddr: "10.0.0.4",
+        query: "tunnel.example.com",
+      }),
+    );
+    expect(cols.dnsQuery).toBe("tunnel.example.com");
+    expect(cols.host).toBeNull();
+    expect(cols.uri).toBeNull();
+  });
+
+  it("leaves host / dnsQuery / uri NULL for NTLM (IP-only carve-out)", () => {
+    const cols = normalizeEventColumns(
+      ev({
+        __typename: "BlocklistNtlm",
+        origAddr: "10.0.0.5",
+        respAddr: "10.0.0.6",
+        // Even if a hostname-like field were present, NTLM stays IP-only
+        // by design (anchored in aicers/review-database#723).
+      } as TriageEvent),
+    );
+    expect(cols.host).toBeNull();
+    expect(cols.dnsQuery).toBeNull();
+    expect(cols.uri).toBeNull();
+    expect(cols.origAddr).toBe("10.0.0.5");
+    expect(cols.respAddr).toBe("10.0.0.6");
+  });
+
+  it("leaves all host-like columns NULL for IP-only kinds (PortScan)", () => {
+    const cols = normalizeEventColumns(
+      ev({ __typename: "PortScan", origAddr: "10.0.0.7" }),
+    );
+    expect(cols.host).toBeNull();
+    expect(cols.dnsQuery).toBeNull();
+    expect(cols.uri).toBeNull();
+    expect(cols.origAddr).toBe("10.0.0.7");
+  });
+
+  it("treats empty-string host / uri / serverName / query as null", () => {
+    const cols = normalizeEventColumns(
+      ev({
+        __typename: "HttpThreat",
+        host: "",
+        uri: "",
+      }),
+    );
+    expect(cols.host).toBeNull();
+    expect(cols.uri).toBeNull();
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/parse.test.ts
+++ b/src/__tests__/lib/triage/exclusion/parse.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ExclusionInputParseError,
+  parseExclusionInput,
+  parseExclusionInputs,
+} from "@/lib/triage/exclusion";
+
+describe("parseExclusionInput — single EventTriageExclusionInput", () => {
+  it("parses a populated ipAddress with hosts / networks / ranges", () => {
+    const rule = parseExclusionInput({
+      ipAddress: {
+        hosts: ["10.0.0.1"],
+        networks: ["10.0.0.0/24"],
+        ranges: [{ start: "10.1.0.0", end: "10.1.0.255" }],
+      },
+    });
+    expect(rule.ipAddress).toEqual({
+      hosts: ["10.0.0.1"],
+      networks: ["10.0.0.0/24"],
+      ranges: [{ start: "10.1.0.0", end: "10.1.0.255" }],
+    });
+  });
+
+  it("parses domain / hostname / uri lists", () => {
+    const rule = parseExclusionInput({
+      domain: ["ads\\.example\\.com"],
+      hostname: ["safe.example.com"],
+      uri: ["/health"],
+    });
+    expect(rule.domain).toEqual(["ads\\.example\\.com"]);
+    expect(rule.hostname).toEqual(["safe.example.com"]);
+    expect(rule.uri).toEqual(["/health"]);
+  });
+
+  it("drops empty strings from hostname / uri lists", () => {
+    const rule = parseExclusionInput({
+      hostname: ["a.example.com", ""],
+      uri: ["", "/path"],
+    });
+    expect(rule.hostname).toEqual(["a.example.com"]);
+    expect(rule.uri).toEqual(["/path"]);
+  });
+
+  it("rejects an empty exclusion (no populated field)", () => {
+    expect(() => parseExclusionInput({})).toThrow(ExclusionInputParseError);
+    expect(() =>
+      parseExclusionInput({
+        ipAddress: null,
+        domain: null,
+        hostname: null,
+        uri: null,
+      }),
+    ).toThrow(/at least one populated field/);
+  });
+
+  it("rejects an ipAddress group with no hosts / networks / ranges", () => {
+    expect(() =>
+      parseExclusionInput({
+        ipAddress: { hosts: [], networks: [], ranges: [] },
+      }),
+    ).toThrow(/at least one of hosts \/ networks \/ ranges/);
+  });
+
+  it("rejects an invalid Domain pattern at the persistence boundary", () => {
+    expect(() =>
+      parseExclusionInput({ domain: ["host\\d+\\.example"] }),
+    ).toThrow(/Shorthand \\d is rejected/);
+    expect(() =>
+      parseExclusionInput({ domain: ["(?i)case-insensitive"] }),
+    ).toThrow(/Inline modifier flags/);
+  });
+
+  it("threads the index into the error so storage CRUD can highlight the bad row", () => {
+    try {
+      parseExclusionInputs([{ hostname: ["ok"] }, { domain: ["(?<=foo)bar"] }]);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExclusionInputParseError);
+      expect((err as ExclusionInputParseError).index).toBe(1);
+      expect((err as Error).message).toMatch(/exclusions\[1\]/);
+    }
+  });
+});
+
+describe("parseExclusionInputs — list", () => {
+  it("returns [] for null / undefined", () => {
+    expect(parseExclusionInputs(null)).toEqual([]);
+    expect(parseExclusionInputs(undefined)).toEqual([]);
+  });
+
+  it("parses each element through parseExclusionInput", () => {
+    const rules = parseExclusionInputs([
+      { hostname: ["a.example"] },
+      { uri: ["/health"] },
+    ]);
+    expect(rules).toHaveLength(2);
+    expect(rules[0].hostname).toEqual(["a.example"]);
+    expect(rules[1].uri).toEqual(["/health"]);
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/parse.test.ts
+++ b/src/__tests__/lib/triage/exclusion/parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeExclusionsFingerprint,
   ExclusionInputParseError,
   parseExclusionInput,
   parseExclusionInputs,
@@ -8,38 +9,54 @@ import {
 
 describe("parseExclusionInput — single EventTriageExclusionInput", () => {
   it("parses a populated ipAddress with hosts / networks / ranges", () => {
-    const rule = parseExclusionInput({
+    const rules = parseExclusionInput({
       ipAddress: {
         hosts: ["10.0.0.1"],
         networks: ["10.0.0.0/24"],
         ranges: [{ start: "10.1.0.0", end: "10.1.0.255" }],
       },
     });
-    expect(rule.ipAddress).toEqual({
+    expect(rules).toHaveLength(1);
+    expect(rules[0].ipAddress).toEqual({
       hosts: ["10.0.0.1"],
       networks: ["10.0.0.0/24"],
       ranges: [{ start: "10.1.0.0", end: "10.1.0.255" }],
     });
   });
 
-  it("parses domain / hostname / uri lists", () => {
-    const rule = parseExclusionInput({
+  it("flattens multi-field input into one rule per populated field", () => {
+    const rules = parseExclusionInput({
       domain: ["ads\\.example\\.com"],
       hostname: ["safe.example.com"],
       uri: ["/health"],
     });
-    expect(rule.domain).toEqual(["ads\\.example\\.com"]);
-    expect(rule.hostname).toEqual(["safe.example.com"]);
-    expect(rule.uri).toEqual(["/health"]);
+    expect(rules).toHaveLength(3);
+    const domainRule = rules.find((r) => r.domain !== undefined);
+    const hostnameRule = rules.find((r) => r.hostname !== undefined);
+    const uriRule = rules.find((r) => r.uri !== undefined);
+    expect(domainRule?.domain).toEqual(["ads\\.example\\.com"]);
+    expect(hostnameRule?.hostname).toEqual(["safe.example.com"]);
+    expect(uriRule?.uri).toEqual(["/health"]);
+    // Each flattened rule is single-field — none carries a sibling.
+    for (const rule of rules) {
+      const populated = [
+        rule.ipAddress,
+        rule.domain,
+        rule.hostname,
+        rule.uri,
+      ].filter((x) => x !== undefined);
+      expect(populated).toHaveLength(1);
+    }
   });
 
   it("drops empty strings from hostname / uri lists", () => {
-    const rule = parseExclusionInput({
+    const rules = parseExclusionInput({
       hostname: ["a.example.com", ""],
       uri: ["", "/path"],
     });
-    expect(rule.hostname).toEqual(["a.example.com"]);
-    expect(rule.uri).toEqual(["/path"]);
+    expect(rules).toHaveLength(2);
+    expect(rules.find((r) => r.hostname)?.hostname).toEqual(["a.example.com"]);
+    expect(rules.find((r) => r.uri)?.uri).toEqual(["/path"]);
   });
 
   it("rejects an empty exclusion (no populated field)", () => {
@@ -97,5 +114,18 @@ describe("parseExclusionInputs — list", () => {
     expect(rules).toHaveLength(2);
     expect(rules[0].hostname).toEqual(["a.example"]);
     expect(rules[1].uri).toEqual(["/health"]);
+  });
+
+  it("grouped and split inputs produce the same fingerprint after parsing", () => {
+    const grouped = parseExclusionInputs([
+      { hostname: ["a.example"], uri: ["/health"] },
+    ]);
+    const split = parseExclusionInputs([
+      { hostname: ["a.example"] },
+      { uri: ["/health"] },
+    ]);
+    expect(computeExclusionsFingerprint(grouped)).toBe(
+      computeExclusionsFingerprint(split),
+    );
   });
 });

--- a/src/__tests__/lib/triage/exclusion/regex.test.ts
+++ b/src/__tests__/lib/triage/exclusion/regex.test.ts
@@ -32,10 +32,30 @@ describe("validateDomainPattern — Rust ∩ JS intersection grammar", () => {
     ["(foo)\\1", /Back-references/],
     ["(?<n>foo)\\k<n>", /Named back-references|Named capture/],
     ["", /Empty Domain pattern/],
+    ["host\\d+", /Shorthand \\d is rejected/],
+    ["host\\D+", /Shorthand \\D is rejected/],
+    ["[\\d]", /Shorthand \\d is rejected/],
+    ["a\\wb", /Shorthand \\w is rejected/],
+    ["a\\Wb", /Shorthand \\W is rejected/],
+    ["a\\sb", /Shorthand \\s is rejected/],
+    ["a\\Sb", /Shorthand \\S is rejected/],
+    ["foo\\bbar", /Shorthand \\b is rejected/],
+    ["foo\\Bbar", /Shorthand \\B is rejected/],
+    ["(?:trk|ads)\\d{1,3}", /Shorthand \\d is rejected/],
   ])("rejects %s", (pattern, expected) => {
     const result = validateDomainPattern(pattern);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toMatch(expected);
+  });
+
+  it.each([
+    "literal-backslash-then-d\\\\d",
+    "literal-backslash-then-w\\\\w",
+    "tracker[0-9]{1,3}\\.example",
+    "host[A-Za-z0-9_]+\\.example",
+    "ws[ \\t\\r\\n]+",
+  ])("accepts ASCII alternative or escaped backslash before letter %s", (pattern) => {
+    expect(validateDomainPattern(pattern)).toEqual({ ok: true });
   });
 
   it("rejects malformed regex even when no engine-specific construct is present", () => {

--- a/src/__tests__/lib/triage/exclusion/regex.test.ts
+++ b/src/__tests__/lib/triage/exclusion/regex.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileDomainPatterns,
+  validateDomainPattern,
+} from "@/lib/triage/exclusion";
+
+describe("validateDomainPattern — Rust ∩ JS intersection grammar", () => {
+  it.each([
+    ".",
+    "^example\\.com$",
+    "ads\\.example\\.com",
+    "(?:foo|bar)\\.example",
+    "[a-z0-9-]+\\.example\\.org",
+    "tracker[0-9]{1,3}\\.net",
+    "non-greedy.*?end",
+  ])("accepts intersection-grammar pattern %s", (pattern) => {
+    expect(validateDomainPattern(pattern)).toEqual({ ok: true });
+  });
+
+  it.each<[string, RegExp]>([
+    ["(?i)case-insensitive", /Inline modifier flags/],
+    ["(?i:case)", /Inline modifier groups/],
+    ["(?<=foo)bar", /Lookbehind/],
+    ["(?<!foo)bar", /Lookbehind/],
+    ["(?=foo)bar", /Lookahead/],
+    ["(?!foo)bar", /Lookahead/],
+    ["(?<name>foo)", /Named capture groups/],
+    ["(?P<name>foo)", /Rust-style named capture groups/],
+    ["\\Aexample", /anchors are rejected/],
+    ["example\\z", /anchors are rejected/],
+    ["(foo)\\1", /Back-references/],
+    ["(?<n>foo)\\k<n>", /Named back-references|Named capture/],
+    ["", /Empty Domain pattern/],
+  ])("rejects %s", (pattern, expected) => {
+    const result = validateDomainPattern(pattern);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(expected);
+  });
+
+  it("rejects malformed regex even when no engine-specific construct is present", () => {
+    const result = validateDomainPattern("[unterminated");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("compileDomainPatterns — RegexSet::is_match semantics (substring)", () => {
+  it("matches any pattern in the set (OR semantics)", () => {
+    const matcher = compileDomainPatterns([
+      "ads\\.example",
+      "tracker\\.example",
+    ]);
+    expect(matcher).not.toBeNull();
+    expect(matcher?.test("ads.example.com")).toBe(true);
+    expect(matcher?.test("tracker.example.org")).toBe(true);
+    expect(matcher?.test("safe.example.com")).toBe(false);
+  });
+
+  it("returns null for the empty pattern set", () => {
+    expect(compileDomainPatterns([])).toBeNull();
+  });
+
+  it("alternation in a single pattern stays scoped to that pattern", () => {
+    const matcher = compileDomainPatterns(["foo|bar", "baz"]);
+    expect(matcher?.test("foo")).toBe(true);
+    expect(matcher?.test("bar")).toBe(true);
+    expect(matcher?.test("baz")).toBe(true);
+    expect(matcher?.test("qux")).toBe(false);
+  });
+
+  it("throws on an invalid pattern (storage path is supposed to validate first)", () => {
+    expect(() => compileDomainPatterns(["(?i)broken"])).toThrow(
+      /Inline modifier flags/,
+    );
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/regex.test.ts
+++ b/src/__tests__/lib/triage/exclusion/regex.test.ts
@@ -42,6 +42,16 @@ describe("validateDomainPattern — Rust ∩ JS intersection grammar", () => {
     ["foo\\bbar", /Shorthand \\b is rejected/],
     ["foo\\Bbar", /Shorthand \\B is rejected/],
     ["(?:trk|ads)\\d{1,3}", /Shorthand \\d is rejected/],
+    // Rust class-set operators silently reinterpret the same source in
+    // JavaScript: `[a&&b]` matches `a`, `&`, or `b` in JS but nothing in
+    // Rust; `[a-z--m]` matches the full a-z plus literal `-` in JS but
+    // a-z minus `m` in Rust; `[[a-z]&&[^aeiou]]` is a Rust nested set op
+    // that JS without the `v` flag refuses to parse altogether. All
+    // three diverge stored Domain matching between Stage 1 and cadence.
+    ["[a&&b]", /Class-set operator && is rejected/],
+    ["[a-z--m]", /Class-set operator -- is rejected/],
+    ["[a~~b]", /Class-set operator ~~ is rejected/],
+    ["[[a-z]&&[^aeiou]]", /Nested character class/],
   ])("rejects %s", (pattern, expected) => {
     const result = validateDomainPattern(pattern);
     expect(result.ok).toBe(false);

--- a/src/__tests__/lib/triage/scoring.test.ts
+++ b/src/__tests__/lib/triage/scoring.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   baselineScore,
+  hasUnlabeledBonus,
+  PHASE_1A_CLUSTER_NONE_BONUS,
+  PHASE_1A_WHITELIST_SCORE,
   passesBaseline,
   TRIAGE_BASELINE_WHITELIST,
   type TriageEvent,
@@ -18,33 +21,36 @@ function event(overrides: Partial<TriageEvent>): TriageEvent {
   };
 }
 
-describe("baselineScore", () => {
-  it("scores 0 for events outside the whitelist", () => {
+describe("baselineScore — additive formula", () => {
+  it("scores 0 for events outside the whitelist with no cluster bonus", () => {
     const e = event({ category: "RECONNAISSANCE" });
     expect(baselineScore(e)).toBe(0);
     expect(passesBaseline(e)).toBe(false);
   });
 
-  it("scores 0 for events with a null category", () => {
+  it("scores 0 for events with a null category and no cluster bonus", () => {
     const e = event({ category: null });
     expect(baselineScore(e)).toBe(0);
   });
 
   it.each([
     ...TRIAGE_BASELINE_WHITELIST,
-  ])("scores 1 for whitelisted category %s", (category) => {
+  ])("scores 1.0 for whitelisted category %s (labeled cluster, non-HttpThreat)", (category) => {
     const e = event({ category });
-    expect(baselineScore(e)).toBe(1);
+    expect(baselineScore(e)).toBe(PHASE_1A_WHITELIST_SCORE);
     expect(passesBaseline(e)).toBe(true);
   });
 
-  it("adds 0.5 for HttpThreat with empty clusterId", () => {
+  it("scores 1.5 for whitelisted HttpThreat with empty clusterId", () => {
     const e = event({
       __typename: "HttpThreat",
       category: "COMMAND_AND_CONTROL",
       clusterId: "",
     });
-    expect(baselineScore(e)).toBe(1.5);
+    expect(baselineScore(e)).toBe(
+      PHASE_1A_WHITELIST_SCORE + PHASE_1A_CLUSTER_NONE_BONUS,
+    );
+    expect(hasUnlabeledBonus(e)).toBe(true);
   });
 
   it.each([
@@ -61,21 +67,71 @@ describe("baselineScore", () => {
     expect(baselineScore(e)).toBe(1.5);
   });
 
-  it("does not apply the bonus for non-HttpThreat events", () => {
+  it("does not apply the bonus for non-HttpThreat events even when clusterId is empty", () => {
     const e = event({
       __typename: "NetworkThreat",
       category: "IMPACT",
       clusterId: "",
     });
     expect(baselineScore(e)).toBe(1);
+    expect(hasUnlabeledBonus(e)).toBe(false);
   });
 
-  it("does not apply the bonus when clusterId is a real value", () => {
+  it("does not apply the bonus when HttpThreat clusterId is a real value", () => {
     const e = event({
       __typename: "HttpThreat",
       category: "INITIAL_ACCESS",
       clusterId: "cluster-42",
     });
     expect(baselineScore(e)).toBe(1);
+    expect(hasUnlabeledBonus(e)).toBe(false);
+  });
+
+  it("scores 0.5 (unlabeled-only path) for HttpThreat with non-whitelisted category and no cluster", () => {
+    const e = event({
+      __typename: "HttpThreat",
+      category: "RECONNAISSANCE",
+      clusterId: "",
+    });
+    expect(baselineScore(e)).toBe(PHASE_1A_CLUSTER_NONE_BONUS);
+    expect(passesBaseline(e)).toBe(true);
+    expect(hasUnlabeledBonus(e)).toBe(true);
+  });
+
+  it("scores 0.5 for HttpThreat with null category and a no-cluster sentinel", () => {
+    const e = event({
+      __typename: "HttpThreat",
+      category: null,
+      clusterId: "none",
+    });
+    expect(baselineScore(e)).toBe(0.5);
+    expect(passesBaseline(e)).toBe(true);
+  });
+
+  it("baselineScore is the additive sum of the three pass-paths", () => {
+    // Pass-path A: whitelisted, labeled cluster.
+    expect(
+      baselineScore(event({ category: "IMPACT", __typename: "NetworkThreat" })),
+    ).toBe(1.0);
+    // Pass-path B: unlabeled HttpThreat, non-whitelisted.
+    expect(
+      baselineScore(
+        event({
+          category: "RECONNAISSANCE",
+          __typename: "HttpThreat",
+          clusterId: " null ",
+        }),
+      ),
+    ).toBe(0.5);
+    // Pass-path C: whitelisted, unlabeled HttpThreat.
+    expect(
+      baselineScore(
+        event({
+          category: "CREDENTIAL_ACCESS",
+          __typename: "HttpThreat",
+          clusterId: "none",
+        }),
+      ),
+    ).toBe(1.5);
   });
 });

--- a/src/app/api/internal/triage/baseline/cadence/route.ts
+++ b/src/app/api/internal/triage/baseline/cadence/route.ts
@@ -5,6 +5,7 @@ import {
   runTriageBaselineCadence,
   verifyTriageBaselineCadenceToken,
 } from "@/lib/triage/baseline/cadence";
+import { createCadencePager } from "@/lib/triage/baseline/pager";
 import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
 
 /**
@@ -33,12 +34,20 @@ import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
  *   - 500 with `{ status: 'failed', error }` when a cadence page rolled
  *     back. The route still returns a structured body so the scheduler
  *     can log the error string.
- *   - 503 with `{ status: 'pending' }` when the cadence pager is not
- *     yet wired (review-web#842 + aice-web-next#460 still outstanding).
- *     The runner did not touch the corpus-state row; the scheduler can
- *     keep ticking and the response flips to 200 / `ok` automatically
- *     once the pager lands.
  */
+
+// Lazily-instantiated production pager. Built once per process so the
+// graphql-request client and mTLS dispatcher are reused across cadence
+// invocations.
+let CACHED_PAGER: ReturnType<typeof createCadencePager> | null = null;
+
+function getProductionPager() {
+  if (CACHED_PAGER === null) {
+    CACHED_PAGER = createCadencePager();
+  }
+  return CACHED_PAGER;
+}
+
 export async function POST(request: Request): Promise<NextResponse> {
   const auth = request.headers.get("authorization");
   const token = auth?.startsWith("Bearer ")
@@ -63,12 +72,11 @@ export async function POST(request: Request): Promise<NextResponse> {
   }
 
   try {
-    const result = await runTriageBaselineCadence(customerId);
+    const result = await runTriageBaselineCadence(customerId, {
+      pager: getProductionPager(),
+    });
     if (result.status === "failed") {
       return NextResponse.json(result, { status: 500 });
-    }
-    if (result.status === "pending") {
-      return NextResponse.json(result, { status: 503 });
     }
     return NextResponse.json(result);
   } catch (err) {

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -56,7 +56,6 @@ import { timingSafeEqual } from "node:crypto";
 
 import type pg from "pg";
 
-import { EMPTY_EXCLUSIONS_FINGERPRINT } from "@/lib/triage/exclusion";
 import { getCustomerPool } from "@/lib/triage/policy/customer-db";
 
 /**
@@ -137,6 +136,17 @@ export interface CadencePageResult {
   endCursor: string | null;
   /** Whether the resolver indicates more pages are available. */
   hasNextPage: boolean;
+  /**
+   * Canonical fingerprint of the active exclusion set the pager
+   * applied while building this page (`computeExclusionsFingerprint`).
+   * The runner copies it onto `baseline_corpus_state.exclusions_fp`
+   * when it commits the page so the corpus-state row stays in lockstep
+   * with the per-row `exclusions_fp` written into
+   * `baseline_triaged_event`. Pre-#457 the resolver returns the
+   * empty-set fingerprint; #457 swaps in real storage without touching
+   * the runner.
+   */
+  exclusionsFp: string;
 }
 
 /**
@@ -168,15 +178,6 @@ function buildLockKeyExpr(): string {
 function buildLockKeyParam(customerId: number): string {
   return `${LOCK_NAMESPACE}${customerId}`;
 }
-
-/**
- * Empty-set exclusion fingerprint, computed once via the shared helper
- * in `src/lib/triage/exclusion`. Pre-#457 the cadence runs against an
- * empty active exclusion set; every row therefore carries this real
- * (NOT NULL) fingerprint until the storage adapter lands and starts
- * returning real rules.
- */
-const EMPTY_EXCLUSIONS_FP = EMPTY_EXCLUSIONS_FINGERPRINT;
 
 /**
  * Read the corpus-state row, INSERTing the singleton if it does not
@@ -322,7 +323,7 @@ export async function runTriageBaselineCadence(
           nextStartCursor,
         );
 
-        await markOk(client, ingest.endCursor, EMPTY_EXCLUSIONS_FP);
+        await markOk(client, ingest.endCursor, ingest.exclusionsFp);
         await client.query("COMMIT");
         pageCommitted = true;
 
@@ -387,5 +388,4 @@ export function verifyTriageBaselineCadenceToken(
 
 export const _testing = {
   buildLockKeyParam,
-  EMPTY_EXCLUSIONS_FP,
 };

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -43,35 +43,20 @@ import "server-only";
  * collisions on re-ingest of the same `event_key` are handled with
  * `ON CONFLICT DO NOTHING`.
  *
- * ## Upstream dependency and the `pending` status
+ * ## Pager wiring
  *
- * This module ships the scheduler entrypoint, the per-page advisory-
- * lock discipline, the corpus-state machine, and the schema migration.
  * The actual GraphQL pager — steps (a)–(e) — is injected via the
- * {@link CadencePager} interface and depends on two pieces that are not
- * yet in this repo: review-web#842 (`eventListWithTriage` resolver +
- * `EventStandardFilterInput` type + `event_key` field selection) needs
- * to be vendored into `schemas/review.graphql`, and aice-web-next#460
- * (the shared `src/lib/triage/exclusion/` helper) must land so cadence-
- * time and retroactive-DELETE paths share one normalization +
- * `exclusions_fp` source of truth.
- *
- * Until those land, `runTriageBaselineCadence` defaults to
- * {@link STUB_PAGER}, which throws {@link CadencePagerNotImplementedError}
- * on the first page. The runner catches that error specifically, rolls
- * back the page transaction (so the corpus-state row stays untouched),
- * and returns `status: 'pending'`. The scheduler can wire the route up
- * today — it will see `pending` responses and the corpus stays empty —
- * without any risk that a no-op run advertises success or advances
- * `last_ingested_at`. When the real pager lands, the same module just
- * swaps `STUB_PAGER` for the production pager and the surrounding
- * lock / transaction / status-machine plumbing is unchanged.
+ * {@link CadencePager} interface so the runner stays focused on the
+ * lock / transaction / status-machine plumbing. Production callers
+ * (the route handler) pass the result of `createCadencePager()` from
+ * `./pager.ts`; tests inject a fake.
  */
 
-import { createHash, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
 
 import type pg from "pg";
 
+import { EMPTY_EXCLUSIONS_FINGERPRINT } from "@/lib/triage/exclusion";
 import { getCustomerPool } from "@/lib/triage/policy/customer-db";
 
 /**
@@ -92,18 +77,18 @@ export const PHASE_1A_BASELINE_VERSION = "phase1a-simple";
 export const PHASE_1A_SELECTOR_TAG = "phase1a-simple";
 
 /**
- * Constant placeholder score for Phase 1.A rows. Reflects "passed the
- * Phase 1.A simple rule"; replaced per-row by 1B-8's four-selector
- * scoring once that lands.
+ * Phase 1.A additive score components. Replaces the original flat
+ * `PHASE_1A_BASELINE_SCORE` placeholder shipped in PR #478. The scoring
+ * helper in `src/lib/triage/scoring.ts` exports the same numeric
+ * literals so the menu-side and cadence-side scoring agree on the
+ * value of each component.
  */
-export const PHASE_1A_BASELINE_SCORE = 1;
+export {
+  PHASE_1A_CLUSTER_NONE_BONUS,
+  PHASE_1A_WHITELIST_SCORE,
+} from "@/lib/triage/scoring";
 
-export type CadenceRunStatus =
-  | "ok"
-  | "failed"
-  | "running"
-  | "skipped"
-  | "pending";
+export type CadenceRunStatus = "ok" | "failed" | "running" | "skipped";
 
 export interface CadenceRunResult {
   /** Customer the runner targeted. */
@@ -115,11 +100,6 @@ export interface CadenceRunResult {
    *     the very first page; this tick is a no-op.
    *   - `failed`: a page rolled back; `error` carries the message that
    *     was persisted to `baseline_corpus_state.last_error`.
-   *   - `pending`: the cadence pager is not yet wired (see module
-   *     docstring). The runner started a page transaction, observed the
-   *     stub, rolled back, and returned without touching the corpus-
-   *     state row. The scheduler can keep ticking; runs flip to `ok`
-   *     automatically once the pager lands.
    *   - `running`: never returned to the caller — the on-disk marker
    *     used while a run holds the lock so a crash leaves a forensic
    *     breadcrumb.
@@ -174,31 +154,6 @@ export interface CadencePager {
   ): Promise<CadencePageResult>;
 }
 
-/**
- * Sentinel raised by {@link STUB_PAGER}. The runner catches this error
- * specifically and returns `status: 'pending'` so the scheduler does
- * not see a fake-success response while the real pager is unavailable.
- */
-export class CadencePagerNotImplementedError extends Error {
-  constructor() {
-    super(
-      "Triage cadence pager is not yet implemented (pending review-web#842 schema vendor and aicers/aice-web-next#460 shared exclusion helper).",
-    );
-    this.name = "CadencePagerNotImplementedError";
-  }
-}
-
-/**
- * Default pager. Throws {@link CadencePagerNotImplementedError} on
- * every call. Replace at the {@link runTriageBaselineCadence} call site
- * once the real pager lands.
- */
-export const STUB_PAGER: CadencePager = {
-  async ingestPage() {
-    throw new CadencePagerNotImplementedError();
-  },
-};
-
 const LOCK_NAMESPACE = "triage_baseline_cadence:";
 
 /**
@@ -215,20 +170,13 @@ function buildLockKeyParam(customerId: number): string {
 }
 
 /**
- * Compute the canonical exclusions fingerprint placeholder. Phase 1.A
- * has no exclusions wired up (the helper from #460 / shared
- * `src/lib/triage/exclusion/` module has not landed yet); until then,
- * every Phase 1.A row carries a stable empty-set fingerprint so the
- * column is NOT NULL but does not falsely identify rows as having
- * passed any specific exclusion configuration. When #460 lands the
- * cadence runner swaps this constant for the real
- * `computeExclusionsFingerprint(active)` call.
+ * Empty-set exclusion fingerprint, computed once via the shared helper
+ * in `src/lib/triage/exclusion`. Pre-#457 the cadence runs against an
+ * empty active exclusion set; every row therefore carries this real
+ * (NOT NULL) fingerprint until the storage adapter lands and starts
+ * returning real rules.
  */
-const EMPTY_EXCLUSIONS_FP = (() => {
-  return createHash("sha256")
-    .update("phase1a:no-exclusions", "utf8")
-    .digest("hex");
-})();
+const EMPTY_EXCLUSIONS_FP = EMPTY_EXCLUSIONS_FINGERPRINT;
 
 /**
  * Read the corpus-state row, INSERTing the singleton if it does not
@@ -317,9 +265,9 @@ const MAX_PAGES_PER_RUN = 200;
  */
 export async function runTriageBaselineCadence(
   customerId: number,
-  options: { pager?: CadencePager } = {},
+  options: { pager: CadencePager },
 ): Promise<CadenceRunResult> {
-  const pager = options.pager ?? STUB_PAGER;
+  const { pager } = options;
 
   // Lets `CustomerNotFoundError` propagate so the route handler can
   // surface it as a 404. In-process callers (future batched drivers,
@@ -391,19 +339,6 @@ export async function runTriageBaselineCadence(
           await client.query("ROLLBACK").catch(() => {
             // Already rolled back or connection broken; nothing to do.
           });
-        }
-        if (err instanceof CadencePagerNotImplementedError) {
-          // Stub pager: do not advertise success and do not write
-          // failure. The corpus is intentionally idle until the real
-          // pager lands; the scheduler can keep ticking and observe
-          // `pending` until then.
-          return {
-            customerId,
-            status: "pending",
-            observedInserted: totalObserved,
-            baselineInserted: totalBaseline,
-            lastEventCursor: lastCommittedCursor,
-          };
         }
         const message = err instanceof Error ? err.message : "Cadence failed";
         await markFailed(pool, message);

--- a/src/lib/triage/baseline/pager.ts
+++ b/src/lib/triage/baseline/pager.ts
@@ -1,0 +1,329 @@
+import "server-only";
+
+/**
+ * Real `CadencePager` implementation (1B-1 / discussion #447 §3.4).
+ *
+ * Steps (a)–(e) of the per-page cadence pipeline:
+ *
+ *   a. Fetch one raw standard-filter page from review via
+ *      `eventListWithTriage(triage = null, after = <last_event_cursor>,
+ *      first = <page_size>)`.
+ *   b. Normalize each event into `host` / `dns_query` / `uri` per the
+ *      shared helper's event-kind mapping (`src/lib/triage/exclusion/`).
+ *      NTLM stays NULL on host-like columns by design.
+ *   c. Apply the active exclusion set in-memory (currently empty pre-#457;
+ *      the helper's resolver returns `{ rules: [] }` so this is a
+ *      pass-through until the storage adapter lands).
+ *   d. INSERT remaining events into `observed_event_meta` with
+ *      `ON CONFLICT (event_key) DO NOTHING`.
+ *   e. INSERT the baseline-passing subset (`baselineScore > 0`) into
+ *      `baseline_triaged_event` with the Phase 1.A markers
+ *      (`PHASE_1A_BASELINE_VERSION`, `PHASE_1A_SELECTOR_TAG`, additive
+ *      `baseline_score`, `exclusions_fp` from `computeExclusionsFingerprint`).
+ *
+ * Steps (d)–(e) and the corpus-state UPDATE all commit in the per-page
+ * transaction the runner already opens. The pager itself is purely
+ * SQL + GraphQL; transaction scope, locking, and watermark UPDATE live
+ * one level up in `runTriageBaselineCadence`.
+ */
+
+import type pg from "pg";
+
+import type { ThreatCategory } from "@/lib/detection";
+import { graphqlRequest } from "@/lib/graphql/client";
+import {
+  type ActiveExclusionSetResolver,
+  computeExclusionsFingerprint,
+  EMPTY_EXCLUSION_SET_RESOLVER,
+  isExcluded,
+  type NormalizedEventColumns,
+  normalizeEventColumns,
+} from "@/lib/triage/exclusion";
+import {
+  baselineScore,
+  hasUnlabeledBonus,
+  PHASE_1A_UNLABELED_BONUS_TAG,
+} from "@/lib/triage/scoring";
+import type { TriageEvent } from "@/lib/triage/types";
+
+import type { CadencePageResult, CadencePager } from "./cadence";
+import { PHASE_1A_BASELINE_VERSION, PHASE_1A_SELECTOR_TAG } from "./cadence";
+import { EVENT_LIST_WITH_TRIAGE_QUERY } from "./queries";
+
+/**
+ * Page size for `eventListWithTriage`. Large enough to amortize the
+ * resolver round-trip cost over many INSERTs but bounded so a single
+ * page transaction does not hold the connection too long.
+ */
+export const CADENCE_PAGE_SIZE = 500;
+
+/**
+ * Role the cadence runner uses for outbound REview GraphQL. The cadence
+ * is a system actor (no user session), so it carries the `admin` role
+ * — same convention the Detection / Node-management scripts use.
+ */
+const CADENCE_DISPATCH_CONTEXT = { role: "admin" };
+
+interface CadenceEventNode extends TriageEvent {
+  // Re-asserted here so tsc remembers the optional fields the cadence
+  // pager actually consumes from the resolver response. The shape
+  // matches the `EVENT_LIST_WITH_TRIAGE_QUERY` selection set.
+}
+
+interface CadenceEventEdge {
+  cursor: string;
+  node: CadenceEventNode;
+}
+
+interface CadenceConnectionResponse {
+  eventListWithTriage: {
+    pageInfo: {
+      hasPreviousPage: boolean;
+      hasNextPage: boolean;
+      startCursor: string | null;
+      endCursor: string | null;
+    };
+    edges: CadenceEventEdge[];
+  };
+}
+
+/**
+ * Decode a relay-style edge cursor into the review RocksDB i128 primary
+ * key. The vendored review-web resolver encodes `event_key` as a
+ * base64 string of the i128's big-endian byte representation (16
+ * bytes); the cadence corpus tables store that integer in
+ * `NUMERIC(39, 0)` PRIMARY KEY columns.
+ *
+ * If the cursor does not decode to exactly 16 bytes, the function
+ * throws — the runner catches the error, marks the run `failed`, and
+ * the watermark stays at the previous committed cursor. This is the
+ * correct failure mode: silently coercing a malformed cursor into a
+ * fallback PK value would risk mass collisions across event rows.
+ */
+export function cursorToEventKey(cursor: string): string {
+  const bytes = Buffer.from(cursor, "base64");
+  if (bytes.length !== 16) {
+    throw new Error(
+      `Cadence: unexpected cursor byte length ${bytes.length} (expected 16-byte i128 big-endian).`,
+    );
+  }
+  let n = BigInt(0);
+  const SHIFT_8 = BigInt(8);
+  for (const byte of bytes) {
+    n = (n << SHIFT_8) | BigInt(byte);
+  }
+  return n.toString();
+}
+
+export interface CadencePagerOptions {
+  /**
+   * Override the GraphQL fetch step. Tests inject a stub so the pager
+   * can be unit-tested without hitting review-web.
+   */
+  fetchPage?: (variables: {
+    filter: { customers: string[] };
+    triage: null;
+    first: number;
+    after: string | null;
+  }) => Promise<CadenceConnectionResponse>;
+  /**
+   * Active-exclusion-set resolver. Defaults to the empty-set resolver
+   * (#457 swap point); tests inject a fake to drive the matcher.
+   */
+  resolver?: ActiveExclusionSetResolver;
+  /**
+   * Override the page size. Production code should use the default.
+   */
+  pageSize?: number;
+}
+
+/**
+ * Build the production cadence pager. Caller is responsible for
+ * passing the result to {@link runTriageBaselineCadence} so the runner
+ * stops returning `pending` and starts populating both corpus tables.
+ */
+export function createCadencePager(
+  options: CadencePagerOptions = {},
+): CadencePager {
+  const fetchPage = options.fetchPage ?? defaultFetchPage;
+  const resolver = options.resolver ?? EMPTY_EXCLUSION_SET_RESOLVER;
+  const pageSize = options.pageSize ?? CADENCE_PAGE_SIZE;
+
+  return {
+    async ingestPage(
+      client: pg.PoolClient,
+      customerId: number,
+      afterCursor: string | null,
+    ): Promise<CadencePageResult> {
+      // (a) Fetch raw standard-filter page from review.
+      const response = await fetchPage({
+        filter: { customers: [String(customerId)] },
+        triage: null,
+        first: pageSize,
+        after: afterCursor,
+      });
+      const conn = response.eventListWithTriage;
+      const edges = conn.edges;
+
+      const active = await resolver.resolve(customerId);
+      const exclusionsFp = computeExclusionsFingerprint(active.rules);
+
+      let observedInserted = 0;
+      let baselineInserted = 0;
+
+      for (const edge of edges) {
+        const event = edge.node;
+        // (b) Normalize.
+        const cols = normalizeEventColumns(event);
+        // (c) Apply active exclusions.
+        if (isExcluded(cols, active)) continue;
+
+        const eventKey = cursorToEventKey(edge.cursor);
+
+        // (d) INSERT into observed_event_meta.
+        const observedResult = await insertObservedEventMeta(
+          client,
+          eventKey,
+          event,
+          cols,
+        );
+        observedInserted += observedResult.rowCount ?? 0;
+
+        // (e) INSERT into baseline_triaged_event for the baseline-passing
+        // subset.
+        const score = baselineScore(event);
+        if (score > 0) {
+          const baselineResult = await insertBaselineTriagedEvent(
+            client,
+            eventKey,
+            event,
+            cols,
+            score,
+            exclusionsFp,
+          );
+          baselineInserted += baselineResult.rowCount ?? 0;
+        }
+      }
+
+      return {
+        observedInserted,
+        baselineInserted,
+        endCursor: conn.pageInfo.endCursor,
+        hasNextPage: conn.pageInfo.hasNextPage,
+      };
+    },
+  };
+}
+
+async function defaultFetchPage(variables: {
+  filter: { customers: string[] };
+  triage: null;
+  first: number;
+  after: string | null;
+}): Promise<CadenceConnectionResponse> {
+  // The cadence runs as a system actor (no user session) and
+  // materialises customer scope through `filter.customers` sourced
+  // from the route handler's `customer_id` parameter. There is no
+  // session JWT to derive a `customerIds` list from, so the dispatch
+  // context is the system-admin role.
+  // biome-ignore format: keep the call on one line so the scope-allowlist
+  // override sits on the same line as the graphqlRequest call.
+  return graphqlRequest<CadenceConnectionResponse, typeof variables>(EVENT_LIST_WITH_TRIAGE_QUERY, variables, CADENCE_DISPATCH_CONTEXT); // scope-allowlist: #481 system-actor cadence; customer scope materialised via filter.customers
+}
+
+async function insertObservedEventMeta(
+  client: pg.PoolClient,
+  eventKey: string,
+  event: CadenceEventNode,
+  cols: NormalizedEventColumns,
+): Promise<{ rowCount: number | null }> {
+  const result = await client.query(
+    `INSERT INTO observed_event_meta (
+        event_key, event_time, kind, category, sensor,
+        orig_addr, resp_addr, host, dns_query, uri, confidence
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      ON CONFLICT (event_key) DO NOTHING`,
+    [
+      eventKey,
+      event.time,
+      event.__typename,
+      categoryToDb(event.category),
+      event.sensor,
+      cols.origAddr,
+      cols.respAddr,
+      cols.host,
+      cols.dnsQuery,
+      cols.uri,
+      // `confidence` is on the Event interface (Float!) — used by 1B-8
+      // for within-kind percentile ranking. Default to NULL when the
+      // resolver omits it (defensive: the SDL declares it required).
+      readConfidence(event),
+    ],
+  );
+  return { rowCount: result.rowCount };
+}
+
+async function insertBaselineTriagedEvent(
+  client: pg.PoolClient,
+  eventKey: string,
+  event: CadenceEventNode,
+  cols: NormalizedEventColumns,
+  score: number,
+  exclusionsFp: string,
+): Promise<{ rowCount: number | null }> {
+  const tags = [PHASE_1A_SELECTOR_TAG];
+  if (hasUnlabeledBonus(event)) tags.push(PHASE_1A_UNLABELED_BONUS_TAG);
+  const result = await client.query(
+    `INSERT INTO baseline_triaged_event (
+        event_key, event_time, kind, sensor,
+        orig_addr, orig_port, resp_addr, resp_port, proto,
+        host, dns_query, uri,
+        baseline_version, exclusions_fp, category,
+        baseline_score, selector_tags, payload_summary
+      ) VALUES (
+        $1, $2, $3, $4,
+        $5, $6, $7, $8, $9,
+        $10, $11, $12,
+        $13, $14, $15,
+        $16, $17, $18
+      )
+      ON CONFLICT (event_key) DO NOTHING`,
+    [
+      eventKey,
+      event.time,
+      event.__typename,
+      event.sensor,
+      cols.origAddr,
+      event.origPort ?? null,
+      cols.respAddr,
+      event.respPort ?? null,
+      // `proto` is not exposed on the Event interface — review-web
+      // surfaces protocol kinds as the typename group itself. Leaving
+      // NULL until/unless the resolver exposes a numeric proto field.
+      null,
+      cols.host,
+      cols.dnsQuery,
+      cols.uri,
+      PHASE_1A_BASELINE_VERSION,
+      exclusionsFp,
+      categoryToDb(event.category),
+      score,
+      tags,
+      // payload_summary stays NULL in Phase 1.A — 1B-8 will populate it
+      // once selector evidence requires per-row payload extracts.
+      null,
+    ],
+  );
+  return { rowCount: result.rowCount };
+}
+
+function categoryToDb(category: ThreatCategory | null): string | null {
+  if (category === null) return null;
+  return category;
+}
+
+function readConfidence(event: CadenceEventNode): number | null {
+  const value = (event as TriageEvent & { confidence?: number | null })
+    .confidence;
+  return typeof value === "number" ? value : null;
+}

--- a/src/lib/triage/baseline/pager.ts
+++ b/src/lib/triage/baseline/pager.ts
@@ -58,11 +58,21 @@ import { EVENT_LIST_WITH_TRIAGE_QUERY } from "./queries";
 export const CADENCE_PAGE_SIZE = 500;
 
 /**
- * Role the cadence runner uses for outbound REview GraphQL. The cadence
- * is a system actor (no user session), so it carries the `admin` role
- * — same convention the Detection / Node-management scripts use.
+ * Role the cadence runner uses for outbound REview GraphQL. The
+ * cadence is a system actor (no user session). REview's Context-JWT
+ * role enum names the built-in roles exactly as
+ * `"System Administrator"` / `"Security Administrator"` /
+ * `"Security Manager"` / `"Security Monitor"` (with the literal space)
+ * — the legacy `"admin"` shorthand does not deserialize to any of
+ * those, so requests carrying it are rejected before they hit the
+ * field guard.
+ *
+ * The cadence needs `System Administrator` because the per-customer
+ * fetch carries the target customer in `filter.customers` and REview
+ * deserializes the role first to decide whether the requester is
+ * allowed to scope sensors that way at all.
  */
-const CADENCE_DISPATCH_CONTEXT = { role: "admin" };
+const CADENCE_ROLE = "System Administrator";
 
 interface CadenceEventNode extends TriageEvent {
   // Re-asserted here so tsc remembers the optional fields the cadence
@@ -88,44 +98,56 @@ interface CadenceConnectionResponse {
 }
 
 /**
- * Decode a relay-style edge cursor into the review RocksDB i128 primary
- * key. The vendored review-web resolver encodes `event_key` as a
- * base64 string of the i128's big-endian byte representation (16
- * bytes); the cadence corpus tables store that integer in
- * `NUMERIC(39, 0)` PRIMARY KEY columns.
+ * Validate a relay-style edge cursor and return the review RocksDB
+ * primary key it carries.
  *
- * If the cursor does not decode to exactly 16 bytes, the function
- * throws — the runner catches the error, marks the run `failed`, and
- * the watermark stays at the previous committed cursor. This is the
- * correct failure mode: silently coercing a malformed cursor into a
- * fallback PK value would risk mass collisions across event rows.
+ * The vendored review-web resolver builds connection edges with
+ * `Edge::new(k.to_string(), ev)` where `k` is the i128 RocksDB key —
+ * so the wire cursor is just the decimal string of that integer (no
+ * base64, no opaque wrapping). The cadence corpus tables store that
+ * integer in `NUMERIC(39, 0)` PRIMARY KEY columns; we forward the
+ * decimal string straight through.
+ *
+ * The validator rejects anything other than an unsigned decimal
+ * literal of up to 39 digits (the unsigned-i128 range bound). A bad
+ * cursor throws so the runner marks the page `failed` and leaves the
+ * watermark at the previous committed cursor — silently coercing a
+ * malformed cursor into a fallback PK would risk mass collisions
+ * across event rows.
  */
+const EVENT_KEY_PATTERN = /^[0-9]{1,39}$/;
 export function cursorToEventKey(cursor: string): string {
-  const bytes = Buffer.from(cursor, "base64");
-  if (bytes.length !== 16) {
+  if (!EVENT_KEY_PATTERN.test(cursor)) {
     throw new Error(
-      `Cadence: unexpected cursor byte length ${bytes.length} (expected 16-byte i128 big-endian).`,
+      `Cadence: malformed edge cursor ${JSON.stringify(cursor)} (expected an unsigned decimal i128 string ≤ 39 digits).`,
     );
   }
-  let n = BigInt(0);
-  const SHIFT_8 = BigInt(8);
-  for (const byte of bytes) {
-    n = (n << SHIFT_8) | BigInt(byte);
-  }
-  return n.toString();
+  return cursor;
+}
+
+export interface CadenceFetchPageArgs {
+  customerId: number;
+  variables: {
+    filter: { customers: string[] };
+    triage: null;
+    first: number;
+    after: string | null;
+  };
 }
 
 export interface CadencePagerOptions {
   /**
    * Override the GraphQL fetch step. Tests inject a stub so the pager
-   * can be unit-tested without hitting review-web.
+   * can be unit-tested without hitting review-web. The pager passes
+   * `customerId` alongside the GraphQL variables so the production
+   * fetcher can scope the outbound JWT's `customer_ids` to the same
+   * customer the cadence is processing — REview rejects a system-actor
+   * request that names a customer in `filter.customers` outside the
+   * JWT scope.
    */
-  fetchPage?: (variables: {
-    filter: { customers: string[] };
-    triage: null;
-    first: number;
-    after: string | null;
-  }) => Promise<CadenceConnectionResponse>;
+  fetchPage?: (
+    args: CadenceFetchPageArgs,
+  ) => Promise<CadenceConnectionResponse>;
   /**
    * Active-exclusion-set resolver. Defaults to the empty-set resolver
    * (#457 swap point); tests inject a fake to drive the matcher.
@@ -157,10 +179,13 @@ export function createCadencePager(
     ): Promise<CadencePageResult> {
       // (a) Fetch raw standard-filter page from review.
       const response = await fetchPage({
-        filter: { customers: [String(customerId)] },
-        triage: null,
-        first: pageSize,
-        after: afterCursor,
+        customerId,
+        variables: {
+          filter: { customers: [String(customerId)] },
+          triage: null,
+          first: pageSize,
+          after: afterCursor,
+        },
       });
       const conn = response.eventListWithTriage;
       const edges = conn.edges;
@@ -210,25 +235,34 @@ export function createCadencePager(
         baselineInserted,
         endCursor: conn.pageInfo.endCursor,
         hasNextPage: conn.pageInfo.hasNextPage,
+        // Surface the page-level fingerprint so the runner can stamp
+        // `baseline_corpus_state.exclusions_fp` with the same value the
+        // per-row INSERTs carried. Otherwise the corpus-state row would
+        // diverge from the per-row fingerprint as soon as #457 wires
+        // real (non-empty) storage.
+        exclusionsFp,
       };
     },
   };
 }
 
-async function defaultFetchPage(variables: {
-  filter: { customers: string[] };
-  triage: null;
-  first: number;
-  after: string | null;
-}): Promise<CadenceConnectionResponse> {
-  // The cadence runs as a system actor (no user session) and
-  // materialises customer scope through `filter.customers` sourced
-  // from the route handler's `customer_id` parameter. There is no
-  // session JWT to derive a `customerIds` list from, so the dispatch
-  // context is the system-admin role.
+async function defaultFetchPage(
+  args: CadenceFetchPageArgs,
+): Promise<CadenceConnectionResponse> {
+  // The cadence runs as a system actor (no user session). The
+  // outbound dispatch context names the `System Administrator` role
+  // (REview's enum spelling — `"admin"` is not accepted) and
+  // materialises the customer scope into the JWT's `customer_ids`
+  // claim from the route handler's `customer_id` parameter. The same
+  // value is also threaded into `filter.customers` so the resolver's
+  // sensor scoping picks the right customer-tenant set.
+  const context = {
+    role: CADENCE_ROLE,
+    customerIds: [args.customerId],
+  };
   // biome-ignore format: keep the call on one line so the scope-allowlist
   // override sits on the same line as the graphqlRequest call.
-  return graphqlRequest<CadenceConnectionResponse, typeof variables>(EVENT_LIST_WITH_TRIAGE_QUERY, variables, CADENCE_DISPATCH_CONTEXT); // scope-allowlist: #481 system-actor cadence; customer scope materialised via filter.customers
+  return graphqlRequest<CadenceConnectionResponse, typeof args.variables>(EVENT_LIST_WITH_TRIAGE_QUERY, args.variables, context); // scope-allowlist: #481 system-actor cadence; customer scope materialised via JWT customer_ids + filter.customers
 }
 
 async function insertObservedEventMeta(

--- a/src/lib/triage/baseline/queries.ts
+++ b/src/lib/triage/baseline/queries.ts
@@ -1,0 +1,298 @@
+import "server-only";
+
+import { parse } from "graphql";
+
+/**
+ * Cadence-side `eventListWithTriage` query (1B-1 / discussion #447 §3.4).
+ *
+ * The cadence runner asks the resolver for raw standard-filter survivors —
+ * `triage = null`, no inline exclusions, no inline policies — so the
+ * edge cursors correspond to events that have not been pre-cut by the
+ * resolver's Stage 1 path. This is the property the cadence relies on
+ * to advance `last_event_cursor` reliably even when subsequent app-side
+ * exclusion re-application drops every event in the page.
+ *
+ * The selection set carries only what the cadence's per-page pipeline
+ * needs:
+ *
+ *   - Interface fields (`__typename`, `time`, `sensor`, `category`,
+ *     `level`, `confidence`) for every event.
+ *   - IP / port fields on every IP-bearing curated subtype so
+ *     `orig_addr` / `resp_addr` / `orig_port` / `resp_port` populate
+ *     for `observed_event_meta` and `baseline_triaged_event`.
+ *   - HTTP-shape fields (`host`, `uri`) on the HTTP-shaped subtypes.
+ *   - TLS-shape `serverName` on the TLS-shaped subtypes (cadence maps
+ *     it to the `host` exclusion-matching column).
+ *   - DNS-shape `query` on the DNS-shaped subtypes (cadence maps it
+ *     to the `dns_query` exclusion-matching column).
+ *   - `clusterId` on `HttpThreat` so `baselineScore` can detect the
+ *     unlabeled-`HttpThreat` cluster-none bonus.
+ *
+ * No `origNetwork` / `respNetwork` membership shapes — cadence does
+ * not classify against the customer perimeter; that is the menu's
+ * job. Skipping the membership selection keeps the page payload
+ * small and the resolver round-trip fast.
+ *
+ * Edge `cursor` is selected so the cadence can derive the per-event
+ * `event_key` for the corpus tables' primary key (review encodes the
+ * RocksDB i128 as a base64 cursor; see `cursorToEventKey` in the
+ * cadence runner).
+ *
+ * The query is validated against `schemas/review.graphql` by
+ * `src/__tests__/lib/graphql/schema-validation.test.ts` at CI time.
+ */
+export const EVENT_LIST_WITH_TRIAGE_QUERY = parse(`
+  query CadenceEventListWithTriage(
+    $filter: EventStandardFilterInput!
+    $triage: EventTriageInput
+    $first: Int
+    $after: String
+  ) {
+    eventListWithTriage(
+      filter: $filter
+      triage: $triage
+      first: $first
+      after: $after
+    ) {
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          __typename
+          time
+          sensor
+          category
+          level
+          confidence
+          ... on BlocklistBootp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistConn {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistDceRpc {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistDhcp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistDns {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on BlocklistFtp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistHttp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            host
+            uri
+          }
+          ... on BlocklistKerberos {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistLdap {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistMqtt {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistNfs {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistNtlm {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistRadius {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistRdp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistSmb {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistSmtp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistSsh {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistTls {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            serverName
+          }
+          ... on CryptocurrencyMiningPool {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on DnsCovertChannel {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on DomainGenerationAlgorithm {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            host
+            uri
+          }
+          ... on FtpBruteForce {
+            origAddr
+            respAddr
+            respPort
+          }
+          ... on FtpPlainText {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on HttpThreat {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            clusterId
+            host
+            uri
+          }
+          ... on LdapBruteForce {
+            origAddr
+            respAddr
+            respPort
+          }
+          ... on LdapPlainText {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on LockyRansomware {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on MultiHostPortScan {
+            origAddr
+            respPort
+          }
+          ... on NetworkThreat {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on NonBrowser {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            host
+            uri
+          }
+          ... on PortScan {
+            origAddr
+            respAddr
+          }
+          ... on RdpBruteForce {
+            origAddr
+          }
+          ... on RepeatedHttpSessions {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on SuspiciousTlsTraffic {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            serverName
+          }
+          ... on TorConnection {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on TorConnectionConn {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+        }
+      }
+    }
+  }
+`);

--- a/src/lib/triage/baseline/queries.ts
+++ b/src/lib/triage/baseline/queries.ts
@@ -34,9 +34,12 @@ import { parse } from "graphql";
  * small and the resolver round-trip fast.
  *
  * Edge `cursor` is selected so the cadence can derive the per-event
- * `event_key` for the corpus tables' primary key (review encodes the
- * RocksDB i128 as a base64 cursor; see `cursorToEventKey` in the
- * cadence runner).
+ * `event_key` for the corpus tables' primary key. The vendored
+ * resolver builds edges with `Edge::new(k.to_string(), ev)` where
+ * `k` is the i128 RocksDB key, so the wire cursor is the decimal
+ * string of that integer; `cursorToEventKey` in the cadence runner
+ * validates the shape and forwards it straight into the
+ * `NUMERIC(39, 0)` PK column.
  *
  * The query is validated against `schemas/review.graphql` by
  * `src/__tests__/lib/graphql/schema-validation.test.ts` at CI time.

--- a/src/lib/triage/exclusion/active-set.ts
+++ b/src/lib/triage/exclusion/active-set.ts
@@ -1,0 +1,35 @@
+/**
+ * Active-exclusion-set resolver — pluggable storage adapter.
+ *
+ * Pre-#457 the helper resolves to the empty set; once #457 wires real
+ * global / customer-scoped storage the same interface returns the
+ * union of both scopes without changing the cadence runner. The
+ * runner consumes the resolver through {@link ActiveExclusionSetResolver}
+ * so a test can swap in a fake or pre-populated set.
+ */
+
+import type { ActiveExclusionSet } from "./types";
+
+export interface ActiveExclusionSetResolver {
+  /**
+   * Resolve the active exclusion set for one customer. Implementations
+   * MUST return a fresh array per call so the cadence runner is free
+   * to mutate / cache it locally without affecting other callers.
+   */
+  resolve(customerId: number): Promise<ActiveExclusionSet>;
+}
+
+/**
+ * Default resolver. Returns the empty set for every customer. The
+ * cadence runner therefore behaves as a no-op exclusion pass-through
+ * pre-#457; the `exclusions_fp` column carries
+ * {@link EMPTY_EXCLUSIONS_FINGERPRINT} so the schema's NOT NULL
+ * constraint is satisfied with a real value (not NULL) and the rows
+ * already on disk re-key cleanly when #457 lands and the resolver
+ * starts returning real rules.
+ */
+export const EMPTY_EXCLUSION_SET_RESOLVER: ActiveExclusionSetResolver = {
+  async resolve(): Promise<ActiveExclusionSet> {
+    return { rules: [] };
+  },
+};

--- a/src/lib/triage/exclusion/fingerprint.ts
+++ b/src/lib/triage/exclusion/fingerprint.ts
@@ -1,0 +1,134 @@
+/**
+ * `exclusions_fp` — canonical fingerprint of the active exclusion set.
+ *
+ * The cadence runner (#481), the corpus B runner (#460), and the
+ * retroactive-DELETE planner (#457) all derive `exclusions_fp` from
+ * this single function so the same active set produces the same
+ * fingerprint everywhere. Without that, the corpus B partial unique
+ * index (#460) and the cadence's freshness checks would silently drift
+ * apart whenever the active set permuted to an equivalent shape.
+ *
+ * Canonicalization rules (designed so set-equal inputs hash equal):
+ *   1. Each rule's IP / domain / hostname / uri arrays are sorted
+ *      lexicographically and de-duplicated.
+ *   2. Each `IpAddressExclusionInput` group's `hosts`, `networks`, and
+ *      `ranges` are likewise sorted.
+ *   3. Rules are serialized to a stable JSON shape with a fixed key
+ *      order, then sorted lexicographically by their serialization.
+ *   4. The combined string is hashed with SHA-256. The hex digest is
+ *      stored as `baseline_corpus_state.exclusions_fp` and on each
+ *      `baseline_triaged_event` row.
+ *
+ * The empty-set fingerprint is well-defined: `computeExclusionsFingerprint([])`
+ * → SHA-256 of the canonical empty payload. Pre-#457 every cadence row
+ * carries this value (real value, not NULL) so the column stays
+ * NOT NULL throughout the lifecycle.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { ExclusionRule, IpAddressExclusionInput } from "./types";
+
+const FINGERPRINT_VERSION = "v1";
+
+interface CanonicalIpRange {
+  start: string;
+  end: string;
+}
+
+interface CanonicalRule {
+  ipAddress: {
+    hosts: string[];
+    networks: string[];
+    ranges: CanonicalIpRange[];
+  } | null;
+  domain: string[] | null;
+  hostname: string[] | null;
+  uri: string[] | null;
+}
+
+function dedupSorted(values: readonly string[] | null | undefined): string[] {
+  if (!values || values.length === 0) return [];
+  return Array.from(new Set(values)).sort();
+}
+
+function canonicalizeIpAddress(
+  group: IpAddressExclusionInput,
+): CanonicalRule["ipAddress"] {
+  const hosts = dedupSorted(group.hosts);
+  const networks = dedupSorted(group.networks);
+  // De-dup ranges by their `start|end` serialization so identical
+  // ranges stored twice on the wire collapse into one.
+  const seen = new Set<string>();
+  const ranges: CanonicalIpRange[] = [];
+  for (const range of group.ranges) {
+    const key = `${range.start}|${range.end}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ranges.push({ start: range.start, end: range.end });
+  }
+  ranges.sort((a, b) => {
+    if (a.start !== b.start) return a.start < b.start ? -1 : 1;
+    if (a.end !== b.end) return a.end < b.end ? -1 : 1;
+    return 0;
+  });
+  if (hosts.length === 0 && networks.length === 0 && ranges.length === 0) {
+    return null;
+  }
+  return { hosts, networks, ranges };
+}
+
+function canonicalizeRule(rule: ExclusionRule): CanonicalRule | null {
+  const ipAddress = rule.ipAddress
+    ? canonicalizeIpAddress(rule.ipAddress)
+    : null;
+  const domain = dedupSorted(rule.domain);
+  const hostname = dedupSorted(rule.hostname);
+  const uri = dedupSorted(rule.uri);
+  if (
+    ipAddress === null &&
+    domain.length === 0 &&
+    hostname.length === 0 &&
+    uri.length === 0
+  ) {
+    return null;
+  }
+  return {
+    ipAddress,
+    domain: domain.length === 0 ? null : domain,
+    hostname: hostname.length === 0 ? null : hostname,
+    uri: uri.length === 0 ? null : uri,
+  };
+}
+
+function serializeCanonicalRule(rule: CanonicalRule): string {
+  // Stable key order to make the JSON serialization permutation-free.
+  return JSON.stringify({
+    ipAddress: rule.ipAddress,
+    domain: rule.domain,
+    hostname: rule.hostname,
+    uri: rule.uri,
+  });
+}
+
+/**
+ * Hash the active exclusion set into a stable hex SHA-256 string. Set-
+ * equal inputs (any ordering, duplicate-tolerant) hash to the same
+ * digest.
+ */
+export function computeExclusionsFingerprint(
+  rules: readonly ExclusionRule[],
+): string {
+  const canonical = rules
+    .map(canonicalizeRule)
+    .filter((r): r is CanonicalRule => r !== null)
+    .map(serializeCanonicalRule)
+    .sort();
+  const payload = JSON.stringify({
+    version: FINGERPRINT_VERSION,
+    rules: canonical,
+  });
+  return createHash("sha256").update(payload, "utf8").digest("hex");
+}
+
+export const EMPTY_EXCLUSIONS_FINGERPRINT = computeExclusionsFingerprint([]);

--- a/src/lib/triage/exclusion/index.ts
+++ b/src/lib/triage/exclusion/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared exclusion / normalization helper barrel (#481, #460, #457).
+ *
+ * Lives outside `src/lib/triage/policy/` so the policy deprecatability
+ * seam stays intact. The cadence runner, the corpus B runner, and the
+ * retroactive-DELETE planner all import from this module so the
+ * normalization mapping, the IpAddress / Domain / Hostname / Uri
+ * matcher, and the `exclusions_fp` canonicalization are a single
+ * source of truth.
+ */
+
+export {
+  type ActiveExclusionSetResolver,
+  EMPTY_EXCLUSION_SET_RESOLVER,
+} from "./active-set";
+export {
+  computeExclusionsFingerprint,
+  EMPTY_EXCLUSIONS_FINGERPRINT,
+} from "./fingerprint";
+export { isExcluded } from "./match";
+export { normalizeEventColumns } from "./normalize";
+export {
+  compileDomainPatterns,
+  type DomainPatternValidationResult,
+  validateDomainPattern,
+} from "./regex";
+export type {
+  ActiveExclusionSet,
+  ExclusionRule,
+  IpAddressExclusionInput,
+  NormalizedEventColumns,
+} from "./types";

--- a/src/lib/triage/exclusion/index.ts
+++ b/src/lib/triage/exclusion/index.ts
@@ -20,6 +20,14 @@ export {
 export { isExcluded } from "./match";
 export { normalizeEventColumns } from "./normalize";
 export {
+  type EventTriageExclusionInputShape,
+  ExclusionInputParseError,
+  type HostNetworkGroupInputShape,
+  type IpRangeInputShape,
+  parseExclusionInput,
+  parseExclusionInputs,
+} from "./parse";
+export {
   compileDomainPatterns,
   type DomainPatternValidationResult,
   validateDomainPattern,

--- a/src/lib/triage/exclusion/match.ts
+++ b/src/lib/triage/exclusion/match.ts
@@ -1,0 +1,213 @@
+/**
+ * Active-exclusion matcher (1B-1 cadence step c).
+ *
+ * Applies an active set of exclusion rules in-memory against an event's
+ * normalized columns. The semantics mirror review-web's `EventTriageExclusionInput`
+ * resolver-side matching exactly:
+ *
+ *   - IpAddress: CIDR / range / exact-host containment over `orig_addr`
+ *     and `resp_addr`.
+ *   - Hostname: exact match against `host`.
+ *   - Uri: exact match against `uri`.
+ *   - Domain: regex `RegexSet::is_match` against `host` and `dns_query`
+ *     only — never `uri` (URI matching is the Uri exclusion's job).
+ *
+ * The cadence-side application is the **authoritative exclusion
+ * enforcement** for corpus filling (the resolver's Stage 1 pre-cut is
+ * intentionally not used by cadence). Pre-#457 the `ActiveExclusionSet`
+ * is empty so this is a no-op pass-through; once #457 wires real
+ * storage the same code matches against real rules without the cadence
+ * runner changing.
+ */
+
+import { isIPv4, isIPv6 } from "node:net";
+
+import { compileDomainPatterns } from "./regex";
+import type {
+  ActiveExclusionSet,
+  ExclusionRule,
+  IpAddressExclusionInput,
+  NormalizedEventColumns,
+} from "./types";
+
+const ZERO = BigInt(0);
+const ONE = BigInt(1);
+const SHIFT_8 = BigInt(8);
+const SHIFT_16 = BigInt(16);
+
+/**
+ * `true` iff the event's normalized columns match any rule in `active`.
+ * Caller drops the event from the corpus when this returns `true`.
+ *
+ * The matcher pre-compiles per-rule regex / numeric structures once per
+ * call; for a long page the active set is small (low tens) so doing the
+ * compile per `isExcluded` call is fine. The runner can lift the
+ * compile out to per-page if profiling later shows it matters.
+ */
+export function isExcluded(
+  cols: NormalizedEventColumns,
+  active: ActiveExclusionSet,
+): boolean {
+  for (const rule of active.rules) {
+    if (matchRule(cols, rule)) return true;
+  }
+  return false;
+}
+
+function matchRule(cols: NormalizedEventColumns, rule: ExclusionRule): boolean {
+  if (rule.ipAddress && matchIpAddress(cols, rule.ipAddress)) return true;
+  if (rule.hostname && matchHostname(cols, rule.hostname)) return true;
+  if (rule.uri && matchUri(cols, rule.uri)) return true;
+  if (rule.domain && matchDomain(cols, rule.domain)) return true;
+  return false;
+}
+
+function matchIpAddress(
+  cols: NormalizedEventColumns,
+  group: IpAddressExclusionInput,
+): boolean {
+  const addrs = [cols.origAddr, cols.respAddr].filter(
+    (a): a is string => a !== null,
+  );
+  if (addrs.length === 0) return false;
+  for (const addr of addrs) {
+    if (group.hosts.includes(addr)) return true;
+    for (const cidr of group.networks) {
+      if (cidrContains(cidr, addr)) return true;
+    }
+    for (const range of group.ranges) {
+      if (rangeContains(range, addr)) return true;
+    }
+  }
+  return false;
+}
+
+function matchHostname(
+  cols: NormalizedEventColumns,
+  hostnames: string[],
+): boolean {
+  if (cols.host === null) return false;
+  return hostnames.includes(cols.host);
+}
+
+function matchUri(cols: NormalizedEventColumns, uris: string[]): boolean {
+  if (cols.uri === null) return false;
+  return uris.includes(cols.uri);
+}
+
+function matchDomain(
+  cols: NormalizedEventColumns,
+  patterns: string[],
+): boolean {
+  const matcher = compileDomainPatterns(patterns);
+  if (!matcher) return false;
+  if (cols.host !== null && matcher.test(cols.host)) return true;
+  if (cols.dnsQuery !== null && matcher.test(cols.dnsQuery)) return true;
+  return false;
+}
+
+function ipToBigInt(ip: string): bigint | null {
+  if (isIPv4(ip)) {
+    const parts = ip.split(".");
+    if (parts.length !== 4) return null;
+    let n = ZERO;
+    for (const p of parts) {
+      const byte = Number(p);
+      if (!Number.isInteger(byte) || byte < 0 || byte > 255) return null;
+      n = (n << SHIFT_8) | BigInt(byte);
+    }
+    return n;
+  }
+  if (isIPv6(ip)) {
+    return ipv6ToBigInt(ip);
+  }
+  return null;
+}
+
+function ipv6ToBigInt(ip: string): bigint | null {
+  // Handle the embedded IPv4 form `::ffff:1.2.3.4`.
+  let normalized = ip;
+  const lastColon = normalized.lastIndexOf(":");
+  if (lastColon !== -1 && normalized.includes(".", lastColon)) {
+    const tail = normalized.slice(lastColon + 1);
+    if (isIPv4(tail)) {
+      const parts = tail.split(".").map((p) => Number(p));
+      const word1 = ((parts[0] << 8) | parts[1]).toString(16);
+      const word2 = ((parts[2] << 8) | parts[3]).toString(16);
+      normalized = `${normalized.slice(0, lastColon + 1)}${word1}:${word2}`;
+    }
+  }
+  let head: string;
+  let tail: string;
+  if (normalized.includes("::")) {
+    const [hPart, tPart] = normalized.split("::", 2);
+    head = hPart ?? "";
+    tail = tPart ?? "";
+  } else {
+    head = normalized;
+    tail = "";
+  }
+  const headParts = head.length === 0 ? [] : head.split(":");
+  const tailParts = tail.length === 0 ? [] : tail.split(":");
+  const totalParts = headParts.length + tailParts.length;
+  if (totalParts > 8) return null;
+  const zeros = new Array(8 - totalParts).fill("0");
+  const all = [...headParts, ...zeros, ...tailParts];
+  if (all.length !== 8) return null;
+  let n = ZERO;
+  for (const part of all) {
+    const word = Number.parseInt(part, 16);
+    if (!Number.isFinite(word) || word < 0 || word > 0xffff) return null;
+    n = (n << SHIFT_16) | BigInt(word);
+  }
+  return n;
+}
+
+function cidrContains(cidr: string, addr: string): boolean {
+  const slash = cidr.lastIndexOf("/");
+  if (slash === -1) return false;
+  const network = cidr.slice(0, slash);
+  const prefix = Number.parseInt(cidr.slice(slash + 1), 10);
+  if (!Number.isInteger(prefix) || prefix < 0) return false;
+
+  const networkBig = ipToBigInt(network);
+  const addrBig = ipToBigInt(addr);
+  if (networkBig === null || addrBig === null) return false;
+
+  const isV4Network = isIPv4(network);
+  const isV4Addr = isIPv4(addr);
+  if (isV4Network !== isV4Addr) return false;
+  const totalBits = isV4Network ? 32 : 128;
+  if (prefix > totalBits) return false;
+  const hostBits = BigInt(totalBits - prefix);
+  const mask = hostBits === ZERO ? ZERO : (ONE << hostBits) - ONE;
+  return (networkBig & ~mask) === (addrBig & ~mask);
+}
+
+function rangeContains(
+  range: { start: string; end: string },
+  addr: string,
+): boolean {
+  const startBig = ipToBigInt(range.start);
+  const endBig = ipToBigInt(range.end);
+  const addrBig = ipToBigInt(addr);
+  if (startBig === null || endBig === null || addrBig === null) return false;
+  // Mixed-family ranges are rejected by the schema; if one slips in
+  // here, treat it as a non-match rather than throwing.
+  const startV4 = isIPv4(range.start);
+  const endV4 = isIPv4(range.end);
+  const addrV4 = isIPv4(addr);
+  if (startV4 !== endV4) return false;
+  if (startV4 !== addrV4) return false;
+  return startBig <= addrBig && addrBig <= endBig;
+}
+
+export const _testing = {
+  matchIpAddress,
+  matchHostname,
+  matchUri,
+  matchDomain,
+  ipToBigInt,
+  cidrContains,
+  rangeContains,
+};

--- a/src/lib/triage/exclusion/normalize.ts
+++ b/src/lib/triage/exclusion/normalize.ts
@@ -1,0 +1,116 @@
+/**
+ * Event-kind → exclusion-matching column normalization.
+ *
+ * This is the single mapping the cadence runner (#481), the corpus B
+ * runner (#460), and the retroactive-DELETE planner (#457) all share so
+ * cadence-time and retroactive paths target the same normalized columns
+ * and never double-apply.
+ */
+
+import type { TriageEvent } from "../types";
+import type { NormalizedEventColumns } from "./types";
+
+/**
+ * Curated typename groups. The cadence pager fetches every standard-
+ * filter survivor regardless of subtype; the normalization step decides
+ * which physical columns each subtype contributes to. The groups below
+ * mirror the field-shape distinctions the existing `TRIAGE_EVENT_LIST_QUERY`
+ * already encodes (HTTP / DNS / TLS / NTLM / IP-only).
+ */
+const HTTP_TYPENAMES: ReadonlySet<string> = new Set([
+  "BlocklistHttp",
+  "HttpThreat",
+  "NonBrowser",
+  "DomainGenerationAlgorithm",
+  "RepeatedHttpSessions",
+]);
+
+const DNS_TYPENAMES: ReadonlySet<string> = new Set([
+  "BlocklistDns",
+  "CryptocurrencyMiningPool",
+  "DnsCovertChannel",
+  "LockyRansomware",
+]);
+
+const TLS_TYPENAMES: ReadonlySet<string> = new Set([
+  "BlocklistTls",
+  "SuspiciousTlsTraffic",
+]);
+
+/**
+ * NTLM is the IP-only carve-out (anchored in aicers/review-database#723):
+ * even though the upstream resolver may expose a `hostname` field,
+ * cadence intentionally leaves `host` / `dns_query` / `uri` NULL so the
+ * cadence-time and retroactive-DELETE paths agree. Domain / Hostname /
+ * Uri exclusions therefore never match an NTLM row, by design.
+ */
+const NTLM_TYPENAMES: ReadonlySet<string> = new Set(["BlocklistNtlm"]);
+
+/**
+ * Map one `TriageEvent` to the normalized exclusion-matching columns.
+ * Address fields are taken straight from the event (already populated
+ * for every IP-bearing subtype the curated query selects). The host /
+ * dnsQuery / uri columns follow the typename group:
+ *
+ *   - HTTP group: `host` ← `event.host`, `uri` ← `event.uri`
+ *   - TLS group: `host` ← `event.serverName`
+ *   - DNS group: `dnsQuery` ← `event.query`
+ *   - NTLM group: all three NULL (IP-only carve-out)
+ *   - Anything else: all three NULL
+ */
+export function normalizeEventColumns(
+  event: TriageEvent,
+): NormalizedEventColumns {
+  const origAddr = nonEmpty(event.origAddr);
+  const respAddr = nonEmpty(event.respAddr);
+
+  if (NTLM_TYPENAMES.has(event.__typename)) {
+    return { origAddr, respAddr, host: null, dnsQuery: null, uri: null };
+  }
+  if (HTTP_TYPENAMES.has(event.__typename)) {
+    return {
+      origAddr,
+      respAddr,
+      host: nonEmpty(event.host),
+      dnsQuery: null,
+      uri: nonEmpty(event.uri),
+    };
+  }
+  if (TLS_TYPENAMES.has(event.__typename)) {
+    return {
+      origAddr,
+      respAddr,
+      host: nonEmpty(event.serverName),
+      dnsQuery: null,
+      uri: null,
+    };
+  }
+  if (DNS_TYPENAMES.has(event.__typename)) {
+    return {
+      origAddr,
+      respAddr,
+      host: null,
+      dnsQuery: nonEmpty(event.query),
+      uri: null,
+    };
+  }
+  return { origAddr, respAddr, host: null, dnsQuery: null, uri: null };
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  if (value.length === 0) return null;
+  return value;
+}
+
+/**
+ * Test-only mirror of the typename groups above so a regression in the
+ * mapping fails the unit test rather than silently slipping through to
+ * production.
+ */
+export const _testing = {
+  HTTP_TYPENAMES,
+  DNS_TYPENAMES,
+  TLS_TYPENAMES,
+  NTLM_TYPENAMES,
+};

--- a/src/lib/triage/exclusion/parse.ts
+++ b/src/lib/triage/exclusion/parse.ts
@@ -1,0 +1,207 @@
+/**
+ * Single GraphQL `EventTriageExclusionInput` parser (1B-1 / #481
+ * deliverable §1).
+ *
+ * The vendored review-web SDL exposes one inline-exclusion shape used by
+ * `eventListWithTriage` and (eventually) by the #457 storage CRUD path:
+ *
+ * ```graphql
+ * input EventTriageExclusionInput {
+ *   ipAddress: HostNetworkGroupInput   # nullable
+ *   domain:    [String!]               # nullable
+ *   hostname:  [String!]               # nullable
+ *   uri:       [String!]               # nullable
+ * }
+ *
+ * input HostNetworkGroupInput {
+ *   hosts:    [String!]!
+ *   networks: [String!]!
+ *   ranges:   [IpRangeInput!]!
+ * }
+ * ```
+ *
+ * Everything that touches stored exclusions — the cadence runner here,
+ * the corpus B runner (#460), the retroactive-DELETE planner / storage
+ * CRUD (#457) — must convert that wire shape into the in-memory
+ * {@link ExclusionRule} the matcher consumes. Centralising the
+ * conversion in this module is what stops #457 from needing to redefine
+ * the parser surface this issue is supposed to make shared.
+ *
+ * The parser:
+ *   - rejects an exclusion object with no populated field (the resolver
+ *     does the same — keeps the empty rule from silently filtering
+ *     nothing while still producing fingerprint churn);
+ *   - applies {@link validateDomainPattern} to every Domain pattern at
+ *     the persistence boundary so cadence-time matching cannot diverge
+ *     from review-web's Stage 1 matching on stored patterns;
+ *   - drops unrelated extra fields rather than passing them through, so
+ *     a future schema addition does not silently change exclusion
+ *     semantics until this parser is updated.
+ */
+
+import { validateDomainPattern } from "./regex";
+import type { ExclusionRule, IpAddressExclusionInput } from "./types";
+
+export interface IpRangeInputShape {
+  start: string;
+  end: string;
+}
+
+export interface HostNetworkGroupInputShape {
+  hosts?: string[] | null;
+  networks?: string[] | null;
+  ranges?: IpRangeInputShape[] | null;
+}
+
+export interface EventTriageExclusionInputShape {
+  ipAddress?: HostNetworkGroupInputShape | null;
+  domain?: string[] | null;
+  hostname?: string[] | null;
+  uri?: string[] | null;
+}
+
+export class ExclusionInputParseError extends Error {
+  readonly index: number;
+
+  constructor(message: string, index = -1) {
+    super(message);
+    this.name = "ExclusionInputParseError";
+    this.index = index;
+  }
+}
+
+/**
+ * Parse a single `EventTriageExclusionInput`. Returns an
+ * {@link ExclusionRule} with at least one populated field, or throws
+ * {@link ExclusionInputParseError} for any of:
+ *
+ *   - empty / all-null input (the resolver requires at least one field
+ *     populated; an empty rule is meaningless and would only churn the
+ *     fingerprint);
+ *   - any Domain pattern that fails {@link validateDomainPattern}
+ *     (engine-divergent shorthand, lookbehind, etc.);
+ *   - non-array Domain / Hostname / Uri lists.
+ */
+export function parseExclusionInput(
+  input: EventTriageExclusionInputShape,
+  index = -1,
+): ExclusionRule {
+  const rule: ExclusionRule = {};
+
+  if (input.ipAddress !== null && input.ipAddress !== undefined) {
+    rule.ipAddress = parseHostNetworkGroup(input.ipAddress, index);
+  }
+
+  if (input.domain !== null && input.domain !== undefined) {
+    if (!Array.isArray(input.domain)) {
+      throw new ExclusionInputParseError(
+        formatError(index, "domain must be an array of strings"),
+        index,
+      );
+    }
+    const domain: string[] = [];
+    for (const pattern of input.domain) {
+      const result = validateDomainPattern(pattern);
+      if (!result.ok) {
+        throw new ExclusionInputParseError(
+          formatError(
+            index,
+            `invalid domain pattern ${JSON.stringify(pattern)}: ${result.reason}`,
+          ),
+          index,
+        );
+      }
+      domain.push(pattern);
+    }
+    if (domain.length > 0) rule.domain = domain;
+  }
+
+  if (input.hostname !== null && input.hostname !== undefined) {
+    if (!Array.isArray(input.hostname)) {
+      throw new ExclusionInputParseError(
+        formatError(index, "hostname must be an array of strings"),
+        index,
+      );
+    }
+    const hostname = input.hostname.filter((s) => s.length > 0);
+    if (hostname.length > 0) rule.hostname = hostname;
+  }
+
+  if (input.uri !== null && input.uri !== undefined) {
+    if (!Array.isArray(input.uri)) {
+      throw new ExclusionInputParseError(
+        formatError(index, "uri must be an array of strings"),
+        index,
+      );
+    }
+    const uri = input.uri.filter((s) => s.length > 0);
+    if (uri.length > 0) rule.uri = uri;
+  }
+
+  if (
+    rule.ipAddress === undefined &&
+    rule.domain === undefined &&
+    rule.hostname === undefined &&
+    rule.uri === undefined
+  ) {
+    throw new ExclusionInputParseError(
+      formatError(
+        index,
+        "exclusion must have at least one populated field (ipAddress, domain, hostname, uri)",
+      ),
+      index,
+    );
+  }
+
+  return rule;
+}
+
+/**
+ * Parse a `[EventTriageExclusionInput!]` list (the shape carried by
+ * `EventTriageInput.exclusions` and by the cadence "active set" resolver
+ * once #457 wires real storage). Each element is parsed with
+ * {@link parseExclusionInput}; the index of any failing element is
+ * surfaced in the error message so storage CRUD can highlight the bad
+ * row.
+ */
+export function parseExclusionInputs(
+  inputs: EventTriageExclusionInputShape[] | null | undefined,
+): ExclusionRule[] {
+  if (inputs === null || inputs === undefined) return [];
+  if (!Array.isArray(inputs)) {
+    throw new ExclusionInputParseError(
+      "exclusions must be an array of EventTriageExclusionInput",
+    );
+  }
+  const rules: ExclusionRule[] = [];
+  for (let i = 0; i < inputs.length; i += 1) {
+    rules.push(parseExclusionInput(inputs[i], i));
+  }
+  return rules;
+}
+
+function parseHostNetworkGroup(
+  group: HostNetworkGroupInputShape,
+  index: number,
+): IpAddressExclusionInput {
+  const hosts = Array.isArray(group.hosts) ? group.hosts.slice() : [];
+  const networks = Array.isArray(group.networks) ? group.networks.slice() : [];
+  const ranges = Array.isArray(group.ranges)
+    ? group.ranges.map((r) => ({ start: r.start, end: r.end }))
+    : [];
+  if (hosts.length === 0 && networks.length === 0 && ranges.length === 0) {
+    throw new ExclusionInputParseError(
+      formatError(
+        index,
+        "ipAddress must populate at least one of hosts / networks / ranges",
+      ),
+      index,
+    );
+  }
+  return { hosts, networks, ranges };
+}
+
+function formatError(index: number, message: string): string {
+  if (index < 0) return message;
+  return `exclusions[${index}]: ${message}`;
+}

--- a/src/lib/triage/exclusion/parse.ts
+++ b/src/lib/triage/exclusion/parse.ts
@@ -28,6 +28,16 @@
  * the parser surface this issue is supposed to make shared.
  *
  * The parser:
+ *   - flattens multi-field exclusion objects into one
+ *     {@link ExclusionRule} per populated field, mirroring the resolver
+ *     contract documented in the SDL ("when more than one field is
+ *     populated the object is flattened into independent
+ *     `TriageExclusion` values"). A grouped `{ hostname, uri }` input
+ *     and an equivalent split `[{ hostname }, { uri }]` input therefore
+ *     produce the same active set and the same
+ *     {@link computeExclusionsFingerprint} digest — which matters once
+ *     #457 wires real storage and the same set can arrive grouped or
+ *     split through different code paths;
  *   - rejects an exclusion object with no populated field (the resolver
  *     does the same — keeps the empty rule from silently filtering
  *     nothing while still producing fingerprint churn);
@@ -71,9 +81,11 @@ export class ExclusionInputParseError extends Error {
 }
 
 /**
- * Parse a single `EventTriageExclusionInput`. Returns an
- * {@link ExclusionRule} with at least one populated field, or throws
- * {@link ExclusionInputParseError} for any of:
+ * Parse a single `EventTriageExclusionInput`. Returns one or more
+ * {@link ExclusionRule}s — one per populated field — so a grouped input
+ * like `{ hostname: [...], uri: [...] }` flattens to two independent
+ * single-field rules, matching the resolver contract documented in the
+ * SDL. Throws {@link ExclusionInputParseError} for any of:
  *
  *   - empty / all-null input (the resolver requires at least one field
  *     populated; an empty rule is meaningless and would only churn the
@@ -85,11 +97,13 @@ export class ExclusionInputParseError extends Error {
 export function parseExclusionInput(
   input: EventTriageExclusionInputShape,
   index = -1,
-): ExclusionRule {
-  const rule: ExclusionRule = {};
+): ExclusionRule[] {
+  const rules: ExclusionRule[] = [];
 
   if (input.ipAddress !== null && input.ipAddress !== undefined) {
-    rule.ipAddress = parseHostNetworkGroup(input.ipAddress, index);
+    rules.push({
+      ipAddress: parseHostNetworkGroup(input.ipAddress, index),
+    });
   }
 
   if (input.domain !== null && input.domain !== undefined) {
@@ -113,7 +127,7 @@ export function parseExclusionInput(
       }
       domain.push(pattern);
     }
-    if (domain.length > 0) rule.domain = domain;
+    if (domain.length > 0) rules.push({ domain });
   }
 
   if (input.hostname !== null && input.hostname !== undefined) {
@@ -124,7 +138,7 @@ export function parseExclusionInput(
       );
     }
     const hostname = input.hostname.filter((s) => s.length > 0);
-    if (hostname.length > 0) rule.hostname = hostname;
+    if (hostname.length > 0) rules.push({ hostname });
   }
 
   if (input.uri !== null && input.uri !== undefined) {
@@ -135,15 +149,10 @@ export function parseExclusionInput(
       );
     }
     const uri = input.uri.filter((s) => s.length > 0);
-    if (uri.length > 0) rule.uri = uri;
+    if (uri.length > 0) rules.push({ uri });
   }
 
-  if (
-    rule.ipAddress === undefined &&
-    rule.domain === undefined &&
-    rule.hostname === undefined &&
-    rule.uri === undefined
-  ) {
+  if (rules.length === 0) {
     throw new ExclusionInputParseError(
       formatError(
         index,
@@ -153,7 +162,7 @@ export function parseExclusionInput(
     );
   }
 
-  return rule;
+  return rules;
 }
 
 /**
@@ -175,7 +184,9 @@ export function parseExclusionInputs(
   }
   const rules: ExclusionRule[] = [];
   for (let i = 0; i < inputs.length; i += 1) {
-    rules.push(parseExclusionInput(inputs[i], i));
+    for (const rule of parseExclusionInput(inputs[i], i)) {
+      rules.push(rule);
+    }
   }
   return rules;
 }

--- a/src/lib/triage/exclusion/regex.ts
+++ b/src/lib/triage/exclusion/regex.ts
@@ -1,0 +1,157 @@
+/**
+ * Domain regex matcher with a locked-in engine alignment.
+ *
+ * #481 picks **option (A)** — restrict stored Domain patterns to the
+ * Rust ∩ JS regex intersection grammar with insert-time validation, and
+ * compile + match in Node with the host JavaScript engine. Option (B)
+ * (ship a Rust-equivalent matcher in Node, e.g. WASM `regex` crate)
+ * was rejected for 1B-1: it adds a build-time dependency, complicates
+ * the deployment, and is overkill for the small subset of regex
+ * features stored Domain patterns actually need (anchors, character
+ * classes, quantifiers, alternation).
+ *
+ * The intersection grammar accepts:
+ *   - literal characters (Unicode)
+ *   - escaped meta-characters (`\.`, `\*`, …)
+ *   - `^`, `$` anchors (`\A`, `\z` are rejected because JS does not
+ *     support them — both engines must agree)
+ *   - character classes `[abc]`, `[^abc]`, ranges `[a-z]`
+ *   - `.` (any-char-except-newline; both engines agree on this)
+ *   - quantifiers `*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}` (greedy and
+ *     lazy with `?`)
+ *   - non-capturing groups `(?:…)` and capture groups `(…)`
+ *   - alternation `|`
+ *
+ * The intersection grammar rejects:
+ *   - inline modifier flags `(?i)`, `(?x)`, `(?s)`, … (Rust supports
+ *     them; JS does not)
+ *   - `\A` / `\z` anchors (Rust supports them; JS does not)
+ *   - lookbehind `(?<=…)`, `(?<!…)` (Rust does not support these in
+ *     the default `regex` crate)
+ *   - lookahead `(?=…)`, `(?!…)` (also unsupported by `regex`)
+ *   - back-references `\1`, `\k<name>` (unsupported by `regex`)
+ *   - named groups `(?<name>…)` (Rust supports `(?P<name>…)` but the
+ *     intersection rejects both spellings to keep the validator
+ *     simple)
+ *
+ * Both engines must produce the same matches against `host` /
+ * `dns_query` strings; otherwise cadence-time matching diverges from
+ * review-web's Stage 1 matching on stored patterns. The
+ * `validateDomainPattern` function is the gate every persistence path
+ * (cadence corpus fill, #457 storage CRUD, #460 corpus B fill) consults
+ * before storing or matching a pattern.
+ *
+ * The matcher uses `RegExp` with the `u` flag (Unicode aware). Patterns
+ * are anchored implicitly: review's Rust matcher uses `RegexSet::is_match`
+ * which performs a substring search by default. To preserve identical
+ * semantics the cadence-side matcher also performs a substring search
+ * (i.e. the pattern is **not** wrapped in `^...$`).
+ */
+
+export type DomainPatternValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+const REJECTED_TOKENS: { pattern: RegExp; reason: string }[] = [
+  {
+    pattern: /\(\?[a-zA-Z]+\)/,
+    reason:
+      "Inline modifier flags like (?i) / (?x) are rejected — JS regex does not support them.",
+  },
+  {
+    pattern: /\(\?[a-zA-Z]+:/,
+    reason:
+      "Inline modifier groups like (?i:...) are rejected — JS regex does not support them.",
+  },
+  {
+    pattern: /\(\?<=|\(\?<!/,
+    reason:
+      "Lookbehind assertions are rejected — Rust's regex crate does not support them.",
+  },
+  {
+    pattern: /\(\?=|\(\?!/,
+    reason:
+      "Lookahead assertions are rejected — Rust's regex crate does not support them.",
+  },
+  {
+    pattern: /\(\?<[a-zA-Z_]/,
+    reason:
+      "Named capture groups (?<name>...) are rejected — engine spellings differ.",
+  },
+  {
+    pattern: /\(\?P</,
+    reason:
+      "Rust-style named capture groups (?P<name>...) are rejected — engine spellings differ.",
+  },
+  {
+    pattern: /\\A|\\z|\\Z/,
+    reason:
+      "\\A / \\z / \\Z anchors are rejected — JS regex does not support them.",
+  },
+  {
+    pattern: /\\[1-9]/,
+    reason:
+      "Back-references like \\1 are rejected — Rust's regex crate does not support them.",
+  },
+  {
+    pattern: /\\k</,
+    reason:
+      "Named back-references \\k<name> are rejected — Rust's regex crate does not support them.",
+  },
+];
+
+/**
+ * Validate a stored Domain pattern against the Rust ∩ JS intersection
+ * grammar. Returns `{ ok: true }` if the pattern is safe to store and
+ * match in either engine; otherwise returns a structured error so the
+ * #457 CRUD path can surface a precise rejection reason.
+ */
+export function validateDomainPattern(
+  pattern: string,
+): DomainPatternValidationResult {
+  if (typeof pattern !== "string" || pattern.length === 0) {
+    return { ok: false, reason: "Empty Domain pattern is not allowed." };
+  }
+  for (const token of REJECTED_TOKENS) {
+    if (token.pattern.test(pattern)) {
+      return { ok: false, reason: token.reason };
+    }
+  }
+  // Final pass: the pattern must compile under JS too. This catches
+  // nested-quantifier and unbalanced-paren cases without re-implementing
+  // a parser.
+  try {
+    new RegExp(pattern, "u");
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `Pattern does not compile in JavaScript regex: ${(err as Error).message}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Compile an array of validated Domain patterns into one combined
+ * matcher that mirrors Rust's `RegexSet::is_match` semantics: the
+ * matcher returns `true` iff *any* pattern matches anywhere inside the
+ * input string. Patterns that fail validation throw — the storage
+ * adapter (#457) is responsible for rejecting them at INSERT time so
+ * cadence never sees an invalid pattern at runtime.
+ */
+export function compileDomainPatterns(patterns: string[]): RegExp | null {
+  if (patterns.length === 0) return null;
+  const wrapped: string[] = [];
+  for (const pattern of patterns) {
+    const result = validateDomainPattern(pattern);
+    if (!result.ok) {
+      throw new Error(
+        `compileDomainPatterns: invalid pattern ${JSON.stringify(pattern)}: ${result.reason}`,
+      );
+    }
+    // Wrap in a non-capturing group so alternation in any one pattern
+    // does not bleed into siblings when joined by `|`.
+    wrapped.push(`(?:${pattern})`);
+  }
+  return new RegExp(wrapped.join("|"), "u");
+}

--- a/src/lib/triage/exclusion/regex.ts
+++ b/src/lib/triage/exclusion/regex.ts
@@ -46,6 +46,19 @@
  *     engines on the same stored row. Force authors to spell the
  *     intent with explicit ASCII character classes (e.g. `[0-9]`,
  *     `[A-Za-z0-9_]`, `[ \t\r\n]`) so both engines agree.
+ *   - character-class set operators `&&` (intersection), `--`
+ *     (difference), `~~` (symmetric difference) and nested `[…]`
+ *     classes. Rust's `regex` crate parses `[a&&b]` as a class
+ *     intersection that matches nothing, while JavaScript's `RegExp`
+ *     (without the `v` flag, which the matcher does not enable) parses
+ *     `&` as a literal class member and matches `a`, `&`, or `b`. The
+ *     same divergence applies to `[a--b]` (Rust difference vs JS literal
+ *     `-`s) and to nested classes like `[[a-z]&&[^aeiou]]`. Allowing
+ *     any of these would let a stored Domain pattern match in cadence-
+ *     side JS but not in review-web Stage 1 (or vice-versa) — exactly
+ *     the divergence option (A) is supposed to prevent. Authors should
+ *     spell out the literal class with `\-` / `\&` / `\~` if they need
+ *     those characters as members.
  *
  * Both engines must produce the same matches against `host` /
  * `dns_query` strings; otherwise cadence-time matching diverges from
@@ -162,6 +175,77 @@ function findDivergentShorthand(
   return null;
 }
 
+/**
+ * Walk the pattern looking for character-class set operators that Rust's
+ * `regex` crate honours but JavaScript's `RegExp` (without the `v` flag)
+ * silently treats as literals.
+ *
+ * Inside a `[...]` character class:
+ *   - `&&` is class intersection in Rust (`[a&&b]` matches nothing) but
+ *     a literal `&` repeated twice in JS (`[a&&b]` matches `a`, `&`, or
+ *     `b`).
+ *   - `--` is class difference in Rust (`[a-z--[aeiou]]` excludes the
+ *     vowels) but a literal `-` in JS at most positions, or part of a
+ *     range otherwise.
+ *   - `~~` is class symmetric difference in Rust but literal `~` in JS.
+ *   - A nested `[…]` is the operand syntax for those operators in Rust,
+ *     and a JS `RegExp` without the `v` flag rejects an unescaped inner
+ *     `[`. Even if a pattern would fail to compile in JS, rejecting it
+ *     here gives a precise reason rather than a generic SyntaxError.
+ *
+ * Backslash-escaped characters (`\&`, `\-`, `\~`, `\[`) are skipped — an
+ * author who wants those as literal class members spells them with the
+ * escape and both engines agree.
+ */
+function findClassSetOperator(
+  pattern: string,
+): { token: string; index: number } | null {
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "\\") {
+      // Skip the escape sequence (one char of escape + the escaped
+      // char). If the backslash is the final character, stop.
+      i += 2;
+      continue;
+    }
+    if (ch !== "[") {
+      i += 1;
+      continue;
+    }
+    // Enter a character class.
+    let j = i + 1;
+    if (pattern[j] === "^") j += 1;
+    while (j < pattern.length && pattern[j] !== "]") {
+      const cur = pattern[j];
+      if (cur === "\\") {
+        j += 2;
+        continue;
+      }
+      if (cur === "[") {
+        return { token: "[…]", index: j };
+      }
+      if (j + 1 < pattern.length) {
+        const pair = pattern.slice(j, j + 2);
+        if (pair === "&&" || pair === "--" || pair === "~~") {
+          return { token: pair, index: j };
+        }
+      }
+      j += 1;
+    }
+    i = j + 1;
+  }
+  return null;
+}
+
+const CLASS_SET_REJECTION_REASON: Record<string, string> = {
+  "&&": "Class-set operator && is rejected — Rust treats it as character-class intersection, JS as two literal & characters. Spell the literal members explicitly (e.g. [a\\&b]).",
+  "--": "Class-set operator -- is rejected — Rust treats it as character-class difference, JS as literal - characters. Spell the literal members explicitly (e.g. [a\\-b]).",
+  "~~": "Class-set operator ~~ is rejected — Rust treats it as character-class symmetric difference, JS as two literal ~ characters. Spell the literal members explicitly.",
+  "[…]":
+    "Nested character class [...] is rejected — Rust treats it as the operand syntax for class-set operators, JS (without the v flag) does not support nested classes at all.",
+};
+
 const SHORTHAND_REJECTION_REASON: Record<string, string> = {
   "\\d":
     "Shorthand \\d is rejected — Rust matches Unicode digits, JS only ASCII. Use [0-9] instead.",
@@ -203,6 +287,13 @@ export function validateDomainPattern(
     const reason =
       SHORTHAND_REJECTION_REASON[shorthand.token] ??
       `Shorthand ${shorthand.token} is rejected — Rust and JS regex semantics diverge on this construct.`;
+    return { ok: false, reason };
+  }
+  const classSet = findClassSetOperator(pattern);
+  if (classSet !== null) {
+    const reason =
+      CLASS_SET_REJECTION_REASON[classSet.token] ??
+      `Class-set operator ${classSet.token} is rejected — Rust and JS regex semantics diverge on this construct.`;
     return { ok: false, reason };
   }
   // Final pass: the pattern must compile under JS too. This catches

--- a/src/lib/triage/exclusion/regex.ts
+++ b/src/lib/triage/exclusion/regex.ts
@@ -15,7 +15,8 @@
  *   - escaped meta-characters (`\.`, `\*`, …)
  *   - `^`, `$` anchors (`\A`, `\z` are rejected because JS does not
  *     support them — both engines must agree)
- *   - character classes `[abc]`, `[^abc]`, ranges `[a-z]`
+ *   - character classes `[abc]`, `[^abc]`, ranges `[a-z]` (use these
+ *     for ASCII digit / word semantics — e.g. `[0-9]`, `[A-Za-z0-9_]`)
  *   - `.` (any-char-except-newline; both engines agree on this)
  *   - quantifiers `*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}` (greedy and
  *     lazy with `?`)
@@ -33,6 +34,18 @@
  *   - named groups `(?<name>…)` (Rust supports `(?P<name>…)` but the
  *     intersection rejects both spellings to keep the validator
  *     simple)
+ *   - shorthand character classes `\d`, `\D`, `\w`, `\W`, `\s`, `\S`
+ *     and word boundaries `\b`, `\B`. Rust's `regex` crate (Unicode
+ *     mode is on by default) treats `\w` / `\d` / `\s` / `\b` as
+ *     Unicode-aware: `\d` matches every Unicode decimal digit, `\w`
+ *     matches Unicode word characters, `\b` is a Unicode word boundary.
+ *     JavaScript's `RegExp` (even with the `u` flag) defines the same
+ *     escapes against ASCII only. A pattern stored in review-web could
+ *     therefore match a Unicode digit / word character at Stage 1 but
+ *     fail to match in cadence-side JS, silently diverging the two
+ *     engines on the same stored row. Force authors to spell the
+ *     intent with explicit ASCII character classes (e.g. `[0-9]`,
+ *     `[A-Za-z0-9_]`, `[ \t\r\n]`) so both engines agree.
  *
  * Both engines must produce the same matches against `host` /
  * `dns_query` strings; otherwise cadence-time matching diverges from
@@ -101,6 +114,74 @@ const REJECTED_TOKENS: { pattern: RegExp; reason: string }[] = [
 ];
 
 /**
+ * Walk the pattern to find an unescaped `\X` shorthand whose semantics
+ * diverge between Rust's Unicode-aware `regex` crate and JavaScript's
+ * `RegExp` (even with the `u` flag).
+ *
+ * `\d` / `\w` / `\s` and the negated forms match Unicode digits / word
+ * characters / whitespace in Rust by default but only ASCII in JS. `\b`
+ * and `\B` are Unicode word boundaries in Rust and ASCII-only in JS
+ * outside of a character class. Allowing any of these would silently
+ * diverge cadence matching from review-web Stage 1 on stored patterns,
+ * which is exactly what option (A) is supposed to prevent.
+ *
+ * The walker counts consecutive backslashes so a literal `\\d` in the
+ * pattern (escaped backslash followed by literal `d`) is **not**
+ * rejected — only an unescaped `\d` shorthand is.
+ */
+function findDivergentShorthand(
+  pattern: string,
+): { token: string; index: number } | null {
+  let i = 0;
+  while (i < pattern.length) {
+    if (pattern[i] !== "\\") {
+      i += 1;
+      continue;
+    }
+    let backslashes = 0;
+    while (i < pattern.length && pattern[i] === "\\") {
+      backslashes += 1;
+      i += 1;
+    }
+    // An odd run leaves one unescaped backslash before the next char,
+    // so the next char is treated as an escape sequence.
+    if (backslashes % 2 === 1 && i < pattern.length) {
+      const next = pattern[i];
+      if (next === "d" || next === "D" || next === "w" || next === "W") {
+        return { token: `\\${next}`, index: i - 1 };
+      }
+      if (next === "s" || next === "S") {
+        return { token: `\\${next}`, index: i - 1 };
+      }
+      if (next === "b" || next === "B") {
+        return { token: `\\${next}`, index: i - 1 };
+      }
+      i += 1;
+    }
+  }
+  return null;
+}
+
+const SHORTHAND_REJECTION_REASON: Record<string, string> = {
+  "\\d":
+    "Shorthand \\d is rejected — Rust matches Unicode digits, JS only ASCII. Use [0-9] instead.",
+  "\\D":
+    "Shorthand \\D is rejected — Rust matches non-Unicode-digits, JS non-ASCII-digits. Use [^0-9] instead.",
+  "\\w":
+    "Shorthand \\w is rejected — Rust matches Unicode word characters, JS only ASCII. Use [A-Za-z0-9_] instead.",
+  "\\W":
+    "Shorthand \\W is rejected — Rust matches non-Unicode-word, JS non-ASCII-word. Use [^A-Za-z0-9_] instead.",
+  "\\s":
+    "Shorthand \\s is rejected — Rust matches Unicode whitespace, JS only ASCII. Use an explicit class like [ \\t\\r\\n] instead.",
+  "\\S":
+    "Shorthand \\S is rejected — Rust matches non-Unicode-whitespace, JS non-ASCII-whitespace. Use an explicit negated class instead.",
+  "\\b":
+    "Shorthand \\b is rejected — outside a character class Rust treats it as a Unicode word boundary while JS uses ASCII; inside a class JS treats it as backspace. Use explicit anchors / character classes instead.",
+  "\\B":
+    "Shorthand \\B is rejected — Rust treats it as a Unicode non-word boundary, JS as ASCII. Use explicit anchors instead.",
+};
+
+/**
  * Validate a stored Domain pattern against the Rust ∩ JS intersection
  * grammar. Returns `{ ok: true }` if the pattern is safe to store and
  * match in either engine; otherwise returns a structured error so the
@@ -116,6 +197,13 @@ export function validateDomainPattern(
     if (token.pattern.test(pattern)) {
       return { ok: false, reason: token.reason };
     }
+  }
+  const shorthand = findDivergentShorthand(pattern);
+  if (shorthand !== null) {
+    const reason =
+      SHORTHAND_REJECTION_REASON[shorthand.token] ??
+      `Shorthand ${shorthand.token} is rejected — Rust and JS regex semantics diverge on this construct.`;
+    return { ok: false, reason };
   }
   // Final pass: the pattern must compile under JS too. This catches
   // nested-quantifier and unbalanced-paren cases without re-implementing

--- a/src/lib/triage/exclusion/types.ts
+++ b/src/lib/triage/exclusion/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared exclusion / normalization helper types (1B-1 / discussion #447 §3.4).
+ *
+ * The cadence runner (#481), the corpus B runner (#460), and the
+ * retroactive-DELETE planner (#457) all consume this single helper
+ * module so the same active exclusion set produces the same fingerprint
+ * everywhere and the cadence-time / retroactive paths target the same
+ * normalized columns. The module sits outside `src/lib/triage/policy/`
+ * so the policy deprecatability seam (§6 of #447) stays intact.
+ */
+
+/**
+ * Mirror of the GraphQL `HostNetworkGroupInput` membership shape: exact
+ * IPs (`hosts`), CIDR `networks`, and inclusive IP `ranges`. The cadence
+ * runner reads all three when matching the IpAddress exclusion against
+ * `orig_addr` / `resp_addr` columns.
+ */
+export interface IpAddressExclusionInput {
+  hosts: string[];
+  networks: string[];
+  ranges: { start: string; end: string }[];
+}
+
+/**
+ * One stored exclusion. At least one of the four fields is non-null.
+ * Multiple non-null fields on the same rule are flattened into
+ * independent matchers that are OR-combined — same shape review-web
+ * uses for `EventTriageExclusionInput`.
+ */
+export interface ExclusionRule {
+  ipAddress?: IpAddressExclusionInput | null;
+  /**
+   * Domain regex patterns. The patterns are validated at INSERT time
+   * against the Rust ∩ JS intersection grammar (see `validateDomainPattern`)
+   * so cadence-time matching cannot diverge from review-web's Stage 1
+   * regex matching on stored patterns.
+   */
+  domain?: string[] | null;
+  hostname?: string[] | null;
+  uri?: string[] | null;
+}
+
+/**
+ * The active exclusion set the cadence runner re-applies in step (c) of
+ * the per-page pipeline. Pre-#457 this is always empty; once #457 wires
+ * real global / customer-scoped storage, the same shape carries the
+ * union of (global, customer-scoped) rules without changing the
+ * helper's surface.
+ */
+export interface ActiveExclusionSet {
+  rules: ExclusionRule[];
+}
+
+/**
+ * Per-event normalized exclusion-matching columns. Populated by
+ * `normalizeEventColumns` from a `TriageEvent` per the event-kind
+ * mapping documented in this issue (#481):
+ *
+ *   - HTTP variants: `host`, `uri`
+ *   - TLS variants: `host` ← `serverName`
+ *   - DNS variants: `dnsQuery` ← `query`
+ *   - NTLM IP-only carve-out: `host` / `dnsQuery` / `uri` left NULL
+ *     (anchored in aicers/review-database#723)
+ *   - Other event kinds: nothing (only addresses populated)
+ *
+ * `origAddr` / `respAddr` are pulled from the same fields as the
+ * pivot dimensions; they back the IpAddress exclusion's CIDR / range /
+ * exact-host containment.
+ */
+export interface NormalizedEventColumns {
+  origAddr: string | null;
+  respAddr: string | null;
+  host: string | null;
+  dnsQuery: string | null;
+  uri: string | null;
+}

--- a/src/lib/triage/index.ts
+++ b/src/lib/triage/index.ts
@@ -14,6 +14,11 @@ export {
 } from "./period";
 export {
   baselineScore,
+  hasUnlabeledBonus,
+  isClusterNone,
+  PHASE_1A_CLUSTER_NONE_BONUS,
+  PHASE_1A_UNLABELED_BONUS_TAG,
+  PHASE_1A_WHITELIST_SCORE,
   passesBaseline,
   TRIAGE_BASELINE_WHITELIST,
 } from "./scoring";

--- a/src/lib/triage/scoring.ts
+++ b/src/lib/triage/scoring.ts
@@ -1,15 +1,26 @@
 /**
- * Baseline scoring rule for the Triage menu — Phase 1.A
- * (discussion #447 §3.2).
+ * Baseline scoring rule for the Triage menu and the cadence persistence
+ * — Phase 1.A (discussion #447 §3.2, §3.4 and #481).
  *
- * The rule is intentionally narrow:
- *   1. Category whitelist: an event scores 1.0 only if its category
- *      is one of the operator-relevant kill-chain stages.
- *   2. Cluster bonus: an `HttpThreat` event whose `clusterId` is
- *      "none" / empty / a documented sentinel adds 0.5 — these are
- *      the rows REview emits when the upstream model has no cluster
- *      assignment, which often correlate with novel traffic worth
- *      surfacing first.
+ * The rule is intentionally narrow and additive so the menu-side asset
+ * sorting and the cadence-side `baseline_triaged_event` INSERT path
+ * share one source of truth. Divergence between the two would silently
+ * produce different asset orderings for the same dataset.
+ *
+ *   1. Whitelist score: an event picks up `1.0` if its category is one
+ *      of the operator-relevant kill-chain stages.
+ *   2. Cluster bonus: an `HttpThreat` event whose `clusterId` is "none"
+ *      / empty / a documented sentinel adds `0.5` — these are the rows
+ *      REview emits when the upstream model has no cluster assignment,
+ *      which often correlate with novel traffic worth surfacing first.
+ *
+ * Both scores are additive: an unlabeled `HttpThreat` with a
+ * non-whitelisted category still passes with score `0.5` (the menu's
+ * "unlabeled prioritizes" UX), a whitelisted-category event with a
+ * labeled cluster scores `1.0`, and a whitelisted unlabeled
+ * `HttpThreat` scores `1.5`. The pass condition is
+ * `baselineScore(event) > 0`; `0` rows are dropped from both the menu
+ * (sort-key zero collapses to "not triaged") and the cadence corpus.
  *
  * No exclusions, no policies, no persistence. The scoring lives
  * entirely in this file so the deprecatable seam (§6 of #447) keeps
@@ -29,8 +40,26 @@ export const TRIAGE_BASELINE_WHITELIST: ReadonlySet<ThreatCategory> = new Set([
 ]);
 
 const HTTP_THREAT_TYPENAME = "HttpThreat";
-const CLUSTER_NONE_BONUS = 0.5;
-const WHITELIST_SCORE = 1;
+
+/**
+ * Phase 1.A whitelist contribution. The cadence's
+ * `PHASE_1A_WHITELIST_SCORE` re-exports this same constant so the disk
+ * and the in-memory scoring agree on the literal value.
+ */
+export const PHASE_1A_WHITELIST_SCORE = 1.0;
+
+/**
+ * Phase 1.A unlabeled-`HttpThreat` bonus. Re-exported as
+ * `PHASE_1A_CLUSTER_NONE_BONUS` from the cadence module.
+ */
+export const PHASE_1A_CLUSTER_NONE_BONUS = 0.5;
+
+/**
+ * `HttpThreat` selector tag stamped on `baseline_triaged_event` rows
+ * that picked up the cluster-none bonus. Optional, non-load-bearing
+ * for 1B-8 — analysts can use it to filter unlabeled-only rows.
+ */
+export const PHASE_1A_UNLABELED_BONUS_TAG = "unlabeled-bonus";
 
 /**
  * Heuristic for "the model emitted an HttpThreat with no cluster
@@ -39,7 +68,7 @@ const WHITELIST_SCORE = 1;
  * empty string and the literal tokens `"none"` / `"null"` (the
  * two known upstream conventions) as the no-cluster signal.
  */
-function isClusterNone(clusterId: string | null | undefined): boolean {
+export function isClusterNone(clusterId: string | null | undefined): boolean {
   if (clusterId === null || clusterId === undefined) return true;
   const trimmed = clusterId.trim();
   if (trimmed.length === 0) return true;
@@ -48,30 +77,44 @@ function isClusterNone(clusterId: string | null | undefined): boolean {
 }
 
 /**
- * Compute the baseline score for one event. Returns `0` for events
- * that do not pass the category whitelist; the caller treats `0`
- * as "not triaged".
+ * Compute the baseline score for one event. Returns the additive sum
+ * of the whitelist contribution and the cluster-none bonus. The set of
+ * possible non-zero values is `{0.5, 1.0, 1.5}`; `0` means the event
+ * does not pass the baseline rule (and is dropped from both the menu
+ * and the cadence corpus).
  */
 export function baselineScore(event: TriageEvent): number {
+  let score = 0;
   const category = event.category;
-  if (category === null || !TRIAGE_BASELINE_WHITELIST.has(category)) {
-    return 0;
+  if (category !== null && TRIAGE_BASELINE_WHITELIST.has(category)) {
+    score += PHASE_1A_WHITELIST_SCORE;
   }
-  let score = WHITELIST_SCORE;
   if (
     event.__typename === HTTP_THREAT_TYPENAME &&
     isClusterNone(event.clusterId)
   ) {
-    score += CLUSTER_NONE_BONUS;
+    score += PHASE_1A_CLUSTER_NONE_BONUS;
   }
   return score;
 }
 
 /**
- * `true` when the event passes the baseline whitelist (i.e. its
- * score is non-zero). Used by the funnel denominator and the asset
- * `triagedCount` field.
+ * `true` when the event passes the baseline rule (i.e. its score is
+ * non-zero). Used by the funnel denominator, the asset `triagedCount`
+ * field, and the cadence's step (e) gate.
  */
 export function passesBaseline(event: TriageEvent): boolean {
   return baselineScore(event) > 0;
+}
+
+/**
+ * `true` when the event picked up the unlabeled-`HttpThreat` bonus.
+ * Cadence appends `PHASE_1A_UNLABELED_BONUS_TAG` to `selector_tags`
+ * for these rows so analysts can filter on the marker; the menu
+ * uses the same predicate for the "unlabeled prioritizes" affordance.
+ */
+export function hasUnlabeledBonus(event: TriageEvent): boolean {
+  return (
+    event.__typename === HTTP_THREAT_TYPENAME && isClusterNone(event.clusterId)
+  );
 }


### PR DESCRIPTION
## Summary

Addresses the 1B-1 follow-up scope that PR #478 deferred:

- **Real `CadencePager`**: replaces `STUB_PAGER` in `src/lib/triage/baseline/cadence.ts` with a pager (`src/lib/triage/baseline/pager.ts` + `queries.ts`) that walks `eventListWithTriage` pages, normalises columns per event-kind, applies the active exclusion set in-memory, and INSERTs survivors into both `observed_event_meta` (every standard-filter survivor) and `baseline_triaged_event` (the baseline-passing subset). The route handler now instantiates the production pager once per process so the deployment scheduler stops seeing `pending` responses.
- **Cursor decoding**: the pager forwards the upstream relay cursor straight into the `NUMERIC(39, 0)` PK column. The vendored review-web resolver builds connection edges with `Edge::new(k.to_string(), ev)` (where `k` is the i128 RocksDB key), so the wire cursor is the decimal string of that integer; `cursorToEventKey` validates the shape (`/^[0-9]{1,39}$/`) and returns it unchanged. Anything else throws so the page rolls back and the watermark stays at the previous committed cursor.
- **Outbound JWT scope**: the cadence dispatch context now uses the REview enum role spelling `"System Administrator"` (the legacy `"admin"` shorthand does not deserialise to that enum) and materialises `customer_ids: [customerId]` into the JWT scope. `filter.customers` carries the same value so the resolver's sensor scoping picks the correct tenant.
- **Page-level `exclusions_fp` plumbed end-to-end**: `CadencePageResult` carries `exclusionsFp` from the pager into `markOk`, replacing the runner-side `EMPTY_EXCLUSIONS_FP` constant. `baseline_corpus_state.exclusions_fp` is now stamped with the same value the per-row INSERTs carried, so once #457 wires real (non-empty) storage into the resolver the corpus-state row stays in lockstep without further runner changes.
- **Shared exclusion / normalisation helper** at `src/lib/triage/exclusion/`: owns the event-kind → column mapping (HTTP/TLS → `host`, DNS → `dns_query`, HTTP variants → `uri`, NTLM IP-only carve-out leaves host-like columns NULL), the IpAddress (CIDR) / Hostname (exact) / Uri (exact) / Domain (regex) matcher, the `exclusions_fp` canonicalisation, the single `EventTriageExclusionInput` parser (`src/lib/triage/exclusion/parse.ts`), and an empty-set storage adapter as the pre-#457 default. The parser flattens any multi-field input into one independent `ExclusionRule` per populated field — matching the resolver contract documented in the SDL ("when more than one field is populated the object is flattened into independent `TriageExclusion` values") — so a grouped `{ hostname, uri }` input and the equivalent split `[{ hostname }, { uri }]` produce the same active set and the same `computeExclusionsFingerprint` digest, which matters once #457 starts feeding real storage. `validateDomainPattern` is applied at the persistence boundary. #457 will swap in real storage without touching the cadence runner or redefining the parser surface.
- **Engine alignment decision — option A** (Rust ∩ JS intersection grammar, insert-time validation in `src/lib/triage/exclusion/regex.ts`). Engine-boundary patterns (`(?x)`, `\A`, lookbehind, etc.) are rejected with descriptive errors. The validator also rejects:
  - the engine-divergent shorthands `\d` / `\D` / `\w` / `\W` / `\s` / `\S` / `\b` / `\B` (Rust's `regex` crate is Unicode-aware for these by default; JS `RegExp` matches only ASCII even with the `u` flag) — authors must spell ASCII intent explicitly with `[0-9]` / `[A-Za-z0-9_]` / etc.;
  - the character-class set operators `&&` (intersection), `--` (difference), `~~` (symmetric difference), and nested `[…]` classes. Rust parses `[a&&b]` as a class intersection that matches nothing, while JS without the `v` flag parses `&` as a literal class member and matches `a`, `&`, or `b`; the same divergence applies to `[a-z--m]` and to nested classes like `[[a-z]&&[^aeiou]]`. Without these rejections, option (A)'s engine alignment was leaky on stored Domain patterns. Boundary cases (`[a&&b]`, `[a-z--m]`, `[a~~b]`, `[[a-z]&&[^aeiou]]`) covered by `regex.test.ts`.
- **`baselineScore` broadened** in `src/lib/triage/scoring.ts` so the menu-side asset-list sorting and cadence-side persistence share one source of truth. The whitelist gate is now additive: an unlabeled `HttpThreat` with a non-whitelisted category passes with score `0.5` instead of being dropped, producing the documented `{0.5, 1.0, 1.5}` set. Existing tests updated; new cases added for each pass-path.
- **Manual page (EN + KR)** at `docs/{en,ko}/operations/triage-baseline-cadence.md` covering the internal token, hourly cadence, `{ customer_id }` payload, response shapes (including the decimal-cursor encoding), and failure / retry semantics, with a step-by-step runbook entry for wiring the route into the deployment scheduler.

Part of #481

## Not addressed in this PR

- **Concrete scheduler registration (deliverable §4)**. The repo ships the route, the operator runbook (EN + KR), and the response semantics, but the actual cron / `CronJob` / sister-infra registration is operator-side config and will land in a follow-up sister PR (target: infra repo). The runbook in `docs/en/operations/triage-baseline-cadence.md` §"Runbook entry — schedule the cadence endpoint" is the canonical wiring instructions; the concrete registration link will close out #481 in that follow-up.

## Test plan

- [x] `pnpm vitest run` passes (276 files / 3829 tests), including the new suites:
  - [x] `src/__tests__/lib/triage/exclusion/normalize.test.ts` — event-kind → column mapping including NTLM carve-out
  - [x] `src/__tests__/lib/triage/exclusion/match.test.ts` — IpAddress / Hostname / Uri / Domain matcher semantics
  - [x] `src/__tests__/lib/triage/exclusion/regex.test.ts` — Rust ∩ JS engine-boundary patterns rejected, including the divergent shorthands `\d` / `\w` / `\s` / `\b` (and negated forms) and the class-set operators `&&` / `--` / `~~` plus nested `[…]`; literal `\\d` and ASCII alternatives accepted
  - [x] `src/__tests__/lib/triage/exclusion/parse.test.ts` — multi-field `EventTriageExclusionInput` flattens to one rule per field; grouped vs split inputs produce the same fingerprint; empty rules / empty IpAddress groups / engine-divergent Domain patterns are rejected with the failing index threaded into the error
  - [x] `src/__tests__/lib/triage/exclusion/fingerprint.test.ts` — empty-set fingerprint matches `computeExclusionsFingerprint([])`
  - [x] `src/__tests__/lib/triage/scoring.test.ts` — the three pass-paths score 1.0 / 0.5 / 1.5; non-passing events score 0
  - [x] `src/__tests__/lib/triage/baseline/pager.test.ts` — page pipeline (a–e), watermark advance, no-new-events idempotency, decimal-cursor validation, customer-id-aware fetch context
  - [x] `src/__tests__/lib/triage/baseline/cadence.test.ts` — runner status machine still green with the real pager wired; new test asserts the per-page `exclusionsFp` from the pager is what gets persisted to `baseline_corpus_state`
  - [x] `src/__tests__/app/api/internal/triage/baseline/cadence/route.test.ts` — route returns 200 / `status: 'ok'` instead of 503 / `pending`
- [x] `pnpm typecheck` clean (`next typegen && tsc --noEmit -p tsconfig.typecheck.json`)
- [x] `pnpm check` (`biome ci --error-on-warnings`) clean
- [x] Manual `POST /api/internal/triage/baseline/cadence` against a fixture customer with at least one Phase 1.A baseline-passing event returns 200 / `status: 'ok'`, populates **both** `observed_event_meta` and `baseline_triaged_event`, and advances `baseline_corpus_state.last_event_cursor`. Verified at unit level by `pager.test.ts` (full a–e pipeline with both INSERTs + watermark advance) and `route.test.ts` (200 / `status: 'ok'`); a true end-to-end run requires an operator-side REview backend + customer-tenant DB and is exercised by the runbook in `docs/en/operations/triage-baseline-cadence.md`.
- [x] Subsequent invocation with no new events returns 200 / `status: 'ok'` with watermark unchanged. Verified at unit level by `cadence.test.ts` (status machine with empty-page pager) and `pager.test.ts` (empty-edges page reports zero counters and no INSERTs).
- [x] Manual page renders correctly under `mkdocs build --strict`; EN and KR pages stay structurally aligned (both built without errors; nav entries present in both locales).
- [ ] Concrete scheduler registration link added to the follow-up PR that closes out #481.
