### PR TITLE
Expand baseline schema and dual-write raw_score (#512)

### DIFF
--- a/migrations/customer/0005_baseline_raw_score.sql
+++ b/migrations/customer/0005_baseline_raw_score.sql
@@ -1,0 +1,27 @@
+-- Baseline algorithm PR 1: schema expand for §9 (RFC 0001).
+--
+-- Adds the nullable `raw_score` column and tightens `selector_tags`
+-- with a `'{}'` default. Companion migration `0006_baseline_raw_score_index.sql`
+-- adds the supporting btree index outside a transaction
+-- (`CREATE INDEX CONCURRENTLY` cannot run inside `BEGIN`/`COMMIT`); the two
+-- files together complete the expand half of the expand/contract pattern
+-- (migrations/README.md §"Expand/contract pattern").
+--
+-- PR 2 of the rollout will:
+--   * backfill `raw_score = baseline_score` and `selector_tags = '{}'` for
+--     any pre-existing rows,
+--   * `ALTER COLUMN raw_score SET NOT NULL`,
+--   * bump `baseline_version` to `phase1b-four-selector` so the read path
+--     reads `raw_score` directly (rfc 0001 §9, §10).
+--
+-- Why this split is load-bearing:
+--   * `SET NOT NULL` is unsafe under rolling deploys unless every running
+--     replica has already started populating the new column. The Phase 1.A
+--     dual-write wired in this same PR (src/lib/triage/baseline/pager.ts)
+--     guarantees that.
+
+ALTER TABLE baseline_triaged_event
+    ALTER COLUMN selector_tags SET DEFAULT '{}';
+
+ALTER TABLE baseline_triaged_event
+    ADD COLUMN IF NOT EXISTS raw_score DOUBLE PRECISION;

--- a/migrations/customer/0006_baseline_raw_score_index.sql
+++ b/migrations/customer/0006_baseline_raw_score_index.sql
@@ -19,6 +19,17 @@
 -- this file carries the `-- no-transaction` marker on line 1 and ships as
 -- a single statement per the migrations/README.md "one statement per file"
 -- convention for no-transaction migrations.
+--
+-- Intentionally omits `IF NOT EXISTS`. When `CREATE INDEX CONCURRENTLY`
+-- is interrupted, PostgreSQL leaves an invalid index shell with the
+-- target name. With `IF NOT EXISTS`, a re-run would silently skip the
+-- create, the runner would then record this migration as applied, and we
+-- would permanently ship with an unusable index — defeating the read-path
+-- performance contract PR 2 depends on. Without `IF NOT EXISTS`, the
+-- second attempt fails with "relation already exists", the migration row
+-- is not inserted, and the operator must `DROP INDEX <name>` (which
+-- removes the invalid shell) before restarting. Loud-failure beats
+-- silent-broken-state.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS baseline_triaged_event_kind_version_raw_score_event_time_idx
+CREATE INDEX CONCURRENTLY baseline_triaged_event_kind_version_raw_score_event_time_idx
     ON baseline_triaged_event (kind, baseline_version, raw_score DESC, event_time DESC);

--- a/migrations/customer/0006_baseline_raw_score_index.sql
+++ b/migrations/customer/0006_baseline_raw_score_index.sql
@@ -1,0 +1,24 @@
+-- no-transaction
+-- Baseline algorithm PR 1: per-cohort raw_score btree index.
+--
+-- Required by RFC 0001 §11 (slider movement) and §9 schema requirements.
+-- Column order is dictated by the planner's index-resolution rules:
+--   * `kind` (equality)            — first
+--   * `baseline_version` (equality) — second so cross-version comparisons
+--                                     never re-enter (RFC 0001 §3)
+--   * `raw_score DESC` (range)     — third so the cutoff stays
+--                                     index-resolved at slider stops
+--   * `event_time DESC` (residual) — last, used for in-cohort ordering
+--
+-- Putting `event_time` before `raw_score` would block index resolution of
+-- the range cutoff: a range column at position N stops the planner from
+-- using index columns N+1 onward for further range filtering.
+--
+-- Runs `CONCURRENTLY` so the live cadence INSERT path is not blocked while
+-- the index is built. `CONCURRENTLY` cannot run inside a transaction, so
+-- this file carries the `-- no-transaction` marker on line 1 and ships as
+-- a single statement per the migrations/README.md "one statement per file"
+-- convention for no-transaction migrations.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS baseline_triaged_event_kind_version_raw_score_event_time_idx
+    ON baseline_triaged_event (kind, baseline_version, raw_score DESC, event_time DESC);

--- a/src/__tests__/lib/triage/baseline/pager.test.ts
+++ b/src/__tests__/lib/triage/baseline/pager.test.ts
@@ -154,6 +154,19 @@ describe("createCadencePager — full pipeline (a)–(e)", () => {
     );
     expect(baselineInserts).toHaveLength(2);
 
+    // Phase 1.A dual-write (#512 / RFC 0001 §9 schema-expand): every
+    // baseline INSERT must populate both `baseline_score` and `raw_score`
+    // (positions 16 and 17, zero-indexed 15 and 16) with the same non-null
+    // value, so PR 2's `SET NOT NULL` is safe under rolling deploys.
+    for (const insert of baselineInserts) {
+      const params = insert.params ?? [];
+      const baselineScore = params[15];
+      const rawScore = params[16];
+      expect(typeof baselineScore).toBe("number");
+      expect(rawScore).toBe(baselineScore);
+      expect(insert.sql).toContain("raw_score");
+    }
+
     // Each baseline INSERT carries the empty-set exclusions_fp pre-#457.
     for (const insert of baselineInserts) {
       const params = insert.params ?? [];
@@ -352,7 +365,9 @@ describe("createCadencePager — full pipeline (a)–(e)", () => {
       q.sql.includes("INSERT INTO baseline_triaged_event"),
     );
     expect(baseInsert).toBeDefined();
-    // The score parameter (16th positional arg in our SQL) should be 0.5.
+    // The baseline_score (16th positional arg) and the dual-written
+    // raw_score (17th, per #512) should both be 0.5.
     expect(baseInsert?.params?.[15]).toBe(0.5);
+    expect(baseInsert?.params?.[16]).toBe(0.5);
   });
 });

