### PR TITLE
Wire Triage baseline cadence cron and dispatcher (#487)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,10 +211,13 @@ TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN=
 # Total dispatcher timeout in milliseconds (#487). When the
 # overall deadline passes, customers not yet attempted are
 # reported as `skipped-timeout` and the next hourly tick picks
-# them up. Keep `infra/cron/run-triage-baseline-dispatch.sh`'s
-# `--max-time` equal to this value so the application-level
-# timeout wins over the network-level timeout. Default 2700000
-# (45 minutes).
+# them up. The in-repo cron service allowlists this var into its
+# job environment (`infra/cron/entrypoint.sh`) and the wrapper
+# (`infra/cron/run-triage-baseline-dispatch.sh`) derives its
+# `--max-time` from it (ms → s, rounded up), so raising this
+# knob also raises the wrapper's network ceiling automatically.
+# Must stay below the hourly cron interval (3600s = 3600000ms).
+# Default 2700000 (45 minutes).
 # TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS=2700000
 
 # Override the base URL the in-repo cron service hits for the

--- a/.env.example
+++ b/.env.example
@@ -186,4 +186,39 @@ APPLY_INTERNAL_CLEANUP_TOKEN=
 # body `{ "customer_id": <positive integer> }`. Invoked hourly
 # per customer to drive corpus A ingestion (1B-1). If unset,
 # the route refuses every request.
+#
+# The same token also guards POST /api/internal/triage/baseline/dispatch
+# (the in-repo `cron` service's hourly fan-out — #487). Both routes
+# run as system actors against the same cadence runner; a separate
+# token would only add operational moving parts without isolating
+# any privilege boundary.
 TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN=
+
+# Triage baseline dispatcher concurrency cap (#487). Limits how
+# many per-customer cadence passes the dispatcher runs in
+# parallel per hourly tick. Default 4. Bump cautiously — each
+# concurrent slot opens its own connection in the customer-tenant
+# DB pool and runs an upstream REview fetch.
+# TRIAGE_BASELINE_DISPATCH_CONCURRENCY=4
+
+# Per-customer hard timeout for the dispatcher in milliseconds
+# (#487). On expiry the dispatcher's AbortSignal fires; the
+# cadence runner rolls back the in-flight page transaction and
+# the per-customer entry reports `status: 'timeout'`. Default
+# 900000 (15 minutes).
+# TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS=900000
+
+# Total dispatcher timeout in milliseconds (#487). When the
+# overall deadline passes, customers not yet attempted are
+# reported as `skipped-timeout` and the next hourly tick picks
+# them up. Keep `infra/cron/run-triage-baseline-dispatch.sh`'s
+# `--max-time` equal to this value so the application-level
+# timeout wins over the network-level timeout. Default 2700000
+# (45 minutes).
+# TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS=2700000
+
+# Override the base URL the in-repo cron service hits for the
+# dispatcher route. Defaults to `http://next-app:3000` — the
+# compose-network name of the `next-app` service. Override only
+# if running the cron container against a non-default network.
+# NEXT_APP_BASE_URL=http://next-app:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,21 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    # Cheap liveness probe gating the `cron` service (#487 §1). The
+    # node:24-bookworm-slim runner does not ship `curl`; the `node -e
+    # fetch(...)` form avoids adding a package to the image. The
+    # endpoint (`/api/health`) intentionally makes no DB call so a
+    # transient upstream blip cannot mask the readiness signal.
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://localhost:3000/api/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
 
   nginx-prod:
     image: nginx:alpine
@@ -60,6 +75,30 @@ services:
     depends_on:
       - next-app
 
+  # In-repo cron service (#487). Hosts every internal-API hourly
+  # trigger for this deployment — currently the Triage baseline
+  # dispatcher, with future cleanup / retention endpoints adding their
+  # own crontab entries. Single service shared across triggers so the
+  # readiness gate / env-passthrough plumbing lives in exactly one
+  # place.
+  cron:
+    build:
+      context: ./infra/cron
+      dockerfile: Dockerfile
+    profiles: [prod]
+    env_file:
+      - .env
+    depends_on:
+      next-app:
+        condition: service_healthy
+    # Persist /var/log/cron across restarts so the timestamped
+    # response bodies survive a `docker compose down`. Operators
+    # inspecting a partial-success incident the next morning need the
+    # full body; the docker logs surface only the one-line summary.
+    volumes:
+      - cron-logs:/var/log/cron
+
 volumes:
   pgdata:
   next-app-data:
+  cron-logs:

--- a/docs/en/operations/triage-baseline-cadence.md
+++ b/docs/en/operations/triage-baseline-cadence.md
@@ -147,7 +147,7 @@ Response:
 | `ok` | cadence runner | Normal successful pass; rows ingested, watermark advanced. |
 | `skipped` | cadence runner | Advisory lock held by a concurrent run, or no new pages — normal "nothing to do". |
 | `failed` | cadence runner | Cadence transaction rolled back; `error` populated. |
-| `timeout` | dispatcher | Per-customer call exceeded `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS` (default 15 min). The dispatcher cancelled the runner via `AbortSignal`; the in-flight page rolled back. |
+| `timeout` | dispatcher | Per-customer call exceeded its effective timeout — the lesser of `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS` (default 15 min) and the remaining total-dispatcher budget. The dispatcher cancelled the runner via `AbortSignal`; the in-flight page rolled back. The total budget bound also applies to already-running customers when the dispatcher's overall deadline elapses, so the dispatcher always returns within `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`. |
 | `skipped-timeout` | dispatcher | Total dispatcher timeout (`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, default 45 min) reached before this customer was attempted; the next hourly tick picks them up. |
 
 `overall` is derived deterministically:

--- a/docs/en/operations/triage-baseline-cadence.md
+++ b/docs/en/operations/triage-baseline-cadence.md
@@ -105,44 +105,146 @@ The runner recognises one specific recovery shape:
   two of our page commits causes a clean stop at the last
   committed watermark and `status: 'ok'` with the partial counters.
 
+## Dispatcher route — `POST /api/internal/triage/baseline/dispatch`
+
+The hourly fan-out lives behind a sibling route the in-repo `cron`
+service hits exactly once per tick. The dispatcher enumerates active
+customers (`SELECT id FROM customers WHERE status = 'active'`) and
+runs one cadence pass per customer with bounded concurrency and a
+per-customer timeout. The per-customer route stays unchanged —
+operators can still POST `{customer_id: N}` for a single-customer
+manual run.
+
+```text
+POST /api/internal/triage/baseline/dispatch
+Authorization: Bearer <TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN>
+Content-Type: application/json
+
+(no body)
+```
+
+Response:
+
+```json
+{
+  "overall": "ok",
+  "perCustomer": [
+    {
+      "customerId": 1,
+      "status": "ok",
+      "observedInserted": 142,
+      "baselineInserted": 9,
+      "lastEventCursor": "1234567890123456789"
+    }
+  ]
+}
+```
+
+`perCustomer[].status` is closed:
+
+| Value | Source | Meaning |
+| :-- | :-- | :-- |
+| `ok` | cadence runner | Normal successful pass; rows ingested, watermark advanced. |
+| `skipped` | cadence runner | Advisory lock held by a concurrent run, or no new pages — normal "nothing to do". |
+| `failed` | cadence runner | Cadence transaction rolled back; `error` populated. |
+| `timeout` | dispatcher | Per-customer call exceeded `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS` (default 15 min). The dispatcher cancelled the runner via `AbortSignal`; the in-flight page rolled back. |
+| `skipped-timeout` | dispatcher | Total dispatcher timeout (`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, default 45 min) reached before this customer was attempted; the next hourly tick picks them up. |
+
+`overall` is derived deterministically:
+
+- `ok` ⇔ every per-customer status is `ok` or `skipped` (a normal
+  skip is part of the steady state, not a failure).
+- `partial` ⇔ at least one per-customer status is `failed`,
+  `timeout`, or `skipped-timeout`, and the dispatcher itself
+  completed.
+- `failed` (HTTP 500) ⇔ the dispatcher itself failed (e.g. customer
+  enumeration query errored). `perCustomer` may be empty.
+
+A single customer's failure does not abort the others — the
+dispatcher reports `partial` and continues.
+
 ## Runbook entry — schedule the cadence endpoint
 
-Add the cadence route to the deployment scheduler in your release
-runbook. The recommended cadence is **once per hour per customer**
-(per discussion #447 §3.4). Hourly cadence keeps the corpus warm
-without doubling the resolver load — the per-page commit + cursor
-advance lets the next tick pick up from where the previous one
-stopped, so a transient outage of one or two cycles is harmless.
+**The `cron` service in `docker-compose.yml` already wires this** —
+see `infra/cron/crontab` for the entry and
+`infra/cron/run-triage-baseline-dispatch.sh` for the wrapper script.
+A `docker compose --profile prod up -d` boot is sufficient to start
+the hourly cadence; no external scheduler config is required.
+
+The cron service depends on `next-app` becoming healthy (the
+`/api/health` readiness gate) before firing its first tick, so a
+half-up backend cannot receive a dispatcher request. The wrapper
+script captures every response body to
+`/var/log/cron/cron-cadence-<ts>.json` inside the cron container
+(persisted via the `cron-logs` named volume) and emits a one-line
+summary to stdout per invocation that `docker compose logs cron`
+surfaces.
+
+Operators running outside the bundled compose may use the same
+dispatcher route from any external scheduler. Recommended cadence is
+**once per hour** (the dispatcher fans out per-customer internally):
+
+```bash
+curl -sS -o /tmp/dispatch.json -w '%{http_code}\n' \
+  --connect-timeout 10 --max-time 2700 \
+  -X POST \
+  -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '' \
+  "$BFF_BASE_URL/api/internal/triage/baseline/dispatch"
+```
+
+Per-customer manual runs still go through the cadence route:
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  "$BFF_BASE_URL/api/internal/triage/baseline/cadence" \
+  -d '{"customer_id": 1}'
+```
+
+Initial provisioning checklist:
 
 1. Provision a strong random token for
    `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`. Store it in your
    secrets manager, rotate on a normal cadence, never check it in.
-2. Set the env var on every BFF instance and on the scheduler that
-   calls the route. The route refuses every request when the env
-   var is unset, so the scheduler must explicitly load it before
-   the first tick.
-3. Wire a recurring caller (cron, Kubernetes `CronJob`, GitHub
-   Actions schedule, etc.) that issues, once per hour per
-   customer:
+2. Set the env var in `.env` (the `cron` service inherits the same
+   `env_file: .env` as `next-app`). The route refuses every
+   request when the env var is unset, so the dispatcher must
+   explicitly load it before the first tick.
+3. Verify the first scheduled run by `docker compose logs cron` and
+   tailing the timestamped response body under `/var/log/cron/`.
+   A healthy first run on a quiet deployment reports modest
+   counters; a `status: 'skipped'` on a first run after an
+   interrupted tick is expected (the previous run is still
+   finishing) and resolves on the subsequent pass.
 
-    ```bash
-    curl -fsS -X POST \
-      -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
-      -H "Content-Type: application/json" \
-      "$BFF_BASE_URL/api/internal/triage/baseline/cadence" \
-      -d '{"customer_id": 1}'
-    ```
+## Monitoring
 
-    If you operate multiple customer-tenant DBs, fan out one HTTP
-    call per `customer_id` per hour. Per-customer advisory locks
-    let independent customers run concurrently.
+`200 / overall: 'partial'` is HTTP-success — a naive `curl -fsS`
+would treat it as fine. To prevent silent partial failures from
+accumulating, **alert on `overall != 'ok'`**. There are three
+keying surfaces:
 
-4. Verify the first scheduled run by tailing the scheduler logs
-   and confirming the JSON body parses cleanly. A healthy first
-   run on a quiet deployment usually reports modest counters; a
-   `status: 'skipped'` on a first run after an interrupted tick
-   is expected (the previous run is still finishing) and should
-   resolve on the subsequent pass.
+1. The dispatcher emits one structured `console.log` line per
+   invocation tagged `triage_baseline_dispatch` carrying `overall`,
+   per-customer status counts, and per-customer counters. This is
+   the canonical line; key your alerting on it.
+2. The cron wrapper script (`run-triage-baseline-dispatch.sh`)
+   re-emits a human-readable warning to stderr on `overall != 'ok'`,
+   which surfaces in `docker compose logs cron`.
+3. `baseline_corpus_state.last_run_status` per customer captures
+   the most recent terminal status; a sweep that finds any row
+   with `last_run_status = 'failed'` older than 1 hour is a
+   confirmed problem.
+
+The wrapper script intentionally exits 0 on `overall: 'partial'` so
+cron's MAILTO does not double-page — alerting on the structured log
+line is the recovery path. Auth misconfiguration (HTTP 401/403) and
+transport failures (DNS, connection refused, `--max-time` reached)
+do exit non-zero, since those are operator errors that need
+immediate attention.
 
 ## Observability
 

--- a/docs/en/operations/triage-baseline-cadence.md
+++ b/docs/en/operations/triage-baseline-cadence.md
@@ -241,7 +241,12 @@ keying surfaces:
 1. The dispatcher emits one structured `console.log` line per
    invocation tagged `triage_baseline_dispatch` carrying `overall`,
    per-customer status counts, and per-customer counters. This is
-   the canonical line; key your alerting on it.
+   the canonical line; key your alerting on it. The same line is
+   also emitted on dispatcher self-failure (e.g. customer
+   enumeration error or enumeration-timeout) with
+   `overall: 'failed'`, an empty `perCustomer`, all counters at 0,
+   and an `error` field — so a single alert rule on
+   `overall != 'ok'` catches both partial and self-failure cases.
 2. The cron wrapper script (`run-triage-baseline-dispatch.sh`)
    re-emits a human-readable warning to stderr on `overall != 'ok'`,
    which surfaces in `docker compose logs cron`.

--- a/docs/en/operations/triage-baseline-cadence.md
+++ b/docs/en/operations/triage-baseline-cadence.md
@@ -194,6 +194,17 @@ curl -sS -o /tmp/dispatch.json -w '%{http_code}\n' \
   "$BFF_BASE_URL/api/internal/triage/baseline/dispatch"
 ```
 
+Keep `--max-time` at-or-above the dispatcher total timeout
+(`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, default 2700000ms =
+2700s), so the application-level timeout — which produces the
+structured `timeout` / `skipped-timeout` rows — wins over the
+network-level timeout (which surfaces as a transport failure with
+no body). The bundled cron wrapper derives `--max-time` from
+`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS` automatically, so the
+two values stay in sync as long as both are set in the same `.env`.
+External schedulers must update their cap manually whenever the
+dispatcher knob is retuned.
+
 Per-customer manual runs still go through the cadence route:
 
 ```bash

--- a/docs/ko/operations/triage-baseline-cadence.md
+++ b/docs/ko/operations/triage-baseline-cadence.md
@@ -146,7 +146,7 @@ Content-Type: application/json
 | `ok` | 케이던스 러너 | 정상 성공 패스 — 행이 인제스트되고 워터마크가 진행됨. |
 | `skipped` | 케이던스 러너 | 동시 실행이 어드바이저리 락을 보유 중이거나 신규 페이지가 없음. 정상적인 "할 일 없음" 상태. |
 | `failed` | 케이던스 러너 | 케이던스 트랜잭션이 롤백됨. `error` 필드 채워짐. |
-| `timeout` | 디스패처 | 고객별 호출이 `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS`(기본 15분)을 초과. 디스패처가 `AbortSignal`로 러너를 취소했고, 진행 중이던 페이지가 롤백됨. |
+| `timeout` | 디스패처 | 고객별 호출이 유효 타임아웃을 초과 — `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS`(기본 15분)와 남은 디스패처 전체 예산 중 더 작은 값. 디스패처가 `AbortSignal`로 러너를 취소했고, 진행 중이던 페이지가 롤백됨. 이 전체 예산 한도는 디스패처 전체 데드라인이 만료될 때 이미 실행 중인 고객에도 적용되어, 디스패처는 항상 `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS` 내에 반환됨. |
 | `skipped-timeout` | 디스패처 | 디스패처 전체 타임아웃(`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, 기본 45분) 도달 전에 이 고객은 시도되지 않음. 다음 시간당 틱이 처리. |
 
 `overall`은 결정적으로 도출됩니다.

--- a/docs/ko/operations/triage-baseline-cadence.md
+++ b/docs/ko/operations/triage-baseline-cadence.md
@@ -234,7 +234,11 @@ curl -fsS -X POST \
 1. 디스패처가 호출당 `triage_baseline_dispatch` 태그가 붙은 한 줄의
    구조화된 `console.log` 라인을 출력하며, `overall`, 고객별 상태
    카운트, 고객별 카운터를 포함합니다. 이것이 정식 라인이며 알림은
-   여기에 키잉합니다.
+   여기에 키잉합니다. 디스패처 자체 실패(예: 고객 열거 오류 또는
+   열거 타임아웃)에서도 동일한 라인이 `overall: 'failed'`, 비어 있는
+   `perCustomer`, 모든 카운터 0, `error` 필드와 함께 출력되므로,
+   `overall != 'ok'` 단일 알림 규칙으로 부분 실패와 자체 실패 양쪽을
+   모두 잡을 수 있습니다.
 2. cron 래퍼 스크립트(`run-triage-baseline-dispatch.sh`)가
    `overall != 'ok'`일 때 stderr로 사람이 읽을 수 있는 경고를
    재출력하며, 이는 `docker compose logs cron`에 표시됩니다.

--- a/docs/ko/operations/triage-baseline-cadence.md
+++ b/docs/ko/operations/triage-baseline-cadence.md
@@ -190,7 +190,15 @@ curl -sS -o /tmp/dispatch.json -w '%{http_code}\n' \
   "$BFF_BASE_URL/api/internal/triage/baseline/dispatch"
 ```
 
-고객별 수동 실행은 여전히 케이던스 라우트를 사용합니다.
+`--max-time`은 디스패처 전체 타임아웃
+(`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, 기본 2700000ms =
+2700s) 이상으로 유지하십시오. 그래야 구조화된 `timeout` /
+`skipped-timeout` 행을 만드는 애플리케이션 레벨 타임아웃이,
+본문 없는 전송 실패로 표면화되는 네트워크 레벨 타임아웃을
+앞섭니다. 번들된 cron 래퍼는 `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`
+값에서 `--max-time`을 자동으로 도출하므로 두 값이 같은 `.env`에
+설정된 한 자동으로 동기화됩니다. 외부 스케줄러를 사용하는 경우
+디스패처 노브를 재조정할 때 캡 값을 직접 갱신해야 합니다.
 
 ```bash
 curl -fsS -X POST \

--- a/docs/ko/operations/triage-baseline-cadence.md
+++ b/docs/ko/operations/triage-baseline-cadence.md
@@ -105,42 +105,140 @@ pg_try_advisory_xact_lock(hashtext('triage_baseline_cadence:' || customer_id))
   획득해 가져가는 경우, 마지막으로 커밋된 워터마크에서 깨끗하게
   멈추고 부분 카운터와 함께 `status: 'ok'`를 반환합니다.
 
+## 디스패처 라우트 — `POST /api/internal/triage/baseline/dispatch`
+
+시간당 팬아웃은 시간당 한 번씩 in-repo `cron` 서비스가 호출하는
+형제 라우트가 처리합니다. 디스패처는 활성 고객을 열거하고
+(`SELECT id FROM customers WHERE status = 'active'`), 고객당 한 번의
+케이던스 패스를 제한된 동시성과 고객별 타임아웃으로 실행합니다.
+고객별 라우트는 변경되지 않으며, 운영자는 단일 고객 수동 실행을
+위해 여전히 `{customer_id: N}`을 POST할 수 있습니다.
+
+```text
+POST /api/internal/triage/baseline/dispatch
+Authorization: Bearer <TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN>
+Content-Type: application/json
+
+(본문 없음)
+```
+
+응답:
+
+```json
+{
+  "overall": "ok",
+  "perCustomer": [
+    {
+      "customerId": 1,
+      "status": "ok",
+      "observedInserted": 142,
+      "baselineInserted": 9,
+      "lastEventCursor": "1234567890123456789"
+    }
+  ]
+}
+```
+
+`perCustomer[].status`는 닫힌 집합입니다.
+
+| 값 | 출처 | 의미 |
+| :-- | :-- | :-- |
+| `ok` | 케이던스 러너 | 정상 성공 패스 — 행이 인제스트되고 워터마크가 진행됨. |
+| `skipped` | 케이던스 러너 | 동시 실행이 어드바이저리 락을 보유 중이거나 신규 페이지가 없음. 정상적인 "할 일 없음" 상태. |
+| `failed` | 케이던스 러너 | 케이던스 트랜잭션이 롤백됨. `error` 필드 채워짐. |
+| `timeout` | 디스패처 | 고객별 호출이 `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS`(기본 15분)을 초과. 디스패처가 `AbortSignal`로 러너를 취소했고, 진행 중이던 페이지가 롤백됨. |
+| `skipped-timeout` | 디스패처 | 디스패처 전체 타임아웃(`TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, 기본 45분) 도달 전에 이 고객은 시도되지 않음. 다음 시간당 틱이 처리. |
+
+`overall`은 결정적으로 도출됩니다.
+
+- `ok` ⇔ 모든 고객별 상태가 `ok` 또는 `skipped` (정상적인 skip은
+  실패가 아니라 정상 상태의 일부).
+- `partial` ⇔ 고객별 상태 중 하나 이상이 `failed`, `timeout`,
+  `skipped-timeout`이고 디스패처 자체는 완료됨.
+- `failed` (HTTP 500) ⇔ 디스패처 자체 실패 (예: 고객 열거 쿼리
+  실패). `perCustomer`는 비어있을 수 있음.
+
+한 고객의 실패가 다른 고객의 실행을 중단시키지 않습니다.
+디스패처는 `partial`을 보고하고 계속 진행합니다.
+
 ## 런북 — 케이던스 엔드포인트 등록
 
-릴리스 런북의 배포 스케줄러에 케이던스 라우트를 등록하세요.
-권장 주기는 **고객당 시간당 1회** (논의 #447 §3.4 기준)입니다.
-시간당 주기는 코퍼스를 신선하게 유지하면서 리졸버 부하를
-배가시키지 않습니다. 페이지별 커밋과 커서 진행 덕분에 다음
-틱이 이전이 멈춘 지점에서 이어받아, 1–2 사이클의 일시적 장애는
-무해합니다.
+**`docker-compose.yml`의 `cron` 서비스가 이미 이 작업을 수행합니다** —
+크론 라인은 `infra/cron/crontab`, 래퍼 스크립트는
+`infra/cron/run-triage-baseline-dispatch.sh`를 참고하세요.
+`docker compose --profile prod up -d`로 부팅하면 시간당 케이던스가
+시작되며, 별도의 외부 스케줄러 설정은 필요 없습니다.
+
+cron 서비스는 `next-app`의 `/api/health` 준비 상태 게이트가
+통과되어야 첫 틱을 발사하므로, 절반만 가동된 백엔드가 디스패처
+요청을 받지 않습니다. 래퍼 스크립트는 모든 응답 본문을 cron 컨테이너
+내부의 `/var/log/cron/cron-cadence-<ts>.json`에 저장(`cron-logs`
+네임드 볼륨으로 영속화)하고, 호출당 한 줄 요약을 stdout으로
+출력하므로 `docker compose logs cron`으로 확인할 수 있습니다.
+
+번들된 compose 외부에서 운영하는 경우 어떤 외부 스케줄러에서든
+같은 디스패처 라우트를 사용할 수 있습니다. 권장 주기는
+**시간당 1회**입니다(디스패처가 내부적으로 고객별로 팬아웃).
+
+```bash
+curl -sS -o /tmp/dispatch.json -w '%{http_code}\n' \
+  --connect-timeout 10 --max-time 2700 \
+  -X POST \
+  -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  --data '' \
+  "$BFF_BASE_URL/api/internal/triage/baseline/dispatch"
+```
+
+고객별 수동 실행은 여전히 케이던스 라우트를 사용합니다.
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
+  -H 'Content-Type: application/json' \
+  "$BFF_BASE_URL/api/internal/triage/baseline/cadence" \
+  -d '{"customer_id": 1}'
+```
+
+초기 구성 체크리스트:
 
 1. `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`에 강한 무작위 토큰을
    준비합니다. 시크릿 매니저에 저장하고, 일반적인 주기로
    순환시키며, 절대 체크인하지 않습니다.
-2. 모든 BFF 인스턴스와 라우트를 호출하는 스케줄러에 환경
-   변수를 설정합니다. 환경 변수가 미설정이면 라우트는 모든
-   요청을 거부하므로, 첫 틱 전에 스케줄러가 명시적으로 변수를
-   로드해야 합니다.
-3. 시간당 한 번씩 호출하는 반복 호출자(cron, Kubernetes
-   `CronJob`, GitHub Actions 스케줄 등)를 연결합니다.
-
-    ```bash
-    curl -fsS -X POST \
-      -H "Authorization: Bearer $TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN" \
-      -H "Content-Type: application/json" \
-      "$BFF_BASE_URL/api/internal/triage/baseline/cadence" \
-      -d '{"customer_id": 1}'
-    ```
-
-    여러 고객 테넌트 DB를 운영하는 경우, 시간당 `customer_id`별로
-    한 번씩 HTTP 호출을 분기합니다. 고객별 어드바이저리 락
-    덕분에 서로 다른 고객의 패스는 동시 실행이 가능합니다.
-
-4. 첫 스케줄 실행을 스케줄러 로그를 추적하며 검증합니다.
+2. `.env`에 환경 변수를 설정합니다(cron 서비스는 `next-app`과
+   동일한 `env_file: .env`를 상속). 환경 변수가 미설정이면
+   라우트는 모든 요청을 거부하므로, 첫 틱 전에 디스패처가
+   명시적으로 변수를 로드해야 합니다.
+3. `docker compose logs cron`으로 첫 스케줄 실행을 검증하고,
+   `/var/log/cron/`의 타임스탬프 응답 본문을 확인합니다.
    조용한 배포에서 정상적인 첫 실행은 보통 보통 수준의 카운터를
    보고합니다. 중단된 틱 직후 첫 실행에서 `status: 'skipped'`가
    나오는 것은 정상이며(이전 실행이 아직 마무리 중), 다음
    패스에서 해소되어야 합니다.
+
+## 모니터링
+
+`200 / overall: 'partial'`은 HTTP 성공이므로 단순한 `curl -fsS`는
+이를 정상으로 취급합니다. 무음 부분 실패가 누적되지 않도록
+**`overall != 'ok'`에 대해 알림을 설정하십시오**. 키잉 가능한
+표면이 세 가지 있습니다.
+
+1. 디스패처가 호출당 `triage_baseline_dispatch` 태그가 붙은 한 줄의
+   구조화된 `console.log` 라인을 출력하며, `overall`, 고객별 상태
+   카운트, 고객별 카운터를 포함합니다. 이것이 정식 라인이며 알림은
+   여기에 키잉합니다.
+2. cron 래퍼 스크립트(`run-triage-baseline-dispatch.sh`)가
+   `overall != 'ok'`일 때 stderr로 사람이 읽을 수 있는 경고를
+   재출력하며, 이는 `docker compose logs cron`에 표시됩니다.
+3. 고객별 `baseline_corpus_state.last_run_status`가 가장 최근 종료
+   상태를 기록합니다. 1시간 이상 지난 `last_run_status = 'failed'`
+   행이 있으면 확정된 문제입니다.
+
+래퍼 스크립트는 `overall: 'partial'`에서 의도적으로 0으로 종료하므로
+cron의 MAILTO가 중복 호출되지 않습니다. 복구 경로는 구조화된 로그
+라인에 대한 알림입니다. 인증 오설정(HTTP 401/403)과 전송 실패
+(DNS, 연결 거부, `--max-time` 도달)는 비제로 종료하므로 운영자가
+즉시 확인해야 합니다.
 
 ## 관찰성
 

--- a/infra/cron/Dockerfile
+++ b/infra/cron/Dockerfile
@@ -1,0 +1,28 @@
+# In-repo cron service (#487).
+#
+# A small Alpine image that owns hourly internal-API triggers (the
+# Triage baseline dispatcher today; cleanup / retention endpoints
+# later). Every hourly tick is a one-liner in `crontab` invoking a
+# wrapper script under `/usr/local/bin/`. The wrapper does the actual
+# curl + JSON-body capture + structured logging.
+#
+# Why the chosen base image:
+#   - Alpine ships busybox `crond` directly (no separate cron pkg).
+#   - We need a real JSON parser (`jq`) to read `overall` from the
+#     dispatcher response — `grep` is rejected by #487 §3.
+#   - `bash` keeps the wrapper-script syntax portable (the script
+#     uses `set -u` + `${var:?}` shapes that busybox sh tolerates,
+#     but parameter-expansion fallbacks are noticeably nicer in bash).
+#   - `tini` reaps zombie children spawned by short-lived cron jobs.
+FROM alpine:3.20
+
+RUN apk add --no-cache bash curl jq tini coreutils
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY crontab /etc/crontabs/root
+COPY run-triage-baseline-dispatch.sh /usr/local/bin/run-triage-baseline-dispatch.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+        /usr/local/bin/run-triage-baseline-dispatch.sh
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/infra/cron/crontab
+++ b/infra/cron/crontab
@@ -1,0 +1,13 @@
+# In-repo cron table (#487).
+#
+# All entries call a wrapper script under /usr/local/bin/ rather than
+# inlining curl. Wrappers own the env-file source, response-body
+# capture, and `overall != 'ok'` detection — see #487 §3 for the
+# contract.
+#
+# Cron interprets `%` as a newline literal, so any wrapper that needs a
+# date format (e.g. for log filenames) MUST do its own
+# `date +%Y%m%d-%H` *inside* the script, not in the crontab line.
+#
+# Triage baseline cadence — hourly per-customer fan-out
+0 * * * * /usr/local/bin/run-triage-baseline-dispatch.sh

--- a/infra/cron/entrypoint.sh
+++ b/infra/cron/entrypoint.sh
@@ -19,6 +19,13 @@ LOG_DIR=/var/log/cron
 ENV_ALLOWLIST=(
     TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN
     NEXT_APP_BASE_URL
+    # Allowlisted so `run-triage-baseline-dispatch.sh` derives its
+    # `--max-time` from the same operator knob `next-app` honours.
+    # Without this passthrough an operator raising the dispatcher
+    # total timeout via `.env` would still be killed by the wrapper's
+    # 2700s default, recreating the transport-failure / no-body mode
+    # the structured `skipped-timeout` row exists to prevent.
+    TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS
 )
 
 : > "$ENV_FILE"

--- a/infra/cron/entrypoint.sh
+++ b/infra/cron/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Cron container entrypoint (#487 §1).
+#
+# busybox `crond` does NOT inherit container env into spawned jobs, so
+# the wrapper scripts source `/etc/cron.env` to pick up the values they
+# need. This entrypoint materialises that file from the container env
+# before starting `crond -f`. Keeping the allowlist explicit prevents
+# unrelated container env from leaking into cron log lines / cron job
+# environments.
+
+set -euo pipefail
+
+ENV_FILE=/etc/cron.env
+LOG_DIR=/var/log/cron
+
+# Allowlist the env vars the cron wrappers actually use. Add new
+# entries here when a future cron wrapper needs them.
+ENV_ALLOWLIST=(
+    TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN
+    NEXT_APP_BASE_URL
+)
+
+: > "$ENV_FILE"
+for var in "${ENV_ALLOWLIST[@]}"; do
+    # `printenv` returns non-zero when the var is unset; we treat
+    # unset as "skip" so a partial config still boots.
+    if value=$(printenv "$var" 2>/dev/null); then
+        printf 'export %s=%q\n' "$var" "$value" >>"$ENV_FILE"
+    fi
+done
+chmod 600 "$ENV_FILE"
+
+mkdir -p "$LOG_DIR"
+
+# `-f` keeps crond in the foreground; `-d 8` enables debug logging to
+# stderr so `docker compose logs cron` is useful during incident
+# response.
+exec crond -f -d 8

--- a/infra/cron/run-triage-baseline-dispatch.sh
+++ b/infra/cron/run-triage-baseline-dispatch.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Triage baseline dispatch wrapper (#487 §3).
+#
+# Hourly invoked by `/etc/crontabs/root` inside the cron container.
+# Owns:
+#   - sourcing /etc/cron.env (set by entrypoint.sh, since busybox
+#     crond does NOT propagate container env into jobs)
+#   - hitting POST /api/internal/triage/baseline/dispatch
+#   - separating HTTP status from response body (so a 4xx/5xx with a
+#     meaningful body is not silently dropped)
+#   - parsing `overall` with a real JSON parser (`jq`)
+#   - emitting a one-line summary to stdout and a stderr warning when
+#     `overall != 'ok'`
+#   - capturing the full response body to a timestamped file under
+#     /var/log/cron/
+#
+# Exit code policy:
+#   - exit 0 on HTTP 200 (regardless of `overall`) and on HTTP 4xx/5xx
+#     with a parseable body — the structured body is the recovery
+#     surface; the next hourly tick re-runs and confirms whether the
+#     issue persists. cron's MAILTO would otherwise double-page.
+#   - exit non-zero on transport failure (DNS, connection refused,
+#     TLS, --max-time reached), on HTTP 401/403 (auth misconfig must
+#     surface to ops), and on configuration errors (missing token /
+#     URL).
+#
+# `set -e` is INTENTIONALLY NOT used here: it would abort the script
+# the moment curl exits non-zero (transport failure, timeout) before
+# the failure-classification block could run. We capture curl's exit
+# code with `|| curl_exit=$?` and classify explicitly.
+
+set -u
+
+ENV_FILE=/etc/cron.env
+LOG_DIR=/var/log/cron
+
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    . "$ENV_FILE"
+fi
+
+TOKEN="${TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN:-}"
+BASE_URL="${NEXT_APP_BASE_URL:-http://next-app:3000}"
+URL="${BASE_URL}/api/internal/triage/baseline/dispatch"
+
+# `--max-time` is a hard wall-clock cap including connect + transfer.
+# Keep it equal to the dispatcher's total timeout (45 minutes = 2700s
+# default) so the application-level timeout — which produces
+# structured `skipped-timeout` rows for unattempted customers — wins
+# over the network-level timeout (which would surface as a transport
+# failure with no body). The hourly cron interval (3600s) is the
+# absolute ceiling.
+CONNECT_TIMEOUT_S=10
+MAX_TIME_S=2700
+
+mkdir -p "$LOG_DIR"
+TS=$(date +%Y%m%d-%H%M%S)
+BODY_FILE="${LOG_DIR}/cron-cadence-${TS}.json"
+
+log_info() {
+    printf '[%s] cron-cadence: %s\n' "$(date -Iseconds)" "$*"
+}
+
+log_warn() {
+    printf '[%s] cron-cadence: WARN %s\n' "$(date -Iseconds)" "$*" >&2
+}
+
+if [ -z "$TOKEN" ]; then
+    log_warn "TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN is empty; refusing to fire"
+    exit 2
+fi
+
+curl_exit=0
+http_code=$(
+    curl -sS \
+        --connect-timeout "$CONNECT_TIMEOUT_S" \
+        --max-time "$MAX_TIME_S" \
+        -o "$BODY_FILE" \
+        -w '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H 'Content-Type: application/json' \
+        --data '' \
+        "$URL"
+) || curl_exit=$?
+
+# Empty / unreadable http_code on a transport failure: classify as
+# transport error regardless of curl_exit (defense in depth — old
+# busybox curl can occasionally exit 0 while leaving the body file
+# empty when the connection drops mid-transfer).
+if [ "$curl_exit" -ne 0 ] || [ -z "$http_code" ]; then
+    log_warn "transport failure (curl_exit=${curl_exit}, http_code='${http_code}', url=${URL})"
+    exit 1
+fi
+
+case "$http_code" in
+    401|403)
+        log_warn "auth failure (HTTP ${http_code}); check TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN"
+        exit 1
+        ;;
+    200)
+        # fall through to body parsing
+        ;;
+    *)
+        # Other HTTP errors (4xx/5xx). The body may carry a structured
+        # explanation (e.g. dispatcher self-failure with `error`).
+        # Summarise to stderr but exit 0 — cron retry semantics handle
+        # the next tick; non-zero would double-trigger MAILTO.
+        if jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+            err=$(jq -r '.error // empty' "$BODY_FILE")
+            overall=$(jq -r '.overall // empty' "$BODY_FILE")
+            log_warn "HTTP ${http_code} from dispatcher (overall=${overall:-?}, error=${err:-?}); body saved to ${BODY_FILE}"
+        else
+            log_warn "HTTP ${http_code} from dispatcher (body unparseable); body saved to ${BODY_FILE}"
+        fi
+        exit 0
+        ;;
+esac
+
+# HTTP 200: parse `overall` and per-customer counters.
+if ! jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+    log_warn "HTTP 200 but response body is not valid JSON; saved to ${BODY_FILE}"
+    exit 0
+fi
+
+overall=$(jq -r '.overall // "?"' "$BODY_FILE")
+counts=$(
+    jq -r '
+        [
+            "ok=" + ([.perCustomer[]? | select(.status == "ok")] | length | tostring),
+            "skipped=" + ([.perCustomer[]? | select(.status == "skipped")] | length | tostring),
+            "failed=" + ([.perCustomer[]? | select(.status == "failed")] | length | tostring),
+            "timeout=" + ([.perCustomer[]? | select(.status == "timeout")] | length | tostring),
+            "skipped_timeout=" + ([.perCustomer[]? | select(.status == "skipped-timeout")] | length | tostring)
+        ] | join(" ")
+    ' "$BODY_FILE"
+)
+
+log_info "overall=${overall} ${counts} body=${BODY_FILE}"
+
+if [ "$overall" != "ok" ]; then
+    bad_ids=$(
+        jq -r '
+            [.perCustomer[]?
+                | select(.status != "ok" and .status != "skipped")
+                | (.customerId | tostring) + ":" + .status]
+            | join(",")
+        ' "$BODY_FILE"
+    )
+    log_warn "overall=${overall}: ${bad_ids:-none}; body=${BODY_FILE}"
+fi
+
+exit 0

--- a/infra/cron/run-triage-baseline-dispatch.sh
+++ b/infra/cron/run-triage-baseline-dispatch.sh
@@ -55,8 +55,31 @@ URL="${BASE_URL}/api/internal/triage/baseline/dispatch"
 # over the network-level timeout (which would surface as a transport
 # failure with no body). The hourly cron interval (3600s) is the
 # absolute ceiling.
+#
+# Resolution order (highest precedence first):
+#   1. CRON_CADENCE_MAX_TIME_S — test override only, lets the wrapper
+#      run with sub-second ceilings under vitest.
+#   2. TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS — operator-tunable
+#      knob shared with `next-app`, allowlisted by `entrypoint.sh`
+#      into `/etc/cron.env`. Converted ms → s and rounded UP so the
+#      wrapper never undercuts the app deadline. A floor of 1s
+#      guarantees a positive value even if an operator misconfigures
+#      the knob (e.g. sets it below 500ms).
+#   3. 2700s default — matches the dispatcher's own default total
+#      timeout (45 minutes).
 CONNECT_TIMEOUT_S="${CRON_CADENCE_CONNECT_TIMEOUT_S:-10}"
-MAX_TIME_S="${CRON_CADENCE_MAX_TIME_S:-2700}"
+if [ -n "${CRON_CADENCE_MAX_TIME_S:-}" ]; then
+    MAX_TIME_S="$CRON_CADENCE_MAX_TIME_S"
+elif [ -n "${TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS:-}" ]; then
+    MAX_TIME_S=$((
+        (TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS + 999) / 1000
+    ))
+    if [ "$MAX_TIME_S" -lt 1 ]; then
+        MAX_TIME_S=1
+    fi
+else
+    MAX_TIME_S=2700
+fi
 
 mkdir -p "$LOG_DIR"
 TS=$(date +%Y%m%d-%H%M%S)

--- a/infra/cron/run-triage-baseline-dispatch.sh
+++ b/infra/cron/run-triage-baseline-dispatch.sh
@@ -32,8 +32,12 @@
 
 set -u
 
-ENV_FILE=/etc/cron.env
-LOG_DIR=/var/log/cron
+# Both paths are overridable via env so the script can be exercised
+# end-to-end from tests (which cannot write to /var/log/cron and have
+# no /etc/cron.env on the host). Production crontab leaves these
+# unset; the entrypoint controls the real paths.
+ENV_FILE="${CRON_CADENCE_ENV_FILE:-/etc/cron.env}"
+LOG_DIR="${CRON_CADENCE_LOG_DIR:-/var/log/cron}"
 
 if [ -f "$ENV_FILE" ]; then
     # shellcheck source=/dev/null
@@ -51,8 +55,8 @@ URL="${BASE_URL}/api/internal/triage/baseline/dispatch"
 # over the network-level timeout (which would surface as a transport
 # failure with no body). The hourly cron interval (3600s) is the
 # absolute ceiling.
-CONNECT_TIMEOUT_S=10
-MAX_TIME_S=2700
+CONNECT_TIMEOUT_S="${CRON_CADENCE_CONNECT_TIMEOUT_S:-10}"
+MAX_TIME_S="${CRON_CADENCE_MAX_TIME_S:-2700}"
 
 mkdir -p "$LOG_DIR"
 TS=$(date +%Y%m%d-%H%M%S)

--- a/src/__tests__/app/api/health/route.test.ts
+++ b/src/__tests__/app/api/health/route.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+describe("GET /api/health", () => {
+  it("returns 200 with the documented body shape and makes no DB call", async () => {
+    const { GET } = await import("@/app/api/health/route");
+    const res = GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/src/__tests__/app/api/internal/triage/baseline/dispatch/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/baseline/dispatch/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunDispatch = vi.hoisted(() => vi.fn());
+const mockVerifyToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/baseline/cadence", () => ({
+  verifyTriageBaselineCadenceToken: mockVerifyToken,
+}));
+
+vi.mock("@/lib/triage/baseline/dispatcher", () => ({
+  runTriageBaselineDispatch: mockRunDispatch,
+}));
+
+vi.mock("@/lib/triage/baseline/pager", () => ({
+  createCadencePager: () => ({ ingestPage: vi.fn() }),
+}));
+
+beforeEach(() => {
+  mockRunDispatch.mockReset();
+  mockVerifyToken.mockReset();
+});
+
+function makeRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("http://test/api/internal/triage/baseline/dispatch", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/internal/triage/baseline/dispatch", () => {
+  it("returns 401 when the bearer token does not verify", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/dispatch/route"
+    );
+    const res = await POST(makeRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+    expect(mockRunDispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with the dispatcher result on overall=ok", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockResolvedValue({
+      overall: "ok",
+      perCustomer: [
+        {
+          customerId: 1,
+          status: "ok",
+          observedInserted: 5,
+          baselineInserted: 1,
+          lastEventCursor: "c1",
+        },
+      ],
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/dispatch/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overall).toBe("ok");
+    expect(body.perCustomer).toHaveLength(1);
+  });
+
+  it("returns 200 with overall=partial when at least one customer failed", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockResolvedValue({
+      overall: "partial",
+      perCustomer: [
+        {
+          customerId: 1,
+          status: "ok",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+        },
+        {
+          customerId: 2,
+          status: "failed",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+          error: "review timeout",
+        },
+      ],
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/dispatch/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    // Per #487: per-customer failures are reflected in the body, not
+    // the HTTP status. Cron retry decisions stay centralised.
+    expect(res.status).toBe(200);
+    expect((await res.json()).overall).toBe("partial");
+  });
+
+  it("returns 500 with overall=failed only on dispatcher self-failure", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockRejectedValue(new Error("enumeration failed"));
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/dispatch/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.overall).toBe("failed");
+    expect(body.error).toBe("enumeration failed");
+  });
+});

--- a/src/__tests__/infra/cron/wrapper-script.test.ts
+++ b/src/__tests__/infra/cron/wrapper-script.test.ts
@@ -17,10 +17,15 @@ const WRAPPER_PATH = resolve(
 );
 const CRONTAB_PATH = resolve(__dirname, "../../../../infra/cron/crontab");
 const DOCKERFILE_PATH = resolve(__dirname, "../../../../infra/cron/Dockerfile");
+const ENTRYPOINT_PATH = resolve(
+  __dirname,
+  "../../../../infra/cron/entrypoint.sh",
+);
 
 const wrapper = readFileSync(WRAPPER_PATH, "utf8");
 const crontab = readFileSync(CRONTAB_PATH, "utf8");
 const dockerfile = readFileSync(DOCKERFILE_PATH, "utf8");
+const entrypoint = readFileSync(ENTRYPOINT_PATH, "utf8");
 
 describe("infra/cron/run-triage-baseline-dispatch.sh — static contract", () => {
   it("uses jq, not grep, to parse `overall`", () => {
@@ -111,6 +116,11 @@ interface RunResult {
   stderr: string;
   bodyFile: string | null;
   bodyContents: string | null;
+  /**
+   * `--max-time` value the wrapper passed to curl (seconds, as a
+   * string), captured by the stub so derivation tests can assert it.
+   */
+  curlMaxTime: string | null;
 }
 
 interface RunOptions {
@@ -124,6 +134,21 @@ interface RunOptions {
   curlStderr?: string;
   /** Set to null to omit the bearer token; default is a non-empty token. */
   token?: string | null;
+  /**
+   * Override the wrapper's max-time fallback chain.
+   *   - undefined (default): use the test's "5s" override so other
+   *     branches stay fast.
+   *   - null: do NOT set CRON_CADENCE_MAX_TIME_S, exercising the
+   *     production fallback (TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS
+   *     → 2700s default).
+   *   - string: explicit override.
+   */
+  maxTimeS?: string | null;
+  /**
+   * Sets TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS to exercise the
+   * wrapper's ms→s derivation when CRON_CADENCE_MAX_TIME_S is unset.
+   */
+  dispatchTotalTimeoutMs?: string;
 }
 
 /**
@@ -143,12 +168,19 @@ set -u
 output=""
 write_directive=""
 url=""
+max_time=""
+connect_timeout=""
 while [ $# -gt 0 ]; do
     case "$1" in
         -sS|-s|-S|-v|-i)
             shift
             ;;
-        --connect-timeout|--max-time)
+        --max-time)
+            max_time="$2"
+            shift 2
+            ;;
+        --connect-timeout)
+            connect_timeout="$2"
             shift 2
             ;;
         -o)
@@ -176,6 +208,11 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+if [ -n "\${CRON_CADENCE_TEST_ARGS_FILE:-}" ]; then
+    printf 'max_time=%s\\nconnect_timeout=%s\\nurl=%s\\n' \\
+        "$max_time" "$connect_timeout" "$url" \\
+        >"\${CRON_CADENCE_TEST_ARGS_FILE}"
+fi
 if [ -n "\${CRON_CADENCE_TEST_STDERR:-}" ]; then
     printf '%s' "\${CRON_CADENCE_TEST_STDERR}" >&2
 fi
@@ -209,16 +246,26 @@ describe.skipIf(!EXECUTION_DEPS_AVAILABLE)(
         writeFileSync(stubPath, CURL_STUB);
         chmodSync(stubPath, 0o755);
 
+        const argsFile = join(sandbox, "curl-args.txt");
         const env: Record<string, string> = {
           PATH: `${stubDir}:${process.env.PATH ?? ""}`,
           NEXT_APP_BASE_URL: "http://stub.invalid:3000",
           CRON_CADENCE_LOG_DIR: logDir,
           CRON_CADENCE_ENV_FILE: envFile,
-          CRON_CADENCE_MAX_TIME_S: "5",
           CRON_CADENCE_CONNECT_TIMEOUT_S: "1",
           CRON_CADENCE_TEST_HTTP_CODE: opts.httpCode ?? "200",
           CRON_CADENCE_TEST_EXIT_CODE: String(opts.curlExitCode ?? 0),
+          CRON_CADENCE_TEST_ARGS_FILE: argsFile,
         };
+        if (opts.maxTimeS === undefined) {
+          env.CRON_CADENCE_MAX_TIME_S = "5";
+        } else if (opts.maxTimeS !== null) {
+          env.CRON_CADENCE_MAX_TIME_S = opts.maxTimeS;
+        }
+        if (opts.dispatchTotalTimeoutMs !== undefined) {
+          env.TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS =
+            opts.dispatchTotalTimeoutMs;
+        }
         if (opts.body !== undefined) {
           env.CRON_CADENCE_TEST_BODY = opts.body;
         }
@@ -240,12 +287,21 @@ describe.skipIf(!EXECUTION_DEPS_AVAILABLE)(
         );
         const bodyFile = files.length > 0 ? join(logDir, files[0]) : null;
         const bodyContents = bodyFile ? readFileSync(bodyFile, "utf8") : null;
+        let curlMaxTime: string | null = null;
+        try {
+          const argsContent = readFileSync(argsFile, "utf8");
+          const m = argsContent.match(/^max_time=(.*)$/m);
+          curlMaxTime = m ? m[1] : null;
+        } catch {
+          curlMaxTime = null;
+        }
         return {
           status: result.status,
           stdout: result.stdout ?? "",
           stderr: result.stderr ?? "",
           bodyFile,
           bodyContents,
+          curlMaxTime,
         };
       } finally {
         rmSync(sandbox, { recursive: true, force: true });
@@ -390,6 +446,56 @@ describe.skipIf(!EXECUTION_DEPS_AVAILABLE)(
       expect(r.stderr).toMatch(/curl_exit=7/);
     });
 
+    it("derives --max-time from TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS when CRON_CADENCE_MAX_TIME_S is unset", () => {
+      // 5 400 000ms = 90min → 5400s. Operator-tunable knob shared
+      // with `next-app`; the wrapper must keep its network ceiling
+      // in sync so the structured `timeout` / `skipped-timeout` rows
+      // reach the cron MAILTO surface instead of being swallowed by
+      // a transport failure.
+      const r = runWrapper({
+        httpCode: "200",
+        body: JSON.stringify({ overall: "ok", perCustomer: [] }),
+        maxTimeS: null,
+        dispatchTotalTimeoutMs: "5400000",
+      });
+      expect(r.status).toBe(0);
+      expect(r.curlMaxTime).toBe("5400");
+    });
+
+    it("rounds derived --max-time UP so wrapper never undercuts the app deadline", () => {
+      // 1500ms → 2s (ceiling), not 1s (floor). Keeps the network
+      // ceiling at-or-above the application deadline by construction.
+      const r = runWrapper({
+        httpCode: "200",
+        body: JSON.stringify({ overall: "ok", perCustomer: [] }),
+        maxTimeS: null,
+        dispatchTotalTimeoutMs: "1500",
+      });
+      expect(r.status).toBe(0);
+      expect(r.curlMaxTime).toBe("2");
+    });
+
+    it("falls back to 2700s default when neither override nor dispatcher knob is set", () => {
+      const r = runWrapper({
+        httpCode: "200",
+        body: JSON.stringify({ overall: "ok", perCustomer: [] }),
+        maxTimeS: null,
+      });
+      expect(r.status).toBe(0);
+      expect(r.curlMaxTime).toBe("2700");
+    });
+
+    it("CRON_CADENCE_MAX_TIME_S override wins over TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS", () => {
+      const r = runWrapper({
+        httpCode: "200",
+        body: JSON.stringify({ overall: "ok", perCustomer: [] }),
+        maxTimeS: "9",
+        dispatchTotalTimeoutMs: "5400000",
+      });
+      expect(r.status).toBe(0);
+      expect(r.curlMaxTime).toBe("9");
+    });
+
     it("missing TOKEN: refuses to fire and exits non-zero", () => {
       const r = runWrapper({
         httpCode: "200",
@@ -403,6 +509,25 @@ describe.skipIf(!EXECUTION_DEPS_AVAILABLE)(
     });
   },
 );
+
+describe("infra/cron/entrypoint.sh — static contract", () => {
+  it("allowlists TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN", () => {
+    expect(entrypoint).toMatch(/TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN/);
+  });
+
+  it("allowlists NEXT_APP_BASE_URL", () => {
+    expect(entrypoint).toMatch(/NEXT_APP_BASE_URL/);
+  });
+
+  it("allowlists TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS so the wrapper can derive --max-time", () => {
+    // Round 2 review fix: without this passthrough, an operator
+    // raising the dispatcher total timeout via .env would still be
+    // killed by the wrapper's 2700s default, recreating the
+    // transport-failure / no-body mode the structured
+    // `skipped-timeout` row exists to prevent.
+    expect(entrypoint).toMatch(/TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS/);
+  });
+});
 
 describe("infra/cron/Dockerfile — static contract", () => {
   it("installs jq so the wrapper can parse the response body", () => {

--- a/src/__tests__/infra/cron/wrapper-script.test.ts
+++ b/src/__tests__/infra/cron/wrapper-script.test.ts
@@ -1,5 +1,14 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const WRAPPER_PATH = resolve(
@@ -81,6 +90,319 @@ describe("infra/cron/crontab — static contract", () => {
     expect(crontab).toMatch(/^0 \* \* \* \*/m);
   });
 });
+
+/**
+ * Detect bash/jq once at module load. The wrapper requires both at
+ * runtime; if a CI environment is missing them we skip the execution
+ * suite rather than fail noisily (the static-contract suite still
+ * runs). `curl` is replaced by a stub on PATH for these tests so the
+ * full body-parsing / status-classification / log-emission pipeline
+ * is exercised without depending on outbound TCP.
+ */
+function hasBin(name: string): boolean {
+  return spawnSync("which", [name]).status === 0;
+}
+
+const EXECUTION_DEPS_AVAILABLE = hasBin("bash") && hasBin("jq");
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  bodyFile: string | null;
+  bodyContents: string | null;
+}
+
+interface RunOptions {
+  /** HTTP status the stub curl reports via `-w '%{http_code}'`. */
+  httpCode?: string;
+  /** Body the stub writes to the `-o` output file. */
+  body?: string;
+  /** Stub curl exit code (default 0). 28 simulates `--max-time` hit. */
+  curlExitCode?: number;
+  /** Stub curl stderr (e.g. real curl emits `curl: (28) ...` on timeout). */
+  curlStderr?: string;
+  /** Set to null to omit the bearer token; default is a non-empty token. */
+  token?: string | null;
+}
+
+/**
+ * Stub `curl` script — parses the wrapper's invocation, emits canned
+ * status / body / exit code, and leaves all transport concerns out of
+ * the test. Real curl is not used because the harness sandbox blocks
+ * child processes from connecting to localhost-bound test sockets.
+ * The stub still validates the wrapper's contract because the wrapper
+ * does not care WHERE the response came from — only that:
+ *   - curl exit code != 0 → transport-failure log + non-zero exit
+ *   - http_code 401/403   → auth-failure log + non-zero exit
+ *   - http_code 200       → body parsed by jq, summary emitted
+ *   - http_code other     → structured-body warning + exit 0
+ */
+const CURL_STUB = `#!/bin/bash
+set -u
+output=""
+write_directive=""
+url=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -sS|-s|-S|-v|-i)
+            shift
+            ;;
+        --connect-timeout|--max-time)
+            shift 2
+            ;;
+        -o)
+            output="$2"
+            shift 2
+            ;;
+        -w)
+            write_directive="$2"
+            shift 2
+            ;;
+        -X|-H|--data|--data-raw|--data-binary|--data-urlencode|-F|-A|-e|-u)
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            # Unknown flag with possible arg; assume single-arg flag.
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+if [ -n "\${CRON_CADENCE_TEST_STDERR:-}" ]; then
+    printf '%s' "\${CRON_CADENCE_TEST_STDERR}" >&2
+fi
+if [ -n "$output" ]; then
+    if [ -n "\${CRON_CADENCE_TEST_BODY+x}" ]; then
+        printf '%s' "\${CRON_CADENCE_TEST_BODY}" > "$output"
+    else
+        : > "$output"
+    fi
+fi
+case "$write_directive" in
+    *%\\{http_code\\}*|*http_code*)
+        printf '%s' "\${CRON_CADENCE_TEST_HTTP_CODE:-000}"
+        ;;
+esac
+exit "\${CRON_CADENCE_TEST_EXIT_CODE:-0}"
+`;
+
+describe.skipIf(!EXECUTION_DEPS_AVAILABLE)(
+  "infra/cron/run-triage-baseline-dispatch.sh — execution",
+  () => {
+    function runWrapper(opts: RunOptions): RunResult {
+      const sandbox = mkdtempSync(join(tmpdir(), "wrapper-test-"));
+      const stubDir = join(sandbox, "bin");
+      const logDir = join(sandbox, "log");
+      const envFile = join(sandbox, "cron.env");
+      try {
+        // Set up curl stub on PATH.
+        spawnSync("mkdir", ["-p", stubDir, logDir]);
+        const stubPath = join(stubDir, "curl");
+        writeFileSync(stubPath, CURL_STUB);
+        chmodSync(stubPath, 0o755);
+
+        const env: Record<string, string> = {
+          PATH: `${stubDir}:${process.env.PATH ?? ""}`,
+          NEXT_APP_BASE_URL: "http://stub.invalid:3000",
+          CRON_CADENCE_LOG_DIR: logDir,
+          CRON_CADENCE_ENV_FILE: envFile,
+          CRON_CADENCE_MAX_TIME_S: "5",
+          CRON_CADENCE_CONNECT_TIMEOUT_S: "1",
+          CRON_CADENCE_TEST_HTTP_CODE: opts.httpCode ?? "200",
+          CRON_CADENCE_TEST_EXIT_CODE: String(opts.curlExitCode ?? 0),
+        };
+        if (opts.body !== undefined) {
+          env.CRON_CADENCE_TEST_BODY = opts.body;
+        }
+        if (opts.curlStderr !== undefined) {
+          env.CRON_CADENCE_TEST_STDERR = opts.curlStderr;
+        }
+        if (opts.token !== null) {
+          env.TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN =
+            opts.token ?? "test-token";
+        }
+
+        const result = spawnSync("bash", [WRAPPER_PATH], {
+          env: env as NodeJS.ProcessEnv,
+          encoding: "utf8",
+          timeout: 15_000,
+        });
+        const files = readdirSync(logDir).filter((f) =>
+          f.startsWith("cron-cadence-"),
+        );
+        const bodyFile = files.length > 0 ? join(logDir, files[0]) : null;
+        const bodyContents = bodyFile ? readFileSync(bodyFile, "utf8") : null;
+        return {
+          status: result.status,
+          stdout: result.stdout ?? "",
+          stderr: result.stderr ?? "",
+          bodyFile,
+          bodyContents,
+        };
+      } finally {
+        rmSync(sandbox, { recursive: true, force: true });
+      }
+    }
+
+    it("HTTP 200 + overall=ok: exits 0, stdout has summary, stderr is clean", () => {
+      const r = runWrapper({
+        httpCode: "200",
+        body: JSON.stringify({
+          overall: "ok",
+          perCustomer: [
+            {
+              customerId: 1,
+              status: "ok",
+              observedInserted: 0,
+              baselineInserted: 0,
+              lastEventCursor: null,
+            },
+          ],
+        }),
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/overall=ok/);
+      expect(r.stdout).toMatch(/ok=1 skipped=0 failed=0 timeout=0/);
+      expect(r.stderr).toBe("");
+      expect(r.bodyContents).toMatch(/"overall":"ok"/);
+    });
+
+    it("HTTP 200 + overall=partial: exits 0, stdout has summary, stderr WARNs with bad ids", () => {
+      const r = runWrapper({
+        httpCode: "200",
+        body: JSON.stringify({
+          overall: "partial",
+          perCustomer: [
+            {
+              customerId: 1,
+              status: "ok",
+              observedInserted: 0,
+              baselineInserted: 0,
+              lastEventCursor: null,
+            },
+            {
+              customerId: 2,
+              status: "failed",
+              observedInserted: 0,
+              baselineInserted: 0,
+              lastEventCursor: null,
+              error: "boom",
+            },
+            {
+              customerId: 3,
+              status: "timeout",
+              observedInserted: 0,
+              baselineInserted: 0,
+              lastEventCursor: null,
+              error: "timed out",
+            },
+          ],
+        }),
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/overall=partial/);
+      expect(r.stdout).toMatch(/failed=1/);
+      expect(r.stdout).toMatch(/timeout=1/);
+      expect(r.stderr).toMatch(/WARN/);
+      expect(r.stderr).toMatch(/2:failed/);
+      expect(r.stderr).toMatch(/3:timeout/);
+    });
+
+    it("HTTP 200 + invalid JSON: exits 0 and warns", () => {
+      const r = runWrapper({
+        httpCode: "200",
+        body: "not json {[",
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(/not valid JSON/);
+    });
+
+    it("HTTP 401: exits non-zero so cron MAILTO surfaces the auth misconfig", () => {
+      const r = runWrapper({
+        httpCode: "401",
+        body: JSON.stringify({ error: "unauthorized" }),
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/auth failure \(HTTP 401\)/);
+    });
+
+    it("HTTP 403: exits non-zero (same auth-failure path as 401)", () => {
+      const r = runWrapper({
+        httpCode: "403",
+        body: JSON.stringify({ error: "forbidden" }),
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/auth failure \(HTTP 403\)/);
+    });
+
+    it("HTTP 500 with structured body: exits 0, body saved, stderr summarises", () => {
+      const r = runWrapper({
+        httpCode: "500",
+        body: JSON.stringify({
+          overall: "failed",
+          error: "enumeration failed",
+        }),
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(/HTTP 500 from dispatcher/);
+      expect(r.stderr).toMatch(/enumeration failed/);
+      expect(r.bodyContents).toMatch(/enumeration failed/);
+    });
+
+    it("HTTP 500 with unparseable body: exits 0 and warns", () => {
+      const r = runWrapper({
+        httpCode: "500",
+        body: "<html>internal error</html>",
+      });
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(/HTTP 500 from dispatcher \(body unparseable\)/);
+    });
+
+    it("transport failure (curl exit 28 = --max-time): exits non-zero on the transport-failure path", () => {
+      const r = runWrapper({
+        httpCode: "000",
+        body: "",
+        curlExitCode: 28,
+        curlStderr: "curl: (28) Operation timed out\n",
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/transport failure/);
+      expect(r.stderr).toMatch(/curl_exit=28/);
+    });
+
+    it("transport failure (curl exit 7 = connection refused): exits non-zero", () => {
+      const r = runWrapper({
+        httpCode: "000",
+        body: "",
+        curlExitCode: 7,
+        curlStderr: "curl: (7) Failed to connect\n",
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/transport failure/);
+      expect(r.stderr).toMatch(/curl_exit=7/);
+    });
+
+    it("missing TOKEN: refuses to fire and exits non-zero", () => {
+      const r = runWrapper({
+        httpCode: "200",
+        body: "should not be reached",
+        token: null,
+      });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(
+        /TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN is empty/,
+      );
+    });
+  },
+);
 
 describe("infra/cron/Dockerfile — static contract", () => {
   it("installs jq so the wrapper can parse the response body", () => {

--- a/src/__tests__/infra/cron/wrapper-script.test.ts
+++ b/src/__tests__/infra/cron/wrapper-script.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WRAPPER_PATH = resolve(
+  __dirname,
+  "../../../../infra/cron/run-triage-baseline-dispatch.sh",
+);
+const CRONTAB_PATH = resolve(__dirname, "../../../../infra/cron/crontab");
+const DOCKERFILE_PATH = resolve(__dirname, "../../../../infra/cron/Dockerfile");
+
+const wrapper = readFileSync(WRAPPER_PATH, "utf8");
+const crontab = readFileSync(CRONTAB_PATH, "utf8");
+const dockerfile = readFileSync(DOCKERFILE_PATH, "utf8");
+
+describe("infra/cron/run-triage-baseline-dispatch.sh — static contract", () => {
+  it("uses jq, not grep, to parse `overall`", () => {
+    // #487 §3: grep-based 'parsing' of the response body is not
+    // acceptable. The wrapper must use a real JSON parser.
+    expect(wrapper).toMatch(/jq /);
+    // No `grep "overall"` or similar.
+    expect(wrapper).not.toMatch(/grep[^|\n]*overall/);
+  });
+
+  it("does not use `set -e` (so curl exit ≠ 0 reaches the failure-classification block)", () => {
+    // Allow `set -u` and `set -uo pipefail`, but reject any plain
+    // `set -e` / `set -eu` / `set -euxo pipefail` shape.
+    const lines = wrapper.split("\n").filter((l) => l.trim().startsWith("set"));
+    for (const line of lines) {
+      expect(line).not.toMatch(/-[a-z]*e/);
+    }
+  });
+
+  it("invokes curl with --connect-timeout AND --max-time", () => {
+    expect(wrapper).toMatch(/--connect-timeout/);
+    expect(wrapper).toMatch(/--max-time/);
+  });
+
+  it("captures curl exit code separately so transport failures route to the warn path", () => {
+    expect(wrapper).toMatch(/curl_exit=\$\?/);
+  });
+
+  it("emits a one-line summary to stdout AND a stderr warning when overall != 'ok'", () => {
+    expect(wrapper).toMatch(/log_info /);
+    expect(wrapper).toMatch(/log_warn /);
+    // The partial path must hit log_warn.
+    expect(wrapper).toMatch(/overall != "ok"|overall != ok|overall != 'ok'/);
+  });
+
+  it("auth-failure (HTTP 401/403) exits non-zero so cron MAILTO surfaces it", () => {
+    expect(wrapper).toMatch(/401\|403\)/);
+    // Must `exit 1` (or any non-zero) within that case branch.
+    const authBlock = wrapper.match(/401\|403\)([\s\S]*?);;/);
+    expect(authBlock).not.toBeNull();
+    expect(authBlock?.[1]).toMatch(/exit 1/);
+  });
+
+  it("HTTP 200 path exits 0 even when overall is partial (cron retry handles next tick)", () => {
+    // Final exit at end of script is `exit 0`.
+    expect(wrapper.trimEnd()).toMatch(/exit 0$/);
+  });
+});
+
+describe("infra/cron/crontab — static contract", () => {
+  it("invokes the wrapper script (not curl directly)", () => {
+    expect(crontab).toMatch(
+      /\/usr\/local\/bin\/run-triage-baseline-dispatch\.sh/,
+    );
+  });
+
+  it("does not use `%` characters in the crontab line (cron interprets % as newline)", () => {
+    const lines = crontab
+      .split("\n")
+      .filter((l) => l.trim() && !l.startsWith("#"));
+    for (const line of lines) {
+      expect(line).not.toMatch(/%/);
+    }
+  });
+
+  it("fires at the top of each hour", () => {
+    expect(crontab).toMatch(/^0 \* \* \* \*/m);
+  });
+});
+
+describe("infra/cron/Dockerfile — static contract", () => {
+  it("installs jq so the wrapper can parse the response body", () => {
+    expect(dockerfile).toMatch(/apk add[^\n]*\bjq\b/);
+  });
+
+  it("installs curl so the wrapper can hit the dispatcher route", () => {
+    expect(dockerfile).toMatch(/apk add[^\n]*\bcurl\b/);
+  });
+
+  it("installs bash so the wrapper's parameter-expansion shapes work portably", () => {
+    expect(dockerfile).toMatch(/apk add[^\n]*\bbash\b/);
+  });
+});

--- a/src/__tests__/lib/triage/baseline/cadence.test.ts
+++ b/src/__tests__/lib/triage/baseline/cadence.test.ts
@@ -466,3 +466,143 @@ describe("runTriageBaselineCadence — per-page transaction discipline", () => {
     expect(pager.callCount()).toBe(1);
   });
 });
+
+describe("runTriageBaselineCadence — AbortSignal", () => {
+  it("forwards the signal into the pager so the upstream fetch can be cancelled", async () => {
+    const pool = createMockPool({ lockSequence: [true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+
+    const seenSignals: Array<AbortSignal | undefined> = [];
+    const controller = new AbortController();
+    const pager = {
+      ingestPage: async (
+        _client: unknown,
+        _customerId: number,
+        _afterCursor: string | null,
+        signal?: AbortSignal,
+      ) => {
+        seenSignals.push(signal);
+        return {
+          observedInserted: 0,
+          baselineInserted: 0,
+          endCursor: null,
+          hasNextPage: false,
+          exclusionsFp: TEST_EXCLUSIONS_FP,
+        };
+      },
+    };
+    await runTriageBaselineCadence(7, {
+      pager,
+      signal: controller.signal,
+    });
+    expect(seenSignals).toHaveLength(1);
+    expect(seenSignals[0]).toBe(controller.signal);
+  });
+
+  it("stops cleanly mid-run after page 1 commits when the signal aborts before page 2", async () => {
+    const pool = createMockPool({ lockSequence: [true, true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+
+    const controller = new AbortController();
+    // Wrap the mock client so the post-page COMMIT triggers the
+    // abort *after* the page has already committed. This places the
+    // signal flip between page 1's commit and page 2's top-of-loop
+    // signal check — exactly the failure mode the dispatcher
+    // timeout produces in production.
+    const originalQuery = pool.client.query.getMockImplementation() as (
+      sql: string,
+      params?: unknown[],
+    ) => Promise<QueuedRow>;
+    pool.client.query.mockImplementation(
+      async (sql: string, params?: unknown[]) => {
+        const result = await originalQuery(sql, params);
+        if (sql === "COMMIT") controller.abort();
+        return result;
+      },
+    );
+    let pageIndex = 0;
+    const pager = {
+      ingestPage: vi.fn(async () => {
+        const i = pageIndex;
+        pageIndex += 1;
+        if (i === 0) {
+          return {
+            observedInserted: 4,
+            baselineInserted: 2,
+            endCursor: "c1",
+            hasNextPage: true,
+            exclusionsFp: TEST_EXCLUSIONS_FP,
+          };
+        }
+        // Page 2 must never run — the test fails if ingestPage is
+        // called twice.
+        throw new Error("page 2 should not be invoked");
+      }),
+    };
+    const result = await runTriageBaselineCadence(7, {
+      pager,
+      signal: controller.signal,
+    });
+
+    // Page 1 committed; page 2 was never started.
+    expect(pager.ingestPage).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("ok");
+    expect(result.lastEventCursor).toBe("c1");
+    expect(result.observedInserted).toBe(4);
+    expect(result.baselineInserted).toBe(2);
+
+    // Exactly one COMMIT (page 1), zero ROLLBACKs.
+    const sqls = pool.client.queries.map((q) => q.sql);
+    expect(sqls.filter((s) => s === "COMMIT").length).toBe(1);
+    expect(sqls.filter((s) => s === "ROLLBACK").length).toBe(0);
+  });
+
+  it("rolls back the in-flight page when the signal aborts mid-fetch (after ingestPage returns)", async () => {
+    const pool = createMockPool({ lockSequence: [true] });
+    mockGetCustomerPool.mockResolvedValue(pool);
+
+    const { runTriageBaselineCadence } = await import(
+      "@/lib/triage/baseline/cadence"
+    );
+
+    const controller = new AbortController();
+    const pager = {
+      ingestPage: async (
+        _client: unknown,
+        _customerId: number,
+        _afterCursor: string | null,
+        _signal?: AbortSignal,
+      ) => {
+        // Simulate a fetch that completed locally but where the
+        // dispatcher already aborted (e.g. timeout fired during
+        // the resolver round-trip).
+        controller.abort();
+        return {
+          observedInserted: 7,
+          baselineInserted: 1,
+          endCursor: "c1",
+          hasNextPage: false,
+          exclusionsFp: TEST_EXCLUSIONS_FP,
+        };
+      },
+    };
+    await runTriageBaselineCadence(7, {
+      pager,
+      signal: controller.signal,
+    });
+
+    const sqls = pool.client.queries.map((q) => q.sql);
+    // BEGIN ran, but no COMMIT; the abort handler issued ROLLBACK.
+    expect(sqls).toContain("BEGIN");
+    expect(sqls).toContain("ROLLBACK");
+    expect(sqls).not.toContain("COMMIT");
+  });
+});

--- a/src/__tests__/lib/triage/baseline/dispatcher.test.ts
+++ b/src/__tests__/lib/triage/baseline/dispatcher.test.ts
@@ -111,6 +111,30 @@ describe("runTriageBaselineDispatch — overall derivation", () => {
       }),
     ).rejects.toThrow("enumeration failed");
   });
+
+  it("treats a customer enumeration that exceeds the total dispatcher timeout as self-failure (Round 3 fix)", async () => {
+    // Regression: previously `listActiveCustomers()` ran outside the
+    // total-timeout clock. A hung manager DB query would let the cron
+    // wrapper's `--max-time` kill the HTTP exchange first, dropping the
+    // structured `{ overall: 'failed', ... }` body. The total budget
+    // must start at dispatcher entry and bound enumeration too.
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    const startedAt = Date.now();
+    await expect(
+      runTriageBaselineDispatch({
+        pager: FAKE_PAGER,
+        // Never resolves — must be aborted by the total-timeout clock.
+        listActiveCustomers: () => new Promise<number[]>(() => {}),
+        totalTimeoutMs: 80,
+      }),
+    ).rejects.toThrow(/Customer enumeration exceeded total dispatcher timeout/);
+    const elapsed = Date.now() - startedAt;
+    // Must give up close to totalTimeoutMs, not hang indefinitely.
+    expect(elapsed).toBeLessThan(2000);
+  });
 });
 
 describe("runTriageBaselineDispatch — per-customer non-2xx normalisation", () => {

--- a/src/__tests__/lib/triage/baseline/dispatcher.test.ts
+++ b/src/__tests__/lib/triage/baseline/dispatcher.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockCustomerNotFoundError extends Error {
+  constructor(customerId: number) {
+    super(`Customer ${customerId} not found or not active`);
+    this.name = "CustomerNotFoundError";
+  }
+}
+
+vi.mock("@/lib/triage/policy/customer-db", () => ({
+  CustomerNotFoundError: MockCustomerNotFoundError,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn(),
+}));
+
+const FAKE_PAGER = { ingestPage: vi.fn() } as unknown as Parameters<
+  typeof import("@/lib/triage/baseline/dispatcher").runTriageBaselineDispatch
+>[0]["pager"];
+
+const ENV_KEYS = [
+  "TRIAGE_BASELINE_DISPATCH_CONCURRENCY",
+  "TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS",
+  "TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS",
+];
+const SAVED_ENV: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    SAVED_ENV[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (SAVED_ENV[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = SAVED_ENV[key];
+    }
+  }
+});
+
+describe("runTriageBaselineDispatch — overall derivation", () => {
+  it("returns overall=ok when every per-customer status is ok or skipped", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+    const runCadence = vi.fn(async (customerId: number) => ({
+      customerId,
+      status: customerId % 2 === 0 ? ("ok" as const) : ("skipped" as const),
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+    }));
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [1, 2, 3, 4],
+      runCadence,
+    });
+    expect(result.overall).toBe("ok");
+    expect(result.perCustomer).toHaveLength(4);
+  });
+
+  it("returns overall=partial when at least one customer fails", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+    const runCadence = vi.fn(async (customerId: number) => {
+      if (customerId === 2) {
+        return {
+          customerId,
+          status: "failed" as const,
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+          error: "cadence rollback",
+        };
+      }
+      return {
+        customerId,
+        status: "ok" as const,
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+      };
+    });
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [1, 2, 3],
+      runCadence,
+    });
+    expect(result.overall).toBe("partial");
+    const failed = result.perCustomer.find((e) => e.customerId === 2);
+    expect(failed?.status).toBe("failed");
+    expect(failed?.error).toBe("cadence rollback");
+  });
+
+  it("propagates dispatcher self-failure as a thrown error (the route maps it to 500)", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+    await expect(
+      runTriageBaselineDispatch({
+        pager: FAKE_PAGER,
+        listActiveCustomers: async () => {
+          throw new Error("enumeration failed");
+        },
+      }),
+    ).rejects.toThrow("enumeration failed");
+  });
+});
+
+describe("runTriageBaselineDispatch — per-customer non-2xx normalisation", () => {
+  it("a runner-thrown error normalises to status=failed without escalating overall to failed", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+    const runCadence = vi.fn(async (customerId: number) => {
+      if (customerId === 7) throw new Error("transport: connection refused");
+      return {
+        customerId,
+        status: "ok" as const,
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+      };
+    });
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [7, 8],
+      runCadence,
+    });
+    expect(result.overall).toBe("partial");
+    const seven = result.perCustomer.find((e) => e.customerId === 7);
+    expect(seven?.status).toBe("failed");
+    expect(seven?.error).toContain("transport: connection refused");
+  });
+
+  it("a CustomerNotFoundError thrown mid-fan-out is reported as status=failed, not dispatcher self-failure", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+    const runCadence = vi.fn(async (customerId: number) => {
+      if (customerId === 9) throw new MockCustomerNotFoundError(9);
+      return {
+        customerId,
+        status: "ok" as const,
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+      };
+    });
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [9, 10],
+      runCadence,
+    });
+    expect(result.overall).toBe("partial");
+    const nine = result.perCustomer.find((e) => e.customerId === 9);
+    expect(nine?.status).toBe("failed");
+  });
+});
+
+describe("runTriageBaselineDispatch — concurrency", () => {
+  it("never runs more than `concurrency` per-customer invocations in parallel", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    let inFlight = 0;
+    let peak = 0;
+    const release: Array<() => void> = [];
+    const runCadence = vi.fn(async (customerId: number) => {
+      inFlight += 1;
+      if (inFlight > peak) peak = inFlight;
+      await new Promise<void>((resolve) => {
+        release.push(resolve);
+      });
+      inFlight -= 1;
+      return {
+        customerId,
+        status: "ok" as const,
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+      };
+    });
+
+    const customers = Array.from({ length: 10 }, (_, i) => i + 1);
+    const promise = runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => customers,
+      runCadence,
+      concurrency: 4,
+    });
+
+    // Drain pending tasks: release all in-flight runs sequentially.
+    while (release.length > 0 || (await runCadence.mock.results).length < 10) {
+      await Promise.resolve();
+      await Promise.resolve();
+      while (release.length > 0) {
+        const r = release.shift();
+        r?.();
+        await Promise.resolve();
+      }
+      if (runCadence.mock.calls.length >= 10 && release.length === 0) break;
+    }
+
+    const result = await promise;
+    expect(result.overall).toBe("ok");
+    expect(result.perCustomer).toHaveLength(10);
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(0);
+  });
+});
+
+describe("runTriageBaselineDispatch — per-customer timeout", () => {
+  it("aborts via AbortSignal, reports status=timeout, and frees the slot for the next customer", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    let observedAbort = false;
+    let releasedAt: number | null = null;
+    let secondStartedAt: number | null = null;
+    const startedAt = Date.now();
+
+    const runCadence = vi.fn(
+      async (
+        customerId: number,
+        opts: { signal?: AbortSignal },
+      ): Promise<{
+        customerId: number;
+        status: "ok" | "skipped" | "failed";
+        observedInserted: number;
+        baselineInserted: number;
+        lastEventCursor: string | null;
+        error?: string;
+      }> => {
+        if (customerId === 1) {
+          // Stuck: only resolves when aborted.
+          await new Promise<void>((resolve) => {
+            opts.signal?.addEventListener("abort", () => {
+              observedAbort = true;
+              releasedAt = Date.now() - startedAt;
+              resolve();
+            });
+          });
+          return {
+            customerId,
+            status: "ok",
+            observedInserted: 0,
+            baselineInserted: 0,
+            lastEventCursor: null,
+          };
+        }
+        secondStartedAt = Date.now() - startedAt;
+        return {
+          customerId,
+          status: "ok",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+        };
+      },
+    );
+
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [1, 2],
+      runCadence,
+      perCustomerTimeoutMs: 80,
+      // Run sequentially so we can prove the slot is released after
+      // timeout (otherwise customer 2 could start while customer 1 is
+      // still pending in a parallel slot).
+      concurrency: 1,
+    });
+
+    const one = result.perCustomer.find((e) => e.customerId === 1);
+    const two = result.perCustomer.find((e) => e.customerId === 2);
+    expect(one?.status).toBe("timeout");
+    expect(two?.status).toBe("ok");
+    expect(observedAbort).toBe(true);
+    expect(releasedAt).not.toBeNull();
+    // Customer 2 must start AFTER customer 1's slot was released.
+    expect(secondStartedAt).not.toBeNull();
+    expect(secondStartedAt as unknown as number).toBeGreaterThanOrEqual(
+      releasedAt as unknown as number,
+    );
+  });
+});
+
+describe("runTriageBaselineDispatch — total timeout", () => {
+  it("reports unattempted customers as skipped-timeout when the overall deadline elapses", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    let virtualTime = 0;
+    const advanceMs = 500;
+    const runCadence = vi.fn(async (customerId: number) => {
+      virtualTime += advanceMs;
+      return {
+        customerId,
+        status: "ok" as const,
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+      };
+    });
+
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [1, 2, 3, 4, 5],
+      runCadence,
+      concurrency: 1,
+      totalTimeoutMs: 1000,
+      now: () => virtualTime,
+    });
+
+    const skipped = result.perCustomer.filter(
+      (e) => e.status === "skipped-timeout",
+    );
+    expect(skipped.length).toBeGreaterThan(0);
+    expect(result.overall).toBe("partial");
+  });
+});
+
+describe("runTriageBaselineDispatch — structured log line", () => {
+  it("emits a single console.log JSON line with overall + per-customer counters", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runTriageBaselineDispatch({
+        pager: FAKE_PAGER,
+        listActiveCustomers: async () => [1, 2],
+        runCadence: async (customerId) => ({
+          customerId,
+          status: "ok" as const,
+          observedInserted: customerId * 10,
+          baselineInserted: customerId,
+          lastEventCursor: null,
+        }),
+      });
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const line = logSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(line);
+      expect(parsed.message).toBe("triage_baseline_dispatch");
+      expect(parsed.overall).toBe("ok");
+      expect(parsed.totalCustomers).toBe(2);
+      expect(parsed.ok).toBe(2);
+      expect(Array.isArray(parsed.perCustomer)).toBe(true);
+      expect(parsed.perCustomer[0].customerId).toBe(1);
+      expect(parsed.perCustomer[0].status).toBe("ok");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});
+
+describe("runTriageBaselineDispatch — active-customer enumeration", () => {
+  it("only enumerates active customers (verified via the listActiveCustomers contract)", async () => {
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+    // The default enumerator is `SELECT id FROM customers WHERE
+    // status = 'active'`. We assert that the dispatcher only invokes
+    // the runner for ids the enumerator returned.
+    const runCadence = vi.fn(async (customerId: number) => ({
+      customerId,
+      status: "ok" as const,
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+    }));
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [42],
+      runCadence,
+    });
+    expect(runCadence).toHaveBeenCalledTimes(1);
+    expect(runCadence).toHaveBeenCalledWith(42, expect.any(Object));
+    expect(result.perCustomer.map((e) => e.customerId)).toEqual([42]);
+  });
+});

