### PR TITLE
Activate customerSensorList dispatch in listSensors (#305)

### DIFF
--- a/src/__tests__/app/detection-sensor-actions.test.ts
+++ b/src/__tests__/app/detection-sensor-actions.test.ts
@@ -97,8 +97,8 @@ describe("fetchSensors server action", () => {
     mockListSensors.mockResolvedValue({
       endpointAvailable: true,
       sensors: [
-        { id: "s1", name: "Sensor One", customerId: "cust-1" },
-        { id: "s2", name: "Sensor Two", customerId: "cust-2" },
+        { id: "s1", name: "Sensor One", customerId: 1 },
+        { id: "s2", name: "Sensor Two", customerId: 2 },
       ],
     });
 
@@ -111,8 +111,8 @@ describe("fetchSensors server action", () => {
       ok: true,
       endpointAvailable: true,
       sensors: [
-        { id: "s1", name: "Sensor One", customerId: "cust-1" },
-        { id: "s2", name: "Sensor Two", customerId: "cust-2" },
+        { id: "s1", name: "Sensor One", customerId: 1 },
+        { id: "s2", name: "Sensor Two", customerId: 2 },
       ],
     });
   });

--- a/src/__tests__/lib/detection/review-integration.test.ts
+++ b/src/__tests__/lib/detection/review-integration.test.ts
@@ -199,6 +199,100 @@ describe("detection ↔ REview wiring (network mocked)", () => {
     expect(typeof result.totalCount).toBe("string");
   });
 
+  it("dispatches listSensors() through the Context JWT and projects { customerId, nodeId, hostFqdn } into { id, name, customerId }", async () => {
+    // Phase Detection-24 wiring: drive the real `listSensors` server
+    // action through the real `graphqlRequest` helper. Verifies:
+    //   1. A POST happens against REview with the SensorList operation.
+    //   2. No explicit `customerIds` argument on the query — scope
+    //      travels on the Context JWT (`signContextJwt(role, customerIds)`).
+    //   3. The wire payload `customerSensorList.nodes[]` (SDL fields
+    //      `customerId: Int!`, `nodeId: ID!`, `hostFqdn: String!`) is
+    //      projected into the consumer-facing
+    //      `{ id, name, customerId: number }` shape.
+    //   4. SystemAdministrator callers ship `customer_ids = undefined`
+    //      on the JWT (review's "all customers" wire semantics) — same
+    //      contract as the event-list path.
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
+
+    fetchSpy.mockResolvedValue(
+      okJson({
+        data: {
+          customerSensorList: {
+            nodes: [
+              {
+                customerId: 42,
+                nodeId: "1",
+                hostFqdn: "sensor-a.example.com",
+              },
+              {
+                customerId: 99,
+                nodeId: "2",
+                hostFqdn: "sensor-b.example.com",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    const { listSensors } = await import("@/lib/detection");
+    const result = await listSensors(makeSession(["Security Monitor"]));
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer mock-jwt-token");
+    expect(signContextJwtSpy).toHaveBeenCalledWith(
+      "Security Monitor",
+      [42, 99],
+    );
+
+    const body = JSON.parse(init.body);
+    expect(body.query).toContain("query SensorList");
+    expect(body.query).toContain("customerSensorList");
+    // No `customerIds` argument shipped to the query — the JWT carries
+    // the scope. The query is parameter-less; review applies the JWT
+    // claims to scope.
+    expect(body.query).not.toContain("$customerIds");
+    expect(body.query).not.toContain("customerIds:");
+
+    expect(result).toEqual({
+      endpointAvailable: true,
+      sensors: [
+        { id: "1", name: "sensor-a.example.com", customerId: 42 },
+        { id: "2", name: "sensor-b.example.com", customerId: 99 },
+      ],
+    });
+    // `customerId` is numeric (post-migration), matching SDL `Int!`.
+    if (result.endpointAvailable) {
+      for (const s of result.sensors) {
+        expect(typeof s.customerId).toBe("number");
+      }
+    }
+  });
+
+  it("listSensors() for SystemAdministrator ships customer_ids = undefined on the JWT", async () => {
+    // Symmetric to the event-list path's JWT claim contract: SysAdmin
+    // omits `customer_ids` from the JWT so review's "all customers"
+    // semantics apply. A fresh install with no `customers` rows still
+    // reaches the endpoint.
+    mockHasPermission.mockResolvedValue(true);
+    mockResolveEffectiveCustomerIds.mockResolvedValue([]);
+
+    fetchSpy.mockResolvedValue(
+      okJson({ data: { customerSensorList: { nodes: [] } } }),
+    );
+
+    const { listSensors } = await import("@/lib/detection");
+    await listSensors(makeSession(["System Administrator"]));
+
+    expect(signContextJwtSpy).toHaveBeenCalledWith(
+      "System Administrator",
+      undefined,
+    );
+  });
+
   it("fixture validates against schemas/review.graphql", async () => {
     // Two-stage regression guard against silent drift:
     //

--- a/src/__tests__/lib/detection/sensors-endpoint-guard.test.ts
+++ b/src/__tests__/lib/detection/sensors-endpoint-guard.test.ts
@@ -9,26 +9,52 @@ import { SENSOR_LIST_ENDPOINT_AVAILABLE } from "@/lib/detection";
 const REPO_ROOT = path.resolve(__dirname, "../../../..");
 const SCHEMA_PATH = path.join(REPO_ROOT, "schemas/review.graphql");
 
-// Candidate field names for the REview sensor-list query. The exact
-// identifier is TBD on the REview side — whichever name ships, the
-// guard below accepts it, so this repo only needs to flip the
-// `SENSOR_LIST_ENDPOINT_AVAILABLE` constant (and add the inline
-// `parse(...)` dispatch) to wire the query.
-const CANDIDATE_FIELDS = ["sensorList", "sensorsForCustomers"] as const;
+const QUERY_FIELD = "customerSensorList";
+const SENSOR_TYPE = "Sensor";
+const SENSOR_NODE_ID_FIELD = "nodeId";
 
-function schemaExposesAnyCandidate(): {
+function schemaExposesSensorListContract(): {
   exposed: boolean;
-  matched: string | null;
+  reason: string | null;
 } {
   const sdl = readFileSync(SCHEMA_PATH, "utf8");
   const schema = buildSchema(sdl);
   const queryType = schema.getQueryType();
-  if (!queryType) return { exposed: false, matched: null };
-  const fields = queryType.getFields();
-  for (const candidate of CANDIDATE_FIELDS) {
-    if (candidate in fields) return { exposed: true, matched: candidate };
+  if (!queryType) {
+    return { exposed: false, reason: "schema has no Query type" };
   }
-  return { exposed: false, matched: null };
+  if (!(QUERY_FIELD in queryType.getFields())) {
+    return {
+      exposed: false,
+      reason: `Query.${QUERY_FIELD} is not defined`,
+    };
+  }
+  const sensorType = schema.getType(SENSOR_TYPE);
+  if (!sensorType || !("getFields" in sensorType)) {
+    return {
+      exposed: false,
+      reason: `type ${SENSOR_TYPE} is not an object/interface type`,
+    };
+  }
+  const sensorFields = (
+    sensorType as {
+      getFields: () => Record<string, { type: { toString(): string } }>;
+    }
+  ).getFields();
+  const nodeIdField = sensorFields[SENSOR_NODE_ID_FIELD];
+  if (!nodeIdField) {
+    return {
+      exposed: false,
+      reason: `${SENSOR_TYPE}.${SENSOR_NODE_ID_FIELD} is not defined`,
+    };
+  }
+  if (nodeIdField.type.toString() !== "ID!") {
+    return {
+      exposed: false,
+      reason: `${SENSOR_TYPE}.${SENSOR_NODE_ID_FIELD} must be ID!, got ${nodeIdField.type.toString()}`,
+    };
+  }
+  return { exposed: true, reason: null };
 }
 
 describe("detection sensor-list endpoint guard", () => {
@@ -41,34 +67,31 @@ describe("detection sensor-list endpoint guard", () => {
     // would first have had to flip the constant — and would trip this
     // test if the vendored schema had not caught up.
     //
-    // When REview ships the query and the schema is bumped in this
-    // repo:
-    //   1. The schema check below starts returning { exposed: true }.
-    //   2. Flip `SENSOR_LIST_ENDPOINT_AVAILABLE` to `true` in
-    //      src/lib/detection/sensors.ts.
-    //   3. Add the `parse(...)` dispatch to ./queries.ts and wire it
-    //      up in listSensors() following the same pattern as
-    //      buildDispatchContext in server-actions.ts.
+    // The matcher accepts the endpoint as "available" only when BOTH:
+    //   - `Query.customerSensorList` exists, and
+    //   - `Sensor.nodeId: ID!` exists.
     //
-    // Leaving any of those three changes out fails CI here.
-    const { exposed, matched } = schemaExposesAnyCandidate();
+    // A pre-review-web-0.33.0 schema that exposed `customerSensorList`
+    // without `Sensor.nodeId` (the old `agentKey` shape, per-agent grain)
+    // would not satisfy the contract: the dispatch projects `nodeId`
+    // into the public `Sensor.id` field, so a schema that lacks it
+    // breaks the projection and must be treated as endpoint-absent.
+    const { exposed, reason } = schemaExposesSensorListContract();
     if (exposed && !SENSOR_LIST_ENDPOINT_AVAILABLE) {
       throw new Error(
-        `schemas/review.graphql now exposes the sensor-list query ` +
-          `(as \`${matched}\`), but SENSOR_LIST_ENDPOINT_AVAILABLE is ` +
-          "still `false`. Flip the constant in " +
-          "src/lib/detection/sensors.ts and wire the inline " +
-          "`parse(...)` dispatch in the same PR.",
+        "schemas/review.graphql now exposes the sensor-list endpoint " +
+          `(Query.${QUERY_FIELD} + ${SENSOR_TYPE}.${SENSOR_NODE_ID_FIELD}), ` +
+          "but SENSOR_LIST_ENDPOINT_AVAILABLE is still `false`. Flip " +
+          "the constant in src/lib/detection/sensors.ts and wire the " +
+          "inline `parse(...)` dispatch in the same PR.",
       );
     }
     if (!exposed && SENSOR_LIST_ENDPOINT_AVAILABLE) {
       throw new Error(
-        `SENSOR_LIST_ENDPOINT_AVAILABLE is \`true\`, but ` +
-          "schemas/review.graphql does not expose any of the " +
-          `expected sensor-list query fields (${CANDIDATE_FIELDS.join(
-            ", ",
-          )}). Either revert the constant or add the missing schema ` +
-          "field in the same PR that vendored the new schema.",
+        "SENSOR_LIST_ENDPOINT_AVAILABLE is `true`, but " +
+          `schemas/review.graphql does not satisfy the sensor-list ` +
+          `contract: ${reason}. Either revert the constant or add the ` +
+          "missing schema field in the same PR that vendored the new schema.",
       );
     }
     expect(SENSOR_LIST_ENDPOINT_AVAILABLE).toBe(exposed);

--- a/src/__tests__/lib/detection/sensors.test.ts
+++ b/src/__tests__/lib/detection/sensors.test.ts
@@ -39,11 +39,16 @@ function makeSession(overrides: Partial<AuthSession> = {}): AuthSession {
   } as AuthSession;
 }
 
+const EMPTY_SENSOR_LIST_RESPONSE = {
+  customerSensorList: { nodes: [] as Array<unknown> },
+};
+
 describe("detection sensors — listSensors()", () => {
   beforeEach(() => {
     mockHasPermission.mockReset();
     mockResolveEffectiveCustomerIds.mockReset();
     mockGraphqlRequest.mockReset();
+    mockGraphqlRequest.mockResolvedValue(EMPTY_SENSOR_LIST_RESPONSE);
   });
 
   // ── Authorization ──────────────────────────────────────────────
@@ -68,7 +73,11 @@ describe("detection sensors — listSensors()", () => {
   it("rejects a non-admin caller with an empty customer scope", async () => {
     // Non-admin (no `customers:access-all`): the empty-scope gate
     // applies as before. The bypass for access-all callers — see
-    // the dedicated test below — is a separate path.
+    // the dedicated test below — is a separate path. The error class
+    // is intentionally `DetectionUnauthorizedError`, not
+    // `DetectionForbiddenError`: `sensor-actions.ts` catches the
+    // former and maps it to `code: "forbidden"` for the drawer; see
+    // the rationale in `sensors.ts`.
     mockHasPermission.mockImplementation(
       async (_roles: string[], permission: string) =>
         permission === "detection:read",
@@ -89,10 +98,10 @@ describe("detection sensors — listSensors()", () => {
   it("does not block an access-all caller (e.g. SysAdmin) with an empty local customers table (#405 L1)", async () => {
     // Symmetric to the bypass in `buildDispatchContext`: a fresh
     // install with no `customers` rows must not lock SysAdmin out
-    // of the sensor enumeration. While the sensor-list endpoint is
-    // still absent the helper returns the `endpoint-absent` variant
-    // rather than throwing, but the empty-scope gate must NOT trip
-    // for an access-all caller along the way.
+    // of the sensor enumeration. The dispatch still happens — review
+    // accepts `customer_ids = None` for SysAdmin (review's "all
+    // customers" wire semantics) and enumerates every customer's
+    // sensors. The BFF's empty-scope gate must NOT trip along the way.
     mockHasPermission.mockResolvedValue(true);
     mockResolveEffectiveCustomerIds.mockResolvedValue([]);
 
@@ -100,15 +109,19 @@ describe("detection sensors — listSensors()", () => {
     const result = await listSensors(
       makeSession({ roles: ["System Administrator"] }),
     );
-    expect(result).toEqual({ endpointAvailable: false });
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+
+    expect(result).toEqual({ endpointAvailable: true, sensors: [] });
+    expect(mockGraphqlRequest).toHaveBeenCalledOnce();
+    const ctx = mockGraphqlRequest.mock.calls[0][2];
+    expect(ctx).toEqual({
+      role: "System Administrator",
+      // SystemAdministrator → `customer_ids = None` on the wire (the
+      // JWT-claim helper returns `undefined`).
+      customerIds: undefined,
+    });
   });
 
-  it("resolves customer_ids for authorized callers before the endpoint check", async () => {
-    // Forward-looking assertion for the customer-scope contract: the
-    // customer_ids list is materialized on every call, even while the
-    // endpoint is absent, so flipping `SENSOR_LIST_ENDPOINT_AVAILABLE`
-    // and wiring the dispatch does not require touching the auth path.
+  it("resolves customer_ids for authorized callers before dispatch", async () => {
     mockHasPermission.mockResolvedValue(true);
     mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
 
@@ -124,34 +137,6 @@ describe("detection sensors — listSensors()", () => {
     ]);
   });
 
-  // ── Fallback: endpoint absent from vendored schema ─────────────
-
-  it("returns the endpoint-absent variant (and an empty list via sensorsOrEmpty) when the endpoint is missing from the vendored schema", async () => {
-    // The vendored schemas/review.graphql does not yet expose the
-    // sensor-list query (#295). While that is true, authorized callers
-    // must receive the `endpoint-absent` variant rather than an error —
-    // downstream consumers (#278 dropdown, #291 event locator) rely on
-    // this degrade-gracefully contract and choose between the
-    // discriminator (locator) or `sensorsOrEmpty()` (dropdown).
-    mockHasPermission.mockResolvedValue(true);
-    mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
-
-    const { listSensors, SENSOR_LIST_ENDPOINT_AVAILABLE, sensorsOrEmpty } =
-      await import("@/lib/detection");
-
-    // Precondition for this regression: the constant really is `false`
-    // in the current snapshot of the vendored schema.
-    expect(SENSOR_LIST_ENDPOINT_AVAILABLE).toBe(false);
-
-    const result = await listSensors(makeSession());
-    expect(result).toEqual({ endpointAvailable: false });
-    // The documented collapse helper still yields the flat empty list
-    // that the issue's fallback clause calls out.
-    expect(sensorsOrEmpty(result)).toEqual([]);
-    // No network traffic at all while the endpoint is absent.
-    expect(mockGraphqlRequest).not.toHaveBeenCalled();
-  });
-
   // ── Consumer-side compile-time guard ───────────────────────────
 
   it("forces consumers to acknowledge the endpoint-availability state at the type level", async () => {
@@ -161,9 +146,15 @@ describe("detection sensors — listSensors()", () => {
     // as always having a `sensors` field — i.e. assumes the endpoint is
     // always available — fails `tsc --noEmit` because `sensors` does
     // not exist on the `endpoint-absent` variant. The @ts-expect-error
-    // lines below lock that guard in: if anyone widens the return
-    // shape to always expose `sensors`, the directives become dead and
+    // line below locks that guard in: if anyone widens the return
+    // shape to always expose `sensors`, the directive becomes dead and
     // tsc fails the test file.
+    //
+    // The discriminator stays in place even after the endpoint has
+    // shipped because a future REview schema rollback would flip
+    // `SENSOR_LIST_ENDPOINT_AVAILABLE` back to `false` and consumers
+    // need a typed signal to fall back to (#278's "Coming soon"
+    // affordance, #291's name → ID skip).
     mockHasPermission.mockResolvedValue(true);
     mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
 
@@ -185,53 +176,47 @@ describe("detection sensors — listSensors()", () => {
     }
   });
 
-  // ── Wire-path guard: activates when the flag flips ─────────────
+  // ── Dispatch contract ──────────────────────────────────────────
 
-  it("dispatches via graphqlRequest with { role, customerIds } once the endpoint flag is true", async () => {
-    // Behavioural counterpart to the schema-vs-constant guard in
-    // `sensors-endpoint-guard.test.ts`. Today this test is a no-op
-    // because `SENSOR_LIST_ENDPOINT_AVAILABLE` is `false`, but it
-    // activates automatically the moment someone flips the constant:
-    //
-    //   - If the dispatch body is still `return []`, `graphqlRequest`
-    //     is never called and this assertion fails — so a future PR
-    //     cannot flip the flag and leave the fallback as the live
-    //     code path.
-    //   - The assertion also locks the wire contract: the caller's
-    //     `customer_ids` travel on the Context JWT (via `graphqlRequest`
-    //     which calls `signContextJwt(role, customerIds)` internally —
-    //     see review-integration.test.ts), not on the query variables.
-    //
-    // Run against the real constant (not a mocked one) so the guard
-    // tracks the production flag, not a test-local override.
-    const { listSensors, SENSOR_LIST_ENDPOINT_AVAILABLE } = await import(
-      "@/lib/detection"
-    );
-    if (!SENSOR_LIST_ENDPOINT_AVAILABLE) {
-      // Flag is still `false`: the fallback path is exercised by the
-      // preceding test. When REview publishes the sensor-list query
-      // (#295) and the constant flips, the assertions below activate
-      // and require a wired graphqlRequest dispatch in listSensors.
-      return;
-    }
-
+  it("dispatches via graphqlRequest with { role, customerIds } and projects the response", async () => {
+    // Wire contract: caller's `customer_ids` travel on the Context JWT
+    // (`graphqlRequest` calls `signContextJwt(role, customerIds)`
+    // internally — see review-integration.test.ts), not on the query
+    // variables. No explicit `customerIds` argument is sent to
+    // `customerSensorList`; review uses the JWT-claim set to scope.
     mockHasPermission.mockResolvedValue(true);
     mockResolveEffectiveCustomerIds.mockResolvedValue([42, 99]);
     mockGraphqlRequest.mockResolvedValue({
-      sensorList: [] as Array<{ id: string; name: string; customerId: string }>,
+      customerSensorList: {
+        nodes: [
+          { customerId: 42, nodeId: "1", hostFqdn: "sensor-a.example.com" },
+          { customerId: 99, nodeId: "2", hostFqdn: "sensor-b.example.com" },
+        ],
+      },
     });
 
-    await listSensors(makeSession({ roles: ["Security Monitor"] }));
+    const { listSensors } = await import("@/lib/detection");
+    const result = await listSensors(
+      makeSession({ roles: ["Security Monitor"] }),
+    );
 
     expect(mockGraphqlRequest).toHaveBeenCalledOnce();
     const call = mockGraphqlRequest.mock.calls[0];
     // graphqlRequest signature: (document, variables, context).
-    // Assert only the context — the document and variables are part
-    // of the wiring change and will be locked in by the PR that
-    // flips the flag.
-    expect(call[2]).toMatchObject({
+    expect(call[1]).toBeUndefined();
+    expect(call[2]).toEqual({
       role: "Security Monitor",
       customerIds: [42, 99],
+    });
+
+    // Projection at the boundary: SDL `nodeId` → public `id`,
+    // SDL `hostFqdn` → public `name`, numeric `customerId` preserved.
+    expect(result).toEqual({
+      endpointAvailable: true,
+      sensors: [
+        { id: "1", name: "sensor-a.example.com", customerId: 42 },
+        { id: "2", name: "sensor-b.example.com", customerId: 99 },
+      ],
     });
   });
 });

--- a/src/lib/detection/queries.ts
+++ b/src/lib/detection/queries.ts
@@ -829,3 +829,20 @@ export const EVENT_FREQUENCY_SERIES_QUERY = parse(`
     eventFrequencySeries(filter: $filter, period: $period)
   }
 `);
+
+// Sensor list (Phase Detection-24). Scope travels on the Context JWT,
+// so no explicit `customerIds` argument is passed — review uses the
+// JWT claim set to filter. One row per Node (sensor-bearing node);
+// `first: 1000` is sized for the practical ceiling of nodes with
+// configured SENSOR agents in the caller's customer scope.
+export const SENSOR_LIST_QUERY = parse(`
+  query SensorList {
+    customerSensorList(first: 1000) {
+      nodes {
+        customerId
+        nodeId
+        hostFqdn
+      }
+    }
+  }
+`);

--- a/src/lib/detection/sensors.ts
+++ b/src/lib/detection/sensors.ts
@@ -3,17 +3,29 @@ import "server-only";
 import { resolveEffectiveCustomerIds } from "@/lib/auth/customer-scope";
 import type { AuthSession } from "@/lib/auth/jwt";
 import { hasPermission } from "@/lib/auth/permissions";
+import { graphqlRequest } from "@/lib/graphql/client";
+import { withReviewErrorMapping } from "@/lib/review/error-mapping";
 
 import { DetectionUnauthorizedError } from "./errors";
+import { SENSOR_LIST_QUERY } from "./queries";
+import { jwtCustomerIdsForDetection } from "./server-actions";
 
 const DETECTION_READ = "detection:read";
 const CUSTOMERS_ACCESS_ALL = "customers:access-all";
 
 /**
  * A sensor (Node) known to REview, scoped to customers the caller can
- * access. The exact field set is a product of the REview query signature
- * and will be finalized when the endpoint lands — see
- * `SENSOR_LIST_ENDPOINT_AVAILABLE` below.
+ * access.
+ *
+ * Field mapping at the dispatch boundary (see `listSensors`):
+ *
+ *   - `id`         ← `customerSensorList.nodes[].nodeId`   (SDL: `ID!`)
+ *   - `name`       ← `customerSensorList.nodes[].hostFqdn` (SDL: `String!`)
+ *   - `customerId` ← `customerSensorList.nodes[].customerId` (SDL: `Int!`)
+ *
+ * `id` substitutes directly into `EventListFilterInput.sensors`, which
+ * review resolves to `node.profile.hostname` for matching against
+ * `Event.sensor` — equal to `hostFqdn` here.
  */
 export interface Sensor {
   /** Opaque REview Node ID. Matches `EventListFilterInput.sensors` entries. */
@@ -21,36 +33,34 @@ export interface Sensor {
   /** Human-readable sensor name as emitted on `Event.sensor`. */
   name: string;
   /** REview customer ID the sensor belongs to. */
-  customerId: string;
+  customerId: number;
 }
 
 /**
  * Whether the vendored REview schema at `schemas/review.graphql` exposes
  * the sensor-list query consumed by this module.
  *
- * The REview-side endpoint is being added in a follow-up schema bump
- * (tracked by #295). Until that bump reaches this repo's
- * `schemas/review.graphql`, this flag stays `false` and `listSensors()`
- * short-circuits to the `endpoint-absent` variant — see the fallback
- * note on `listSensors()`.
+ * The REview-side endpoint shipped in review-web 0.33.0 (review 0.50.0)
+ * as `customerSensorList`, with one row per Node (Sensor.nodeId: ID!).
+ * The constant is retained — not deleted — so a future schema rollback
+ * (or a schema bump that removes the field) flips back to `false`
+ * automatically via the endpoint-guard test, and `listSensors()`
+ * degrades to the `{ endpointAvailable: false }` variant rather than
+ * dispatching against a missing field.
  *
  * ## Three-way CI guard
  *
- * When REview ships the endpoint, flip this constant to `true` in the
- * **same PR** that bumps the vendored schema and wires the inline
- * `parse(...)` dispatch.
  * `src/__tests__/lib/detection/sensors-endpoint-guard.test.ts` enforces
- * the three-way contract at CI time — flipping the constant without a
- * matching schema field fails, and schema drift without a constant
- * flip fails.
+ * the three-way contract at CI time: the constant must match what the
+ * vendored SDL exposes (both `Query.customerSensorList` and
+ * `Sensor.nodeId: ID!` must be present). A pre-0.33.0 schema that
+ * exposes only `customerSensorList` (without `Sensor.nodeId`) is
+ * treated as endpoint-absent so the projection below stays safe.
  * `src/__tests__/lib/detection/sensors.test.ts` additionally asserts
- * that, when the constant is `true`, `listSensors()` dispatches through
- * `graphqlRequest` with `{ role, customerIds }` — so flipping the
- * constant while leaving the dispatch body a placeholder also fails CI.
- * The schema bump, constant flip, and dispatch wiring therefore cannot
- * land piecemeal.
+ * that, when the constant is `true`, `listSensors()` dispatches
+ * through `graphqlRequest` with `{ role, customerIds }`.
  */
-export const SENSOR_LIST_ENDPOINT_AVAILABLE = false as const;
+export const SENSOR_LIST_ENDPOINT_AVAILABLE = true as const;
 
 /**
  * Result shape returned by `listSensors()`.
@@ -91,6 +101,22 @@ export function sensorsOrEmpty(result: SensorListResult): readonly Sensor[] {
   return result.endpointAvailable ? result.sensors : [];
 }
 
+// Wire-shape of the `customerSensorList` payload. Hand-written rather
+// than codegen'd: `scripts/codegen-detection-types.mjs` is a fixed
+// root-type walker (events only). Keeping this inline matches the rest
+// of Detection's "selection set is small, the projection is local"
+// pattern. Three scalars, one projection point.
+interface SensorListNode {
+  customerId: number;
+  nodeId: string;
+  hostFqdn: string;
+}
+interface SensorListResponse {
+  customerSensorList: {
+    nodes: SensorListNode[];
+  };
+}
+
 /**
  * Return the sensors visible to the caller.
  *
@@ -102,37 +128,38 @@ export function sensorsOrEmpty(result: SensorListResult): readonly Sensor[] {
  *   1. Caller must hold `detection:read`.
  *   2. The caller's effective `customer_ids` must resolve to a
  *      non-empty list — an empty scope is rejected as a
- *      misconfiguration.
+ *      misconfiguration (except for callers holding
+ *      `customers:access-all`; see below).
+ *
+ * Empty-scope handling intentionally throws `DetectionUnauthorizedError`
+ * (not `DetectionForbiddenError`). The `sensor-actions.ts` server
+ * action catches the former and maps it to `code: "forbidden"` for
+ * the drawer; aligning with `buildDispatchContext`'s `Forbidden` would
+ * fall through that catch and surface as a generic `server-error` to
+ * the dropdown — a UX regression. Broader Detection auth-error
+ * alignment is out of scope for this module.
  *
  * When REview is reached, scope travels on the Context JWT
  * (`signContextJwt(role, customerIds)`), not on query arguments. REview
  * applies the scope from the JWT claim set and returns only sensors
- * belonging to the caller's accessible customers.
+ * belonging to the caller's accessible customers. SystemAdministrator
+ * callers ship `customer_ids = undefined` (review's "all customers"
+ * wire semantics) so the bootstrap admin on a fresh install reaches
+ * the endpoint even before any `customers` rows are materialized;
+ * every other role ships the materialized list. The branch is shared
+ * with `searchEvents` via {@link jwtCustomerIdsForDetection}.
  *
  * ## Fallback when the endpoint is absent
  *
- * If `SENSOR_LIST_ENDPOINT_AVAILABLE` is `false` (REview has not yet
- * published the query in the vendored schema), this function resolves
- * to the `{ endpointAvailable: false }` variant **instead of throwing**.
- * Pass the result through `sensorsOrEmpty()` to recover the "empty
- * list" iteration shape — the two consumers degrade gracefully:
- *
- *   - #278 Sensor dropdown: renders a disabled "Coming soon"
- *     placeholder (the same affordance as Customer) so operators
- *     immediately understand why the control is non-interactive. A
- *     transient fetch failure is surfaced as a separate retryable
- *     error state rather than being collapsed into this
- *     endpoint-absent copy. When REview ships the endpoint and the
- *     constant flips to `true`, the placeholder is replaced with the
- *     functional multi-select without any further client-side
- *     refactor.
- *   - #291 event locator: skips name → ID resolution and omits
- *     `sensors: [<id>]` from the tight filter (same behaviour as a
- *     name mismatch / out-of-scope event).
- *
- * The fallback is **after** the authorization check, not before: an
- * unauthorized caller is rejected even while the endpoint is missing,
- * so the auth contract is uniform regardless of schema state.
+ * The compile guard and `SENSOR_LIST_ENDPOINT_AVAILABLE` constant are
+ * retained even now that the endpoint has shipped: a future REview
+ * schema rollback (or accidental removal of `customerSensorList` /
+ * `Sensor.nodeId`) flips the endpoint-guard test, the constant goes
+ * back to `false`, and this function degrades gracefully to the
+ * `{ endpointAvailable: false }` variant instead of dispatching
+ * against a missing field. Consumers (#278 dropdown, #291 locator)
+ * branch on the discriminator and degrade the same way they did
+ * during the pre-rollout window.
  */
 export async function listSensors(
   session: AuthSession,
@@ -164,28 +191,45 @@ export async function listSensors(
   }
 
   if (!SENSOR_LIST_ENDPOINT_AVAILABLE) {
-    // REview has not yet published the sensor-list query in the
-    // vendored schema (#295). The `endpoint-absent` variant signals
-    // this state to consumers at the type level — see
-    // `SENSOR_LIST_ENDPOINT_AVAILABLE` for the promote-to-live
-    // procedure.
+    // Defensive branch retained for a future schema rollback. The
+    // endpoint-guard test flips the constant back to `false` if the
+    // vendored SDL ever loses `customerSensorList` or `Sensor.nodeId`,
+    // and the `{ endpointAvailable: false }` variant signals the state
+    // to consumers at the type level.
     return { endpointAvailable: false };
   }
 
-  // When REview ships `sensorList` (or `sensorsForCustomers` — exact
-  // identifier TBD), add the `parse(...)` document to `./queries.ts`
-  // and dispatch here via `graphqlRequest` with
-  // `{ role: session.roles[0], customerIds }`. The customer scope MUST
-  // travel on the Context JWT, not as a query argument — mirror the
-  // contract in `buildDispatchContext` (server-actions.ts). The
-  // `endpointAvailable: true` discriminator must be set on the returned
-  // object so the type-level guard in `SensorListResult` narrows the
-  // `sensors` field for consumers.
-  //
-  // Unreachable while SENSOR_LIST_ENDPOINT_AVAILABLE is the literal
-  // `false`; the narrowed type documents the intent, and the
-  // behavioural guard in `sensors.test.ts` (which imports the real
-  // constant and asserts dispatch when it is `true`) prevents this
-  // branch from staying a no-op if the constant is ever flipped.
-  return { endpointAvailable: true, sensors: [] };
+  const role = session.roles[0];
+  // listSensors runs its own permission + customer-scope gates above
+  // (see DetectionUnauthorizedError throws) and reuses
+  // `jwtCustomerIdsForDetection` from server-actions.ts for the JWT
+  // claim shape. `buildDispatchContext` is filter-oriented (validates
+  // `filter.input.customers`) and would change the empty-scope error
+  // class to DetectionForbiddenError, which sensor-actions.ts does not
+  // catch — see this module's docstring.
+  const data = await withReviewErrorMapping(
+    // biome-ignore format: keep the override on the helper-name line so
+    // scripts/check-dispatch-context.mjs sees `// scope-allowlist:` within
+    // the call expression range (helper-name → opening paren).
+    graphqlRequest<SensorListResponse>( // scope-allowlist: own auth gate + reused JWT helper (see comment above)
+      SENSOR_LIST_QUERY,
+      undefined,
+      {
+        role,
+        customerIds: jwtCustomerIdsForDetection(role, customerIds),
+      },
+    ),
+  );
+
+  // Map the wire payload onto the consumer-facing `Sensor` shape.
+  // The boundary lives here so the rest of Detection keeps the
+  // `{ id, name, customerId }` projection used by #278's dropdown
+  // and the page-session cache. SDL field names (`nodeId`,
+  // `hostFqdn`) are intentionally not leaked through the public API.
+  const sensors: Sensor[] = data.customerSensorList.nodes.map((node) => ({
+    id: node.nodeId,
+    name: node.hostFqdn,
+    customerId: node.customerId,
+  }));
+  return { endpointAvailable: true, sensors };
 }

--- a/src/lib/detection/server-actions.ts
+++ b/src/lib/detection/server-actions.ts
@@ -183,11 +183,17 @@ async function buildDispatchContext(
  * the bootstrap admin and ships the materialized list for every
  * other caller — including custom roles that grant
  * `customers:access-all`.
+ *
+ * Exported so `sensors.ts` (and any future Detection dispatch that
+ * does not need `buildDispatchContext`'s filter validation) can
+ * produce a JWT-claim set that matches the event-list path exactly,
+ * without duplicating the SystemAdministrator carve-out.
  */
-function jwtCustomerIdsForDetection(
-  ctx: Pick<DispatchContext, "role" | "customerIds">,
+export function jwtCustomerIdsForDetection(
+  role: string,
+  customerIds: number[],
 ): number[] | undefined {
-  return ctx.role === SYSTEM_ADMINISTRATOR ? undefined : ctx.customerIds;
+  return role === SYSTEM_ADMINISTRATOR ? undefined : customerIds;
 }
 
 // ── Variable shapes (match the `.graphql` operations one-for-one) ──
@@ -238,7 +244,10 @@ export async function searchEvents(
         last: args.last ?? null,
         before: args.before ?? null,
       },
-      { role: ctx.role, customerIds: jwtCustomerIdsForDetection(ctx) },
+      {
+        role: ctx.role,
+        customerIds: jwtCustomerIdsForDetection(ctx.role, ctx.customerIds),
+      },
       signal,
     ),
   );
@@ -304,7 +313,10 @@ async function dispatchCounter<TPayload>(
     graphqlRequest<Record<string, TPayload>, CounterVariables>(
       document,
       { filter: ctx.filter, first },
-      { role: ctx.role, customerIds: jwtCustomerIdsForDetection(ctx) },
+      {
+        role: ctx.role,
+        customerIds: jwtCustomerIdsForDetection(ctx.role, ctx.customerIds),
+      },
       signal,
     ),
   );
@@ -467,7 +479,10 @@ export async function fetchEventByLocator(
     graphqlRequest<EventDetailResult, EventByIdVariables>(
       EVENT_BY_ID_QUERY,
       { id: locator.id },
-      { role: ctx.role, customerIds: jwtCustomerIdsForDetection(ctx) },
+      {
+        role: ctx.role,
+        customerIds: jwtCustomerIdsForDetection(ctx.role, ctx.customerIds),
+      },
       signal,
     ),
   );
@@ -509,7 +524,10 @@ export async function lookupIpLocation(
       graphqlRequest<IpLocationResult, IpLocationVariables>(
         IP_LOCATION_QUERY,
         { address },
-        { role: ctx.role, customerIds: jwtCustomerIdsForDetection(ctx) },
+        {
+          role: ctx.role,
+          customerIds: jwtCustomerIdsForDetection(ctx.role, ctx.customerIds),
+        },
         signal,
       ),
     );
@@ -537,7 +555,10 @@ export async function eventFrequencySeries(
     graphqlRequest<EventFrequencySeriesResult, FrequencySeriesVariables>(
       EVENT_FREQUENCY_SERIES_QUERY,
       { filter: ctx.filter, period },
-      { role: ctx.role, customerIds: jwtCustomerIdsForDetection(ctx) },
+      {
+        role: ctx.role,
+        customerIds: jwtCustomerIdsForDetection(ctx.role, ctx.customerIds),
+      },
       signal,
     ),
   );


### PR DESCRIPTION
## Summary

review-web 0.33.0 (review 0.50.0, vendored by #510) ships `customerSensorList` with `Sensor.nodeId: ID!` — substitutable directly into `EventListFilterInput.sensors`. This PR flips `SENSOR_LIST_ENDPOINT_AVAILABLE` to `true`, adds the inline `SENSOR_LIST_QUERY` parse document, and wires `listSensors()` to dispatch through `graphqlRequest`.

- Customer scope travels on the Context JWT — no explicit `customerIds` argument is sent on the query. `jwtCustomerIdsForDetection` is promoted from `server-actions.ts` so the SystemAdministrator carve-out (`customer_ids = undefined` on the wire) is reused verbatim. `buildDispatchContext` is not reused: it would change the empty-scope error class to `DetectionForbiddenError`, which `sensor-actions.ts` does not catch, and would regress the dropdown UX.
- The wire payload `{ customerId, nodeId, hostFqdn }` is projected at the boundary into the existing public `{ id, name, customerId }` shape so consumers (#278 dropdown, page-session cache) stay unchanged. `Sensor.customerId` migrates from `string` to `number` to match the SDL's `Int!`; the small handful of fixtures referencing it are updated in lockstep.
- The endpoint-guard matcher now requires BOTH `Query.customerSensorList` AND `Sensor.nodeId: ID!`. A future REview rollback (or a pre-0.33.0 SDL exposing the field without `nodeId`) flips the constant back to `false`, the `{ endpointAvailable: false }` fallback variant degrades consumers gracefully, and the `@ts-expect-error` compile guard stays active.

## Test plan

- [x] `pnpm biome check` clean on the changed files
- [x] `pnpm tsc --noEmit` passes (including the `@ts-expect-error` consumer compile guard against widening `SensorListResult`)
- [x] `pnpm vitest run` for `sensors.test.ts`, `sensors-endpoint-guard.test.ts`, `review-integration.test.ts`, `detection-sensor-actions.test.ts` passes
- [x] Endpoint-guard test: schema-vs-constant contract — flipping the constant requires both `Query.customerSensorList` and `Sensor.nodeId: ID!` in the vendored SDL
- [x] Dispatch test: `listSensors()` calls `graphqlRequest` with `{ role, customerIds }`, with NO `customerIds` argument on the query
- [x] Network-mocked integration test: real `graphqlRequest` → real `signContextJwt`; verifies Authorization header, JWT-claim contract, and the `{ customerId, nodeId, hostFqdn }` → `{ id, name, customerId }` projection
- [x] SystemAdministrator path: `signContextJwt` is called with `customerIds = undefined` (review's "all customers" wire semantics)
- [x] Non-admin empty-scope still throws `DetectionUnauthorizedError` (preserves the `sensor-actions.ts` catch → `code: "forbidden"` mapping for the drawer)
- [x] Access-all caller with empty `customers` table dispatches successfully (no empty-scope trip)
- [x] `Sensor.customerId` is numeric in fixtures and at runtime; `tsc` would catch any stragglers

Closes #305