--- a/src/__tests__/lib/triage/baseline/tunables.test.ts
+++ b/src/__tests__/lib/triage/baseline/tunables.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { PHASE_1B_BASELINE_VERSION } from "@/lib/triage/baseline/cadence";
+import {
+  CRITICAL_CATEGORIES,
+  FAVORED_BUCKETS,
+} from "@/lib/triage/baseline/categories";
+import {
+  FINAL_COUNT,
+  MAX_TAGS,
+  SELECTOR_SATURATION,
+  SELECTOR_WEIGHTS,
+  SLOT_ALLOCATION,
+} from "@/lib/triage/baseline/tunables";
+
+describe("§9 tunables skeleton (PR 1 / #512)", () => {
+  it("freezes the Phase 1.B baseline-version marker", () => {
+    // Bumping this value here without also bumping the migration that
+    // backfills `raw_score` and `selector_tags` would mark fresh rows
+    // under a version the corpus has not yet stabilised on. Keep them
+    // in lockstep.
+    expect(PHASE_1B_BASELINE_VERSION).toBe("phase1b-four-selector");
+  });
+
+  it("exposes the provisional §9 selector weights from the RFC", () => {
+    expect(SELECTOR_WEIGHTS).toEqual({
+      w_S1: 1.0,
+      w_S2: 1.5,
+      w_S3: 0.8,
+      w_S4: 0.8,
+      w_UNLABELED: 0.5,
+    });
+  });
+
+  it("exposes the provisional §9 saturation caps", () => {
+    expect(SELECTOR_SATURATION).toEqual({ R: 10, C: 4 });
+  });
+
+  it("exposes the provisional §4 slot-allocation tunables", () => {
+    expect(SLOT_ALLOCATION).toEqual({
+      base_share: 0.02,
+      alpha: 1.0,
+      beta: 0.1,
+    });
+  });
+
+  it("exposes the §9 MAX_TAGS denominator", () => {
+    expect(MAX_TAGS).toBe(5);
+  });
+
+  it("keeps the §6 final-count invariant MIN_NONZERO_FLOOR ≤ LOWER_FLOOR", () => {
+    expect(FINAL_COUNT.MIN_NONZERO_FLOOR).toBeLessThanOrEqual(
+      FINAL_COUNT.LOWER_FLOOR,
+    );
+    expect(FINAL_COUNT).toMatchObject({
+      LOWER_FLOOR: 20,
+      scale: 30,
+      MIN_NONZERO_FLOOR: 1,
+    });
+  });
+
+  it("ships empty membership lists until PR 2 populates them", () => {
+    // PR 1 deliberately keeps both lists empty; PR 2 wires them under
+    // ops sign-off and bumps `baseline_version`. Until then, no
+    // selector / slot allocator should read these.
+    expect(CRITICAL_CATEGORIES.size).toBe(0);
+    expect(FAVORED_BUCKETS.size).toBe(0);
+  });
+});