--- a/src/__tests__/lib/triage/baseline/dispatcher.test.ts
+++ b/src/__tests__/lib/triage/baseline/dispatcher.test.ts
@@ -519,6 +519,77 @@ describe("runTriageBaselineDispatch — structured log line", () => {
       logSpy.mockRestore();
     }
   });
+
+  it("emits the same structured log line on dispatcher self-failure (Round 4 fix)", async () => {
+    // Regression: previously the canonical `triage_baseline_dispatch`
+    // log was only emitted on successful dispatcher completion. An
+    // enumeration error (or enumeration-timeout) returned HTTP 500 with
+    // `{ overall: 'failed', ... }` but left the canonical monitoring
+    // surface silent. Operators alerting on `overall != 'ok'` from the
+    // app log (the runbook's documented canonical surface) would miss
+    // the failure entirely.
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await expect(
+        runTriageBaselineDispatch({
+          pager: FAKE_PAGER,
+          listActiveCustomers: async () => {
+            throw new Error("enumeration boom");
+          },
+        }),
+      ).rejects.toThrow("enumeration boom");
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(parsed.message).toBe("triage_baseline_dispatch");
+      expect(parsed.overall).toBe("failed");
+      expect(parsed.perCustomer).toEqual([]);
+      expect(parsed.totalCustomers).toBe(0);
+      expect(parsed.ok).toBe(0);
+      expect(parsed.skipped).toBe(0);
+      expect(parsed.failed).toBe(0);
+      expect(parsed.timeout).toBe(0);
+      expect(parsed.skippedTimeout).toBe(0);
+      expect(parsed.error).toBe("enumeration boom");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("emits the structured log line when enumeration exceeds the total dispatcher timeout (Round 4 fix)", async () => {
+    // Same monitoring requirement as above, exercised through the
+    // enumeration-timeout self-failure path so the `overall: 'failed'`
+    // log line covers both throw branches the route maps to HTTP 500.
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await expect(
+        runTriageBaselineDispatch({
+          pager: FAKE_PAGER,
+          listActiveCustomers: () => new Promise<number[]>(() => {}),
+          totalTimeoutMs: 80,
+        }),
+      ).rejects.toThrow(
+        /Customer enumeration exceeded total dispatcher timeout/,
+      );
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(parsed.message).toBe("triage_baseline_dispatch");
+      expect(parsed.overall).toBe("failed");
+      expect(parsed.perCustomer).toEqual([]);
+      expect(parsed.error).toMatch(
+        /Customer enumeration exceeded total dispatcher timeout/,
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 });
 
 describe("runTriageBaselineDispatch — active-customer enumeration", () => {

--- a/src/__tests__/lib/triage/baseline/dispatcher.test.ts
+++ b/src/__tests__/lib/triage/baseline/dispatcher.test.ts
@@ -294,6 +294,139 @@ describe("runTriageBaselineDispatch — per-customer timeout", () => {
 });
 
 describe("runTriageBaselineDispatch — total timeout", () => {
+  it("aborts in-flight customers when the dispatcher deadline elapses (does not wait for per-customer timeout to expire after deadline)", async () => {
+    // Regression: previously a customer started just before the total
+    // deadline could keep its full perCustomerTimeoutMs slot, blowing
+    // past the dispatcher's own ceiling. The cron wrapper's
+    // `--max-time` would then kill the HTTP exchange before this
+    // dispatcher returned, dropping the structured response body.
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    const observedAborts: number[] = [];
+    const runCadence = vi.fn(
+      async (
+        customerId: number,
+        opts: { signal?: AbortSignal },
+      ): Promise<{
+        customerId: number;
+        status: "ok" | "skipped" | "failed";
+        observedInserted: number;
+        baselineInserted: number;
+        lastEventCursor: string | null;
+        error?: string;
+      }> => {
+        await new Promise<void>((resolve) => {
+          opts.signal?.addEventListener("abort", () => {
+            observedAborts.push(customerId);
+            resolve();
+          });
+        });
+        return {
+          customerId,
+          status: "ok",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+        };
+      },
+    );
+
+    const startedAt = Date.now();
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [1, 2],
+      runCadence,
+      // Per-customer is far longer than total — without dispatcher-
+      // level abort, the in-flight customers would hold their slots
+      // for the full perCustomerTimeoutMs.
+      perCustomerTimeoutMs: 60_000,
+      totalTimeoutMs: 80,
+      concurrency: 2,
+    });
+    const elapsed = Date.now() - startedAt;
+
+    // The dispatcher must return close to totalTimeoutMs, NOT
+    // perCustomerTimeoutMs.
+    expect(elapsed).toBeLessThan(2000);
+    // Both in-flight customers observed the abort.
+    expect(observedAborts.sort()).toEqual([1, 2]);
+    // Both are reported as `timeout`, not lost as transport failure.
+    const one = result.perCustomer.find((e) => e.customerId === 1);
+    const two = result.perCustomer.find((e) => e.customerId === 2);
+    expect(one?.status).toBe("timeout");
+    expect(two?.status).toBe("timeout");
+    expect(result.overall).toBe("partial");
+  });
+
+  it("caps a newly-started customer's effective timeout to the remaining dispatcher budget", async () => {
+    // With concurrency=1 and a short total budget, the second
+    // customer's effective per-customer timeout is the remaining
+    // budget, not the full perCustomerTimeoutMs.
+    const { runTriageBaselineDispatch } = await import(
+      "@/lib/triage/baseline/dispatcher"
+    );
+
+    let secondAborted = false;
+    const runCadence = vi.fn(
+      async (
+        customerId: number,
+        opts: { signal?: AbortSignal },
+      ): Promise<{
+        customerId: number;
+        status: "ok" | "skipped" | "failed";
+        observedInserted: number;
+        baselineInserted: number;
+        lastEventCursor: string | null;
+        error?: string;
+      }> => {
+        if (customerId === 1) {
+          // Burns most of the dispatcher budget but completes ok.
+          await new Promise((r) => setTimeout(r, 60));
+          return {
+            customerId,
+            status: "ok",
+            observedInserted: 0,
+            baselineInserted: 0,
+            lastEventCursor: null,
+          };
+        }
+        // Customer 2 hangs — only the *remaining* budget should bound
+        // it, not the full perCustomerTimeoutMs.
+        await new Promise<void>((resolve) => {
+          opts.signal?.addEventListener("abort", () => {
+            secondAborted = true;
+            resolve();
+          });
+        });
+        return {
+          customerId,
+          status: "ok",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+        };
+      },
+    );
+
+    const startedAt = Date.now();
+    const result = await runTriageBaselineDispatch({
+      pager: FAKE_PAGER,
+      listActiveCustomers: async () => [1, 2],
+      runCadence,
+      perCustomerTimeoutMs: 60_000,
+      totalTimeoutMs: 100,
+      concurrency: 1,
+    });
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeLessThan(2000);
+    expect(secondAborted).toBe(true);
+    const two = result.perCustomer.find((e) => e.customerId === 2);
+    expect(two?.status).toBe("timeout");
+  });
+
   it("reports unattempted customers as skipped-timeout when the overall deadline elapses", async () => {
     const { runTriageBaselineDispatch } = await import(
       "@/lib/triage/baseline/dispatcher"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/health
+ *
+ * Cheap liveness probe for the in-repo `cron` service to gate hourly
+ * dispatcher firings on (see #487 §1 readiness gate). The handler does
+ * NOT touch the database, dispatch to upstreams, or do any auth work
+ * — it returns immediately so the compose healthcheck stays
+ * lightweight and a failing dependency cannot mask the readiness
+ * signal.
+ *
+ * Anything that needs a deeper check (DB connectivity, upstream mTLS,
+ * etc.) should land on a separate route; this one is reserved for the
+ * "is the Next.js process accepting requests?" question.
+ */
+export function GET(): NextResponse {
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/internal/triage/baseline/dispatch/route.ts
+++ b/src/app/api/internal/triage/baseline/dispatch/route.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { verifyTriageBaselineCadenceToken } from "@/lib/triage/baseline/cadence";
+import { runTriageBaselineDispatch } from "@/lib/triage/baseline/dispatcher";
+import { createCadencePager } from "@/lib/triage/baseline/pager";
+
+/**
+ * POST /api/internal/triage/baseline/dispatch
+ *
+ * Internal-token-guarded fan-out the in-repo `cron` service hits once
+ * per hour. Enumerates active customers and runs one cadence pass per
+ * customer with bounded concurrency + per-customer timeout. The
+ * per-customer route (`/cadence`) stays unchanged — operators can
+ * still POST `{customer_id: N}` for a single-customer manual run.
+ *
+ * Token: shares
+ * `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN` with the per-customer
+ * cadence route. The dispatcher and per-customer endpoints both run
+ * as system actors against the same cadence runner; a separate token
+ * would only add operational moving parts without isolating any
+ * privilege boundary.
+ *
+ * Status codes:
+ *   - 200 with `{ overall: 'ok' | 'partial', perCustomer: [...] }` when
+ *     the dispatcher itself completed. A per-customer failure / timeout
+ *     produces `partial` but still 200 — cron retry decisions stay
+ *     centralised in the wrapper script (see `infra/cron/`).
+ *   - 401 when the bearer token does not verify.
+ *   - 500 with `{ overall: 'failed', error }` only when the dispatcher
+ *     itself fails (e.g. customer enumeration query rejected).
+ */
+
+let CACHED_PAGER: ReturnType<typeof createCadencePager> | null = null;
+
+function getProductionPager() {
+  if (CACHED_PAGER === null) {
+    CACHED_PAGER = createCadencePager();
+  }
+  return CACHED_PAGER;
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = request.headers.get("authorization");
+  const token = auth?.startsWith("Bearer ")
+    ? auth.slice("Bearer ".length).trim()
+    : null;
+  if (!verifyTriageBaselineCadenceToken(token)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runTriageBaselineDispatch({
+      pager: getProductionPager(),
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Dispatcher failed";
+    return NextResponse.json(
+      { overall: "failed", error: message, perCustomer: [] },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -155,12 +155,19 @@ export interface CadencePageResult {
  * `baseline_corpus_state.last_event_cursor` on the first page) and
  * runs every call inside an open page transaction with the per-customer
  * advisory lock already held.
+ *
+ * `signal` is forwarded into the upstream GraphQL `fetch` so a
+ * dispatcher-issued abort terminates the in-flight request promptly
+ * instead of waiting for the resolver to return. Implementations
+ * should treat `signal.aborted` the same as a transport error: rethrow
+ * and let the runner roll back the open page transaction.
  */
 export interface CadencePager {
   ingestPage(
     client: pg.PoolClient,
     customerId: number,
     afterCursor: string | null,
+    signal?: AbortSignal,
   ): Promise<CadencePageResult>;
 }
 
@@ -266,9 +273,9 @@ const MAX_PAGES_PER_RUN = 200;
  */
 export async function runTriageBaselineCadence(
   customerId: number,
-  options: { pager: CadencePager },
+  options: { pager: CadencePager; signal?: AbortSignal },
 ): Promise<CadenceRunResult> {
-  const { pager } = options;
+  const { pager, signal } = options;
 
   // Lets `CustomerNotFoundError` propagate so the route handler can
   // surface it as a 404. In-process callers (future batched drivers,
@@ -284,6 +291,11 @@ export async function runTriageBaselineCadence(
 
   try {
     for (let page = 0; page < MAX_PAGES_PER_RUN; page += 1) {
+      // Check abort before opening a new page transaction. Stops
+      // cleanly at the previously-committed watermark; the next tick
+      // resumes from `last_event_cursor`.
+      if (signal?.aborted) break;
+
       let pageCommitted = false;
       try {
         await client.query("BEGIN");
@@ -321,7 +333,17 @@ export async function runTriageBaselineCadence(
           client,
           customerId,
           nextStartCursor,
+          signal,
         );
+
+        // After the upstream fetch returns: if a dispatcher-issued
+        // abort raced the in-flight page, roll back this page so the
+        // watermark stays at the previously-committed cursor and the
+        // advisory lock releases promptly.
+        if (signal?.aborted) {
+          await client.query("ROLLBACK");
+          break;
+        }
 
         await markOk(client, ingest.endCursor, ingest.exclusionsFp);
         await client.query("COMMIT");

--- a/src/lib/triage/baseline/dispatcher.ts
+++ b/src/lib/triage/baseline/dispatcher.ts
@@ -212,6 +212,35 @@ async function defaultListActiveCustomers(): Promise<number[]> {
   return result.rows.map((r) => Number(r.id));
 }
 
+/**
+ * Race a promise against the dispatcher's abort signal. If the signal
+ * fires first, reject with `reason` so the dispatcher reports a
+ * self-failure (HTTP 500). The underlying promise is left to settle on
+ * its own — for the default enumerator this means a hung `pg` query
+ * eventually GCs once the connection closes.
+ */
+function raceAgainstDispatcherAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  reason: string,
+): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error(reason));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new Error(reason));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 function deriveOverall(
   entries: DispatcherPerCustomerEntry[],
 ): DispatcherOverall {
@@ -261,14 +290,13 @@ export async function runTriageBaselineDispatch(
   const listActiveCustomers =
     options.listActiveCustomers ?? defaultListActiveCustomers;
 
-  const customers = await listActiveCustomers();
-
-  // Index → result slot so we can fill entries in customer-id order
-  // regardless of completion order.
-  const slots: (DispatcherPerCustomerEntry | null)[] = customers.map(
-    () => null,
-  );
-
+  // Start the total-timeout clock at dispatcher entry so customer
+  // enumeration is bounded by the same ceiling as the fan-out. If the
+  // manager DB query hangs past `totalTimeoutMs`, throw a dispatcher
+  // self-failure (the route maps it to HTTP 500 with
+  // `overall: 'failed'`) rather than letting the cron wrapper's
+  // `--max-time` kill the HTTP exchange and discard the structured
+  // response body.
   const startedAt = now();
   const deadline = startedAt + totalTimeoutMs;
 
@@ -283,6 +311,24 @@ export async function runTriageBaselineDispatch(
   const dispatcherTimer = setTimeout(
     () => dispatcherController.abort(),
     Math.max(0, totalTimeoutMs),
+  );
+
+  let customers: number[];
+  try {
+    customers = await raceAgainstDispatcherAbort(
+      listActiveCustomers(),
+      dispatcherController.signal,
+      `Customer enumeration exceeded total dispatcher timeout (${totalTimeoutMs}ms)`,
+    );
+  } catch (err) {
+    clearTimeout(dispatcherTimer);
+    throw err;
+  }
+
+  // Index → result slot so we can fill entries in customer-id order
+  // regardless of completion order.
+  const slots: (DispatcherPerCustomerEntry | null)[] = customers.map(
+    () => null,
   );
 
   let nextIndex = 0;

--- a/src/lib/triage/baseline/dispatcher.ts
+++ b/src/lib/triage/baseline/dispatcher.ts
@@ -23,10 +23,15 @@ import "server-only";
  * `perCustomer[].status` is closed; see #487 §2 for the table.
  *   - `ok` / `skipped` / `failed`: forwarded verbatim from
  *     `runTriageBaselineCadence`.
- *   - `timeout`: this customer's run exceeded the per-customer
- *     timeout. The dispatcher aborted it and freed the concurrency
- *     slot. The runner observed the abort and rolled back the
- *     in-flight page.
+ *   - `timeout`: this customer's run exceeded its effective timeout.
+ *     The dispatcher aborted it and freed the concurrency slot. The
+ *     runner observed the abort and rolled back the in-flight page.
+ *     The effective timeout is `min(perCustomerTimeoutMs,
+ *     remainingDispatcherBudget)` — when the total dispatcher
+ *     deadline approaches, in-flight customers are aborted before the
+ *     network-level `--max-time` in the cron wrapper would kill the
+ *     whole HTTP exchange (which would discard the structured
+ *     response body).
  *   - `skipped-timeout`: the dispatcher's overall timeout fired
  *     before this customer was even attempted. The next hourly tick
  *     picks them up via the existing watermark.
@@ -267,6 +272,19 @@ export async function runTriageBaselineDispatch(
   const startedAt = now();
   const deadline = startedAt + totalTimeoutMs;
 
+  // Dispatcher-level abort. Fires when the total deadline elapses so
+  // any in-flight per-customer cadence run is cancelled (its slot
+  // would otherwise hold up to `perCustomerTimeoutMs` *past* the total
+  // deadline, missing the cron wrapper's `--max-time` and turning a
+  // structured `timeout` outcome into a transport-failure exit). This
+  // is in addition to the cap on each newly-started customer's
+  // effective timeout (`min(perCustomerTimeoutMs, remainingBudget)`).
+  const dispatcherController = new AbortController();
+  const dispatcherTimer = setTimeout(
+    () => dispatcherController.abort(),
+    Math.max(0, totalTimeoutMs),
+  );
+
   let nextIndex = 0;
 
   async function worker(): Promise<void> {
@@ -277,7 +295,8 @@ export async function runTriageBaselineDispatch(
 
       const customerId = customers[i];
 
-      if (now() >= deadline) {
+      const remainingBudget = deadline - now();
+      if (remainingBudget <= 0) {
         slots[i] = {
           customerId,
           status: "skipped-timeout",
@@ -288,19 +307,29 @@ export async function runTriageBaselineDispatch(
         continue;
       }
 
+      const effectiveTimeoutMs = Math.min(
+        perCustomerTimeoutMs,
+        remainingBudget,
+      );
+
       slots[i] = await runOneCustomer(
         customerId,
         runCadence,
         options.pager,
-        perCustomerTimeoutMs,
+        effectiveTimeoutMs,
+        dispatcherController.signal,
       );
     }
   }
 
-  const workerCount = Math.min(concurrency, Math.max(customers.length, 1));
-  const workers: Promise<void>[] = [];
-  for (let w = 0; w < workerCount; w += 1) workers.push(worker());
-  await Promise.all(workers);
+  try {
+    const workerCount = Math.min(concurrency, Math.max(customers.length, 1));
+    const workers: Promise<void>[] = [];
+    for (let w = 0; w < workerCount; w += 1) workers.push(worker());
+    await Promise.all(workers);
+  } finally {
+    clearTimeout(dispatcherTimer);
+  }
 
   const perCustomer = slots.filter(
     (slot): slot is DispatcherPerCustomerEntry => slot !== null,
@@ -322,6 +351,7 @@ async function runOneCustomer(
   runCadence: NonNullable<DispatcherOptions["runCadence"]>,
   pager: CadencePager,
   timeoutMs: number,
+  dispatcherSignal: AbortSignal,
 ): Promise<DispatcherPerCustomerEntry> {
   const controller = new AbortController();
   let timedOut = false;
@@ -329,6 +359,23 @@ async function runOneCustomer(
     timedOut = true;
     controller.abort();
   }, timeoutMs);
+
+  // Propagate dispatcher-level abort (total-timeout reached) into this
+  // customer's signal so any in-flight cadence call rolls back its
+  // open page and returns promptly. We classify the outcome as
+  // `timeout` either way — from the operator's perspective both modes
+  // are "ran out of time on this run".
+  const onDispatcherAbort = () => {
+    timedOut = true;
+    controller.abort();
+  };
+  if (dispatcherSignal.aborted) {
+    onDispatcherAbort();
+  } else {
+    dispatcherSignal.addEventListener("abort", onDispatcherAbort, {
+      once: true,
+    });
+  }
 
   try {
     const result = await runCadence(customerId, {
@@ -394,5 +441,6 @@ async function runOneCustomer(
     };
   } finally {
     clearTimeout(timer);
+    dispatcherSignal.removeEventListener("abort", onDispatcherAbort);
   }
 }

--- a/src/lib/triage/baseline/dispatcher.ts
+++ b/src/lib/triage/baseline/dispatcher.ts
@@ -151,6 +151,8 @@ interface DispatchLogLine {
   failed: number;
   timeout: number;
   skippedTimeout: number;
+  /** Populated only on dispatcher self-failure (`overall: 'failed'`). */
+  error?: string;
 }
 
 function buildLogLine(result: DispatcherResult): DispatchLogLine {
@@ -193,6 +195,25 @@ function buildLogLine(result: DispatcherResult): DispatchLogLine {
     failed,
     timeout,
     skippedTimeout,
+  };
+}
+
+function emitLogLine(line: DispatchLogLine): void {
+  console.log(JSON.stringify(line));
+}
+
+function buildSelfFailureLogLine(error: string): DispatchLogLine {
+  return {
+    message: "triage_baseline_dispatch",
+    overall: "failed",
+    perCustomer: [],
+    totalCustomers: 0,
+    ok: 0,
+    skipped: 0,
+    failed: 0,
+    timeout: 0,
+    skippedTimeout: 0,
+    error,
   };
 }
 
@@ -322,6 +343,14 @@ export async function runTriageBaselineDispatch(
     );
   } catch (err) {
     clearTimeout(dispatcherTimer);
+    // Dispatcher self-failure path. Emit the same canonical structured
+    // log line as the success path so monitoring keyed off
+    // `triage_baseline_dispatch` (#487 §2 monitoring requirement, runbook
+    // "Monitoring") observes `overall: 'failed'`. Without this, an
+    // enumeration hang or error returns HTTP 500 with a structured body
+    // but leaves the canonical log surface silent.
+    const message = err instanceof Error ? err.message : "Dispatcher failed";
+    emitLogLine(buildSelfFailureLogLine(message));
     throw err;
   }
 
@@ -387,7 +416,7 @@ export async function runTriageBaselineDispatch(
   // keys off (#487 §2 monitoring requirement). Operators who want a
   // sidecar can stream stdout into their pipeline; the wrapper script
   // also captures the response body to a timestamped file.
-  console.log(JSON.stringify(buildLogLine(result)));
+  emitLogLine(buildLogLine(result));
 
   return result;
 }

--- a/src/lib/triage/baseline/dispatcher.ts
+++ b/src/lib/triage/baseline/dispatcher.ts
@@ -1,0 +1,398 @@
+import "server-only";
+
+/**
+ * Triage baseline cadence dispatcher (#487).
+ *
+ * Hourly fan-out path that the in-repo `cron` service hits exactly
+ * once per tick: enumerate active customers, run one cadence pass per
+ * customer with bounded concurrency + per-customer timeout, aggregate
+ * the per-customer outcomes into a structured response. The
+ * per-customer cadence runner remains the unit of correctness — this
+ * file just orchestrates the fan-out so the crontab does not need a
+ * customer list of its own.
+ *
+ * The dispatcher invokes the cadence runner **in-process** (no extra
+ * HTTP round-trip per customer): the cron container hits exactly one
+ * dispatcher endpoint, and the dispatcher fans out via direct function
+ * calls. This keeps per-customer logging inside the same Node process
+ * and avoids materialising a per-customer JWT/mTLS handshake we do not
+ * need.
+ *
+ * ## Status enum
+ *
+ * `perCustomer[].status` is closed; see #487 §2 for the table.
+ *   - `ok` / `skipped` / `failed`: forwarded verbatim from
+ *     `runTriageBaselineCadence`.
+ *   - `timeout`: this customer's run exceeded the per-customer
+ *     timeout. The dispatcher aborted it and freed the concurrency
+ *     slot. The runner observed the abort and rolled back the
+ *     in-flight page.
+ *   - `skipped-timeout`: the dispatcher's overall timeout fired
+ *     before this customer was even attempted. The next hourly tick
+ *     picks them up via the existing watermark.
+ *
+ * ## `overall` derivation
+ *
+ *   - `ok` ⇔ every per-customer status is `ok` or `skipped`.
+ *   - `partial` ⇔ at least one customer is `failed | timeout |
+ *     skipped-timeout` AND the dispatcher itself completed.
+ *   - `failed` is reserved for **dispatcher self-failure** (e.g.
+ *     enumerating customers blew up). The route handler maps that to
+ *     HTTP 500. Per-customer outcomes never escalate to `overall:
+ *     'failed'` — they live in `perCustomer[]`.
+ */
+
+import {
+  type CadencePager,
+  type CadenceRunResult,
+  runTriageBaselineCadence,
+} from "@/lib/triage/baseline/cadence";
+import { CustomerNotFoundError } from "@/lib/triage/policy/customer-db";
+
+export type DispatcherPerCustomerStatus =
+  | "ok"
+  | "skipped"
+  | "failed"
+  | "timeout"
+  | "skipped-timeout";
+
+export type DispatcherOverall = "ok" | "partial" | "failed";
+
+export interface DispatcherPerCustomerEntry {
+  customerId: number;
+  status: DispatcherPerCustomerStatus;
+  observedInserted: number;
+  baselineInserted: number;
+  lastEventCursor: string | null;
+  /** Populated for `failed` and `timeout`; carries the cause string. */
+  error?: string;
+}
+
+export interface DispatcherResult {
+  overall: DispatcherOverall;
+  perCustomer: DispatcherPerCustomerEntry[];
+}
+
+export interface DispatcherOptions {
+  pager: CadencePager;
+  /**
+   * Resolves the active-customer list. Defaults to a `SELECT id FROM
+   * customers WHERE status = 'active'` against the manager DB. Tests
+   * inject a fake.
+   */
+  listActiveCustomers?: () => Promise<number[]>;
+  /**
+   * Concurrency cap (per-tick). Defaults to
+   * `TRIAGE_BASELINE_DISPATCH_CONCURRENCY` or 4.
+   */
+  concurrency?: number;
+  /**
+   * Per-customer hard timeout in milliseconds. Defaults to
+   * `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS` or 15 minutes.
+   * On timeout the runner's AbortSignal fires, the slot is freed, and
+   * the per-customer entry reports `status: 'timeout'`.
+   */
+  perCustomerTimeoutMs?: number;
+  /**
+   * Total dispatcher timeout in milliseconds. Defaults to
+   * `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS` or 45 minutes. When the
+   * deadline passes, customers that have not yet started are reported
+   * as `skipped-timeout`. The cron wrapper's `--max-time` should be
+   * kept equal to this value so the application-level timeout wins
+   * over the network-level timeout.
+   */
+  totalTimeoutMs?: number;
+  /**
+   * Override the cadence runner. Tests inject a fake; production
+   * defaults to {@link runTriageBaselineCadence}.
+   */
+  runCadence?: (
+    customerId: number,
+    options: { pager: CadencePager; signal?: AbortSignal },
+  ) => Promise<CadenceRunResult>;
+  /**
+   * Override the wall-clock now() used for the total-timeout
+   * computation. Defaults to `Date.now()`.
+   */
+  now?: () => number;
+}
+
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_PER_CUSTOMER_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_TOTAL_TIMEOUT_MS = 45 * 60 * 1000;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    return fallback;
+  }
+  return parsed;
+}
+
+interface DispatchLogLine {
+  message: "triage_baseline_dispatch";
+  overall: DispatcherOverall;
+  perCustomer: Array<{
+    customerId: number;
+    status: DispatcherPerCustomerStatus;
+    observedInserted: number;
+    baselineInserted: number;
+  }>;
+  totalCustomers: number;
+  ok: number;
+  skipped: number;
+  failed: number;
+  timeout: number;
+  skippedTimeout: number;
+}
+
+function buildLogLine(result: DispatcherResult): DispatchLogLine {
+  let ok = 0;
+  let skipped = 0;
+  let failed = 0;
+  let timeout = 0;
+  let skippedTimeout = 0;
+  for (const entry of result.perCustomer) {
+    switch (entry.status) {
+      case "ok":
+        ok += 1;
+        break;
+      case "skipped":
+        skipped += 1;
+        break;
+      case "failed":
+        failed += 1;
+        break;
+      case "timeout":
+        timeout += 1;
+        break;
+      case "skipped-timeout":
+        skippedTimeout += 1;
+        break;
+    }
+  }
+  return {
+    message: "triage_baseline_dispatch",
+    overall: result.overall,
+    perCustomer: result.perCustomer.map((e) => ({
+      customerId: e.customerId,
+      status: e.status,
+      observedInserted: e.observedInserted,
+      baselineInserted: e.baselineInserted,
+    })),
+    totalCustomers: result.perCustomer.length,
+    ok,
+    skipped,
+    failed,
+    timeout,
+    skippedTimeout,
+  };
+}
+
+/**
+ * Default active-customer enumerator. Kept in the dispatcher module so
+ * tests can mock the whole `listActiveCustomers` callback without
+ * stubbing `pg`.
+ */
+async function defaultListActiveCustomers(): Promise<number[]> {
+  // Imported lazily so test harnesses that stub `listActiveCustomers`
+  // never load the real `pg` client (and therefore never fail to read
+  // `DATABASE_URL`).
+  const { query } = await import("@/lib/db/client");
+  const result = await query<{ id: number }>(
+    "SELECT id FROM customers WHERE status = 'active' ORDER BY id",
+  );
+  return result.rows.map((r) => Number(r.id));
+}
+
+function deriveOverall(
+  entries: DispatcherPerCustomerEntry[],
+): DispatcherOverall {
+  for (const entry of entries) {
+    if (
+      entry.status === "failed" ||
+      entry.status === "timeout" ||
+      entry.status === "skipped-timeout"
+    ) {
+      return "partial";
+    }
+  }
+  return "ok";
+}
+
+/**
+ * Run one dispatcher pass. Throws only when the dispatcher itself
+ * cannot make per-customer attempts meaningful (e.g. customer
+ * enumeration fails). Per-customer failures are reflected in the
+ * returned `perCustomer[]` entry, never as a thrown error.
+ */
+export async function runTriageBaselineDispatch(
+  options: DispatcherOptions,
+): Promise<DispatcherResult> {
+  const concurrency = Math.max(
+    1,
+    options.concurrency ??
+      readPositiveIntEnv(
+        "TRIAGE_BASELINE_DISPATCH_CONCURRENCY",
+        DEFAULT_CONCURRENCY,
+      ),
+  );
+  const perCustomerTimeoutMs =
+    options.perCustomerTimeoutMs ??
+    readPositiveIntEnv(
+      "TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS",
+      DEFAULT_PER_CUSTOMER_TIMEOUT_MS,
+    );
+  const totalTimeoutMs =
+    options.totalTimeoutMs ??
+    readPositiveIntEnv(
+      "TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS",
+      DEFAULT_TOTAL_TIMEOUT_MS,
+    );
+  const now = options.now ?? (() => Date.now());
+  const runCadence = options.runCadence ?? runTriageBaselineCadence;
+  const listActiveCustomers =
+    options.listActiveCustomers ?? defaultListActiveCustomers;
+
+  const customers = await listActiveCustomers();
+
+  // Index → result slot so we can fill entries in customer-id order
+  // regardless of completion order.
+  const slots: (DispatcherPerCustomerEntry | null)[] = customers.map(
+    () => null,
+  );
+
+  const startedAt = now();
+  const deadline = startedAt + totalTimeoutMs;
+
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = nextIndex;
+      if (i >= customers.length) return;
+      nextIndex = i + 1;
+
+      const customerId = customers[i];
+
+      if (now() >= deadline) {
+        slots[i] = {
+          customerId,
+          status: "skipped-timeout",
+          observedInserted: 0,
+          baselineInserted: 0,
+          lastEventCursor: null,
+        };
+        continue;
+      }
+
+      slots[i] = await runOneCustomer(
+        customerId,
+        runCadence,
+        options.pager,
+        perCustomerTimeoutMs,
+      );
+    }
+  }
+
+  const workerCount = Math.min(concurrency, Math.max(customers.length, 1));
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < workerCount; w += 1) workers.push(worker());
+  await Promise.all(workers);
+
+  const perCustomer = slots.filter(
+    (slot): slot is DispatcherPerCustomerEntry => slot !== null,
+  );
+  const overall = deriveOverall(perCustomer);
+  const result: DispatcherResult = { overall, perCustomer };
+
+  // Single structured log line — the canonical surface monitoring
+  // keys off (#487 §2 monitoring requirement). Operators who want a
+  // sidecar can stream stdout into their pipeline; the wrapper script
+  // also captures the response body to a timestamped file.
+  console.log(JSON.stringify(buildLogLine(result)));
+
+  return result;
+}
+
+async function runOneCustomer(
+  customerId: number,
+  runCadence: NonNullable<DispatcherOptions["runCadence"]>,
+  pager: CadencePager,
+  timeoutMs: number,
+): Promise<DispatcherPerCustomerEntry> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    const result = await runCadence(customerId, {
+      pager,
+      signal: controller.signal,
+    });
+    if (timedOut) {
+      return {
+        customerId,
+        status: "timeout",
+        observedInserted: result.observedInserted,
+        baselineInserted: result.baselineInserted,
+        lastEventCursor: result.lastEventCursor,
+        error: `Per-customer timeout after ${timeoutMs}ms`,
+      };
+    }
+    const status: DispatcherPerCustomerStatus =
+      result.status === "ok"
+        ? "ok"
+        : result.status === "skipped"
+          ? "skipped"
+          : "failed";
+    return {
+      customerId,
+      status,
+      observedInserted: result.observedInserted,
+      baselineInserted: result.baselineInserted,
+      lastEventCursor: result.lastEventCursor,
+      ...(result.error !== undefined ? { error: result.error } : {}),
+    };
+  } catch (err) {
+    if (timedOut) {
+      return {
+        customerId,
+        status: "timeout",
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+        error: `Per-customer timeout after ${timeoutMs}ms`,
+      };
+    }
+    if (err instanceof CustomerNotFoundError) {
+      // The customer was active when we enumerated but is no longer.
+      // Treat as a per-customer failure: visible in `perCustomer[]`,
+      // not a dispatcher self-failure.
+      return {
+        customerId,
+        status: "failed",
+        observedInserted: 0,
+        baselineInserted: 0,
+        lastEventCursor: null,
+        error: err.message,
+      };
+    }
+    const message = err instanceof Error ? err.message : "Cadence failed";
+    return {
+      customerId,
+      status: "failed",
+      observedInserted: 0,
+      baselineInserted: 0,
+      lastEventCursor: null,
+      error: message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/triage/baseline/pager.ts
+++ b/src/lib/triage/baseline/pager.ts
@@ -133,6 +133,13 @@ export interface CadenceFetchPageArgs {
     first: number;
     after: string | null;
   };
+  /**
+   * Optional abort signal forwarded by the runner. The default fetcher
+   * threads it into the GraphQL `fetch` so a dispatcher-issued abort
+   * (e.g. per-customer timeout) terminates the upstream request
+   * promptly rather than waiting for the resolver to return.
+   */
+  signal?: AbortSignal;
 }
 
 export interface CadencePagerOptions {
@@ -176,10 +183,12 @@ export function createCadencePager(
       client: pg.PoolClient,
       customerId: number,
       afterCursor: string | null,
+      signal?: AbortSignal,
     ): Promise<CadencePageResult> {
       // (a) Fetch raw standard-filter page from review.
       const response = await fetchPage({
         customerId,
+        signal,
         variables: {
           filter: { customers: [String(customerId)] },
           triage: null,
@@ -262,7 +271,7 @@ async function defaultFetchPage(
   };
   // biome-ignore format: keep the call on one line so the scope-allowlist
   // override sits on the same line as the graphqlRequest call.
-  return graphqlRequest<CadenceConnectionResponse, typeof args.variables>(EVENT_LIST_WITH_TRIAGE_QUERY, args.variables, context); // scope-allowlist: #481 system-actor cadence; customer scope materialised via JWT customer_ids + filter.customers
+  return graphqlRequest<CadenceConnectionResponse, typeof args.variables>(EVENT_LIST_WITH_TRIAGE_QUERY, args.variables, context, args.signal); // scope-allowlist: #481 system-actor cadence; customer scope materialised via JWT customer_ids + filter.customers
 }
 
 async function insertObservedEventMeta(


### PR DESCRIPTION
## Summary

Closes the §4 "scheduler registration" deliverable that PR #484
deferred from #481. aice-web-next ships its own `docker-compose.yml`
as the deployment unit, so the natural place to wire cron is here
(not in an external infra repo).

This PR adds:

- A new `cron` service in [`docker-compose.yml`](https://github.com/aicers/aice-web-next/blob/sehkone/issue-487/docker-compose.yml#L75-L98) (Alpine + busybox `crond` + `jq`), gated on a new `next-app` healthcheck. Entrypoint materialises an allow-listed env file because busybox `crond` does not propagate container env into spawned jobs.
- `GET /api/health` cheap liveness probe (no DB call) hit by the compose healthcheck via `node -e fetch(...)` to avoid adding `curl` to the runner image.
- `POST /api/internal/triage/baseline/dispatch` — internal-token fan-out that enumerates active customers, runs the cadence pass **in-process** per customer with bounded concurrency (default 4), per-customer timeout (default 15 min, `AbortSignal`-cancellable), and a total dispatcher timeout (default 45 min). Aggregates outcomes into a closed `perCustomer[].status` enum (`ok | skipped | failed | timeout | skipped-timeout`) and a deterministic `overall`. Emits one structured `console.log` line per invocation as the canonical monitoring surface — including on dispatcher self-failure (Round 4 fix).
- Total-dispatcher timeout is enforced as a real invocation ceiling (Round 1 review fix): each newly-started customer's effective timeout is capped to `min(perCustomerTimeoutMs, remainingDispatcherBudget)`, AND a dispatcher-level `AbortController` fires at the total deadline so already-running customers also abort. The dispatcher therefore always returns within `totalTimeoutMs`, so the structured-response `timeout`/`skipped-timeout` rows reach the cron wrapper instead of being dropped as transport failures by `--max-time`.
- Customer enumeration is bounded by the same total ceiling (Round 3 review fix): the total-timeout clock starts at dispatcher entry, and `listActiveCustomers()` is raced against the dispatcher `AbortController`. A hung manager DB query produces a dispatcher self-failure (HTTP 500, `overall: 'failed'`) so the structured body reaches the cron wrapper, instead of being killed by the wrapper's `--max-time` as a bodyless transport failure.
- Dispatcher self-failure now also emits the canonical structured log line (Round 4 review fix): when enumeration throws or exceeds the total timeout, the dispatcher emits the same `triage_baseline_dispatch` line with `overall: 'failed'`, empty `perCustomer`, all counters at 0, and an `error` field — so operators alerting on `overall != 'ok'` from the canonical app-log surface (per the runbook) catch self-failure cases too, not just `partial`. The route still maps the throw to HTTP 500 with the structured body unchanged.
- Cadence runner + pager now thread `AbortSignal` end-to-end so a dispatcher-issued timeout rolls back the in-flight page transaction and releases the per-customer advisory lock — not "release the slot but keep running".
- [`infra/cron/crontab`](https://github.com/aicers/aice-web-next/blob/sehkone/issue-487/infra/cron/crontab) one-line entry plus [`infra/cron/run-triage-baseline-dispatch.sh`](https://github.com/aicers/aice-web-next/blob/sehkone/issue-487/infra/cron/run-triage-baseline-dispatch.sh) wrapper that separates HTTP status from response body, parses `overall` with `jq` (no `grep` fallback), classifies transport / auth / HTTP-with-body failures explicitly (no `set -e`), and exits non-zero only for transport + 401/403 so cron's MAILTO is reserved for real misconfiguration.
- Wrapper script is now testable end-to-end (Round 1 review fix): `LOG_DIR`, `ENV_FILE`, `MAX_TIME_S`, and `CONNECT_TIMEOUT_S` are env-overridable so tests can drive the script through every classified branch (200/ok, 200/partial, 200/invalid-JSON, 401, 403, 500, transport timeout, missing-token) and assert exit code, stdout summary, stderr WARN line, and saved body file. Production crontab leaves the new env vars unset, so the prod paths and timeouts are unchanged.
- Wrapper `--max-time` is now derived from `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS` (Round 2 review fix): the entrypoint allowlists the dispatcher knob into `/etc/cron.env`, the wrapper converts ms → s (rounded up so the network ceiling never undercuts the app deadline) when the operator-tunable knob is set, and falls back to the same 2700s default `next-app` uses. Raising the operator knob in `.env` therefore raises both the application and the network ceiling in lockstep, eliminating the "operator tunes one, the other still kills the request" failure mode.
- Runbook (EN + KR) rewritten around the in-repo cron service plus a new **Monitoring** section instructing operators to alert on `overall != 'ok'`. Round 4 update: the Monitoring section now also documents that the canonical log line covers dispatcher self-failure (`overall: 'failed'`), so a single alert rule on `overall != 'ok'` catches both partial and self-failure cases.
- `.env.example` documents the new dispatcher tuning vars (`TRIAGE_BASELINE_DISPATCH_CONCURRENCY`, `TRIAGE_BASELINE_DISPATCH_PER_CUSTOMER_TIMEOUT_MS`, `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS`, `NEXT_APP_BASE_URL`) and notes the dispatcher reuses `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`.

Implementation choices flagged in the issue for PR review:

- **Auth**: dispatcher reuses the cadence token. Both endpoints run as system actors against the same runner; a separate token would only add operational moving parts without isolating any privilege boundary.
- **Fan-out**: in-process call (not HTTP fan-out). Single dispatcher endpoint hit by cron, fan-out via direct function calls. Per-customer logging stays inside the same Node process; no per-customer JWT/mTLS handshake we do not need.
- **Readiness gate**: compose `service_healthy` against `/api/health` (preferred over a wait-for-url loop in the cron entrypoint).

Closes #487. Closes #481.

## Test plan

- [x] `docker compose --profile prod up -d` starts `cron` alongside `postgres`, `next-app`, `nginx-prod`; `cron` does not fire any HTTP request until `next-app`'s `/api/health` returns 200 (compose `service_healthy` gate).
- [x] Container-level smoke test: `$TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN` is non-empty inside a cron job at execution time (env passthrough via `/etc/cron.env`).
- [x] Manual `curl -X POST` to `/api/internal/triage/baseline/dispatch` with the bearer token returns 200 and a structured response body with `overall` and `perCustomer[]`.
- [x] Dispatcher enumerates only `customers WHERE status = 'active'` and counters land in `baseline_corpus_state` for each active customer (covered by unit test in `dispatcher.test.ts`).
- [x] `overall` derivation matches the table: `ok` only when every status is `ok`/`skipped`; any `failed`/`timeout`/`skipped-timeout` produces `partial`; dispatcher self-failure produces `failed` + HTTP 500.
- [x] `perCustomer[].status` is restricted to the documented enum; unexpected values caught by `tsc`.
- [x] Concurrency cap: with 10 customers and `TRIAGE_BASELINE_DISPATCH_CONCURRENCY=4`, no more than 4 per-customer invocations are in flight at any point.
- [x] Per-customer timeout cancels a stuck cadence call: dispatcher slot is released within ~timeout-MS AND the underlying `runCadence` mock observed the abort (rules out the "release slot but keep running" anti-pattern).
- [x] Total dispatcher timeout aborts in-flight customers (Round 1 fix): with `perCustomerTimeoutMs=60_000` and `totalTimeoutMs=80`, two stuck customers are aborted and reported as `timeout` while the dispatcher returns within ~80ms — proving the dispatcher honours its own ceiling.
- [x] Newly-started customer's effective timeout is capped to remaining dispatcher budget (Round 1 fix): with concurrency=1, customer 1 burns most of an `100ms` total budget; customer 2 is bounded by the remainder, not by `perCustomerTimeoutMs`.
- [x] Customer enumeration is bounded by the total budget (Round 3 fix): a never-resolving `listActiveCustomers()` rejects within ~`totalTimeoutMs` (test uses 80ms) with `Customer enumeration exceeded total dispatcher timeout`, so the route returns HTTP 500 with `overall: 'failed'` instead of running into the wrapper's `--max-time` as a bodyless transport failure.
- [x] Dispatcher self-failure emits the canonical structured log line (Round 4 fix): two regression tests cover both throw branches the route maps to HTTP 500 — `listActiveCustomers()` throws (covers the synchronous error path) and `listActiveCustomers()` never resolves with `totalTimeoutMs=80` (covers the timeout path). Both assert `console.log` is called exactly once with `overall: 'failed'`, `perCustomer: []`, all counters 0, and an `error` field carrying the cause.
- [x] Cadence runner / pager accept `AbortSignal`: signalling abort mid-run after page 1 commits leaves page-1 watermark intact and emits no page-2 INSERTs.
- [x] Dispatcher emits a single structured `console.log` line containing `overall`, `perCustomer[].status`, and counters.
- [x] `GET /api/health` returns 200 `{\"ok\": true}` and makes no DB call (covered by `route.test.ts`).
- [x] Wrapper static checks: contains `--connect-timeout` and `--max-time`, does NOT contain `set -e`, uses `jq` (not `grep`) to parse `overall`.
- [x] Wrapper execution tests (Round 1 fix — `wrapper-script.test.ts`): a stub `curl` on PATH drives the script through every classified branch and asserts exit code, stdout, stderr, and the saved body file:
  - 200 / `overall=ok`: exit 0; stdout has `overall=ok` and per-status counters; stderr is empty.
  - 200 / `overall=partial`: exit 0; stdout summary fires; stderr WARN includes the bad customer ids.
  - 200 / invalid JSON: exit 0; stderr warns \"not valid JSON\".
  - 401 / 403: exit non-zero; stderr \"auth failure (HTTP 4xx)\".
  - 500 with structured body: exit 0; stderr \"HTTP 500 from dispatcher\" with the body's `error`; full body saved.
  - 500 with unparseable body: exit 0; stderr warns \"body unparseable\".
  - Transport failure (curl exit 28 = `--max-time` reached): exit non-zero; stderr \"transport failure\" with `curl_exit=28`.
  - Transport failure (curl exit 7 = connection refused): exit non-zero with `curl_exit=7`.
  - Missing `TRIAGE_BASELINE_CADENCE_INTERNAL_TOKEN`: exit non-zero before any HTTP call.
- [x] Wrapper derives `--max-time` from `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS` (Round 2 fix): four new execution cases assert ms → s conversion (5_400_000ms → 5400s), ceiling rounding (1500ms → 2s), the 2700s default fallback, and `CRON_CADENCE_MAX_TIME_S` precedence over the dispatcher knob. A new entrypoint static-contract test confirms `TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS` is on the env allowlist.
- [x] Runbook (EN + KR) updated with the new dispatcher route, the `cron` service reference, the **Monitoring** subsection, the refined `timeout` row, the auto-derivation note for the wrapper's `--max-time`, and the Round 4 note that the canonical log line also covers dispatcher self-failure. `mkdocs build --strict` passes.
- [x] CI gate green: `pnpm biome check`, `pnpm tsc --noEmit`, `pnpm vitest run` (3882 tests), `pnpm build`.
