### PR TITLE
Switch agent-dir prune from denylist to allowlist

### DIFF
--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -30,12 +30,29 @@ jobs:
       #   - codex and gemini-cli are universal agents that read directly
       #     from `.agents/skills/`, so no extra dir is needed for them
       # Prune everything else so the weekly PR stays small.
+      #
+      # Deletion is scoped to the shapes the `skills` CLI actually produces:
+      #   - root `skills/` (legacy top-level dir)
+      #   - `.<agent>/skills/`
+      #   - `.<agent>/agent/skills/`
+      # The dot-prefix gate protects future non-dotted project dirs that may
+      # happen to contain a `skills/` subdir (e.g. `tools/skills/`) from being
+      # wiped. If the CLI ever introduces a structurally different layout, the
+      # next weekly PR will surface it and we extend the shape list here.
       - name: Prune non-allowlisted agent directories
         run: |
-          rm -rf .adal .agent .augment .bob .codebuddy .commandcode .continue \
-            .cortex .crush .factory .goose .iflow .junie .kilocode .kiro \
-            .kode .mcpjam .mux .neovate .openhands .pi .pochi .qoder .qwen \
-            .roo .trae .vibe .windsurf .zencoder skills
+          shopt -s nullglob dotglob
+          for entry in */ .*/; do
+            name=${entry%/}
+            case "$name" in
+              .|..|.git|.github|.agents|.claude) continue ;;
+            esac
+            if [ "$name" = "skills" ] ||
+               { [ "${name#.}" != "$name" ] &&
+                 { [ -d "$name/skills" ] || [ -d "$name/agent/skills" ]; }; }; then
+              rm -rf "$name"
+            fi
+          done
       # `skills update` pulls every skill its configured source repos expose,
       # including new ones we never opted in to. The CLI has no per-skill
       # allowlist flag in v1.5.0, so post-prune to the skill set we actually


### PR DESCRIPTION
## Summary

The hardcoded denylist in the `Update Agent Skills` workflow misses any new agent the `skills` CLI starts targeting (e.g. the `.aider-desk`, `.devin`, `.tabnine`, … dirs added in #431), so unwanted agent dirs leak into the weekly auto-PR.

Replace the denylist with a name-agnostic loop scoped to the shapes the `skills` CLI actually produces:

- legacy root `skills/`
- `.<agent>/skills/`
- `.<agent>/agent/skills/`

The dot-prefix gate protects future non-dotted project dirs that may happen to contain a `skills/` subdir (e.g. `tools/skills/`) from being wiped — `actions/checkout` materializes all tracked dirs alongside the CLI-generated ones, so a blanket "drop anything not in KEEP" loop would be unsafe.

If the CLI ever introduces a structurally different layout (e.g. `<agent>/extensions/skills/`), this loop will leak it — fine, the next weekly PR will surface it and we extend the shape list.

Closes #435

## Test plan

Verified locally with the simulation from the issue: created a sandbox with `.devin/skills`, `.tabnine/agent/skills`, `.aider-desk/skills`, and root `skills/` alongside tracked dirs (`src/`, `docs/`, `migrations/`, `public/`, `scripts/`, `schemas/`, `e2e/`, and a `tools/skills/` honeypot), then ran the new prune script.

- [x] All four CLI-shaped dirs (`.devin`, `.tabnine`, `.aider-desk`, root `skills`) pruned
- [x] `tools/skills/` survived (dot-prefix gate works)
- [x] All tracked repo dirs (`src/`, `docs/`, …) untouched
- [x] `.agents/skills/`, `.claude/`, `.github/` survived (explicit `case` exclusions)