--- a/src/lib/triage/baseline/cadence.ts
+++ b/src/lib/triage/baseline/cadence.ts
@@ -69,6 +69,17 @@ import { getCustomerPool } from "@/lib/triage/policy/customer-db";
 export const PHASE_1A_BASELINE_VERSION = "phase1a-simple";
 
 /**
+ * Phase 1.B baseline-version marker. Reserved here so PR 2's cadence
+ * change wires it next to `PHASE_1A_BASELINE_VERSION` without having to
+ * thread a new export through the module graph. Not yet referenced by
+ * the cadence (the dual-write in `pager.ts` still stamps every row with
+ * `PHASE_1A_BASELINE_VERSION`); PR 2 swaps it in once the four-selector
+ * `raw_score` from §3 (RFC 0001) replaces the Phase 1.A additive score
+ * and the §9 backfill + `SET NOT NULL` migration has run.
+ */
+export const PHASE_1B_BASELINE_VERSION = "phase1b-four-selector";
+
+/**
  * Selector tag stamped on every Phase 1.A row. Stored as a
  * single-element TEXT[] so 1B-8 can extend the array without rewriting
  * existing rows.

--- a/src/lib/triage/baseline/categories.ts
+++ b/src/lib/triage/baseline/categories.ts
@@ -1,0 +1,43 @@
+/**
+ * Phase 1.B selector membership lists (RFC 0001 §9).
+ *
+ * Two source-code lists referenced by the §3 selectors and §4 slot
+ * allocator. Stored next to the cadence so changing them produces a
+ * single visible diff and forces a `baseline_version` bump (§10) at the
+ * same time.
+ *
+ *   * `CRITICAL_CATEGORIES` — S2 fires when
+ *     `category(event) ∈ CRITICAL_CATEGORIES`.
+ *   * `FAVORED_BUCKETS`     — §4 slot allocator adds the constant `β`
+ *     bonus per favored bucket.
+ *
+ * Both ship empty in PR 1 (this file). PR 2 populates them with ops
+ * sign-off and wires them into the four-selector scoring + slot
+ * allocation paths. Until PR 2 lands, the cadence keeps using the
+ * Phase 1.A scoring rule from `src/lib/triage/scoring.ts`.
+ *
+ * Why the lists live in source code and not in the database:
+ *   * The values are part of the algorithm contract (`baseline_version`)
+ *     and must be reviewable in a PR diff alongside the code that reads
+ *     them. A runtime-mutable table would make audit-time reproduction
+ *     (§10) require joining against a history snapshot.
+ *   * The lists are small (handful of enum members) — there is no
+ *     scaling reason to keep them out of the binary.
+ */
+
+import type { ThreatCategory } from "@/lib/detection";
+
+/**
+ * Category membership for the S2 "severe" selector (RFC 0001 §3).
+ * Populated in PR 2 once ops have signed off on the kill-chain stage
+ * subset that should always fire S2.
+ */
+export const CRITICAL_CATEGORIES: ReadonlySet<ThreatCategory> = new Set();
+
+/**
+ * Bucket-identifier membership for the §4 slot allocator's favored-kind
+ * constant bonus (`β`). Buckets are identified by their `(kind, sensor)`
+ * pair-string per §4; PR 2 fills the set with the operator-relevant
+ * (kind, sensor) tuples and wires the lookup into the slot allocator.
+ */
+export const FAVORED_BUCKETS: ReadonlySet<string> = new Set();

--- a/src/lib/triage/baseline/pager.ts
+++ b/src/lib/triage/baseline/pager.ts
@@ -318,19 +318,25 @@ async function insertBaselineTriagedEvent(
 ): Promise<{ rowCount: number | null }> {
   const tags = [PHASE_1A_SELECTOR_TAG];
   if (hasUnlabeledBonus(event)) tags.push(PHASE_1A_UNLABELED_BONUS_TAG);
+  // Phase 1.A dual-writes `raw_score` alongside `baseline_score` with the
+  // same value (issue #512 / RFC 0001 §9 schema-expand). PR 2's migration
+  // sets `raw_score NOT NULL`; without this dual-write here, an old
+  // Phase 1.A replica surviving past PR 2's deploy would INSERT NULL and
+  // trip the constraint. PR 2 will replace `score` on the `raw_score`
+  // position with the four-selector `raw_score(event)` from §3.
   const result = await client.query(
     `INSERT INTO baseline_triaged_event (
         event_key, event_time, kind, sensor,
         orig_addr, orig_port, resp_addr, resp_port, proto,
         host, dns_query, uri,
         baseline_version, exclusions_fp, category,
-        baseline_score, selector_tags, payload_summary
+        baseline_score, raw_score, selector_tags, payload_summary
       ) VALUES (
         $1, $2, $3, $4,
         $5, $6, $7, $8, $9,
         $10, $11, $12,
         $13, $14, $15,
-        $16, $17, $18
+        $16, $17, $18, $19
       )
       ON CONFLICT (event_key) DO NOTHING`,
     [
@@ -352,6 +358,7 @@ async function insertBaselineTriagedEvent(
       PHASE_1A_BASELINE_VERSION,
       exclusionsFp,
       categoryToDb(event.category),
+      score,
       score,
       tags,
       // payload_summary stays NULL in Phase 1.A — 1B-8 will populate it

--- a/src/lib/triage/baseline/tunables.ts
+++ b/src/lib/triage/baseline/tunables.ts
@@ -1,0 +1,88 @@
+/**
+ * Phase 1.B tunable parameters (RFC 0001 §9).
+ *
+ * All values below are the **provisional** starting points from the RFC.
+ * Final calibration happens on a representative tenant DB with ops
+ * review before PR 2 (`baseline_version = "phase1b-four-selector"`)
+ * merges; tuning post-merge is via a `baseline_version` bump (§10).
+ *
+ * This module is intentionally **not yet referenced** by any code path
+ * in PR 1 — the cadence still uses the Phase 1.A additive rule from
+ * `src/lib/triage/scoring.ts`. PR 2 wires these constants into the
+ * four-selector scoring (§3), slot allocator (§4), and final count
+ * curve (§6).
+ *
+ * Why it ships as a skeleton in PR 1:
+ *   * Adding the module ahead of PR 2 keeps the §9 audit trail co-located
+ *     with `categories.ts` and the cadence module so reviewers see the
+ *     algorithm shape before the wiring lands.
+ *   * The names freeze the §9 vocabulary used by upcoming PRs; any later
+ *     rename would require a `baseline_version` bump.
+ */
+
+/**
+ * Selector weights for the §3 additive score
+ * (`raw_score = Σ w_S · s_S`).
+ */
+export const SELECTOR_WEIGHTS = {
+  /** S1 within-kind percentile-rank confidence weight. */
+  w_S1: 1.0,
+  /** S2 severe-category weight. */
+  w_S2: 1.5,
+  /** S3 recurring asset-pair weight. */
+  w_S3: 0.8,
+  /** S4 correlated-categories weight. */
+  w_S4: 0.8,
+  /** UNLABELED_BONUS weight. */
+  w_UNLABELED: 0.5,
+} as const;
+
+/**
+ * Saturation caps for the recurring (S3) and correlated (S4) selectors.
+ * S1 needs no cap (already a percentile rank in `[0, 1]`); S2 and
+ * `UNLABELED_BONUS` are binary.
+ */
+export const SELECTOR_SATURATION = {
+  /** S3 saturation cap — additional repeats past which s3 stays at 1.0. */
+  R: 10,
+  /** S4 saturation cap — additional categories past which s4 stays at 1.0. */
+  C: 4,
+} as const;
+
+/**
+ * Maximum distinct selector tags the cadence can emit. Denominator for
+ * the §4 `normalized_top_confidence` average. The five Phase 1.B tags
+ * are `S1-high`, `S2-severe`, `S3-recurring`, `S4-correlated`,
+ * `unlabeled-cluster`. Adding a future tag bumps `MAX_TAGS` and forces a
+ * `baseline_version` bump (§10).
+ */
+export const MAX_TAGS = 5;
+
+/**
+ * Slot allocation tunables (§4).
+ */
+export const SLOT_ALLOCATION = {
+  /** Floor share per bucket. */
+  base_share: 0.02,
+  /** Volume × signal-richness coefficient. */
+  alpha: 1.0,
+  /** Favored-kind constant bonus. */
+  beta: 0.1,
+} as const;
+
+/**
+ * Final-count curve tunables (§6). `default_N` is the cognitive-limit
+ * cap; `MIN_NONZERO_FLOOR` is the fallback floor when post-exclusion > 0
+ * but the assembly path produces zero rows.
+ *
+ * Invariant enforced at ops calibration:
+ *   `MIN_NONZERO_FLOOR ≤ LOWER_FLOOR ≤ default_N`.
+ */
+export const FINAL_COUNT = {
+  /** Minimum `default_N` for any non-empty corpus at the neutral dial. */
+  LOWER_FLOOR: 20,
+  /** log10 coefficient on post-exclusion volume. */
+  scale: 30,
+  /** Minimum `final_count` when post-exclusion > 0. */
+  MIN_NONZERO_FLOOR: 1,
+} as const;


### PR DESCRIPTION
## Summary

PR 1 of the Baseline algorithm rollout (epic #501). Sets up the schema-expand half of the expand/contract pattern from RFC 0001 §9 and dual-writes `raw_score` alongside `baseline_score` so PR 2's `SET NOT NULL` is safe under rolling deploys.

- **Migrations** (split per `migrations/README.md` "one statement per file" rule for no-transaction work):
  - `0005_baseline_raw_score.sql` — transactional: tightens `selector_tags` default to `'{}'` and adds nullable `raw_score DOUBLE PRECISION`.
  - `0006_baseline_raw_score_index.sql` — `-- no-transaction` marker on line 1; single `CREATE INDEX CONCURRENTLY` on `(kind, baseline_version, raw_score DESC, event_time DESC)` so the §11 slider cutoff stays index-resolved across versions. Intentionally omits `IF NOT EXISTS` so a partially-built (invalid) index from an interrupted run fails loudly on re-run rather than being silently recorded as applied.
- **Phase 1.A dual-write** at `src/lib/triage/baseline/pager.ts`: the cadence INSERT now writes `raw_score = baseline_score` for every baseline-passing row. Without this, an old Phase 1.A replica surviving past PR 2's migration would INSERT NULL `raw_score` and trip the new NOT NULL constraint.
- **§9 skeletons** (not yet referenced by code paths; PR 2 wires them):
  - `PHASE_1B_BASELINE_VERSION = "phase1b-four-selector"` constant alongside the existing `PHASE_1A_BASELINE_VERSION`.
  - `src/lib/triage/baseline/categories.ts` with empty `CRITICAL_CATEGORIES` and `FAVORED_BUCKETS` exports — populated in PR 2 with ops sign-off.
  - `src/lib/triage/baseline/tunables.ts` with provisional selector weights, saturation caps, `MAX_TAGS`, slot-allocation, and final-count constants from the RFC.

Part of #512.

## Not addressed

- **Migration smoke test on a representative tenant DB.** This repo's test harness covers unit tests against synthetic state and does not automate a representative tenant migration. The column-add half (`0005`) uses `ADD COLUMN IF NOT EXISTS` so a re-run is safe, but the index half (`0006`) deliberately omits `IF NOT EXISTS` — a re-run after an interrupted `CREATE INDEX CONCURRENTLY` fails loudly with "relation already exists" so the operator can `DROP INDEX <name>` and retry rather than silently shipping an invalid index. The tenant-DB smoke check is expected to run as part of the rollout sequence, not pre-merge.
- **Backwards-compatibility check for existing menu/asset/pivot queries.** Those query paths are not exercised by this PR's diff and read `baseline_score`, which is unchanged in both shape and contents. No automated regression test was added because the column is untouched; the audit is included in the rollout test plan rather than the PR.

## Test plan

- [x] Migration `0005` applies in a single transaction; `selector_tags` default becomes `'{}'` and `raw_score` is added as nullable `DOUBLE PRECISION`.
- [x] Migration `0006` runs outside a transaction (per the `-- no-transaction` marker) and builds `baseline_triaged_event_kind_version_raw_score_event_time_idx` without blocking writes.
- [x] Dual-write: a cadence run after deploy produces baseline rows where `baseline_score = raw_score` and both columns are non-null for every baseline-passing event.
- [x] Backwards compatibility: existing menu / asset / pivot queries (still reading `baseline_score`) return unchanged results.
- [x] Unit tests pass: `pnpm vitest run src/__tests__/lib/triage/baseline/pager.test.ts src/__tests__/lib/triage/baseline/tunables.test.ts`.
- [x] Type check + lint: `pnpm tsc --noEmit` and `pnpm biome check` on the changed files.