### PR TITLE
Add corpus B schema, runner, and inline-policy encoder (#460)

### DIFF
--- a/migrations/customer/0008_policy_corpus_b.sql
+++ b/migrations/customer/0008_policy_corpus_b.sql
@@ -1,0 +1,164 @@
+-- Triage policy corpus B schema (1B-6 / discussion #447 §3.4-3.5).
+--
+-- Two tables in every customer-tenant DB. The corpus B runner
+-- (src/lib/triage/policy/corpus-b/) creates one `policy_triage_run`
+-- per user-triggered "With my policies" request and fills
+-- `policy_triaged_event` with the per-event triage outcome for that
+-- run. Each run's identity is the tuple
+-- `(owner_account_id, period_start, period_end,
+--   policies_fingerprint, exclusions_fingerprint, baseline_version)`;
+-- the partial unique index on `(status IN ('computing', 'ready'))`
+-- enforces "one active run per fingerprint" while letting
+-- `failed` / `superseded` rows accumulate for diagnostics.
+--
+-- `owner_account_id` references `auth_db.accounts(id)`. PostgreSQL
+-- does not support cross-database foreign keys, so existence is
+-- enforced at the application layer: the API checks the caller's
+-- account exists when creating a run, the menu filters out runs
+-- whose `owner_account_id` no longer resolves at read time, and
+-- corpus B cleanup (1B-7) eventually removes orphans.
+--
+-- The normalized exclusion-matching columns (`orig_addr`, `resp_addr`,
+-- `host`, `dns_query`, `uri`) mirror corpus A so 1B-2's retroactive
+-- DELETE planner applies symmetrically across all three persistence
+-- tables.
+
+CREATE TABLE IF NOT EXISTS policy_triage_run (
+    -- BIGSERIAL so the recompute transaction can pre-allocate `new_id`
+    -- before the supersede-then-INSERT pair commits.
+    id                      BIGSERIAL PRIMARY KEY,
+
+    -- Account that triggered the run. UUID NOT NULL to match
+    -- `auth_db.accounts(id)`. Cross-DB FK is not supported; the
+    -- application layer enforces existence.
+    owner_account_id        UUID NOT NULL,
+
+    -- Selection window. `period_end - period_start` is bounded by the
+    -- 30-day menu cap (#447 §3.2); enforcement lives in the
+    -- application layer because it is a product rule, not a schema
+    -- invariant.
+    period_start            TIMESTAMPTZ NOT NULL,
+    period_end              TIMESTAMPTZ NOT NULL,
+
+    -- Active-fingerprint columns. `policies_fingerprint` is a
+    -- canonicalized hash of the inline policy set, computed by
+    -- `computePoliciesFingerprint` (see
+    -- src/lib/triage/policy/corpus-b/fingerprint.ts).
+    -- `exclusions_fingerprint` is the same canonical hash the cadence
+    -- runner writes to `baseline_corpus_state.exclusions_fp` so a
+    -- subsequent exclusion change reliably changes the active slot.
+    -- `baseline_version` ties the run to the deterministic baseline
+    -- algorithm version that produced it (#447 §3.6 / 1B-8).
+    policies_fingerprint    TEXT NOT NULL,
+    exclusions_fingerprint  TEXT NOT NULL,
+    baseline_version        TEXT NOT NULL,
+
+    -- Run lifecycle. `computing` and `ready` occupy the active slot
+    -- (per the partial unique index below); `failed` and `superseded`
+    -- are terminal and coexist with a fresh attempt for the same
+    -- fingerprint without conflict.
+    status                  TEXT NOT NULL DEFAULT 'computing'
+                            CHECK (status IN ('computing', 'ready', 'failed', 'superseded')),
+
+    -- Lineage. `replaces` is set on a new row produced by a
+    -- recompute and points back at the row it supersedes;
+    -- `superseded_by` is set on the old row when the new row commits.
+    -- ON DELETE SET NULL so 1B-7 retention can prune old rows without
+    -- a foreign-key cascade chain.
+    replaces                BIGINT REFERENCES policy_triage_run(id) ON DELETE SET NULL,
+    superseded_by           BIGINT REFERENCES policy_triage_run(id) ON DELETE SET NULL,
+    refresh_reason          TEXT,
+
+    -- Diagnostics. `last_error` is populated for `failed` rows
+    -- (encoding error, transport error, the 1B-7 timeout marker, etc.).
+    -- `computation_duration_ms` lets the recompute confirm modal
+    -- estimate the wait without re-running the work.
+    computation_duration_ms BIGINT,
+    last_error              TEXT,
+
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finalized_at            TIMESTAMPTZ
+);
+
+-- "One active run per fingerprint" — see §3.5 "Active-fingerprint
+-- uniqueness via partial unique index" in the issue body. `failed`
+-- and `superseded` are intentionally outside the predicate so:
+--
+--   * Cached-vs-new: a `ready` row claims the slot and is reused.
+--   * Concurrency:    a second concurrent INSERT for the same
+--                     fingerprint conflicts; the loser re-queries the
+--                     existing run.
+--   * Zombie recovery:1B-7's timeout transitions a stale `computing`
+--                     row to `failed`, immediately freeing the slot.
+--   * Recompute:      the supersede transition drops the previous
+--                     row out of the slot before the new one enters.
+CREATE UNIQUE INDEX IF NOT EXISTS policy_triage_run_active_fingerprint
+    ON policy_triage_run (
+        owner_account_id, period_start, period_end,
+        policies_fingerprint, exclusions_fingerprint, baseline_version
+    )
+    WHERE status IN ('computing', 'ready');
+
+-- 1B-7 retention scans by status + created_at; the index keeps the
+-- nightly sweep O(log n).
+CREATE INDEX IF NOT EXISTS policy_triage_run_status_created_idx
+    ON policy_triage_run (status, created_at);
+CREATE INDEX IF NOT EXISTS policy_triage_run_owner_created_idx
+    ON policy_triage_run (owner_account_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS policy_triaged_event (
+    -- One row per (run, event). `run_id` cascades on DELETE so 1B-7
+    -- pruning a run cleans up its event rows in the same transaction.
+    run_id              BIGINT NOT NULL REFERENCES policy_triage_run(id) ON DELETE CASCADE,
+    -- review's RocksDB primary key (i128). Same NUMERIC(39,0) shape
+    -- as `baseline_triaged_event.event_key`.
+    event_key           NUMERIC(39, 0) NOT NULL,
+
+    -- Event identity / display columns. Subset of what corpus A
+    -- stores — corpus B is policy-mode only and does not carry the
+    -- baseline-centric snapshot.
+    event_time          TIMESTAMPTZ NOT NULL,
+    kind                TEXT NOT NULL,
+    sensor              TEXT NOT NULL,
+    orig_addr           INET,
+    orig_port           INTEGER,
+    resp_addr           INET,
+    resp_port           INTEGER,
+    proto               INTEGER,
+
+    -- Normalized exclusion-matching columns. Populated at INSERT time
+    -- using the same event-kind mapping as corpus A so 1B-2's DELETE
+    -- planner applies to all three persistence tables symmetrically.
+    -- NTLM carve-out: NTLM rows leave these three NULL (only IP-based
+    -- exclusions can match NTLM via orig_addr / resp_addr).
+    host                TEXT,
+    dns_query           TEXT,
+    uri                 TEXT,
+
+    category            TEXT,
+    -- Triage score snapshot — JSONB because corpus B produces a
+    -- policy outcome (list of `TriageScore { policyId, score }`),
+    -- not a single scalar baseline_score. Exact JSON shape is owned
+    -- by the runner module.
+    policy_triage_snapshot JSONB NOT NULL,
+
+    PRIMARY KEY (run_id, event_key)
+);
+
+-- Mirror corpus A's index footprint so 1B-2's DELETE planner can
+-- target the same set of columns by index in all three tables.
+-- IpAddress exclusion uses CIDR containment (<<, <<=) which a btree
+-- on `inet` does NOT index efficiently; use GiST with inet_ops.
+CREATE INDEX IF NOT EXISTS policy_triaged_event_orig_addr_gist
+    ON policy_triaged_event USING gist (orig_addr inet_ops);
+CREATE INDEX IF NOT EXISTS policy_triaged_event_resp_addr_gist
+    ON policy_triaged_event USING gist (resp_addr inet_ops);
+CREATE INDEX IF NOT EXISTS policy_triaged_event_host_idx
+    ON policy_triaged_event (host);
+CREATE INDEX IF NOT EXISTS policy_triaged_event_dns_query_idx
+    ON policy_triaged_event (dns_query);
+CREATE INDEX IF NOT EXISTS policy_triaged_event_uri_idx
+    ON policy_triaged_event (uri);
+-- Menu reads filter by run_id + event_time descending.
+CREATE INDEX IF NOT EXISTS policy_triaged_event_run_event_time_idx
+    ON policy_triaged_event (run_id, event_time DESC);

--- a/migrations/customer/0008_policy_corpus_b.sql
+++ b/migrations/customer/0008_policy_corpus_b.sql
@@ -64,9 +64,15 @@ CREATE TABLE IF NOT EXISTS policy_triage_run (
     -- recompute and points back at the row it supersedes;
     -- `superseded_by` is set on the old row when the new row commits.
     -- ON DELETE SET NULL so 1B-7 retention can prune old rows without
-    -- a foreign-key cascade chain.
+    -- a foreign-key cascade chain. `superseded_by` is DEFERRABLE
+    -- INITIALLY DEFERRED so the recompute transaction (§3.5) can pre-
+    -- allocate `new_id` from the sequence, mark the old row
+    -- `superseded` with `superseded_by=new_id`, then INSERT the new
+    -- row with `id=new_id` in the same transaction without tripping
+    -- the FK check at statement boundary.
     replaces                BIGINT REFERENCES policy_triage_run(id) ON DELETE SET NULL,
-    superseded_by           BIGINT REFERENCES policy_triage_run(id) ON DELETE SET NULL,
+    superseded_by           BIGINT REFERENCES policy_triage_run(id) ON DELETE SET NULL
+                            DEFERRABLE INITIALLY DEFERRED,
     refresh_reason          TEXT,
 
     -- Diagnostics. `last_error` is populated for `failed` rows

--- a/src/__tests__/app/api/triage/policies/route.test.ts
+++ b/src/__tests__/app/api/triage/policies/route.test.ts
@@ -236,7 +236,7 @@ describe("POST /api/triage/policies", () => {
   it("rejects a legacy 'match' cmp_kind that is not in AttrCmpKind", async () => {
     // `match` / `not_match` were dropped in Round 5 to keep the stored
     // shape aligned with review-web's `AttrCmpKind` enum (see
-    // src/lib/triage/policy/inline-input.ts). Zod's enum check now
+    // src/lib/triage/inline-policy/kinds.ts). Zod's enum check now
     // rejects the value before it ever reaches the repository.
     const { POST } = await import("@/app/api/triage/policies/route");
     const request = new NextRequest(

--- a/src/__tests__/lib/triage/inline-policy/encode.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/encode.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  encodeRuleBytes,
+  encodeValueByKind,
+  InlinePolicyEncodingError,
+} from "@/lib/triage/inline-policy";
+import type { PacketAttr } from "@/lib/triage/policy/types";
+
+/**
+ * Round-trip guard for the byte-array encoder.
+ *
+ * Each test pins one of the documented wire-format claims from the
+ * issue body's "Encoding rules per `value_kind`" table. A failure here
+ * is a wire-format break that would cause `eventListWithTriage`'s
+ * resolver to read garbage into its `firstValue` / `secondValue`
+ * fields.
+ */
+
+function buildRule(overrides: Partial<PacketAttr>): PacketAttr {
+  return {
+    raw_event_kind: "http",
+    attr_name: "host",
+    value_kind: "string",
+    cmp_kind: "equal",
+    first_value: "",
+    second_value: null,
+    weight: null,
+    ...overrides,
+  };
+}
+
+describe("encodeValueByKind", () => {
+  it("encodes bool 'true' as 0x01 and 'false' as 0x00", () => {
+    expect(encodeValueByKind("bool", "true")).toEqual([0x01]);
+    expect(encodeValueByKind("bool", "false")).toEqual([0x00]);
+  });
+
+  it("encodes string as UTF-8 bytes", () => {
+    expect(encodeValueByKind("string", "AB")).toEqual([0x41, 0x42]);
+    // 3-byte UTF-8 for the EURO SIGN (U+20AC).
+    expect(encodeValueByKind("string", "€")).toEqual([0xe2, 0x82, 0xac]);
+  });
+
+  it("encodes integer as 8-byte big-endian two's complement i64", () => {
+    expect(encodeValueByKind("integer", "0")).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(encodeValueByKind("integer", "1")).toEqual([0, 0, 0, 0, 0, 0, 0, 1]);
+    expect(encodeValueByKind("integer", "-1")).toEqual([
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    ]);
+    // i64 min and max boundaries.
+    expect(encodeValueByKind("integer", "9223372036854775807")).toEqual([
+      0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    ]);
+    expect(encodeValueByKind("integer", "-9223372036854775808")).toEqual([
+      0x80, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+  });
+
+  it("encodes u_integer as 8-byte big-endian unsigned u64", () => {
+    expect(encodeValueByKind("u_integer", "0")).toEqual([
+      0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+    expect(encodeValueByKind("u_integer", "18446744073709551615")).toEqual([
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    ]);
+  });
+
+  it("encodes float as 8-byte big-endian IEEE-754 f64", () => {
+    // 1.0 in IEEE-754 double: 0x3FF0000000000000.
+    expect(encodeValueByKind("float", "1.0")).toEqual([
+      0x3f, 0xf0, 0, 0, 0, 0, 0, 0,
+    ]);
+    // 0.0
+    expect(encodeValueByKind("float", "0")).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("encodes ipaddr v4 literal as 4 packed octets", () => {
+    expect(encodeValueByKind("ipaddr", "1.2.3.4")).toEqual([1, 2, 3, 4]);
+    expect(encodeValueByKind("ipaddr", "127.0.0.1")).toEqual([127, 0, 0, 1]);
+  });
+
+  it("encodes ipaddr v6 literal as 16 packed octets", () => {
+    const out = encodeValueByKind("ipaddr", "::1");
+    expect(out).toHaveLength(16);
+    expect(out[15]).toBe(0x01);
+    for (let i = 0; i < 15; i += 1) expect(out[i]).toBe(0);
+  });
+
+  it("encodes ipv6 with embedded ipv4 form (::ffff:1.2.3.4)", () => {
+    const out = encodeValueByKind("ipaddr", "::ffff:1.2.3.4");
+    expect(out).toHaveLength(16);
+    expect(out.slice(10)).toEqual([0xff, 0xff, 1, 2, 3, 4]);
+  });
+
+  it("rejects CIDR notation for value_kind=ipaddr", () => {
+    expect(() => encodeValueByKind("ipaddr", "1.2.3.0/24")).toThrow(
+      InlinePolicyEncodingError,
+    );
+    expect(() => encodeValueByKind("ipaddr", "2001:db8::/32")).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("rejects vector with a structured error", () => {
+    expect(() => encodeValueByKind("vector", "[1,2,3]")).toThrow(
+      InlinePolicyEncodingError,
+    );
+    try {
+      encodeValueByKind("vector", "[1,2,3]");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InlinePolicyEncodingError);
+      expect((err as InlinePolicyEncodingError).kind).toBe(
+        "vector_unsupported",
+      );
+    }
+  });
+
+  it("rejects invalid bool", () => {
+    expect(() => encodeValueByKind("bool", "yes")).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("rejects i64 overflow", () => {
+    expect(() => encodeValueByKind("integer", "9223372036854775808")).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("rejects negative u64", () => {
+    expect(() => encodeValueByKind("u_integer", "-1")).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("rejects non-numeric integer string", () => {
+    expect(() => encodeValueByKind("integer", "abc")).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("rejects invalid IP literal", () => {
+    expect(() => encodeValueByKind("ipaddr", "not-an-ip")).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+});
+
+describe("encodeRuleBytes", () => {
+  it("encodes both first and second values for a range cmp", () => {
+    const rule = buildRule({
+      value_kind: "integer",
+      cmp_kind: "close_range",
+      first_value: "1",
+      second_value: "10",
+    });
+    const out = encodeRuleBytes(rule);
+    expect(out.firstValue).toHaveLength(8);
+    expect(out.secondValue).toHaveLength(8);
+    expect(out.firstValue[7]).toBe(1);
+    expect((out.secondValue as number[])[7]).toBe(10);
+  });
+
+  it("omits secondValue (null) for a single-value cmp", () => {
+    const rule = buildRule({
+      value_kind: "integer",
+      cmp_kind: "equal",
+      first_value: "5",
+      second_value: null,
+    });
+    const out = encodeRuleBytes(rule);
+    expect(out.secondValue).toBeNull();
+  });
+
+  it("rejects a range cmp with empty second_value", () => {
+    const rule = buildRule({
+      value_kind: "integer",
+      cmp_kind: "open_range",
+      first_value: "1",
+      second_value: null,
+    });
+    expect(() => encodeRuleBytes(rule)).toThrow(InlinePolicyEncodingError);
+  });
+
+  it("rejects a single-value cmp that carries a non-empty second_value", () => {
+    const rule = buildRule({
+      value_kind: "integer",
+      cmp_kind: "equal",
+      first_value: "1",
+      second_value: "2",
+    });
+    expect(() => encodeRuleBytes(rule)).toThrow(InlinePolicyEncodingError);
+  });
+});

--- a/src/__tests__/lib/triage/inline-policy/encode.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/encode.test.ts
@@ -213,6 +213,23 @@ describe("encodeValueByKind", () => {
     );
   });
 
+  it("rejects empty / whitespace-only integer and u_integer strings", () => {
+    // `BigInt("")` and `BigInt("   ".trim())` both evaluate to `0n`,
+    // so without an explicit guard a malformed JSONB `first_value: ""`
+    // would silently encode as zero rather than failing the run.
+    for (const kind of ["integer", "u_integer"] as const) {
+      expect(() => encodeValueByKind(kind, "")).toThrow(
+        InlinePolicyEncodingError,
+      );
+      expect(() => encodeValueByKind(kind, "   ")).toThrow(
+        InlinePolicyEncodingError,
+      );
+      expect(() => encodeValueByKind(kind, "\t\n")).toThrow(
+        InlinePolicyEncodingError,
+      );
+    }
+  });
+
   it("rejects invalid IP literal", () => {
     expect(() => encodeValueByKind("ipaddr", "not-an-ip")).toThrow(
       InlinePolicyEncodingError,

--- a/src/__tests__/lib/triage/inline-policy/encode.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/encode.test.ts
@@ -4,8 +4,8 @@ import {
   encodeRuleBytes,
   encodeValueByKind,
   InlinePolicyEncodingError,
+  type PacketAttrRule,
 } from "@/lib/triage/inline-policy";
-import type { PacketAttr } from "@/lib/triage/policy/types";
 
 /**
  * Round-trip guard for the byte-array encoder.
@@ -17,7 +17,7 @@ import type { PacketAttr } from "@/lib/triage/policy/types";
  * fields.
  */
 
-function buildRule(overrides: Partial<PacketAttr>): PacketAttr {
+function buildRule(overrides: Partial<PacketAttrRule>): PacketAttrRule {
   return {
     raw_event_kind: "http",
     attr_name: "host",

--- a/src/__tests__/lib/triage/inline-policy/encode.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/encode.test.ts
@@ -122,6 +122,18 @@ describe("encodeValueByKind", () => {
     );
   });
 
+  it("rejects bool with non-lowercase letter casing", () => {
+    // Per #460: accepted stored inputs are case-sensitive `"true"` /
+    // `"false"`. Any other casing is an encoding error so the runner
+    // surfaces it as a structured `last_error` rather than silently
+    // accepting widened storage shapes.
+    for (const v of ["True", "TRUE", "False", "FALSE"]) {
+      expect(() => encodeValueByKind("bool", v)).toThrow(
+        InlinePolicyEncodingError,
+      );
+    }
+  });
+
   it("rejects i64 overflow", () => {
     expect(() => encodeValueByKind("integer", "9223372036854775808")).toThrow(
       InlinePolicyEncodingError,

--- a/src/__tests__/lib/triage/inline-policy/encode.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/encode.test.ts
@@ -134,6 +134,67 @@ describe("encodeValueByKind", () => {
     }
   });
 
+  it("accepts JSON boolean literals for value_kind=bool", () => {
+    // Per #460's encoding-rules table, the JSONB boundary may hand us
+    // a native `true`/`false` in addition to the case-sensitive
+    // strings. Both must encode to the same single-byte payload.
+    expect(encodeValueByKind("bool", true)).toEqual([0x01]);
+    expect(encodeValueByKind("bool", false)).toEqual([0x00]);
+  });
+
+  it("rejects bool with other shapes (number / null / object)", () => {
+    for (const v of [0, 1, null, {}, "1", "0"] as unknown[]) {
+      expect(() => encodeValueByKind("bool", v)).toThrow(
+        InlinePolicyEncodingError,
+      );
+    }
+  });
+
+  it("accepts JSON numeric integers for integer / u_integer", () => {
+    // Safe-integer-range JSON numbers must encode the same as their
+    // string representation. Numbers outside the safe-integer range
+    // are rejected separately because JSON has already lost precision.
+    expect(encodeValueByKind("integer", 1)).toEqual([0, 0, 0, 0, 0, 0, 0, 1]);
+    expect(encodeValueByKind("u_integer", 42)).toEqual([
+      0, 0, 0, 0, 0, 0, 0, 42,
+    ]);
+    expect(() =>
+      encodeValueByKind("integer", Number.MAX_SAFE_INTEGER + 1),
+    ).toThrow(InlinePolicyEncodingError);
+    expect(() => encodeValueByKind("integer", 1.5)).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("accepts JSON numbers for float", () => {
+    expect(encodeValueByKind("float", 1)).toEqual([
+      0x3f, 0xf0, 0, 0, 0, 0, 0, 0,
+    ]);
+    expect(() => encodeValueByKind("float", Number.NaN)).toThrow(
+      InlinePolicyEncodingError,
+    );
+  });
+
+  it("rejects non-string / non-number shapes with structured errors", () => {
+    // Each of these would previously throw a `TypeError: value.trim is
+    // not a function` (or similar) without policy/rule context. The
+    // defensive boundary must convert them to `InlinePolicyEncodingError`.
+    for (const kind of ["integer", "u_integer", "float"] as const) {
+      expect(() => encodeValueByKind(kind, null)).toThrow(
+        InlinePolicyEncodingError,
+      );
+      expect(() => encodeValueByKind(kind, {})).toThrow(
+        InlinePolicyEncodingError,
+      );
+    }
+    expect(() => encodeValueByKind("string", 42 as unknown as string)).toThrow(
+      InlinePolicyEncodingError,
+    );
+    expect(() =>
+      encodeValueByKind("ipaddr", null as unknown as string),
+    ).toThrow(InlinePolicyEncodingError);
+  });
+
   it("rejects i64 overflow", () => {
     expect(() => encodeValueByKind("integer", "9223372036854775808")).toThrow(
       InlinePolicyEncodingError,

--- a/src/__tests__/lib/triage/inline-policy/graphql-names.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/graphql-names.test.ts
@@ -38,7 +38,7 @@ function readEnumMembers(enumName: string): Set<string> {
   );
 }
 
-describe("inline-input enum translators", () => {
+describe("inline-policy graphql-name translators", () => {
   it("maps every RAW_EVENT_KINDS literal to a GraphQL RawEventKind member", () => {
     const members = readEnumMembers("RawEventKind");
     for (const kind of RAW_EVENT_KINDS) {

--- a/src/__tests__/lib/triage/inline-policy/graphql-names.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/graphql-names.test.ts
@@ -3,19 +3,17 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
-  cmpKindToGraphql,
-  rawEventKindToGraphql,
-  responseKindToGraphql,
-  threatCategoryToGraphql,
-  valueKindToGraphql,
-} from "@/lib/triage/policy/inline-input";
-import {
   CMP_KINDS,
+  cmpKindToGraphql,
   RAW_EVENT_KINDS,
   RESPONSE_KINDS,
+  rawEventKindToGraphql,
+  responseKindToGraphql,
   THREAT_CATEGORIES,
+  threatCategoryToGraphql,
   VALUE_KINDS,
-} from "@/lib/triage/policy/types";
+  valueKindToGraphql,
+} from "@/lib/triage/inline-policy";
 
 /**
  * Round-trip guard: every literal accepted by the stored TriagePolicy

--- a/src/__tests__/lib/triage/inline-policy/translate.test.ts
+++ b/src/__tests__/lib/triage/inline-policy/translate.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  InlinePolicyEncodingError,
+  translatePolicyToInlineInput,
+} from "@/lib/triage/inline-policy";
+import type { TriagePolicyRow } from "@/lib/triage/policy/types";
+
+/**
+ * Acceptance tests for the inline-policy translator (1B-6 / #460).
+ *
+ *   - Round-trip a stored TriagePolicy row through the byte encoder
+ *     and check the wire-shape result against the documented contract.
+ *   - Panic-free smoke for `Confidence.threat_category = None` at the
+ *     **runner boundary** — even when the storage shape allows null
+ *     (or a hand-crafted inline input synthesises one), the runner
+ *     must surface a sensible inline object rather than panicking.
+ *   - Encoding errors surface as structured `InlinePolicyEncodingError`
+ *     instances carrying enough context for `last_error`.
+ */
+
+function buildPolicy(overrides: Partial<TriagePolicyRow>): TriagePolicyRow {
+  return {
+    id: 1,
+    name: "test",
+    packet_attr: [],
+    confidence: [],
+    response: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("translatePolicyToInlineInput", () => {
+  it("round-trips a stored row to the documented wire shape", () => {
+    const policy = buildPolicy({
+      id: 42,
+      packet_attr: [
+        {
+          raw_event_kind: "http",
+          attr_name: "host",
+          value_kind: "string",
+          cmp_kind: "equal",
+          first_value: "AB",
+          second_value: null,
+          weight: 0.5,
+        },
+      ],
+      confidence: [
+        {
+          threat_category: "execution",
+          threat_kind: "MaliciousScript",
+          confidence: 0.9,
+          weight: 1.0,
+        },
+      ],
+      response: [
+        {
+          minimum_score: 0.5,
+          kind: "manual",
+        },
+      ],
+    });
+    const out = translatePolicyToInlineInput(policy);
+    expect(out.id).toBe(42);
+    expect(out.packetAttr).toEqual([
+      {
+        rawEventKind: "HTTP",
+        attrName: "host",
+        valueKind: "STRING",
+        cmpKind: "EQUAL",
+        firstValue: [0x41, 0x42],
+        secondValue: null,
+        weight: 0.5,
+      },
+    ]);
+    expect(out.confidence).toEqual([
+      {
+        threatCategory: "EXECUTION",
+        threatKind: "MaliciousScript",
+        confidence: 0.9,
+        weight: 1.0,
+      },
+    ]);
+    expect(out.response).toEqual([{ minimumScore: 0.5, kind: "MANUAL" }]);
+  });
+
+  it("does not panic when Confidence.threat_category is null (runner-boundary smoke)", () => {
+    // Storage currently requires `threat_category`, but the runner must
+    // defend against a null arriving via any path — synthesized in
+    // tests, future storage relaxation, or hand-crafted inline input.
+    // The translator surfaces a null `threatCategory` rather than
+    // throwing.
+    const policy = buildPolicy({
+      confidence: [
+        {
+          // biome-ignore lint/suspicious/noExplicitAny: deliberately bypassing storage type
+          threat_category: null as any,
+          threat_kind: "MaliciousScript",
+          confidence: 0.9,
+          weight: null,
+        },
+      ],
+    });
+    const out = translatePolicyToInlineInput(policy);
+    expect(out.confidence[0].threatCategory).toBeNull();
+    expect(out.confidence[0].threatKind).toBe("MaliciousScript");
+  });
+
+  it("surfaces a structured error with policyId context on encoding failure", () => {
+    const policy = buildPolicy({
+      id: 7,
+      packet_attr: [
+        {
+          raw_event_kind: "http",
+          attr_name: "addr",
+          value_kind: "ipaddr",
+          cmp_kind: "equal",
+          first_value: "10.0.0.0/24",
+          second_value: null,
+          weight: null,
+        },
+      ],
+    });
+    try {
+      translatePolicyToInlineInput(policy);
+      expect.fail("expected InlinePolicyEncodingError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InlinePolicyEncodingError);
+      const e = err as InlinePolicyEncodingError;
+      expect(e.kind).toBe("ipaddr_cidr_not_supported");
+      expect(e.context?.policyId).toBe(7);
+      expect(e.context?.ruleIndex).toBe(0);
+    }
+  });
+
+  it("surfaces a structured error for vector value_kind", () => {
+    const policy = buildPolicy({
+      id: 3,
+      packet_attr: [
+        {
+          raw_event_kind: "http",
+          attr_name: "anything",
+          value_kind: "vector",
+          cmp_kind: "equal",
+          first_value: "[1,2,3]",
+          second_value: null,
+          weight: null,
+        },
+      ],
+    });
+    try {
+      translatePolicyToInlineInput(policy);
+      expect.fail("expected InlinePolicyEncodingError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InlinePolicyEncodingError);
+      expect((err as InlinePolicyEncodingError).kind).toBe(
+        "vector_unsupported",
+      );
+      expect((err as InlinePolicyEncodingError).context?.policyId).toBe(3);
+    }
+  });
+});

--- a/src/__tests__/lib/triage/policy/corpus-b/fingerprint.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/fingerprint.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computePoliciesFingerprint,
+  EMPTY_POLICIES_FINGERPRINT,
+} from "@/lib/triage/policy/corpus-b/fingerprint";
+import type { TriagePolicyRow } from "@/lib/triage/policy/types";
+
+function buildPolicy(overrides: Partial<TriagePolicyRow>): TriagePolicyRow {
+  return {
+    id: 1,
+    name: "p",
+    packet_attr: [],
+    confidence: [],
+    response: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("computePoliciesFingerprint", () => {
+  it("produces a stable empty-set fingerprint", () => {
+    const fp = computePoliciesFingerprint([]);
+    expect(fp).toBe(EMPTY_POLICIES_FINGERPRINT);
+    expect(fp).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("hashes set-equal inputs identically (policy order)", () => {
+    const a: TriagePolicyRow[] = [
+      buildPolicy({ id: 1, name: "a" }),
+      buildPolicy({ id: 2, name: "b" }),
+    ];
+    const b: TriagePolicyRow[] = [
+      buildPolicy({ id: 2, name: "b" }),
+      buildPolicy({ id: 1, name: "a" }),
+    ];
+    expect(computePoliciesFingerprint(a)).toBe(computePoliciesFingerprint(b));
+  });
+
+  it("hashes intra-policy rule order permutations identically", () => {
+    const ruleA = {
+      raw_event_kind: "http" as const,
+      attr_name: "host",
+      value_kind: "string" as const,
+      cmp_kind: "equal" as const,
+      first_value: "evil",
+      second_value: null,
+      weight: 1,
+    };
+    const ruleB = { ...ruleA, attr_name: "uri", first_value: "/admin" };
+    const a = buildPolicy({ packet_attr: [ruleA, ruleB] });
+    const b = buildPolicy({ packet_attr: [ruleB, ruleA] });
+    expect(computePoliciesFingerprint([a])).toBe(
+      computePoliciesFingerprint([b]),
+    );
+  });
+
+  it("changes when rule values change", () => {
+    const a = buildPolicy({
+      packet_attr: [
+        {
+          raw_event_kind: "http",
+          attr_name: "host",
+          value_kind: "string",
+          cmp_kind: "equal",
+          first_value: "evil",
+          second_value: null,
+          weight: null,
+        },
+      ],
+    });
+    const b = buildPolicy({
+      packet_attr: [
+        {
+          raw_event_kind: "http",
+          attr_name: "host",
+          value_kind: "string",
+          cmp_kind: "equal",
+          first_value: "good",
+          second_value: null,
+          weight: null,
+        },
+      ],
+    });
+    expect(computePoliciesFingerprint([a])).not.toBe(
+      computePoliciesFingerprint([b]),
+    );
+  });
+
+  it("changes when policy id changes", () => {
+    const a = buildPolicy({ id: 1 });
+    const b = buildPolicy({ id: 2 });
+    expect(computePoliciesFingerprint([a])).not.toBe(
+      computePoliciesFingerprint([b]),
+    );
+  });
+});

--- a/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
@@ -5,7 +5,7 @@ const mockFindActiveRun = vi.hoisted(() => vi.fn());
 const mockInsertComputingRun = vi.hoisted(() => vi.fn());
 const mockRecomputeRun = vi.hoisted(() => vi.fn());
 const mockInsertTriagedEventsBatch = vi.hoisted(() => vi.fn());
-const mockMarkRunReady = vi.hoisted(() => vi.fn());
+const mockMarkRunReadyOnClient = vi.hoisted(() => vi.fn());
 const mockMarkRunFailed = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/triage/policy/customer-db", () => ({
@@ -22,7 +22,7 @@ vi.mock("@/lib/triage/policy/corpus-b/repository", async () => {
     insertComputingRun: mockInsertComputingRun,
     recomputeRun: mockRecomputeRun,
     insertTriagedEventsBatch: mockInsertTriagedEventsBatch,
-    markRunReady: mockMarkRunReady,
+    markRunReadyOnClient: mockMarkRunReadyOnClient,
     markRunFailed: mockMarkRunFailed,
   };
 });
@@ -70,7 +70,7 @@ describe("runCorpusBTriage", () => {
     mockInsertComputingRun.mockReset();
     mockRecomputeRun.mockReset();
     mockInsertTriagedEventsBatch.mockReset();
-    mockMarkRunReady.mockReset();
+    mockMarkRunReadyOnClient.mockReset();
     mockMarkRunFailed.mockReset();
   });
 
@@ -119,7 +119,7 @@ describe("runCorpusBTriage", () => {
     mockFindActiveRun.mockResolvedValueOnce(null);
     mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "42" }));
     mockInsertTriagedEventsBatch.mockResolvedValueOnce(1);
-    mockMarkRunReady.mockResolvedValueOnce(undefined);
+    mockMarkRunReadyOnClient.mockResolvedValueOnce(undefined);
 
     const { runCorpusBTriage } = await import(
       "@/lib/triage/policy/corpus-b/runner"
@@ -175,7 +175,7 @@ describe("runCorpusBTriage", () => {
     expect(result.reusedCache).toBe(false);
     expect(result.run.status).toBe("ready");
     expect(result.insertedEventCount).toBe(1);
-    expect(mockMarkRunReady).toHaveBeenCalledOnce();
+    expect(mockMarkRunReadyOnClient).toHaveBeenCalledOnce();
     const insertCall = mockInsertTriagedEventsBatch.mock.calls[0];
     const insertedRows = insertCall[2];
     expect(insertedRows).toHaveLength(1);
@@ -194,7 +194,7 @@ describe("runCorpusBTriage", () => {
     mockFindActiveRun.mockResolvedValueOnce(null);
     mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "43" }));
     mockInsertTriagedEventsBatch.mockResolvedValue(0);
-    mockMarkRunReady.mockResolvedValueOnce(undefined);
+    mockMarkRunReadyOnClient.mockResolvedValueOnce(undefined);
 
     const { runCorpusBTriage } = await import(
       "@/lib/triage/policy/corpus-b/runner"
@@ -275,6 +275,12 @@ describe("runCorpusBTriage", () => {
   });
 
   it("transitions to failed and persists last_error on encoding failure", async () => {
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "44" }));
+    mockMarkRunFailed.mockResolvedValueOnce(undefined);
+
     const { runCorpusBTriage } = await import(
       "@/lib/triage/policy/corpus-b/runner"
     );
@@ -319,8 +325,67 @@ describe("runCorpusBTriage", () => {
         },
       },
     );
+    // Encoding errors must now persist a real `failed` row so the
+    // menu / audit can surface them and 1B-7 retention can clean
+    // them up — synthesised pseudo-rows are no longer acceptable.
     expect(result.run.status).toBe("failed");
     expect(result.run.lastError).toContain("vector_unsupported");
-    expect(mockInsertComputingRun).not.toHaveBeenCalled();
+    expect(mockInsertComputingRun).toHaveBeenCalledOnce();
+    expect(mockMarkRunFailed).toHaveBeenCalledOnce();
+    const failCall = mockMarkRunFailed.mock.calls[0];
+    expect(failCall[1]).toBe("44");
+    expect(String(failCall[2])).toContain("vector_unsupported");
+  });
+
+  it("fails the run when the page cap is reached with more pages available", async () => {
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "45" }));
+    mockInsertTriagedEventsBatch.mockResolvedValue(0);
+    mockMarkRunFailed.mockResolvedValueOnce(undefined);
+
+    const { _testing, runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+
+    let fetchCalls = 0;
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => {
+          fetchCalls += 1;
+          return {
+            eventListWithTriage: {
+              pageInfo: {
+                hasPreviousPage: false,
+                hasNextPage: true,
+                startCursor: null,
+                endCursor: String(fetchCalls),
+              },
+              edges: [],
+            },
+          };
+        },
+      },
+    );
+
+    expect(fetchCalls).toBe(_testing.MAX_PAGES_PER_RUN);
+    expect(result.run.status).toBe("failed");
+    expect(result.run.lastError).toContain("page cap");
+    expect(mockMarkRunFailed).toHaveBeenCalledOnce();
   });
 });

--- a/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
@@ -244,7 +244,7 @@ describe("runCorpusBTriage", () => {
                   origAddr: "10.0.0.1",
                   respAddr: "10.0.0.2",
                   serverName: "evil.example",
-                  triageScores: [],
+                  triageScores: [{ policyId: "1", score: 2.0 }],
                 },
               },
               {
@@ -259,7 +259,7 @@ describe("runCorpusBTriage", () => {
                   origAddr: "10.0.0.1",
                   respAddr: "10.0.0.2",
                   serverName: "good.example",
-                  triageScores: [],
+                  triageScores: [{ policyId: "1", score: 1.0 }],
                 },
               },
             ],
@@ -275,6 +275,93 @@ describe("runCorpusBTriage", () => {
     const insertedRows = mockInsertTriagedEventsBatch.mock.calls[0][2];
     expect(insertedRows).toHaveLength(1);
     expect(insertedRows[0].host).toBe("good.example");
+  });
+
+  it("drops events with no policy match (null/empty triageScores)", async () => {
+    // `eventListWithTriage` returns every event passing the standard
+    // filter; non-matching events have `triageScores` null or empty.
+    // The runner must not persist those — "With my policies" should
+    // be a zero-row ready run when nothing matched, not the full
+    // standard-filter corpus with empty score lists.
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "45" }));
+    mockInsertTriagedEventsBatch.mockResolvedValue(0);
+    mockMarkRunReadyOnClient.mockResolvedValueOnce(1);
+
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => ({
+          eventListWithTriage: {
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: false,
+              startCursor: null,
+              endCursor: "2",
+            },
+            edges: [
+              {
+                cursor: "1",
+                node: {
+                  __typename: "HttpThreat",
+                  id: "1",
+                  time: "2026-04-15T00:00:00.000Z",
+                  sensor: "s",
+                  category: null,
+                  level: null,
+                  origAddr: "10.0.0.1",
+                  respAddr: "10.0.0.2",
+                  host: "a.example",
+                  uri: "/x",
+                  triageScores: null,
+                },
+              },
+              {
+                cursor: "2",
+                node: {
+                  __typename: "HttpThreat",
+                  id: "2",
+                  time: "2026-04-15T00:00:00.000Z",
+                  sensor: "s",
+                  category: null,
+                  level: null,
+                  origAddr: "10.0.0.1",
+                  respAddr: "10.0.0.2",
+                  host: "b.example",
+                  uri: "/y",
+                  triageScores: [],
+                },
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(result.run.status).toBe("ready");
+    expect(result.insertedEventCount).toBe(0);
+    // The batch INSERT is not called at all when no row survived
+    // the exclusion + score filter — preferred over a zero-row call.
+    expect(mockInsertTriagedEventsBatch).not.toHaveBeenCalled();
   });
 
   it("transitions to failed and persists last_error on encoding failure", async () => {

--- a/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
@@ -1,0 +1,326 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCustomerPool = vi.hoisted(() => vi.fn());
+const mockFindActiveRun = vi.hoisted(() => vi.fn());
+const mockInsertComputingRun = vi.hoisted(() => vi.fn());
+const mockRecomputeRun = vi.hoisted(() => vi.fn());
+const mockInsertTriagedEventsBatch = vi.hoisted(() => vi.fn());
+const mockMarkRunReady = vi.hoisted(() => vi.fn());
+const mockMarkRunFailed = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/policy/customer-db", () => ({
+  getCustomerPool: mockGetCustomerPool,
+}));
+
+vi.mock("@/lib/triage/policy/corpus-b/repository", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/triage/policy/corpus-b/repository")
+  >("@/lib/triage/policy/corpus-b/repository");
+  return {
+    ...actual,
+    findActiveRun: mockFindActiveRun,
+    insertComputingRun: mockInsertComputingRun,
+    recomputeRun: mockRecomputeRun,
+    insertTriagedEventsBatch: mockInsertTriagedEventsBatch,
+    markRunReady: mockMarkRunReady,
+    markRunFailed: mockMarkRunFailed,
+  };
+});
+
+interface FakePoolClient {
+  query: ReturnType<typeof vi.fn>;
+  release: () => void;
+}
+
+function buildFakePool(): {
+  pool: { connect: () => Promise<FakePoolClient> };
+  client: FakePoolClient;
+} {
+  const client: FakePoolClient = {
+    query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    release: () => undefined,
+  };
+  const pool = { connect: async () => client };
+  return { pool, client };
+}
+
+const buildRun = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: "1",
+  ownerAccountId: "00000000-0000-0000-0000-000000000001",
+  periodStartIso: "2026-04-01T00:00:00.000Z",
+  periodEndIso: "2026-04-30T00:00:00.000Z",
+  policiesFingerprint: "fp-policies",
+  exclusionsFingerprint: "fp-exclusions",
+  baselineVersion: "phase1b-four-selector",
+  status: "computing" as const,
+  replaces: null,
+  supersededBy: null,
+  refreshReason: null,
+  computationDurationMs: null,
+  lastError: null,
+  createdAtIso: "2026-05-12T00:00:00.000Z",
+  finalizedAtIso: null,
+  ...overrides,
+});
+
+describe("runCorpusBTriage", () => {
+  beforeEach(() => {
+    mockGetCustomerPool.mockReset();
+    mockFindActiveRun.mockReset();
+    mockInsertComputingRun.mockReset();
+    mockRecomputeRun.mockReset();
+    mockInsertTriagedEventsBatch.mockReset();
+    mockMarkRunReady.mockReset();
+    mockMarkRunFailed.mockReset();
+  });
+
+  it("returns the cache hit when an active ready run exists", async () => {
+    mockFindActiveRun.mockResolvedValueOnce(buildRun({ status: "ready" }));
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => ({
+          eventListWithTriage: {
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: false,
+              startCursor: null,
+              endCursor: null,
+            },
+            edges: [],
+          },
+        }),
+      },
+    );
+    expect(result.reusedCache).toBe(true);
+    expect(result.run.status).toBe("ready");
+    expect(mockInsertComputingRun).not.toHaveBeenCalled();
+  });
+
+  it("inserts a fresh run and persists matching events", async () => {
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "42" }));
+    mockInsertTriagedEventsBatch.mockResolvedValueOnce(1);
+    mockMarkRunReady.mockResolvedValueOnce(undefined);
+
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => ({
+          eventListWithTriage: {
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: false,
+              startCursor: null,
+              endCursor: "1",
+            },
+            edges: [
+              {
+                cursor: "12345",
+                node: {
+                  __typename: "HttpThreat",
+                  id: "12345",
+                  time: "2026-04-15T00:00:00.000Z",
+                  sensor: "sensor-1",
+                  category: null,
+                  level: null,
+                  origAddr: "10.0.0.1",
+                  respAddr: "10.0.0.2",
+                  host: "evil.example",
+                  uri: "/admin",
+                  triageScores: [{ policyId: "1", score: 1.5 }],
+                },
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(result.reusedCache).toBe(false);
+    expect(result.run.status).toBe("ready");
+    expect(result.insertedEventCount).toBe(1);
+    expect(mockMarkRunReady).toHaveBeenCalledOnce();
+    const insertCall = mockInsertTriagedEventsBatch.mock.calls[0];
+    const insertedRows = insertCall[2];
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0]).toMatchObject({
+      eventKey: "12345",
+      kind: "HttpThreat",
+      host: "evil.example",
+      uri: "/admin",
+      snapshot: { scores: [{ policyId: 1, score: 1.5 }] },
+    });
+  });
+
+  it("drops events that match the active exclusion set (app-side fallback)", async () => {
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "43" }));
+    mockInsertTriagedEventsBatch.mockResolvedValue(0);
+    mockMarkRunReady.mockResolvedValueOnce(undefined);
+
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            // TLS host exclusion via Hostname — Stage 1 may not match
+            // until #723, but the in-memory re-application here does.
+            return {
+              rules: [{ hostname: ["evil.example"] }],
+            };
+          },
+        },
+        fetchPage: async () => ({
+          eventListWithTriage: {
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: false,
+              startCursor: null,
+              endCursor: "1",
+            },
+            edges: [
+              {
+                cursor: "1",
+                node: {
+                  __typename: "BlocklistTls",
+                  id: "1",
+                  time: "2026-04-15T00:00:00.000Z",
+                  sensor: "s",
+                  category: null,
+                  level: null,
+                  origAddr: "10.0.0.1",
+                  respAddr: "10.0.0.2",
+                  serverName: "evil.example",
+                  triageScores: [],
+                },
+              },
+              {
+                cursor: "2",
+                node: {
+                  __typename: "BlocklistTls",
+                  id: "2",
+                  time: "2026-04-15T00:00:00.000Z",
+                  sensor: "s",
+                  category: null,
+                  level: null,
+                  origAddr: "10.0.0.1",
+                  respAddr: "10.0.0.2",
+                  serverName: "good.example",
+                  triageScores: [],
+                },
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(result.run.status).toBe("ready");
+    // Exactly one event should have been forwarded to the batch INSERT
+    // — the `evil.example` row is dropped by the in-memory rematch.
+    expect(mockInsertTriagedEventsBatch).toHaveBeenCalledOnce();
+    const insertedRows = mockInsertTriagedEventsBatch.mock.calls[0][2];
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0].host).toBe("good.example");
+  });
+
+  it("transitions to failed and persists last_error on encoding failure", async () => {
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [
+          {
+            id: 7,
+            name: "bad",
+            packet_attr: [
+              {
+                raw_event_kind: "http",
+                attr_name: "addr",
+                value_kind: "vector",
+                cmp_kind: "equal",
+                first_value: "[1,2,3]",
+                second_value: null,
+                weight: null,
+              },
+            ],
+            confidence: [],
+            response: [],
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => {
+          throw new Error("fetch should not be called when encoding fails");
+        },
+      },
+    );
+    expect(result.run.status).toBe("failed");
+    expect(result.run.lastError).toContain("vector_unsupported");
+    expect(mockInsertComputingRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
@@ -7,6 +7,7 @@ const mockRecomputeRun = vi.hoisted(() => vi.fn());
 const mockInsertTriagedEventsBatch = vi.hoisted(() => vi.fn());
 const mockMarkRunReadyOnClient = vi.hoisted(() => vi.fn());
 const mockMarkRunFailed = vi.hoisted(() => vi.fn());
+const mockGetRunById = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/triage/policy/customer-db", () => ({
   getCustomerPool: mockGetCustomerPool,
@@ -24,6 +25,7 @@ vi.mock("@/lib/triage/policy/corpus-b/repository", async () => {
     insertTriagedEventsBatch: mockInsertTriagedEventsBatch,
     markRunReadyOnClient: mockMarkRunReadyOnClient,
     markRunFailed: mockMarkRunFailed,
+    getRunById: mockGetRunById,
   };
 });
 
@@ -72,6 +74,7 @@ describe("runCorpusBTriage", () => {
     mockInsertTriagedEventsBatch.mockReset();
     mockMarkRunReadyOnClient.mockReset();
     mockMarkRunFailed.mockReset();
+    mockGetRunById.mockReset();
   });
 
   it("returns the cache hit when an active ready run exists", async () => {
@@ -119,7 +122,7 @@ describe("runCorpusBTriage", () => {
     mockFindActiveRun.mockResolvedValueOnce(null);
     mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "42" }));
     mockInsertTriagedEventsBatch.mockResolvedValueOnce(1);
-    mockMarkRunReadyOnClient.mockResolvedValueOnce(undefined);
+    mockMarkRunReadyOnClient.mockResolvedValueOnce(1);
 
     const { runCorpusBTriage } = await import(
       "@/lib/triage/policy/corpus-b/runner"
@@ -194,7 +197,7 @@ describe("runCorpusBTriage", () => {
     mockFindActiveRun.mockResolvedValueOnce(null);
     mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "43" }));
     mockInsertTriagedEventsBatch.mockResolvedValue(0);
-    mockMarkRunReadyOnClient.mockResolvedValueOnce(undefined);
+    mockMarkRunReadyOnClient.mockResolvedValueOnce(1);
 
     const { runCorpusBTriage } = await import(
       "@/lib/triage/policy/corpus-b/runner"
@@ -387,5 +390,117 @@ describe("runCorpusBTriage", () => {
     expect(result.run.status).toBe("failed");
     expect(result.run.lastError).toContain("page cap");
     expect(mockMarkRunFailed).toHaveBeenCalledOnce();
+  });
+
+  it("fails the run when hasNextPage=true but endCursor is null", async () => {
+    // A malformed pagination response — the resolver claims more pages
+    // exist but does not give us a cursor to fetch them with. Treating
+    // this as a clean exit would materialise an incomplete run as
+    // `ready`; instead it must transition to `failed` like the page-cap
+    // case.
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "46" }));
+    mockInsertTriagedEventsBatch.mockResolvedValue(0);
+    mockMarkRunFailed.mockResolvedValueOnce(undefined);
+
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => ({
+          eventListWithTriage: {
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: true,
+              startCursor: null,
+              endCursor: null,
+            },
+            edges: [],
+          },
+        }),
+      },
+    );
+
+    expect(result.run.status).toBe("failed");
+    expect(result.run.lastError).toContain("endCursor=null");
+    expect(mockMarkRunFailed).toHaveBeenCalledOnce();
+    expect(mockMarkRunReadyOnClient).not.toHaveBeenCalled();
+  });
+
+  it("does not revive a terminal row when the ready flip finds zero rows", async () => {
+    // Simulates 1B-7's reaper transitioning the row to `failed` (or a
+    // concurrent recompute marking it `superseded`) while this runner
+    // was mid-flight. `markRunReadyOnClient` returns rowCount 0 because
+    // of its `AND status = 'computing'` guard, and the runner must
+    // surface the terminal row instead of resurrecting it.
+    const fakePool = buildFakePool();
+    mockGetCustomerPool.mockResolvedValue(fakePool.pool);
+    mockFindActiveRun.mockResolvedValueOnce(null);
+    mockInsertComputingRun.mockResolvedValueOnce(buildRun({ id: "47" }));
+    mockInsertTriagedEventsBatch.mockResolvedValue(0);
+    mockMarkRunReadyOnClient.mockResolvedValueOnce(0);
+    mockGetRunById.mockResolvedValueOnce(
+      buildRun({
+        id: "47",
+        status: "failed",
+        lastError: "timeout: runner did not finalize",
+      }),
+    );
+
+    const { runCorpusBTriage } = await import(
+      "@/lib/triage/policy/corpus-b/runner"
+    );
+    const result = await runCorpusBTriage(
+      {
+        customerId: 1,
+        ownerAccountId: "00000000-0000-0000-0000-000000000001",
+        periodStartIso: "2026-04-01T00:00:00.000Z",
+        periodEndIso: "2026-04-30T00:00:00.000Z",
+        policies: [],
+        baselineVersion: "phase1b-four-selector",
+        refreshReason: null,
+      },
+      {
+        exclusionResolver: {
+          async resolve() {
+            return { rules: [] };
+          },
+        },
+        fetchPage: async () => ({
+          eventListWithTriage: {
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: false,
+              startCursor: null,
+              endCursor: "1",
+            },
+            edges: [],
+          },
+        }),
+      },
+    );
+
+    expect(result.run.status).toBe("failed");
+    expect(result.run.lastError).toBe("timeout: runner did not finalize");
+    expect(mockMarkRunFailed).not.toHaveBeenCalled();
+    expect(mockGetRunById).toHaveBeenCalledOnce();
   });
 });

--- a/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/runner.test.ts
@@ -420,11 +420,19 @@ describe("runCorpusBTriage", () => {
     // them up — synthesised pseudo-rows are no longer acceptable.
     expect(result.run.status).toBe("failed");
     expect(result.run.lastError).toContain("vector_unsupported");
+    // The persisted `last_error` must identify the offending policy
+    // and rule so the menu / audit / 1B-7 retention surfaces can act
+    // on it without re-deriving the location from the raw error kind.
+    expect(result.run.lastError).toContain("policyId=7");
+    expect(result.run.lastError).toContain("packet_attr.0");
     expect(mockInsertComputingRun).toHaveBeenCalledOnce();
     expect(mockMarkRunFailed).toHaveBeenCalledOnce();
     const failCall = mockMarkRunFailed.mock.calls[0];
     expect(failCall[1]).toBe("44");
-    expect(String(failCall[2])).toContain("vector_unsupported");
+    const persisted = String(failCall[2]);
+    expect(persisted).toContain("vector_unsupported");
+    expect(persisted).toContain("policyId=7");
+    expect(persisted).toContain("packet_attr.0");
   });
 
   it("fails the run when the page cap is reached with more pages available", async () => {

--- a/src/__tests__/lib/triage/policy/inline-translator.test.ts
+++ b/src/__tests__/lib/triage/policy/inline-translator.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  InlinePolicyEncodingError,
-  translatePolicyToInlineInput,
-} from "@/lib/triage/inline-policy";
+import { InlinePolicyEncodingError } from "@/lib/triage/inline-policy";
+import { translatePolicyToInlineInput } from "@/lib/triage/policy/inline-translator";
 import type { TriagePolicyRow } from "@/lib/triage/policy/types";
 
 /**

--- a/src/lib/triage/inline-policy/encode.ts
+++ b/src/lib/triage/inline-policy/encode.ts
@@ -1,0 +1,344 @@
+/**
+ * Byte-array encoding for inline policy `firstValue` / `secondValue`.
+ *
+ * `eventListWithTriage`'s `PacketAttrInput` carries `firstValue:
+ * [Int!]!` and `secondValue: [Int!]` on the wire — packed byte arrays
+ * whose layout depends on the rule's `value_kind`. The stored
+ * TriagePolicy shape (#459 / `src/lib/triage/policy/types.ts`) keeps
+ * those values as human-readable JSONB strings tagged by `value_kind`.
+ * This module bridges the two so the corpus B runner can call the
+ * resolver with a faithful inline policy without policy-side code
+ * touching wire encoding.
+ *
+ * Lives outside `src/lib/triage/policy/` per the §6 deprecatability
+ * rule — the encoder is the **inline-policy boundary** and is shared
+ * with any future inline-policy caller. Removing the policy mode
+ * leaves this module in place; baseline-side code never needs it but
+ * the encoder does not depend on the policy/ namespace either.
+ *
+ * The encoding rules below are anchored in `eventListWithTriage`'s
+ * resolver expectations (review-web#842); any deviation is a bug,
+ * not a tunable. The round-trip test in
+ * `__tests__/lib/triage/inline-policy/encode.test.ts` pins each
+ * encoding against the documented contract.
+ */
+
+import { isIPv4, isIPv6 } from "node:net";
+
+import type { CmpKind, PacketAttr, ValueKind } from "@/lib/triage/policy/types";
+import { RANGE_CMP_KINDS } from "@/lib/triage/policy/types";
+
+/**
+ * Structured error surfaced when a stored `packet_attr` rule cannot be
+ * encoded for the inline `PacketAttrInput` shape. The corpus B runner
+ * catches these and transitions the run to `status='failed'` with
+ * `last_error` identifying the offending policy / rule — never a
+ * thrown panic.
+ */
+export class InlinePolicyEncodingError extends Error {
+  readonly kind: string;
+  /** Optional context the runner forwards into `last_error`. */
+  readonly context?: Record<string, unknown>;
+
+  constructor(
+    kind: string,
+    message: string,
+    context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "InlinePolicyEncodingError";
+    this.kind = kind;
+    this.context = context;
+  }
+}
+
+/**
+ * One encoded `PacketAttrInput`. Field names are camelCase because the
+ * GraphQL wire-side input expects camelCase.
+ */
+export interface EncodedPacketAttrInput {
+  rawEventKind: string;
+  attrName: string;
+  valueKind: string;
+  cmpKind: string;
+  /** Required `[Int!]!`. */
+  firstValue: number[];
+  /** Nullable `[Int!]`; `null` for single-value comparisons. */
+  secondValue: number[] | null;
+  weight: number | null;
+}
+
+const U8_MAX = 0xff;
+
+const I64_MIN = -(BigInt(1) << BigInt(63));
+const I64_MAX = (BigInt(1) << BigInt(63)) - BigInt(1);
+const U64_MAX = (BigInt(1) << BigInt(64)) - BigInt(1);
+
+/**
+ * Encode the bytes for one stored `packet_attr` rule's `firstValue` and
+ * `secondValue` payloads. Used by `encodePacketAttrInput` and exposed
+ * directly so tests can drive the encoding without going through the
+ * full enum-name conversion.
+ *
+ * `cmpKind` decides whether `secondValue` must be encoded (range cmp
+ * kinds) or omitted (`null`). Range cmps with missing `second_value`
+ * have already been rejected at policy storage time
+ * (`validatePolicySemantics`), but the encoder defends again so a
+ * hand-crafted inline call cannot smuggle one through.
+ */
+export function encodeRuleBytes(rule: PacketAttr): {
+  firstValue: number[];
+  secondValue: number[] | null;
+} {
+  const valueKind = rule.value_kind as ValueKind;
+  const cmpKind = rule.cmp_kind as CmpKind;
+  const firstValue = encodeValueByKind(valueKind, rule.first_value);
+  if (!RANGE_CMP_KINDS.has(cmpKind)) {
+    if (
+      rule.second_value !== null &&
+      rule.second_value !== undefined &&
+      rule.second_value.length > 0
+    ) {
+      // Stored row has a non-empty `second_value` for a non-range
+      // comparison; the resolver expects `secondValue: null` here.
+      // Encoding it would silently change the rule's semantics — the
+      // engine would treat the extra bytes as the upper bound of a
+      // range. Fail loudly instead.
+      throw new InlinePolicyEncodingError(
+        "second_value_unexpected",
+        `cmp_kind '${cmpKind}' does not accept second_value`,
+        { cmpKind },
+      );
+    }
+    return { firstValue, secondValue: null };
+  }
+  if (
+    rule.second_value === null ||
+    rule.second_value === undefined ||
+    rule.second_value.length === 0
+  ) {
+    throw new InlinePolicyEncodingError(
+      "second_value_required",
+      `cmp_kind '${cmpKind}' requires a non-empty second_value`,
+      { cmpKind },
+    );
+  }
+  const secondValue = encodeValueByKind(valueKind, rule.second_value);
+  return { firstValue, secondValue };
+}
+
+/**
+ * Encode one stored value (as JSONB-stored text) according to its
+ * declared `value_kind`. Returns an array of `[0, 255]` integers ready
+ * for the GraphQL `[Int!]!` shape.
+ */
+export function encodeValueByKind(kind: ValueKind, value: string): number[] {
+  switch (kind) {
+    case "bool":
+      return [encodeBool(value)];
+    case "string":
+      return encodeUtf8(value);
+    case "integer":
+      return encodeI64(value);
+    case "u_integer":
+      return encodeU64(value);
+    case "float":
+      return encodeF64(value);
+    case "ipaddr":
+      return encodeIpLiteral(value);
+    case "vector":
+      // Vector is out of scope for this issue per §3.5 — the stored
+      // shape has no separate element kind, so the wire-format target
+      // is ambiguous. Reject so the runner can transition to failed.
+      throw new InlinePolicyEncodingError(
+        "vector_unsupported",
+        "value_kind 'vector' is not supported by the inline-policy encoder",
+        { valueKind: kind },
+      );
+  }
+}
+
+function encodeBool(value: string): number {
+  if (value === "true" || value === "True" || value === "TRUE") return 0x01;
+  if (value === "false" || value === "False" || value === "FALSE") return 0x00;
+  throw new InlinePolicyEncodingError(
+    "bool_invalid",
+    `Expected 'true' or 'false' for value_kind=bool, got ${JSON.stringify(value)}`,
+    { valueKind: "bool" },
+  );
+}
+
+function encodeUtf8(value: string): number[] {
+  const bytes = Buffer.from(value, "utf8");
+  const out = new Array<number>(bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) out[i] = bytes[i];
+  return out;
+}
+
+function encodeI64(value: string): number[] {
+  const trimmed = value.trim();
+  let big: bigint;
+  try {
+    big = BigInt(trimmed);
+  } catch {
+    throw new InlinePolicyEncodingError(
+      "integer_invalid",
+      `Expected i64 string for value_kind=integer, got ${JSON.stringify(value)}`,
+      { valueKind: "integer" },
+    );
+  }
+  if (big < I64_MIN || big > I64_MAX) {
+    throw new InlinePolicyEncodingError(
+      "integer_overflow",
+      `Value ${trimmed} does not fit in i64`,
+      { valueKind: "integer" },
+    );
+  }
+  // Two's complement big-endian, 8 bytes.
+  const buf = Buffer.alloc(8);
+  buf.writeBigInt64BE(big, 0);
+  return Array.from(buf.values());
+}
+
+function encodeU64(value: string): number[] {
+  const trimmed = value.trim();
+  let big: bigint;
+  try {
+    big = BigInt(trimmed);
+  } catch {
+    throw new InlinePolicyEncodingError(
+      "u_integer_invalid",
+      `Expected u64 string for value_kind=u_integer, got ${JSON.stringify(value)}`,
+      { valueKind: "u_integer" },
+    );
+  }
+  if (big < BigInt(0) || big > U64_MAX) {
+    throw new InlinePolicyEncodingError(
+      "u_integer_overflow",
+      `Value ${trimmed} does not fit in u64`,
+      { valueKind: "u_integer" },
+    );
+  }
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(big, 0);
+  return Array.from(buf.values());
+}
+
+function encodeF64(value: string): number[] {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    throw new InlinePolicyEncodingError(
+      "float_invalid",
+      `Expected finite IEEE-754 number for value_kind=float, got ${JSON.stringify(value)}`,
+      { valueKind: "float" },
+    );
+  }
+  const buf = Buffer.alloc(8);
+  buf.writeDoubleBE(num, 0);
+  return Array.from(buf.values());
+}
+
+function encodeIpLiteral(value: string): number[] {
+  // CIDR is intentionally rejected at the encoder boundary. Prefix
+  // length has no agreed wire representation in `PacketAttrInput`;
+  // CIDR is an exclusion / network-group concern, not an inline
+  // packet-attr concern. Even if storage (#459) currently allows a
+  // CIDR string for `value_kind=ipaddr`, the inline encoder must not.
+  if (value.includes("/")) {
+    throw new InlinePolicyEncodingError(
+      "ipaddr_cidr_not_supported",
+      `CIDR notation is not supported by the inline-policy encoder (value_kind=ipaddr expects an IP literal): ${JSON.stringify(value)}`,
+      { valueKind: "ipaddr" },
+    );
+  }
+  if (isIPv4(value)) {
+    const parts = value.split(".");
+    if (parts.length !== 4) {
+      throw new InlinePolicyEncodingError(
+        "ipaddr_invalid",
+        `Invalid IPv4 literal: ${JSON.stringify(value)}`,
+        { valueKind: "ipaddr" },
+      );
+    }
+    const out: number[] = [];
+    for (const p of parts) {
+      const n = Number(p);
+      if (!Number.isInteger(n) || n < 0 || n > U8_MAX) {
+        throw new InlinePolicyEncodingError(
+          "ipaddr_invalid",
+          `Invalid IPv4 octet ${JSON.stringify(p)} in ${JSON.stringify(value)}`,
+          { valueKind: "ipaddr" },
+        );
+      }
+      out.push(n);
+    }
+    return out;
+  }
+  if (isIPv6(value)) {
+    return encodeIpv6(value);
+  }
+  throw new InlinePolicyEncodingError(
+    "ipaddr_invalid",
+    `Not a valid IP literal: ${JSON.stringify(value)}`,
+    { valueKind: "ipaddr" },
+  );
+}
+
+function encodeIpv6(value: string): number[] {
+  // Expand the optional `::` and any embedded IPv4 suffix (e.g.
+  // `::ffff:1.2.3.4`) into eight 16-bit groups, then emit 16 bytes
+  // big-endian. Behaviour matches Node's net `isIPv6`.
+  let normalized = value;
+  const lastColon = normalized.lastIndexOf(":");
+  if (lastColon !== -1 && normalized.includes(".", lastColon)) {
+    const tail = normalized.slice(lastColon + 1);
+    if (isIPv4(tail)) {
+      const parts = tail.split(".").map((p) => Number(p));
+      const w1 = ((parts[0] << 8) | parts[1]).toString(16);
+      const w2 = ((parts[2] << 8) | parts[3]).toString(16);
+      normalized = `${normalized.slice(0, lastColon + 1)}${w1}:${w2}`;
+    }
+  }
+  let head: string;
+  let tail: string;
+  if (normalized.includes("::")) {
+    const [h, t] = normalized.split("::", 2);
+    head = h ?? "";
+    tail = t ?? "";
+  } else {
+    head = normalized;
+    tail = "";
+  }
+  const headParts = head.length === 0 ? [] : head.split(":");
+  const tailParts = tail.length === 0 ? [] : tail.split(":");
+  if (headParts.length + tailParts.length > 8) {
+    throw new InlinePolicyEncodingError(
+      "ipaddr_invalid",
+      `Invalid IPv6 literal: ${JSON.stringify(value)}`,
+      { valueKind: "ipaddr" },
+    );
+  }
+  const zeros = new Array(8 - headParts.length - tailParts.length).fill("0");
+  const all = [...headParts, ...zeros, ...tailParts];
+  if (all.length !== 8) {
+    throw new InlinePolicyEncodingError(
+      "ipaddr_invalid",
+      `Invalid IPv6 literal: ${JSON.stringify(value)}`,
+      { valueKind: "ipaddr" },
+    );
+  }
+  const out: number[] = [];
+  for (const part of all) {
+    const word = Number.parseInt(part, 16);
+    if (!Number.isFinite(word) || word < 0 || word > 0xffff) {
+      throw new InlinePolicyEncodingError(
+        "ipaddr_invalid",
+        `Invalid IPv6 word ${JSON.stringify(part)} in ${JSON.stringify(value)}`,
+        { valueKind: "ipaddr" },
+      );
+    }
+    out.push((word >> 8) & U8_MAX);
+    out.push(word & U8_MAX);
+  }
+  return out;
+}

--- a/src/lib/triage/inline-policy/encode.ts
+++ b/src/lib/triage/inline-policy/encode.ts
@@ -3,18 +3,17 @@
  *
  * `eventListWithTriage`'s `PacketAttrInput` carries `firstValue:
  * [Int!]!` and `secondValue: [Int!]` on the wire — packed byte arrays
- * whose layout depends on the rule's `value_kind`. The stored
- * TriagePolicy shape (#459 / `src/lib/triage/policy/types.ts`) keeps
- * those values as human-readable JSONB strings tagged by `value_kind`.
- * This module bridges the two so the corpus B runner can call the
- * resolver with a faithful inline policy without policy-side code
- * touching wire encoding.
+ * whose layout depends on the rule's `value_kind`. This module is the
+ * **inline-policy seam**: it knows the wire enums (`./kinds`) and the
+ * GraphQL name mapping (`./graphql-names`) but does NOT depend on the
+ * storage namespace at `src/lib/triage/policy/`, so the encoder can
+ * be reused by any future inline-policy caller without dragging in the
+ * policy-mode CRUD layer (§6 deprecatability seam in #447).
  *
- * Lives outside `src/lib/triage/policy/` per the §6 deprecatability
- * rule — the encoder is the **inline-policy boundary** and is shared
- * with any future inline-policy caller. Removing the policy mode
- * leaves this module in place; baseline-side code never needs it but
- * the encoder does not depend on the policy/ namespace either.
+ * The storage→wire translator that consumes a stored `TriagePolicyRow`
+ * lives at `src/lib/triage/policy/inline-translator.ts` because it
+ * legitimately depends on the storage shape; the dependency direction
+ * is `triage/policy/ → triage/inline-policy/`, never the reverse.
  *
  * The encoding rules below are anchored in `eventListWithTriage`'s
  * resolver expectations (review-web#842); any deviation is a bug,
@@ -25,8 +24,25 @@
 
 import { isIPv4, isIPv6 } from "node:net";
 
-import type { CmpKind, PacketAttr, ValueKind } from "@/lib/triage/policy/types";
-import { RANGE_CMP_KINDS } from "@/lib/triage/policy/types";
+import { type CmpKind, RANGE_CMP_KINDS, type ValueKind } from "./kinds";
+
+/**
+ * Minimal wire-shape view of one stored `packet_attr` rule that the
+ * encoder consumes. Mirrors the subset of the storage `PacketAttr`
+ * shape the encoder cares about so the inline-policy seam does not
+ * import `triage/policy/types`. Storage callers feed their stored row
+ * in directly — the shape is structurally compatible with `PacketAttr`
+ * but does not require the storage namespace to be present.
+ */
+export interface PacketAttrRule {
+  raw_event_kind: string;
+  attr_name: string;
+  value_kind: string;
+  cmp_kind: string;
+  first_value: unknown;
+  second_value?: unknown;
+  weight?: number | null;
+}
 
 /**
  * Structured error surfaced when a stored `packet_attr` rule cannot be
@@ -93,7 +109,7 @@ const U64_MAX = (BigInt(1) << BigInt(64)) - BigInt(1);
  * mismatch must surface as a structured `InlinePolicyEncodingError`
  * rather than a `TypeError` from `.trim()` or similar.
  */
-export function encodeRuleBytes(rule: PacketAttr): {
+export function encodeRuleBytes(rule: PacketAttrRule): {
   firstValue: number[];
   secondValue: number[] | null;
 } {

--- a/src/lib/triage/inline-policy/encode.ts
+++ b/src/lib/triage/inline-policy/encode.ts
@@ -159,8 +159,12 @@ export function encodeValueByKind(kind: ValueKind, value: string): number[] {
 }
 
 function encodeBool(value: string): number {
-  if (value === "true" || value === "True" || value === "TRUE") return 0x01;
-  if (value === "false" || value === "False" || value === "FALSE") return 0x00;
+  // Per issue #460: accepted stored inputs are the JSON `true`/`false`
+  // literals and the strings `"true"`/`"false"` — case-sensitive.
+  // Anything else (including `"True"`, `"TRUE"`, `"False"`, `"FALSE"`)
+  // is an encoding error.
+  if (value === "true") return 0x01;
+  if (value === "false") return 0x00;
   throw new InlinePolicyEncodingError(
     "bool_invalid",
     `Expected 'true' or 'false' for value_kind=bool, got ${JSON.stringify(value)}`,

--- a/src/lib/triage/inline-policy/encode.ts
+++ b/src/lib/triage/inline-policy/encode.ts
@@ -218,7 +218,24 @@ function encodeUtf8(value: string): number[] {
  * value.
  */
 function normalizeIntegerSource(value: unknown, kind: string): string {
-  if (typeof value === "string") return value.trim();
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    // `BigInt("")` and `BigInt("   ".trim())` both evaluate to `0n`, so
+    // an empty / whitespace-only JSONB `first_value` (or `second_value`)
+    // would silently encode as zero — a real, valid wire payload that
+    // does not represent any rule the operator wrote. The encoder is
+    // the defensive boundary per #460, so reject up front with a
+    // structured error instead of letting the runner persist a
+    // zero-bytes rule.
+    if (trimmed.length === 0) {
+      throw new InlinePolicyEncodingError(
+        `${kind}_invalid`,
+        `Expected integer for value_kind=${kind}, got empty string`,
+        { valueKind: kind },
+      );
+    }
+    return trimmed;
+  }
   if (typeof value === "number") {
     if (!Number.isFinite(value) || !Number.isInteger(value)) {
       throw new InlinePolicyEncodingError(

--- a/src/lib/triage/inline-policy/encode.ts
+++ b/src/lib/triage/inline-policy/encode.ts
@@ -85,6 +85,13 @@ const U64_MAX = (BigInt(1) << BigInt(64)) - BigInt(1);
  * have already been rejected at policy storage time
  * (`validatePolicySemantics`), but the encoder defends again so a
  * hand-crafted inline call cannot smuggle one through.
+ *
+ * `rule.first_value` / `rule.second_value` are typed as `string` at the
+ * stored-row layer (#459's Zod schema), but the JSONB storage boundary
+ * may hand us strings, numbers, or booleans depending on caller. The
+ * encoder is the defensive boundary called out in #460: every shape
+ * mismatch must surface as a structured `InlinePolicyEncodingError`
+ * rather than a `TypeError` from `.trim()` or similar.
  */
 export function encodeRuleBytes(rule: PacketAttr): {
   firstValue: number[];
@@ -93,12 +100,13 @@ export function encodeRuleBytes(rule: PacketAttr): {
   const valueKind = rule.value_kind as ValueKind;
   const cmpKind = rule.cmp_kind as CmpKind;
   const firstValue = encodeValueByKind(valueKind, rule.first_value);
+  const second = rule.second_value as unknown;
+  const hasSecond =
+    second !== null &&
+    second !== undefined &&
+    !(typeof second === "string" && second.length === 0);
   if (!RANGE_CMP_KINDS.has(cmpKind)) {
-    if (
-      rule.second_value !== null &&
-      rule.second_value !== undefined &&
-      rule.second_value.length > 0
-    ) {
+    if (hasSecond) {
       // Stored row has a non-empty `second_value` for a non-range
       // comparison; the resolver expects `secondValue: null` here.
       // Encoding it would silently change the rule's semantics — the
@@ -112,32 +120,34 @@ export function encodeRuleBytes(rule: PacketAttr): {
     }
     return { firstValue, secondValue: null };
   }
-  if (
-    rule.second_value === null ||
-    rule.second_value === undefined ||
-    rule.second_value.length === 0
-  ) {
+  if (!hasSecond) {
     throw new InlinePolicyEncodingError(
       "second_value_required",
       `cmp_kind '${cmpKind}' requires a non-empty second_value`,
       { cmpKind },
     );
   }
-  const secondValue = encodeValueByKind(valueKind, rule.second_value);
+  const secondValue = encodeValueByKind(valueKind, second);
   return { firstValue, secondValue };
 }
 
 /**
- * Encode one stored value (as JSONB-stored text) according to its
- * declared `value_kind`. Returns an array of `[0, 255]` integers ready
- * for the GraphQL `[Int!]!` shape.
+ * Encode one stored value according to its declared `value_kind`.
+ * Returns an array of `[0, 255]` integers ready for the GraphQL
+ * `[Int!]!` shape.
+ *
+ * The stored TriagePolicy JSONB boundary may hand us strings, numbers,
+ * or booleans depending on origin. Each branch below normalizes the
+ * accepted shapes up front and converts every other shape into a
+ * structured {@link InlinePolicyEncodingError}, so the runner sees one
+ * error class regardless of where the bad shape came from.
  */
-export function encodeValueByKind(kind: ValueKind, value: string): number[] {
+export function encodeValueByKind(kind: ValueKind, value: unknown): number[] {
   switch (kind) {
     case "bool":
       return [encodeBool(value)];
     case "string":
-      return encodeUtf8(value);
+      return encodeUtf8(requireString(value, "string"));
     case "integer":
       return encodeI64(value);
     case "u_integer":
@@ -145,7 +155,7 @@ export function encodeValueByKind(kind: ValueKind, value: string): number[] {
     case "float":
       return encodeF64(value);
     case "ipaddr":
-      return encodeIpLiteral(value);
+      return encodeIpLiteral(requireString(value, "ipaddr"));
     case "vector":
       // Vector is out of scope for this issue per §3.5 — the stored
       // shape has no separate element kind, so the wire-format target
@@ -158,16 +168,36 @@ export function encodeValueByKind(kind: ValueKind, value: string): number[] {
   }
 }
 
-function encodeBool(value: string): number {
-  // Per issue #460: accepted stored inputs are the JSON `true`/`false`
-  // literals and the strings `"true"`/`"false"` — case-sensitive.
-  // Anything else (including `"True"`, `"TRUE"`, `"False"`, `"FALSE"`)
-  // is an encoding error.
+function requireString(value: unknown, kind: string): string {
+  if (typeof value !== "string") {
+    throw new InlinePolicyEncodingError(
+      `${kind}_invalid`,
+      `Expected string for value_kind=${kind}, got ${describeShape(value)}`,
+      { valueKind: kind },
+    );
+  }
+  return value;
+}
+
+function describeShape(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function encodeBool(value: unknown): number {
+  // Per #460's "Encoding rules per `value_kind`" table: accepted
+  // lexical inputs from JSONB storage are the JSON `true`/`false`
+  // literals **and** the strings `"true"`/`"false"` (case-sensitive).
+  // Anything else (`"True"`, `"TRUE"`, `1`, `0`, etc.) is an
+  // encoding error.
+  if (value === true) return 0x01;
+  if (value === false) return 0x00;
   if (value === "true") return 0x01;
   if (value === "false") return 0x00;
   throw new InlinePolicyEncodingError(
     "bool_invalid",
-    `Expected 'true' or 'false' for value_kind=bool, got ${JSON.stringify(value)}`,
+    `Expected boolean or 'true'/'false' for value_kind=bool, got ${JSON.stringify(value)}`,
     { valueKind: "bool" },
   );
 }
@@ -179,15 +209,50 @@ function encodeUtf8(value: string): number[] {
   return out;
 }
 
-function encodeI64(value: string): number[] {
-  const trimmed = value.trim();
+/**
+ * Normalize a JSONB scalar into a bigint-parseable string for the
+ * fixed-width integer encoders. JSON numbers beyond
+ * `Number.MAX_SAFE_INTEGER` cannot be trusted as i64 / u64 because
+ * the lexer has already lost precision — those are rejected with a
+ * structured error so the runner does not silently encode the wrong
+ * value.
+ */
+function normalizeIntegerSource(value: unknown, kind: string): string {
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new InlinePolicyEncodingError(
+        `${kind}_invalid`,
+        `Expected integer for value_kind=${kind}, got non-integer number ${JSON.stringify(value)}`,
+        { valueKind: kind },
+      );
+    }
+    if (!Number.isSafeInteger(value)) {
+      throw new InlinePolicyEncodingError(
+        `${kind}_invalid`,
+        `JSON number ${value} exceeds safe-integer range for value_kind=${kind}; pass as a string to preserve precision`,
+        { valueKind: kind },
+      );
+    }
+    return String(value);
+  }
+  if (typeof value === "bigint") return value.toString();
+  throw new InlinePolicyEncodingError(
+    `${kind}_invalid`,
+    `Expected integer for value_kind=${kind}, got ${describeShape(value)}`,
+    { valueKind: kind },
+  );
+}
+
+function encodeI64(value: unknown): number[] {
+  const trimmed = normalizeIntegerSource(value, "integer");
   let big: bigint;
   try {
     big = BigInt(trimmed);
   } catch {
     throw new InlinePolicyEncodingError(
       "integer_invalid",
-      `Expected i64 string for value_kind=integer, got ${JSON.stringify(value)}`,
+      `Expected i64 value for value_kind=integer, got ${JSON.stringify(value)}`,
       { valueKind: "integer" },
     );
   }
@@ -204,15 +269,15 @@ function encodeI64(value: string): number[] {
   return Array.from(buf.values());
 }
 
-function encodeU64(value: string): number[] {
-  const trimmed = value.trim();
+function encodeU64(value: unknown): number[] {
+  const trimmed = normalizeIntegerSource(value, "u_integer");
   let big: bigint;
   try {
     big = BigInt(trimmed);
   } catch {
     throw new InlinePolicyEncodingError(
       "u_integer_invalid",
-      `Expected u64 string for value_kind=u_integer, got ${JSON.stringify(value)}`,
+      `Expected u64 value for value_kind=u_integer, got ${JSON.stringify(value)}`,
       { valueKind: "u_integer" },
     );
   }
@@ -228,8 +293,26 @@ function encodeU64(value: string): number[] {
   return Array.from(buf.values());
 }
 
-function encodeF64(value: string): number[] {
-  const num = Number(value);
+function encodeF64(value: unknown): number[] {
+  let num: number;
+  if (typeof value === "number") {
+    num = value;
+  } else if (typeof value === "string") {
+    if (value.trim().length === 0) {
+      throw new InlinePolicyEncodingError(
+        "float_invalid",
+        `Expected finite IEEE-754 number for value_kind=float, got empty string`,
+        { valueKind: "float" },
+      );
+    }
+    num = Number(value);
+  } else {
+    throw new InlinePolicyEncodingError(
+      "float_invalid",
+      `Expected number or numeric string for value_kind=float, got ${describeShape(value)}`,
+      { valueKind: "float" },
+    );
+  }
   if (!Number.isFinite(num)) {
     throw new InlinePolicyEncodingError(
       "float_invalid",

--- a/src/lib/triage/inline-policy/graphql-names.ts
+++ b/src/lib/triage/inline-policy/graphql-names.ts
@@ -1,19 +1,20 @@
 /**
- * Translator from the stored TriagePolicy shape to review-web's
- * GraphQL inline policy input enum names.
+ * lower_snake_case → GraphQL SCREAMING_SNAKE_CASE enum-name translator
+ * for the inline triage policy boundary.
  *
- * The downstream `eventListWithTriage` path described in #447 §2.1
- * passes a stored policy inline as `PacketAttrInput` /
- * `ConfidenceInput` / `ResponseInput`. The byte-array encoding of
- * `firstValue` / `secondValue` (`[Int!]!` in GraphQL) is owned by the
- * inline-policy boundary that lives outside this `triage/policy/`
- * deprecatability namespace, so this module only handles the enum
- * name translation. The accompanying test
- * (`__tests__/lib/triage/policy/inline-input.test.ts`) iterates every
- * literal in `VALUE_KINDS` / `CMP_KINDS` / `RESPONSE_KINDS` /
- * `THREAT_CATEGORIES` and confirms the mapping is total — i.e. the
- * stored schema cannot persist a kind the GraphQL contract has no
- * name for.
+ * Every kind defined in `./kinds.ts` maps to its review-web GraphQL
+ * enum member here. The accompanying test
+ * (`__tests__/lib/triage/inline-policy/graphql-names.test.ts`) iterates
+ * every literal in `VALUE_KINDS` / `CMP_KINDS` / `RESPONSE_KINDS` /
+ * `RAW_EVENT_KINDS` / `THREAT_CATEGORIES` and confirms the mapping is
+ * total — i.e. no kind that storage accepts is silently dropped by the
+ * inline-policy encoder.
+ *
+ * Lives in `triage/inline-policy/` so callers other than corpus B can
+ * reach the translator without depending on `triage/policy/`. The
+ * storage namespace at `src/lib/triage/policy/inline-input.ts`
+ * re-exports these for backwards compatibility with internal callers
+ * that pre-date the split.
  */
 
 import type {
@@ -22,7 +23,7 @@ import type {
   ResponseKind,
   ThreatCategory,
   ValueKind,
-} from "./types";
+} from "./kinds";
 
 /**
  * Mirror of `enum ValueKind` in `schemas/review.graphql:8095`.

--- a/src/lib/triage/inline-policy/graphql-names.ts
+++ b/src/lib/triage/inline-policy/graphql-names.ts
@@ -12,9 +12,8 @@
  *
  * Lives in `triage/inline-policy/` so callers other than corpus B can
  * reach the translator without depending on `triage/policy/`. The
- * storage namespace at `src/lib/triage/policy/inline-input.ts`
- * re-exports these for backwards compatibility with internal callers
- * that pre-date the split.
+ * storage-side translator at `src/lib/triage/policy/inline-translator.ts`
+ * imports these names directly.
  */
 
 import type {

--- a/src/lib/triage/inline-policy/index.ts
+++ b/src/lib/triage/inline-policy/index.ts
@@ -1,10 +1,15 @@
 /**
- * Inline-policy boundary barrel (1B-6 / discussion #447 §3.5).
+ * Inline-policy seam (1B-6 / discussion #447 §3.5).
  *
- * Bridges the stored TriagePolicy shape (#459, JSONB) to the
- * `eventListWithTriage` `EventTriagePolicyInput` shape on the wire.
- * Shared with any future inline-policy caller; not part of the
- * policy/ deprecatability namespace.
+ * Owns the wire enums, GraphQL enum-name mapping, and the byte-array
+ * encoder for review-web's `eventListWithTriage` `EventTriagePolicyInput`.
+ * Shared with every inline-policy caller; deliberately NOT part of the
+ * `triage/policy/` deprecatability namespace, so removing the policy
+ * mode leaves the seam in place for other callers.
+ *
+ * The storage→wire translator that consumes `TriagePolicyRow` lives at
+ * `src/lib/triage/policy/inline-translator.ts` — re-exported there
+ * because it legitimately depends on the storage shape.
  */
 
 export {
@@ -12,10 +17,25 @@ export {
   encodeRuleBytes,
   encodeValueByKind,
   InlinePolicyEncodingError,
+  type PacketAttrRule,
 } from "./encode";
 export {
-  type EncodedConfidenceInput,
-  type EncodedEventTriagePolicyInput,
-  type EncodedResponseInput,
-  translatePolicyToInlineInput,
-} from "./translate";
+  cmpKindToGraphql,
+  rawEventKindToGraphql,
+  responseKindToGraphql,
+  threatCategoryToGraphql,
+  valueKindToGraphql,
+} from "./graphql-names";
+export {
+  CMP_KINDS,
+  type CmpKind,
+  RANGE_CMP_KINDS,
+  RAW_EVENT_KINDS,
+  type RawEventKind,
+  RESPONSE_KINDS,
+  type ResponseKind,
+  THREAT_CATEGORIES,
+  type ThreatCategory,
+  VALUE_KINDS,
+  type ValueKind,
+} from "./kinds";

--- a/src/lib/triage/inline-policy/index.ts
+++ b/src/lib/triage/inline-policy/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Inline-policy boundary barrel (1B-6 / discussion #447 §3.5).
+ *
+ * Bridges the stored TriagePolicy shape (#459, JSONB) to the
+ * `eventListWithTriage` `EventTriagePolicyInput` shape on the wire.
+ * Shared with any future inline-policy caller; not part of the
+ * policy/ deprecatability namespace.
+ */
+
+export {
+  type EncodedPacketAttrInput,
+  encodeRuleBytes,
+  encodeValueByKind,
+  InlinePolicyEncodingError,
+} from "./encode";
+export {
+  type EncodedConfidenceInput,
+  type EncodedEventTriagePolicyInput,
+  type EncodedResponseInput,
+  translatePolicyToInlineInput,
+} from "./translate";

--- a/src/lib/triage/inline-policy/kinds.ts
+++ b/src/lib/triage/inline-policy/kinds.ts
@@ -1,0 +1,108 @@
+/**
+ * Wire-side enum literal sets for the inline triage policy boundary.
+ *
+ * Each set mirrors the matching GraphQL enum in `schemas/review.graphql`
+ * (lower_snake_case here vs. SCREAMING_SNAKE_CASE in the schema). The
+ * round-trip test in `__tests__/lib/triage/inline-policy/graphql-names.test.ts`
+ * iterates every literal and asserts the mapping in `./graphql-names.ts`
+ * stays total — i.e. the stored schema cannot persist a kind the
+ * GraphQL contract has no name for.
+ *
+ * Lives in `triage/inline-policy/` (the inline-policy seam shared with
+ * every inline-policy caller) so the byte encoder can compile without
+ * importing from `triage/policy/`. The storage namespace at
+ * `src/lib/triage/policy/` re-exports these for its Zod schemas, so
+ * `triage/policy/ → triage/inline-policy/` is the only dependency
+ * direction the §6 seam allows.
+ */
+
+export const VALUE_KINDS = [
+  "string",
+  "integer",
+  "u_integer",
+  "vector",
+  "float",
+  "ipaddr",
+  "bool",
+] as const;
+export type ValueKind = (typeof VALUE_KINDS)[number];
+
+export const CMP_KINDS = [
+  "less",
+  "equal",
+  "greater",
+  "less_or_equal",
+  "greater_or_equal",
+  "contain",
+  "open_range",
+  "close_range",
+  "left_open_range",
+  "right_open_range",
+  "not_equal",
+  "not_contain",
+  "not_open_range",
+  "not_close_range",
+  "not_left_open_range",
+  "not_right_open_range",
+] as const;
+export type CmpKind = (typeof CMP_KINDS)[number];
+
+// Range cmp kinds require a non-empty `second_value` so the engine has
+// both ends of the interval. Single source of truth shared by the
+// encoder (`./encode.ts`) and storage-side semantic validation
+// (`src/lib/triage/policy/validation.ts`).
+export const RANGE_CMP_KINDS = new Set<CmpKind>([
+  "open_range",
+  "close_range",
+  "left_open_range",
+  "right_open_range",
+  "not_open_range",
+  "not_close_range",
+  "not_left_open_range",
+  "not_right_open_range",
+]);
+
+export const RESPONSE_KINDS = ["manual", "blacklist", "whitelist"] as const;
+export type ResponseKind = (typeof RESPONSE_KINDS)[number];
+
+export const RAW_EVENT_KINDS = [
+  "bootp",
+  "conn",
+  "dhcp",
+  "dns",
+  "ftp",
+  "http",
+  "kerberos",
+  "ldap",
+  "log",
+  "mqtt",
+  "network",
+  "nfs",
+  "ntlm",
+  "radius",
+  "rdp",
+  "smb",
+  "smtp",
+  "ssh",
+  "tls",
+  "window",
+] as const;
+export type RawEventKind = (typeof RAW_EVENT_KINDS)[number];
+
+export const THREAT_CATEGORIES = [
+  "reconnaissance",
+  "initial_access",
+  "execution",
+  "credential_access",
+  "discovery",
+  "lateral_movement",
+  "command_and_control",
+  "exfiltration",
+  "impact",
+  "collection",
+  "defense_evasion",
+  "persistence",
+  "privilege_escalation",
+  "resource_development",
+] as const;
+export type ThreatCategory = (typeof THREAT_CATEGORIES)[number];

--- a/src/lib/triage/inline-policy/translate.ts
+++ b/src/lib/triage/inline-policy/translate.ts
@@ -1,0 +1,167 @@
+/**
+ * Stored TriagePolicy row → inline `EventTriagePolicyInput`.
+ *
+ * Combines the enum-name translator (`src/lib/triage/policy/inline-input.ts`)
+ * with the byte-array encoder from `./encode.ts` so the corpus B runner
+ * can call `eventListWithTriage(triage: { policies: [...] })` with a
+ * faithful wire representation of stored rows. Lives outside
+ * `src/lib/triage/policy/` per §6: this is the inline-policy boundary
+ * (shared with any future inline-policy caller), not a policy-mode
+ * orchestrator.
+ */
+
+import {
+  cmpKindToGraphql,
+  rawEventKindToGraphql,
+  responseKindToGraphql,
+  threatCategoryToGraphql,
+  valueKindToGraphql,
+} from "@/lib/triage/policy/inline-input";
+import type {
+  CmpKind,
+  Confidence,
+  PacketAttr,
+  RawEventKind,
+  Response,
+  ResponseKind,
+  ThreatCategory,
+  TriagePolicyRow,
+  ValueKind,
+} from "@/lib/triage/policy/types";
+
+import {
+  type EncodedPacketAttrInput,
+  encodeRuleBytes,
+  InlinePolicyEncodingError,
+} from "./encode";
+
+/**
+ * Wire-shape ConfidenceInput. `threatCategory` is nullable to mirror
+ * review-web's schema: a confidence rule that elides the category
+ * matches against any category for its `(threatKind, confidence)`
+ * pair. The runner-side panic-free contract requires us to round-trip
+ * this null faithfully — see the smoke test in
+ * `__tests__/lib/triage/inline-policy/translate.test.ts`.
+ */
+export interface EncodedConfidenceInput {
+  threatCategory: string | null;
+  threatKind: string;
+  confidence: number;
+  weight: number | null;
+}
+
+export interface EncodedResponseInput {
+  minimumScore: number;
+  kind: string;
+}
+
+export interface EncodedEventTriagePolicyInput {
+  id: number;
+  packetAttr: EncodedPacketAttrInput[];
+  confidence: EncodedConfidenceInput[];
+  response: EncodedResponseInput[];
+}
+
+/**
+ * Translate one stored `TriagePolicyRow` into the wire-shape
+ * `EventTriagePolicyInput` the resolver expects.
+ *
+ * Throws {@link InlinePolicyEncodingError} on any encoding-time
+ * failure (bad ipaddr literal, vector value kind, etc.). The corpus B
+ * runner surfaces the error as `status='failed'` with `last_error`
+ * identifying the policy.
+ */
+export function translatePolicyToInlineInput(
+  policy: TriagePolicyRow,
+): EncodedEventTriagePolicyInput {
+  try {
+    return {
+      id: policy.id,
+      packetAttr: policy.packet_attr.map((rule, index) =>
+        translatePacketAttr(rule, policy.id, index),
+      ),
+      confidence: policy.confidence.map((rule, index) =>
+        translateConfidence(rule, policy.id, index),
+      ),
+      response: policy.response.map((rule, index) =>
+        translateResponse(rule, policy.id, index),
+      ),
+    };
+  } catch (err) {
+    if (err instanceof InlinePolicyEncodingError) {
+      // Re-throw with policy id context populated. Throw the same
+      // structured error type so the runner's catch sees a single
+      // class.
+      throw new InlinePolicyEncodingError(err.kind, err.message, {
+        ...err.context,
+        policyId: policy.id,
+      });
+    }
+    throw err;
+  }
+}
+
+function translatePacketAttr(
+  rule: PacketAttr,
+  policyId: number,
+  index: number,
+): EncodedPacketAttrInput {
+  let bytes: { firstValue: number[]; secondValue: number[] | null };
+  try {
+    bytes = encodeRuleBytes(rule);
+  } catch (err) {
+    if (err instanceof InlinePolicyEncodingError) {
+      throw new InlinePolicyEncodingError(err.kind, err.message, {
+        ...err.context,
+        policyId,
+        ruleIndex: index,
+        path: `packet_attr.${index}`,
+      });
+    }
+    throw err;
+  }
+  return {
+    rawEventKind: rawEventKindToGraphql(rule.raw_event_kind as RawEventKind),
+    attrName: rule.attr_name,
+    valueKind: valueKindToGraphql(rule.value_kind as ValueKind),
+    cmpKind: cmpKindToGraphql(rule.cmp_kind as CmpKind),
+    firstValue: bytes.firstValue,
+    secondValue: bytes.secondValue,
+    weight: rule.weight ?? null,
+  };
+}
+
+function translateConfidence(
+  rule: Confidence,
+  _policyId: number,
+  _index: number,
+): EncodedConfidenceInput {
+  // `threat_category` is Required at the storage layer (#459's Zod
+  // schema enforces it). Defend against a hand-crafted inline value
+  // sneaking a null in via the runner's test harnesses: if it ever
+  // arrives null here we must NOT panic — translate to `null` and
+  // let the resolver see the optional field unset. The runner-side
+  // smoke test (panic-free) covers this contract.
+  const category = rule.threat_category as ThreatCategory | null | undefined;
+  const threatCategory =
+    category === null || category === undefined
+      ? null
+      : threatCategoryToGraphql(category);
+  return {
+    threatCategory,
+    threatKind: rule.threat_kind,
+    confidence: rule.confidence,
+    weight: rule.weight ?? null,
+  };
+}
+
+function translateResponse(
+  rule: Response,
+  _policyId: number,
+  _index: number,
+): EncodedResponseInput {
+  return {
+    minimumScore: rule.minimum_score,
+    kind: responseKindToGraphql(rule.kind as ResponseKind),
+  };
+}

--- a/src/lib/triage/policy/corpus-b/fingerprint.ts
+++ b/src/lib/triage/policy/corpus-b/fingerprint.ts
@@ -1,0 +1,142 @@
+/**
+ * `policies_fingerprint` — canonical fingerprint of the inline policy
+ * set used to seed a corpus B run.
+ *
+ * Mirrors the design of `exclusions_fp` from `src/lib/triage/exclusion/
+ * fingerprint.ts`: equal logical inputs (any ordering of policies,
+ * any ordering of rules within a policy, any duplicate-tolerant set
+ * shape) hash to the same digest so the corpus B partial unique index
+ * recognises a recompute that re-selects the same policies as a
+ * cache hit.
+ *
+ * Canonicalization rules:
+ *
+ *   1. Each policy's `packet_attr` / `confidence` / `response` arrays
+ *      are sorted by a stable per-element JSON serialization; nullable
+ *      fields are normalized to `null`.
+ *   2. Policies are serialized to a stable JSON shape and sorted by
+ *      their serialization (the id is included).
+ *   3. The combined string is hashed with SHA-256; the hex digest is
+ *      stored on `policy_triage_run.policies_fingerprint`.
+ *
+ * The empty policy set is well-defined: `computePoliciesFingerprint([])`
+ * → SHA-256 of the canonical empty payload. Pre-#459 the API would
+ * not call corpus B with an empty set in practice, but the empty case
+ * is well-defined for tests / future replay.
+ */
+
+import { createHash } from "node:crypto";
+
+import type {
+  Confidence,
+  PacketAttr,
+  Response,
+  TriagePolicyRow,
+} from "../types";
+
+const FINGERPRINT_VERSION = "v1";
+
+interface CanonicalPacketAttr {
+  raw_event_kind: string;
+  attr_name: string;
+  value_kind: string;
+  cmp_kind: string;
+  first_value: string;
+  second_value: string | null;
+  weight: number | null;
+}
+
+interface CanonicalConfidence {
+  threat_category: string | null;
+  threat_kind: string;
+  confidence: number;
+  weight: number | null;
+}
+
+interface CanonicalResponse {
+  minimum_score: number;
+  kind: string;
+}
+
+interface CanonicalPolicy {
+  id: number;
+  packet_attr: CanonicalPacketAttr[];
+  confidence: CanonicalConfidence[];
+  response: CanonicalResponse[];
+}
+
+function canonicalizePacketAttr(rule: PacketAttr): CanonicalPacketAttr {
+  return {
+    raw_event_kind: rule.raw_event_kind,
+    attr_name: rule.attr_name,
+    value_kind: rule.value_kind,
+    cmp_kind: rule.cmp_kind,
+    first_value: rule.first_value,
+    second_value:
+      rule.second_value === undefined || rule.second_value === null
+        ? null
+        : rule.second_value,
+    weight: rule.weight ?? null,
+  };
+}
+
+function canonicalizeConfidence(rule: Confidence): CanonicalConfidence {
+  return {
+    threat_category: rule.threat_category ?? null,
+    threat_kind: rule.threat_kind,
+    confidence: rule.confidence,
+    weight: rule.weight ?? null,
+  };
+}
+
+function canonicalizeResponse(rule: Response): CanonicalResponse {
+  return {
+    minimum_score: rule.minimum_score,
+    kind: rule.kind,
+  };
+}
+
+function sortBySerialized<T>(items: T[]): T[] {
+  return items
+    .map((item) => ({ item, s: JSON.stringify(item) }))
+    .sort((a, b) => (a.s < b.s ? -1 : a.s > b.s ? 1 : 0))
+    .map(({ item }) => item);
+}
+
+function canonicalizePolicy(policy: TriagePolicyRow): CanonicalPolicy {
+  return {
+    id: policy.id,
+    packet_attr: sortBySerialized(
+      policy.packet_attr.map(canonicalizePacketAttr),
+    ),
+    confidence: sortBySerialized(policy.confidence.map(canonicalizeConfidence)),
+    response: sortBySerialized(policy.response.map(canonicalizeResponse)),
+  };
+}
+
+/**
+ * Hash the inline policy set into a stable hex SHA-256 string. The
+ * function consumes stored `TriagePolicyRow` objects directly so the
+ * corpus B runner can fingerprint a snapshot of the policies in one
+ * place — the fingerprint covers id, rule shape, and rule values, so
+ * the partial unique index recognises rule edits and policy renames
+ * as distinct fingerprints.
+ *
+ * Set-equal inputs (any policy ordering, any rule ordering inside a
+ * policy) hash to the same digest.
+ */
+export function computePoliciesFingerprint(
+  policies: ReadonlyArray<TriagePolicyRow>,
+): string {
+  const canonical = policies
+    .map(canonicalizePolicy)
+    .map((p) => JSON.stringify(p))
+    .sort();
+  const payload = JSON.stringify({
+    version: FINGERPRINT_VERSION,
+    policies: canonical,
+  });
+  return createHash("sha256").update(payload, "utf8").digest("hex");
+}
+
+export const EMPTY_POLICIES_FINGERPRINT = computePoliciesFingerprint([]);

--- a/src/lib/triage/policy/corpus-b/index.ts
+++ b/src/lib/triage/policy/corpus-b/index.ts
@@ -18,6 +18,7 @@ export {
   listTriagedEvents,
   markRunFailed,
   markRunReady,
+  markRunReadyOnClient,
   PolicyTriageRunActiveSlotConflict,
   recomputeRun,
 } from "./repository";

--- a/src/lib/triage/policy/corpus-b/index.ts
+++ b/src/lib/triage/policy/corpus-b/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Corpus B (on-demand, "With my policies") barrel.
+ *
+ * Lives inside `triage/policy/` per §6 of #447 — removing the policy
+ * mode removes this directory. The shared exclusion / inline-policy
+ * helpers stay in place because baseline-side code still uses them.
+ */
+
+export {
+  computePoliciesFingerprint,
+  EMPTY_POLICIES_FINGERPRINT,
+} from "./fingerprint";
+export {
+  findActiveRun,
+  getRunById,
+  insertComputingRun,
+  insertTriagedEventsBatch,
+  listTriagedEvents,
+  markRunFailed,
+  markRunReady,
+  PolicyTriageRunActiveSlotConflict,
+  recomputeRun,
+} from "./repository";
+export {
+  CORPUS_B_BASELINE_VERSION,
+  CORPUS_B_PAGE_SIZE,
+  type CorpusBRunnerOptions,
+  type CorpusBRunRequest,
+  type CorpusBRunResult,
+  recomputeCorpusBRun,
+  runCorpusBTriage,
+} from "./runner";
+export type {
+  PolicyTriagedEventRow,
+  PolicyTriageRunRow,
+  PolicyTriageRunStatus,
+  PolicyTriageScoreSnapshot,
+} from "./types";

--- a/src/lib/triage/policy/corpus-b/queries.ts
+++ b/src/lib/triage/policy/corpus-b/queries.ts
@@ -15,6 +15,15 @@ import { parse } from "graphql";
  *     exclusions app-side before INSERT (closes the TLS / NTLM gap
  *     from aicers/review-database#723).
  *
+ * The IP-bearing curated subtype fragments mirror corpus A's set
+ * (`src/lib/triage/baseline/queries.ts`) one-for-one. The issue's
+ * "same exclusion-matching columns as corpus A" contract and 1B-2's
+ * symmetric DELETE planner both rely on `policy_triaged_event` rows
+ * carrying the same `orig_addr` / `resp_addr` / `host` / `dns_query`
+ * / `uri` coverage as corpus A — omitting a subtype here would leave
+ * those columns NULL for that event kind and IP exclusions would
+ * silently miss it.
+ *
  * Edge `cursor` is selected so the runner can derive `event_key`
  * straight into `policy_triaged_event.event_key` (NUMERIC(39, 0));
  * the per-event `id` is not needed because identity flows through
@@ -55,12 +64,42 @@ export const CORPUS_B_EVENT_LIST_QUERY = parse(`
             policyId
             score
           }
+          ... on BlocklistBootp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistConn {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistDceRpc {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistDhcp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
           ... on BlocklistDns {
             origAddr
             respAddr
             origPort
             respPort
             query
+          }
+          ... on BlocklistFtp {
+            origAddr
+            respAddr
+            origPort
+            respPort
           }
           ... on BlocklistHttp {
             origAddr
@@ -70,7 +109,61 @@ export const CORPUS_B_EVENT_LIST_QUERY = parse(`
             host
             uri
           }
+          ... on BlocklistKerberos {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistLdap {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistMqtt {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistNfs {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
           ... on BlocklistNtlm {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistRadius {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistRdp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistSmb {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistSmtp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistSsh {
             origAddr
             respAddr
             origPort
@@ -105,6 +198,17 @@ export const CORPUS_B_EVENT_LIST_QUERY = parse(`
             host
             uri
           }
+          ... on FtpBruteForce {
+            origAddr
+            respAddr
+            respPort
+          }
+          ... on FtpPlainText {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
           ... on HttpThreat {
             origAddr
             respAddr
@@ -114,12 +218,33 @@ export const CORPUS_B_EVENT_LIST_QUERY = parse(`
             host
             uri
           }
+          ... on LdapBruteForce {
+            origAddr
+            respAddr
+            respPort
+          }
+          ... on LdapPlainText {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
           ... on LockyRansomware {
             origAddr
             respAddr
             origPort
             respPort
             query
+          }
+          ... on MultiHostPortScan {
+            origAddr
+            respPort
+          }
+          ... on NetworkThreat {
+            origAddr
+            respAddr
+            origPort
+            respPort
           }
           ... on NonBrowser {
             origAddr
@@ -128,6 +253,13 @@ export const CORPUS_B_EVENT_LIST_QUERY = parse(`
             respPort
             host
             uri
+          }
+          ... on PortScan {
+            origAddr
+            respAddr
+          }
+          ... on RdpBruteForce {
+            origAddr
           }
           ... on RepeatedHttpSessions {
             origAddr

--- a/src/lib/triage/policy/corpus-b/queries.ts
+++ b/src/lib/triage/policy/corpus-b/queries.ts
@@ -1,0 +1,161 @@
+import "server-only";
+
+import { parse } from "graphql";
+
+/**
+ * Corpus B `eventListWithTriage` query. Differs from the cadence's
+ * query in two load-bearing ways:
+ *
+ *   - `triage` is populated (policies + exclusions); the resolver
+ *     therefore runs Stage 1 exclusion pre-cut and attaches
+ *     `triageScores` for every matching policy.
+ *   - Selection set carries the scoring fields the runner persists
+ *     into `policy_triaged_event.policy_triage_snapshot`, plus the
+ *     normalized-column source fields the runner needs to re-apply
+ *     exclusions app-side before INSERT (closes the TLS / NTLM gap
+ *     from aicers/review-database#723).
+ *
+ * Edge `cursor` is selected so the runner can derive `event_key`
+ * straight into `policy_triaged_event.event_key` (NUMERIC(39, 0));
+ * the per-event `id` is not needed because identity flows through
+ * the cursor, matching the cadence pager's contract.
+ *
+ * The query is validated against `schemas/review.graphql` by
+ * `src/__tests__/lib/graphql/schema-validation.test.ts` at CI time.
+ */
+export const CORPUS_B_EVENT_LIST_QUERY = parse(`
+  query CorpusBEventListWithTriage(
+    $filter: EventStandardFilterInput!
+    $triage: EventTriageInput
+    $first: Int
+    $after: String
+  ) {
+    eventListWithTriage(
+      filter: $filter
+      triage: $triage
+      first: $first
+      after: $after
+    ) {
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          __typename
+          time
+          sensor
+          category
+          level
+          confidence
+          triageScores {
+            policyId
+            score
+          }
+          ... on BlocklistDns {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on BlocklistHttp {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            host
+            uri
+          }
+          ... on BlocklistNtlm {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on BlocklistTls {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            serverName
+          }
+          ... on CryptocurrencyMiningPool {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on DnsCovertChannel {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on DomainGenerationAlgorithm {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            host
+            uri
+          }
+          ... on HttpThreat {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            clusterId
+            host
+            uri
+          }
+          ... on LockyRansomware {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            query
+          }
+          ... on NonBrowser {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            host
+            uri
+          }
+          ... on RepeatedHttpSessions {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on SuspiciousTlsTraffic {
+            origAddr
+            respAddr
+            origPort
+            respPort
+            serverName
+          }
+          ... on TorConnection {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+          ... on TorConnectionConn {
+            origAddr
+            respAddr
+            origPort
+            respPort
+          }
+        }
+      }
+    }
+  }
+`);

--- a/src/lib/triage/policy/corpus-b/repository.ts
+++ b/src/lib/triage/policy/corpus-b/repository.ts
@@ -277,6 +277,10 @@ export async function recomputeRun(
  * `policy_triaged_event` rows; this UPDATE only flips the status flag
  * and records duration. `created_at` from the row is read to compute
  * the elapsed duration if not provided.
+ *
+ * Pool-scoped wrapper for callers that do not need to compose with an
+ * outer transaction. The runner uses {@link markRunReadyOnClient} so
+ * the status flip stays in the same transaction as the event inserts.
  */
 export async function markRunReady(
   customerId: number,
@@ -284,7 +288,22 @@ export async function markRunReady(
   computationDurationMs: number,
 ): Promise<void> {
   const pool = await getCustomerPool(customerId);
-  await pool.query(
+  await markRunReadyOnClient(pool, runId, computationDurationMs);
+}
+
+/**
+ * Same UPDATE as {@link markRunReady} but runs on a caller-supplied
+ * `pg` client (or pool). The runner uses this to keep the
+ * `computing → ready` transition in the same transaction as the event
+ * INSERTs, so a crash between event commit and ready flip cannot
+ * leave the slot occupied as `computing` until 1B-7's reaper notices.
+ */
+export async function markRunReadyOnClient(
+  executor: Pick<pg.PoolClient, "query"> | Pick<pg.Pool, "query">,
+  runId: string,
+  computationDurationMs: number,
+): Promise<void> {
+  await executor.query(
     `UPDATE policy_triage_run
         SET status = 'ready',
             computation_duration_ms = $2,

--- a/src/lib/triage/policy/corpus-b/repository.ts
+++ b/src/lib/triage/policy/corpus-b/repository.ts
@@ -198,11 +198,24 @@ export interface RecomputeInput extends NewRunInput {
  * unique slot is never double-occupied (§3.5 "Recompute transaction
  * model").
  *
+ * The supersede UPDATE is guarded on `(owner_account_id, period_start,
+ * period_end)` in addition to `id`, so a stale, mistaken, or hostile
+ * caller cannot terminalise a `ready` row belonging to a different
+ * owner / window by passing the wrong `oldRunId`. The recompute model
+ * is defined for "the same user's same window with new selection
+ * conditions", so the fingerprints (policies / exclusions /
+ * baseline_version) are intentionally NOT in the WHERE clause — those
+ * are exactly what changes across a recompute. Route-level checks
+ * remain useful, but this repository helper is the lifecycle boundary
+ * that mutates terminal state and must not rely on `id` alone.
+ *
  * Returns the new run row on success. Throws
  * {@link PolicyTriageRunActiveSlotConflict} when:
  *
  *   - the existing row's status changed (already superseded / reaped),
- *     in which case the caller re-queries the active slot, or
+ *     the row does not match the supplied owner / window, or no row
+ *     exists for the id, in which case the caller re-queries the
+ *     active slot, or
  *   - the INSERT trips the partial unique index (a concurrent
  *     recompute won the race).
  */
@@ -222,13 +235,27 @@ export async function recomputeRun(
     );
     const newId = idResult.rows[0].new_id;
 
-    // Step 2: supersede the old row, but only if it's still `ready`.
-    // Rowcount = 0 means another transaction got there first.
+    // Step 2: supersede the old row, but only if it is still `ready`
+    // AND it belongs to the same owner / window we are recomputing
+    // for. Rowcount = 0 means another transaction got there first OR
+    // the supplied `oldRunId` does not match the recompute target —
+    // either way the caller must re-query the active slot rather than
+    // terminalise an unrelated row.
     const upd = await client.query(
       `UPDATE policy_triage_run
           SET status = 'superseded', superseded_by = $1, finalized_at = NOW()
-        WHERE id = $2 AND status = 'ready'`,
-      [newId, input.oldRunId],
+        WHERE id = $2
+          AND status = 'ready'
+          AND owner_account_id = $3
+          AND period_start = $4
+          AND period_end = $5`,
+      [
+        newId,
+        input.oldRunId,
+        input.ownerAccountId,
+        input.periodStartIso,
+        input.periodEndIso,
+      ],
     );
     if ((upd.rowCount ?? 0) === 0) {
       await client.query("ROLLBACK");

--- a/src/lib/triage/policy/corpus-b/repository.ts
+++ b/src/lib/triage/policy/corpus-b/repository.ts
@@ -1,0 +1,442 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { getCustomerPool } from "../customer-db";
+import type {
+  PolicyTriagedEventRow,
+  PolicyTriageRunRow,
+  PolicyTriageRunStatus,
+} from "./types";
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * Raised when the partial unique index
+ * `policy_triage_run_active_fingerprint` rejects an INSERT/UPDATE for
+ * a fingerprint that another transaction has already claimed.
+ *
+ * Caller is expected to re-query the active slot and either return the
+ * existing run (cache hit) or report the race to the user.
+ */
+export class PolicyTriageRunActiveSlotConflict extends Error {
+  constructor() {
+    super("Active fingerprint slot is already occupied");
+    this.name = "PolicyTriageRunActiveSlotConflict";
+  }
+}
+
+export function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+interface RunDbRow {
+  id: string;
+  owner_account_id: string;
+  period_start: Date;
+  period_end: Date;
+  policies_fingerprint: string;
+  exclusions_fingerprint: string;
+  baseline_version: string;
+  status: PolicyTriageRunStatus;
+  replaces: string | null;
+  superseded_by: string | null;
+  refresh_reason: string | null;
+  computation_duration_ms: string | null;
+  last_error: string | null;
+  created_at: Date;
+  finalized_at: Date | null;
+}
+
+function rowToRun(row: RunDbRow): PolicyTriageRunRow {
+  return {
+    id: row.id,
+    ownerAccountId: row.owner_account_id,
+    periodStartIso: row.period_start.toISOString(),
+    periodEndIso: row.period_end.toISOString(),
+    policiesFingerprint: row.policies_fingerprint,
+    exclusionsFingerprint: row.exclusions_fingerprint,
+    baselineVersion: row.baseline_version,
+    status: row.status,
+    replaces: row.replaces,
+    supersededBy: row.superseded_by,
+    refreshReason: row.refresh_reason,
+    computationDurationMs:
+      row.computation_duration_ms === null
+        ? null
+        : Number(row.computation_duration_ms),
+    lastError: row.last_error,
+    createdAtIso: row.created_at.toISOString(),
+    finalizedAtIso: row.finalized_at?.toISOString() ?? null,
+  };
+}
+
+const RUN_COLUMNS = `
+  id::text                                 AS id,
+  owner_account_id                         AS owner_account_id,
+  period_start, period_end,
+  policies_fingerprint, exclusions_fingerprint, baseline_version,
+  status,
+  replaces::text                           AS replaces,
+  superseded_by::text                      AS superseded_by,
+  refresh_reason,
+  computation_duration_ms::text            AS computation_duration_ms,
+  last_error,
+  created_at,
+  finalized_at
+`;
+
+export interface ActiveRunLookupInput {
+  ownerAccountId: string;
+  periodStartIso: string;
+  periodEndIso: string;
+  policiesFingerprint: string;
+  exclusionsFingerprint: string;
+  baselineVersion: string;
+}
+
+/**
+ * Look up the active (`computing` or `ready`) run for the given
+ * fingerprint, or `null` if no row occupies the slot. Reading directly
+ * from the partial-unique index slot — at most one row matches.
+ */
+export async function findActiveRun(
+  customerId: number,
+  input: ActiveRunLookupInput,
+): Promise<PolicyTriageRunRow | null> {
+  const pool = await getCustomerPool(customerId);
+  const { rows } = await pool.query<RunDbRow>(
+    `SELECT ${RUN_COLUMNS}
+       FROM policy_triage_run
+      WHERE owner_account_id = $1
+        AND period_start = $2
+        AND period_end = $3
+        AND policies_fingerprint = $4
+        AND exclusions_fingerprint = $5
+        AND baseline_version = $6
+        AND status IN ('computing', 'ready')`,
+    [
+      input.ownerAccountId,
+      input.periodStartIso,
+      input.periodEndIso,
+      input.policiesFingerprint,
+      input.exclusionsFingerprint,
+      input.baselineVersion,
+    ],
+  );
+  return rows.length === 0 ? null : rowToRun(rows[0]);
+}
+
+/**
+ * Fetch one run by id (any status), or `null` if not found.
+ */
+export async function getRunById(
+  customerId: number,
+  runId: string,
+): Promise<PolicyTriageRunRow | null> {
+  const pool = await getCustomerPool(customerId);
+  const { rows } = await pool.query<RunDbRow>(
+    `SELECT ${RUN_COLUMNS} FROM policy_triage_run WHERE id = $1`,
+    [runId],
+  );
+  return rows.length === 0 ? null : rowToRun(rows[0]);
+}
+
+export interface NewRunInput extends ActiveRunLookupInput {
+  refreshReason: string | null;
+}
+
+/**
+ * Insert a fresh `computing` run for the given fingerprint. Throws
+ * {@link PolicyTriageRunActiveSlotConflict} when the partial-unique
+ * index rejects the INSERT — caller re-queries the active slot.
+ */
+export async function insertComputingRun(
+  customerId: number,
+  input: NewRunInput,
+): Promise<PolicyTriageRunRow> {
+  const pool = await getCustomerPool(customerId);
+  try {
+    const { rows } = await pool.query<RunDbRow>(
+      `INSERT INTO policy_triage_run (
+          owner_account_id, period_start, period_end,
+          policies_fingerprint, exclusions_fingerprint, baseline_version,
+          status, refresh_reason
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, 'computing', $7)
+       RETURNING ${RUN_COLUMNS}`,
+      [
+        input.ownerAccountId,
+        input.periodStartIso,
+        input.periodEndIso,
+        input.policiesFingerprint,
+        input.exclusionsFingerprint,
+        input.baselineVersion,
+        input.refreshReason,
+      ],
+    );
+    return rowToRun(rows[0]);
+  } catch (err) {
+    if (isUniqueViolation(err)) throw new PolicyTriageRunActiveSlotConflict();
+    throw err;
+  }
+}
+
+export interface RecomputeInput extends NewRunInput {
+  /** The existing `ready` run being replaced. */
+  oldRunId: string;
+}
+
+/**
+ * Recompute transaction: supersede the existing `ready` row and
+ * INSERT a fresh `computing` row in one transaction so the partial
+ * unique slot is never double-occupied (§3.5 "Recompute transaction
+ * model").
+ *
+ * Returns the new run row on success. Throws
+ * {@link PolicyTriageRunActiveSlotConflict} when:
+ *
+ *   - the existing row's status changed (already superseded / reaped),
+ *     in which case the caller re-queries the active slot, or
+ *   - the INSERT trips the partial unique index (a concurrent
+ *     recompute won the race).
+ */
+export async function recomputeRun(
+  customerId: number,
+  input: RecomputeInput,
+): Promise<PolicyTriageRunRow> {
+  const pool = await getCustomerPool(customerId);
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Step 1: pre-allocate the new id so step 2's UPDATE can set
+    // `superseded_by`.
+    const idResult = await client.query<{ new_id: string }>(
+      `SELECT nextval('policy_triage_run_id_seq')::text AS new_id`,
+    );
+    const newId = idResult.rows[0].new_id;
+
+    // Step 2: supersede the old row, but only if it's still `ready`.
+    // Rowcount = 0 means another transaction got there first.
+    const upd = await client.query(
+      `UPDATE policy_triage_run
+          SET status = 'superseded', superseded_by = $1, finalized_at = NOW()
+        WHERE id = $2 AND status = 'ready'`,
+      [newId, input.oldRunId],
+    );
+    if ((upd.rowCount ?? 0) === 0) {
+      await client.query("ROLLBACK");
+      throw new PolicyTriageRunActiveSlotConflict();
+    }
+
+    // Step 3: INSERT the new computing row with the pre-allocated id.
+    let inserted: RunDbRow;
+    try {
+      const { rows } = await client.query<RunDbRow>(
+        `INSERT INTO policy_triage_run (
+            id, owner_account_id, period_start, period_end,
+            policies_fingerprint, exclusions_fingerprint, baseline_version,
+            status, refresh_reason, replaces
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'computing', $8, $9)
+         RETURNING ${RUN_COLUMNS}`,
+        [
+          newId,
+          input.ownerAccountId,
+          input.periodStartIso,
+          input.periodEndIso,
+          input.policiesFingerprint,
+          input.exclusionsFingerprint,
+          input.baselineVersion,
+          input.refreshReason,
+          input.oldRunId,
+        ],
+      );
+      inserted = rows[0];
+    } catch (err) {
+      await client.query("ROLLBACK");
+      if (isUniqueViolation(err)) throw new PolicyTriageRunActiveSlotConflict();
+      throw err;
+    }
+    await client.query("COMMIT");
+    return rowToRun(inserted);
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Mark a `computing` run `ready` after its events have been inserted.
+ * The caller is expected to have already populated
+ * `policy_triaged_event` rows; this UPDATE only flips the status flag
+ * and records duration. `created_at` from the row is read to compute
+ * the elapsed duration if not provided.
+ */
+export async function markRunReady(
+  customerId: number,
+  runId: string,
+  computationDurationMs: number,
+): Promise<void> {
+  const pool = await getCustomerPool(customerId);
+  await pool.query(
+    `UPDATE policy_triage_run
+        SET status = 'ready',
+            computation_duration_ms = $2,
+            finalized_at = NOW(),
+            last_error = NULL
+      WHERE id = $1`,
+    [runId, computationDurationMs],
+  );
+}
+
+/**
+ * Mark a `computing` run `failed` with the supplied error message.
+ * Idempotent against repeated calls so the runner's catch path can
+ * surface the failure even when the in-flight transaction has already
+ * rolled back.
+ */
+export async function markRunFailed(
+  customerId: number,
+  runId: string,
+  lastError: string,
+): Promise<void> {
+  const pool = await getCustomerPool(customerId);
+  await pool.query(
+    `UPDATE policy_triage_run
+        SET status = 'failed',
+            last_error = $2,
+            finalized_at = COALESCE(finalized_at, NOW())
+      WHERE id = $1 AND status = 'computing'`,
+    [runId, lastError],
+  );
+}
+
+interface TriagedEventDbRow {
+  run_id: string;
+  event_key: string;
+  event_time: Date;
+  kind: string;
+  sensor: string;
+  orig_addr: string | null;
+  orig_port: number | null;
+  resp_addr: string | null;
+  resp_port: number | null;
+  proto: number | null;
+  host: string | null;
+  dns_query: string | null;
+  uri: string | null;
+  category: string | null;
+  policy_triage_snapshot: PolicyTriagedEventRow["snapshot"];
+}
+
+function rowToTriagedEvent(row: TriagedEventDbRow): PolicyTriagedEventRow {
+  return {
+    runId: row.run_id,
+    eventKey: row.event_key,
+    eventTimeIso: row.event_time.toISOString(),
+    kind: row.kind,
+    sensor: row.sensor,
+    origAddr: row.orig_addr,
+    origPort: row.orig_port,
+    respAddr: row.resp_addr,
+    respPort: row.resp_port,
+    proto: row.proto,
+    host: row.host,
+    dnsQuery: row.dns_query,
+    uri: row.uri,
+    category: row.category,
+    snapshot: row.policy_triage_snapshot,
+  };
+}
+
+/**
+ * Insert a batch of `policy_triaged_event` rows. Returns the inserted
+ * row count. `ON CONFLICT DO NOTHING` is intentional: a re-run of the
+ * same page on the same run should be idempotent. The runner inserts
+ * inside its own transaction so a final failure can roll back the
+ * page-level work without leaving partial results behind.
+ */
+export async function insertTriagedEventsBatch(
+  client: pg.PoolClient,
+  runId: string,
+  rows: ReadonlyArray<Omit<PolicyTriagedEventRow, "runId">>,
+): Promise<number> {
+  if (rows.length === 0) return 0;
+  const params: unknown[] = [];
+  const placeholders: string[] = [];
+  for (const row of rows) {
+    const base = params.length;
+    const ph: string[] = [];
+    for (let i = 1; i <= 15; i += 1) ph.push(`$${base + i}`);
+    placeholders.push(`(${ph.join(", ")})`);
+    params.push(
+      runId,
+      row.eventKey,
+      row.eventTimeIso,
+      row.kind,
+      row.sensor,
+      row.origAddr,
+      row.origPort,
+      row.respAddr,
+      row.respPort,
+      row.proto,
+      row.host,
+      row.dnsQuery,
+      row.uri,
+      row.category,
+      JSON.stringify(row.snapshot),
+    );
+  }
+  const result = await client.query(
+    `INSERT INTO policy_triaged_event (
+        run_id, event_key, event_time, kind, sensor,
+        orig_addr, orig_port, resp_addr, resp_port, proto,
+        host, dns_query, uri, category, policy_triage_snapshot
+      ) VALUES ${placeholders.join(", ")}
+      ON CONFLICT (run_id, event_key) DO NOTHING`,
+    params,
+  );
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Read the events attached to one run. Used by the menu's "With my
+ * policies" view and by tests.
+ */
+export async function listTriagedEvents(
+  customerId: number,
+  runId: string,
+): Promise<PolicyTriagedEventRow[]> {
+  const pool = await getCustomerPool(customerId);
+  const { rows } = await pool.query<TriagedEventDbRow>(
+    `SELECT run_id::text                AS run_id,
+            event_key::text             AS event_key,
+            event_time,
+            kind,
+            sensor,
+            orig_addr::text             AS orig_addr,
+            orig_port,
+            resp_addr::text             AS resp_addr,
+            resp_port,
+            proto,
+            host, dns_query, uri,
+            category,
+            policy_triage_snapshot
+       FROM policy_triaged_event
+      WHERE run_id = $1
+      ORDER BY event_time DESC, event_key DESC`,
+    [runId],
+  );
+  return rows.map(rowToTriagedEvent);
+}
+
+export const _testing = {
+  rowToRun,
+  rowToTriagedEvent,
+};

--- a/src/lib/triage/policy/corpus-b/repository.ts
+++ b/src/lib/triage/policy/corpus-b/repository.ts
@@ -275,8 +275,10 @@ export async function recomputeRun(
  * Mark a `computing` run `ready` after its events have been inserted.
  * The caller is expected to have already populated
  * `policy_triaged_event` rows; this UPDATE only flips the status flag
- * and records duration. `created_at` from the row is read to compute
- * the elapsed duration if not provided.
+ * and records duration. Returns the number of rows updated — `0` means
+ * the row was no longer `computing` (already reaped by 1B-7 or
+ * superseded by a concurrent recompute), in which case the caller must
+ * not commit the in-flight transaction.
  *
  * Pool-scoped wrapper for callers that do not need to compose with an
  * outer transaction. The runner uses {@link markRunReadyOnClient} so
@@ -286,9 +288,9 @@ export async function markRunReady(
   customerId: number,
   runId: string,
   computationDurationMs: number,
-): Promise<void> {
+): Promise<number> {
   const pool = await getCustomerPool(customerId);
-  await markRunReadyOnClient(pool, runId, computationDurationMs);
+  return markRunReadyOnClient(pool, runId, computationDurationMs);
 }
 
 /**
@@ -297,21 +299,31 @@ export async function markRunReady(
  * `computing → ready` transition in the same transaction as the event
  * INSERTs, so a crash between event commit and ready flip cannot
  * leave the slot occupied as `computing` until 1B-7's reaper notices.
+ *
+ * The `AND status = 'computing'` guard is load-bearing: without it, a
+ * runner that finishes after 1B-7's reaper transitioned its row to
+ * `failed` (or after a concurrent recompute marked it `superseded`)
+ * would revive that terminal row back to `ready`, violating the
+ * "`failed` and `superseded` are terminal" contract from #460's
+ * "Run lifecycle and zombie recovery" section. Returns the rowcount
+ * so the caller can detect the lost-slot case and roll back instead
+ * of committing.
  */
 export async function markRunReadyOnClient(
   executor: Pick<pg.PoolClient, "query"> | Pick<pg.Pool, "query">,
   runId: string,
   computationDurationMs: number,
-): Promise<void> {
-  await executor.query(
+): Promise<number> {
+  const result = await executor.query(
     `UPDATE policy_triage_run
         SET status = 'ready',
             computation_duration_ms = $2,
             finalized_at = NOW(),
             last_error = NULL
-      WHERE id = $1`,
+      WHERE id = $1 AND status = 'computing'`,
     [runId, computationDurationMs],
   );
+  return result.rowCount ?? 0;
 }
 
 /**

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -1,0 +1,532 @@
+import "server-only";
+
+/**
+ * Corpus B on-demand runner (1B-6 / discussion #447 §3.4-3.5).
+ *
+ * Orchestrates one user-triggered "With my policies" run:
+ *
+ *   1. Claim the active fingerprint slot — either by INSERTing a fresh
+ *      `computing` row or by superseding an existing `ready` row in a
+ *      recompute transaction.
+ *   2. Page through `eventListWithTriage` with `triage` populated (the
+ *      caller's policies plus the active global+customer-scoped
+ *      exclusion set), persisting matching events into
+ *      `policy_triaged_event`.
+ *   3. Re-apply the same active exclusion set in-memory against the
+ *      normalized columns BEFORE INSERT — this is the app-side
+ *      fallback that closes the TLS / NTLM gap from
+ *      review-database#723. Until #723 lands, this is load-bearing for
+ *      TLS Domain/Hostname exclusions; after #723 it is still correct,
+ *      just no longer the only enforcement.
+ *   4. Mark the run `ready` and record duration. Encoding errors,
+ *      transport errors, etc. transition the run to `failed` with a
+ *      structured `last_error` — never an unhandled panic.
+ *
+ * The runner is intentionally independent of the menu read-path: the
+ * caller (API route) hands it a snapshot of the policies + period, and
+ * the runner does not consult the menu's display logic. The
+ * "deprecatability seam" rule in §6 keeps this file inside
+ * `triage/policy/corpus-b/` so removing the policy mode removes the
+ * runner; the shared exclusion / inline-policy helpers stay in place.
+ */
+
+import { graphqlRequest } from "@/lib/graphql/client";
+import {
+  type ActiveExclusionSet,
+  type ActiveExclusionSetResolver,
+  computeExclusionsFingerprint,
+  type ExclusionRule,
+  isExcluded,
+  normalizeEventColumns,
+  STORAGE_EXCLUSION_SET_RESOLVER,
+} from "@/lib/triage/exclusion";
+import {
+  type EncodedEventTriagePolicyInput,
+  InlinePolicyEncodingError,
+  translatePolicyToInlineInput,
+} from "@/lib/triage/inline-policy";
+import type { TriageEvent } from "@/lib/triage/types";
+
+import { getCustomerPool } from "../customer-db";
+import type { TriagePolicyRow } from "../types";
+
+import { computePoliciesFingerprint } from "./fingerprint";
+import { CORPUS_B_EVENT_LIST_QUERY } from "./queries";
+import {
+  findActiveRun,
+  insertComputingRun,
+  insertTriagedEventsBatch,
+  markRunFailed,
+  markRunReady,
+  PolicyTriageRunActiveSlotConflict,
+  recomputeRun,
+} from "./repository";
+import type { PolicyTriagedEventRow, PolicyTriageRunRow } from "./types";
+
+/**
+ * Phase 1.B baseline-version marker. Mirrors the cadence's marker so
+ * a corpus B run for a window where corpus A is in the same algorithm
+ * version reads from the same baseline_version cohort.
+ */
+export { PHASE_1B_BASELINE_VERSION as CORPUS_B_BASELINE_VERSION } from "@/lib/triage/baseline/cadence";
+
+/**
+ * Per-page fetch size. The corpus B window is bounded by the menu cap
+ * (30 days; see #447 §3.2), so a single run typically completes in a
+ * handful of pages.
+ */
+export const CORPUS_B_PAGE_SIZE = 500;
+
+/**
+ * Hard cap on pages per run. Defends against a runaway resolver
+ * `hasNextPage = true` loop.
+ */
+const MAX_PAGES_PER_RUN = 200;
+
+const CORPUS_B_ROLE = "System Administrator";
+
+export interface CorpusBRunRequest {
+  customerId: number;
+  ownerAccountId: string;
+  periodStartIso: string;
+  periodEndIso: string;
+  policies: ReadonlyArray<TriagePolicyRow>;
+  baselineVersion: string;
+  /** Why this run was started. `null` for a fresh run; `"selection-conditions-changed"` for a recompute. */
+  refreshReason: string | null;
+  signal?: AbortSignal;
+}
+
+export interface CorpusBRunResult {
+  /** Final run row (status = `ready`, `failed`, or `superseded` if a race lost). */
+  run: PolicyTriageRunRow;
+  /** Number of rows persisted into `policy_triaged_event`. */
+  insertedEventCount: number;
+  /** `true` when the run was reused from a previous `ready` row in the same fingerprint slot. */
+  reusedCache: boolean;
+}
+
+/**
+ * Encoded inline `EventTriageInput.exclusions`. Used by the corpus B
+ * runner to forward the active exclusion set to the resolver's
+ * Stage 1 pre-cut.
+ */
+function exclusionsForResolver(rules: ReadonlyArray<ExclusionRule>): unknown[] {
+  // The resolver's `EventTriageExclusionInput` is one rule per object;
+  // a single rule carrying multiple populated fields is flattened to
+  // independent `TriageExclusion` values, so passing one rule per
+  // populated field is symmetric.
+  const out: unknown[] = [];
+  for (const rule of rules) {
+    const r: Record<string, unknown> = {};
+    if (rule.ipAddress) r.ipAddress = rule.ipAddress;
+    if (rule.domain && rule.domain.length > 0) r.domain = rule.domain;
+    if (rule.hostname && rule.hostname.length > 0) r.hostname = rule.hostname;
+    if (rule.uri && rule.uri.length > 0) r.uri = rule.uri;
+    if (Object.keys(r).length > 0) out.push(r);
+  }
+  return out;
+}
+
+type CorpusBFetchVariables = {
+  filter: {
+    start: string;
+    end: string;
+    customers: string[];
+  };
+  triage: {
+    policies: EncodedEventTriagePolicyInput[];
+    exclusions: unknown[];
+  };
+  first: number;
+  after: string | null;
+} & Record<string, unknown>;
+
+interface ResolverEventNode extends TriageEvent {
+  __typename: string;
+  triageScores?: { policyId: string; score: number }[] | null;
+}
+
+interface ResolverEdge {
+  cursor: string;
+  node: ResolverEventNode;
+}
+
+interface ResolverPage {
+  eventListWithTriage: {
+    pageInfo: {
+      hasPreviousPage: boolean;
+      hasNextPage: boolean;
+      startCursor: string | null;
+      endCursor: string | null;
+    };
+    edges: ResolverEdge[];
+  };
+}
+
+export interface CorpusBRunnerOptions {
+  /** Override the default storage-backed exclusion resolver (tests). */
+  exclusionResolver?: ActiveExclusionSetResolver;
+  /** Override the default GraphQL fetch (tests). */
+  fetchPage?: (
+    variables: CorpusBFetchVariables,
+    signal?: AbortSignal,
+  ) => Promise<ResolverPage>;
+  /** Override the per-page size (tests). */
+  pageSize?: number;
+}
+
+/**
+ * The principal entry point. Returns the final run row plus the count
+ * of inserted `policy_triaged_event` rows. The caller (API route)
+ * decides how to surface "reused cache" vs "fresh run" to the user.
+ *
+ * Errors are wrapped: any throw inside the page loop transitions the
+ * `computing` row to `failed` (with `last_error`) and returns the
+ * resulting row. The function itself only throws when the slot-
+ * conflict re-query fails — i.e. a malformed input that cannot find
+ * its own active slot — which is an internal-server-error condition
+ * for the route handler.
+ */
+export async function runCorpusBTriage(
+  request: CorpusBRunRequest,
+  options: CorpusBRunnerOptions = {},
+): Promise<CorpusBRunResult> {
+  const exclusionResolver =
+    options.exclusionResolver ?? STORAGE_EXCLUSION_SET_RESOLVER;
+  const fetchPage = options.fetchPage ?? defaultFetchPage;
+  const pageSize = options.pageSize ?? CORPUS_B_PAGE_SIZE;
+  const startedAt = Date.now();
+
+  // Encode policies up front so an encoding error fails the run
+  // before any DB writes happen. The runner converts the error into
+  // `status='failed'` with a structured `last_error` rather than a
+  // panic (acceptance criterion).
+  let encodedPolicies: EncodedEventTriagePolicyInput[];
+  try {
+    encodedPolicies = request.policies.map(translatePolicyToInlineInput);
+  } catch (err) {
+    return failBeforeInsert(request, err);
+  }
+
+  const policiesFingerprint = computePoliciesFingerprint(request.policies);
+  const active = await exclusionResolver.resolve(request.customerId);
+  const exclusionsFingerprint = computeExclusionsFingerprint(active.rules);
+
+  const lookup = {
+    ownerAccountId: request.ownerAccountId,
+    periodStartIso: request.periodStartIso,
+    periodEndIso: request.periodEndIso,
+    policiesFingerprint,
+    exclusionsFingerprint,
+    baselineVersion: request.baselineVersion,
+  };
+
+  // Active-slot lookup. A `ready` row is returned as a cache hit;
+  // a `computing` row means another runner is mid-flight — also
+  // returned, the caller can poll. Either way no new row is created.
+  const existing = await findActiveRun(request.customerId, lookup);
+  if (existing) {
+    return { run: existing, insertedEventCount: 0, reusedCache: true };
+  }
+
+  // Claim the slot. The recompute path is the caller's responsibility:
+  // if the caller already knows a `ready` row exists with a stale
+  // fingerprint and the user clicked "Recompute", the caller invokes
+  // {@link recomputeCorpusBRun}. The non-recompute path here only ever
+  // INSERTs a fresh row.
+  let run: PolicyTriageRunRow;
+  try {
+    run = await insertComputingRun(request.customerId, {
+      ...lookup,
+      refreshReason: request.refreshReason,
+    });
+  } catch (err) {
+    if (err instanceof PolicyTriageRunActiveSlotConflict) {
+      // Race: someone created the active row between findActiveRun
+      // and insertComputingRun. Re-query the slot and treat as cache.
+      const after = await findActiveRun(request.customerId, lookup);
+      if (after) {
+        return { run: after, insertedEventCount: 0, reusedCache: true };
+      }
+    }
+    throw err;
+  }
+
+  return runInsideClaimedSlot({
+    request,
+    run,
+    encodedPolicies,
+    active,
+    fetchPage,
+    pageSize,
+    startedAt,
+  });
+}
+
+/**
+ * Recompute helper for the common "user clicked Recompute on a stale
+ * `ready` row" flow. Pre-allocates the new id, supersedes the old
+ * row, INSERTs the new one, then runs the same page loop.
+ */
+export async function recomputeCorpusBRun(
+  oldRunId: string,
+  request: CorpusBRunRequest,
+  options: CorpusBRunnerOptions = {},
+): Promise<CorpusBRunResult> {
+  const exclusionResolver =
+    options.exclusionResolver ?? STORAGE_EXCLUSION_SET_RESOLVER;
+  const fetchPage = options.fetchPage ?? defaultFetchPage;
+  const pageSize = options.pageSize ?? CORPUS_B_PAGE_SIZE;
+  const startedAt = Date.now();
+
+  let encodedPolicies: EncodedEventTriagePolicyInput[];
+  try {
+    encodedPolicies = request.policies.map(translatePolicyToInlineInput);
+  } catch (err) {
+    return failBeforeInsert(request, err);
+  }
+
+  const policiesFingerprint = computePoliciesFingerprint(request.policies);
+  const active = await exclusionResolver.resolve(request.customerId);
+  const exclusionsFingerprint = computeExclusionsFingerprint(active.rules);
+
+  let run: PolicyTriageRunRow;
+  try {
+    run = await recomputeRun(request.customerId, {
+      ownerAccountId: request.ownerAccountId,
+      periodStartIso: request.periodStartIso,
+      periodEndIso: request.periodEndIso,
+      policiesFingerprint,
+      exclusionsFingerprint,
+      baselineVersion: request.baselineVersion,
+      refreshReason: request.refreshReason ?? "selection-conditions-changed",
+      oldRunId,
+    });
+  } catch (err) {
+    if (err instanceof PolicyTriageRunActiveSlotConflict) {
+      // Either the old row was already superseded / reaped, or a
+      // concurrent recompute won the race. Re-query the active slot
+      // to surface whichever row is now there.
+      const after = await findActiveRun(request.customerId, {
+        ownerAccountId: request.ownerAccountId,
+        periodStartIso: request.periodStartIso,
+        periodEndIso: request.periodEndIso,
+        policiesFingerprint,
+        exclusionsFingerprint,
+        baselineVersion: request.baselineVersion,
+      });
+      if (after) {
+        return { run: after, insertedEventCount: 0, reusedCache: true };
+      }
+    }
+    throw err;
+  }
+
+  return runInsideClaimedSlot({
+    request,
+    run,
+    encodedPolicies,
+    active,
+    fetchPage,
+    pageSize,
+    startedAt,
+  });
+}
+
+interface ClaimedSlotArgs {
+  request: CorpusBRunRequest;
+  run: PolicyTriageRunRow;
+  encodedPolicies: EncodedEventTriagePolicyInput[];
+  active: ActiveExclusionSet;
+  fetchPage: (
+    variables: CorpusBFetchVariables,
+    signal?: AbortSignal,
+  ) => Promise<ResolverPage>;
+  pageSize: number;
+  startedAt: number;
+}
+
+async function runInsideClaimedSlot(
+  args: ClaimedSlotArgs,
+): Promise<CorpusBRunResult> {
+  const {
+    request,
+    run,
+    encodedPolicies,
+    active,
+    fetchPage,
+    pageSize,
+    startedAt,
+  } = args;
+  const pool = await getCustomerPool(request.customerId);
+  const client = await pool.connect();
+  let inserted = 0;
+  try {
+    await client.query("BEGIN");
+    let after: string | null = null;
+    for (let page = 0; page < MAX_PAGES_PER_RUN; page += 1) {
+      if (request.signal?.aborted) {
+        throw new Error("aborted by caller");
+      }
+      const variables: CorpusBFetchVariables = {
+        filter: {
+          start: request.periodStartIso,
+          end: request.periodEndIso,
+          customers: [String(request.customerId)],
+        },
+        triage: {
+          policies: encodedPolicies,
+          exclusions: exclusionsForResolver(active.rules),
+        },
+        first: pageSize,
+        after,
+      };
+      const response = await fetchPage(variables, request.signal);
+      const conn = response.eventListWithTriage;
+      const rows: Omit<PolicyTriagedEventRow, "runId">[] = [];
+      for (const edge of conn.edges) {
+        const event = edge.node;
+        const cols = normalizeEventColumns(event);
+        // App-side re-application of the active exclusion set. Stage 1
+        // already pre-cut what it can; this pass closes the TLS / NTLM
+        // gap from review-database#723 with full Domain regex
+        // semantics. Drops are fine — corpus B is a single bounded
+        // run, so watermark forward-progress is not a concern.
+        if (isExcluded(cols, { rules: active.rules })) continue;
+        rows.push({
+          eventKey: cursorToEventKey(edge.cursor),
+          eventTimeIso: event.time,
+          kind: event.__typename,
+          sensor: event.sensor,
+          origAddr: cols.origAddr,
+          origPort: event.origPort ?? null,
+          respAddr: cols.respAddr,
+          respPort: event.respPort ?? null,
+          proto: null,
+          host: cols.host,
+          dnsQuery: cols.dnsQuery,
+          uri: cols.uri,
+          category: event.category ?? null,
+          snapshot: {
+            scores: (event.triageScores ?? []).map((s) => ({
+              policyId: Number(s.policyId),
+              score: s.score,
+            })),
+          },
+        });
+      }
+      if (rows.length > 0) {
+        inserted += await insertTriagedEventsBatch(client, run.id, rows);
+      }
+      if (!conn.pageInfo.hasNextPage) break;
+      if (conn.pageInfo.endCursor === null) break;
+      after = conn.pageInfo.endCursor;
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {
+      // Already rolled back / connection broken.
+    });
+    const message = err instanceof Error ? err.message : String(err);
+    await markRunFailed(request.customerId, run.id, message).catch(() => {
+      // Best-effort: the original error is what matters.
+    });
+    return {
+      run: { ...run, status: "failed", lastError: message },
+      insertedEventCount: 0,
+      reusedCache: false,
+    };
+  } finally {
+    client.release();
+  }
+  const elapsed = Date.now() - startedAt;
+  await markRunReady(request.customerId, run.id, elapsed);
+  return {
+    run: {
+      ...run,
+      status: "ready",
+      computationDurationMs: elapsed,
+      finalizedAtIso: new Date().toISOString(),
+    },
+    insertedEventCount: inserted,
+    reusedCache: false,
+  };
+}
+
+const EVENT_KEY_PATTERN = /^[0-9]{1,39}$/;
+function cursorToEventKey(cursor: string): string {
+  if (!EVENT_KEY_PATTERN.test(cursor)) {
+    throw new Error(
+      `Corpus B: malformed edge cursor ${JSON.stringify(cursor)} (expected an unsigned decimal i128 string ≤ 39 digits).`,
+    );
+  }
+  return cursor;
+}
+
+/**
+ * Shape an encoding-error failure response without writing any row.
+ * The acceptance criterion requires encoding errors to surface as
+ * `status='failed'` with `last_error` populated — but encoding fails
+ * before a row is INSERTed, so we synthesise a pseudo-row that carries
+ * the same shape the caller would otherwise see, and leave the
+ * persistence as a no-op. Production callers should also forward the
+ * structured `InlinePolicyEncodingError` to their audit log.
+ */
+function failBeforeInsert(
+  request: CorpusBRunRequest,
+  err: unknown,
+): CorpusBRunResult {
+  const message =
+    err instanceof InlinePolicyEncodingError
+      ? `${err.kind}: ${err.message}`
+      : err instanceof Error
+        ? err.message
+        : String(err);
+  const nowIso = new Date().toISOString();
+  return {
+    run: {
+      id: "0",
+      ownerAccountId: request.ownerAccountId,
+      periodStartIso: request.periodStartIso,
+      periodEndIso: request.periodEndIso,
+      policiesFingerprint: "",
+      exclusionsFingerprint: "",
+      baselineVersion: request.baselineVersion,
+      status: "failed",
+      replaces: null,
+      supersededBy: null,
+      refreshReason: request.refreshReason,
+      computationDurationMs: null,
+      lastError: message,
+      createdAtIso: nowIso,
+      finalizedAtIso: nowIso,
+    },
+    insertedEventCount: 0,
+    reusedCache: false,
+  };
+}
+
+async function defaultFetchPage(
+  variables: CorpusBFetchVariables,
+  signal?: AbortSignal,
+): Promise<ResolverPage> {
+  const customerIdNum = Number(variables.filter.customers[0]);
+  const context = {
+    role: CORPUS_B_ROLE,
+    customerIds: Number.isFinite(customerIdNum) ? [customerIdNum] : [],
+  };
+  return graphqlRequest<ResolverPage, CorpusBFetchVariables>(
+    // scope-allowlist: corpus B system-actor runner; customer scope materialised via JWT customer_ids + filter.customers
+    CORPUS_B_EVENT_LIST_QUERY,
+    variables,
+    context,
+    signal,
+  );
+}
+
+export const _testing = {
+  cursorToEventKey,
+  exclusionsForResolver,
+  failBeforeInsert,
+};

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -57,7 +57,7 @@ import {
   insertComputingRun,
   insertTriagedEventsBatch,
   markRunFailed,
-  markRunReady,
+  markRunReadyOnClient,
   PolicyTriageRunActiveSlotConflict,
   recomputeRun,
 } from "./repository";
@@ -198,17 +198,12 @@ export async function runCorpusBTriage(
   const pageSize = options.pageSize ?? CORPUS_B_PAGE_SIZE;
   const startedAt = Date.now();
 
-  // Encode policies up front so an encoding error fails the run
-  // before any DB writes happen. The runner converts the error into
-  // `status='failed'` with a structured `last_error` rather than a
-  // panic (acceptance criterion).
-  let encodedPolicies: EncodedEventTriagePolicyInput[];
-  try {
-    encodedPolicies = request.policies.map(translatePolicyToInlineInput);
-  } catch (err) {
-    return failBeforeInsert(request, err);
-  }
-
+  // Fingerprinting does not depend on byte encoding, so the slot can
+  // be claimed before policies are encoded. Encoding happens inside
+  // `runInsideClaimedSlot` so an `InlinePolicyEncodingError` flows
+  // through the same `markRunFailed` path as fetch / DB errors —
+  // every failure mode ends up as a real `status='failed'` row with
+  // `last_error` populated, never a synthesised pseudo-row.
   const policiesFingerprint = computePoliciesFingerprint(request.policies);
   const active = await exclusionResolver.resolve(request.customerId);
   const exclusionsFingerprint = computeExclusionsFingerprint(active.rules);
@@ -256,7 +251,6 @@ export async function runCorpusBTriage(
   return runInsideClaimedSlot({
     request,
     run,
-    encodedPolicies,
     active,
     fetchPage,
     pageSize,
@@ -279,13 +273,6 @@ export async function recomputeCorpusBRun(
   const fetchPage = options.fetchPage ?? defaultFetchPage;
   const pageSize = options.pageSize ?? CORPUS_B_PAGE_SIZE;
   const startedAt = Date.now();
-
-  let encodedPolicies: EncodedEventTriagePolicyInput[];
-  try {
-    encodedPolicies = request.policies.map(translatePolicyToInlineInput);
-  } catch (err) {
-    return failBeforeInsert(request, err);
-  }
 
   const policiesFingerprint = computePoliciesFingerprint(request.policies);
   const active = await exclusionResolver.resolve(request.customerId);
@@ -326,7 +313,6 @@ export async function recomputeCorpusBRun(
   return runInsideClaimedSlot({
     request,
     run,
-    encodedPolicies,
     active,
     fetchPage,
     pageSize,
@@ -337,7 +323,6 @@ export async function recomputeCorpusBRun(
 interface ClaimedSlotArgs {
   request: CorpusBRunRequest;
   run: PolicyTriageRunRow;
-  encodedPolicies: EncodedEventTriagePolicyInput[];
   active: ActiveExclusionSet;
   fetchPage: (
     variables: CorpusBFetchVariables,
@@ -347,24 +332,43 @@ interface ClaimedSlotArgs {
   startedAt: number;
 }
 
+/**
+ * Raised when the per-run page cap fires while the resolver still
+ * reports `hasNextPage = true`. Surfaced as a structured run failure
+ * so a truncated run is never silently materialised as `ready`.
+ */
+class CorpusBPageCapExceededError extends Error {
+  constructor(maxPages: number) {
+    super(
+      `Corpus B: page cap of ${maxPages} reached with more pages still available; run truncated and marked failed`,
+    );
+    this.name = "CorpusBPageCapExceededError";
+  }
+}
+
 async function runInsideClaimedSlot(
   args: ClaimedSlotArgs,
 ): Promise<CorpusBRunResult> {
-  const {
-    request,
-    run,
-    encodedPolicies,
-    active,
-    fetchPage,
-    pageSize,
-    startedAt,
-  } = args;
+  const { request, run, active, fetchPage, pageSize, startedAt } = args;
   const pool = await getCustomerPool(request.customerId);
   const client = await pool.connect();
   let inserted = 0;
+  let elapsed = 0;
   try {
     await client.query("BEGIN");
+
+    // Encode policies inside the transaction so an
+    // `InlinePolicyEncodingError` rolls back any partial work and
+    // flows through the same `markRunFailed` path as fetch / DB
+    // errors. The claimed `policy_triage_run` row already exists at
+    // this point; marking it `failed` honours #460's acceptance
+    // criterion that encoding errors transition the run to
+    // `status='failed'` with `last_error` populated.
+    const encodedPolicies = request.policies.map(translatePolicyToInlineInput);
+
     let after: string | null = null;
+    let truncated = false;
+    let lastHasNextPage = false;
     for (let page = 0; page < MAX_PAGES_PER_RUN; page += 1) {
       if (request.signal?.aborted) {
         throw new Error("aborted by caller");
@@ -419,16 +423,32 @@ async function runInsideClaimedSlot(
       if (rows.length > 0) {
         inserted += await insertTriagedEventsBatch(client, run.id, rows);
       }
+      lastHasNextPage = conn.pageInfo.hasNextPage;
       if (!conn.pageInfo.hasNextPage) break;
       if (conn.pageInfo.endCursor === null) break;
       after = conn.pageInfo.endCursor;
+      if (page + 1 === MAX_PAGES_PER_RUN) {
+        truncated = true;
+      }
     }
+    if (truncated && lastHasNextPage) {
+      throw new CorpusBPageCapExceededError(MAX_PAGES_PER_RUN);
+    }
+
+    // Mark the run `ready` inside the same transaction as the event
+    // INSERTs so the `computing → ready` flip is atomic with the
+    // event rows. A crash between event commit and a separate ready
+    // UPDATE would otherwise leave the slot occupied as `computing`
+    // until 1B-7's reaper noticed.
+    elapsed = Date.now() - startedAt;
+    await markRunReadyOnClient(client, run.id, elapsed);
+
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK").catch(() => {
       // Already rolled back / connection broken.
     });
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatRunError(err);
     await markRunFailed(request.customerId, run.id, message).catch(() => {
       // Best-effort: the original error is what matters.
     });
@@ -440,8 +460,6 @@ async function runInsideClaimedSlot(
   } finally {
     client.release();
   }
-  const elapsed = Date.now() - startedAt;
-  await markRunReady(request.customerId, run.id, elapsed);
   return {
     run: {
       ...run,
@@ -454,6 +472,16 @@ async function runInsideClaimedSlot(
   };
 }
 
+function formatRunError(err: unknown): string {
+  if (err instanceof InlinePolicyEncodingError) {
+    return `${err.kind}: ${err.message}`;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
 const EVENT_KEY_PATTERN = /^[0-9]{1,39}$/;
 function cursorToEventKey(cursor: string): string {
   if (!EVENT_KEY_PATTERN.test(cursor)) {
@@ -462,49 +490,6 @@ function cursorToEventKey(cursor: string): string {
     );
   }
   return cursor;
-}
-
-/**
- * Shape an encoding-error failure response without writing any row.
- * The acceptance criterion requires encoding errors to surface as
- * `status='failed'` with `last_error` populated — but encoding fails
- * before a row is INSERTed, so we synthesise a pseudo-row that carries
- * the same shape the caller would otherwise see, and leave the
- * persistence as a no-op. Production callers should also forward the
- * structured `InlinePolicyEncodingError` to their audit log.
- */
-function failBeforeInsert(
-  request: CorpusBRunRequest,
-  err: unknown,
-): CorpusBRunResult {
-  const message =
-    err instanceof InlinePolicyEncodingError
-      ? `${err.kind}: ${err.message}`
-      : err instanceof Error
-        ? err.message
-        : String(err);
-  const nowIso = new Date().toISOString();
-  return {
-    run: {
-      id: "0",
-      ownerAccountId: request.ownerAccountId,
-      periodStartIso: request.periodStartIso,
-      periodEndIso: request.periodEndIso,
-      policiesFingerprint: "",
-      exclusionsFingerprint: "",
-      baselineVersion: request.baselineVersion,
-      status: "failed",
-      replaces: null,
-      supersededBy: null,
-      refreshReason: request.refreshReason,
-      computationDurationMs: null,
-      lastError: message,
-      createdAtIso: nowIso,
-      finalizedAtIso: nowIso,
-    },
-    insertedEventCount: 0,
-    reusedCache: false,
-  };
 }
 
 async function defaultFetchPage(
@@ -524,5 +509,6 @@ async function defaultFetchPage(
 export const _testing = {
   cursorToEventKey,
   exclusionsForResolver,
-  failBeforeInsert,
+  CorpusBPageCapExceededError,
+  MAX_PAGES_PER_RUN,
 };

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -546,12 +546,55 @@ async function runInsideClaimedSlot(
 
 function formatRunError(err: unknown): string {
   if (err instanceof InlinePolicyEncodingError) {
-    return `${err.kind}: ${err.message}`;
+    // Per #460, encoding failures must persist a `last_error` that
+    // identifies the offending policy/rule. The translator attaches
+    // `policyId`, `ruleIndex`, and `path` to the error context; we
+    // serialize those into the persisted string so the menu / audit /
+    // 1B-7 retention surfaces can pinpoint the bad rule without having
+    // to re-derive it from the raw error kind.
+    const context = formatEncodingErrorContext(err.context);
+    const suffix = context.length === 0 ? "" : ` (${context})`;
+    return `${err.kind}: ${err.message}${suffix}`;
   }
   if (err instanceof Error) {
     return err.message;
   }
   return String(err);
+}
+
+function formatEncodingErrorContext(
+  context: Record<string, unknown> | undefined,
+): string {
+  if (!context) return "";
+  // Stable key order so the persisted `last_error` is diffable across
+  // runs and tests. The most identifying fields come first.
+  const ORDER = [
+    "policyId",
+    "ruleIndex",
+    "path",
+    "valueKind",
+    "cmpKind",
+  ] as const;
+  const parts: string[] = [];
+  for (const key of ORDER) {
+    const value = context[key];
+    if (value === undefined || value === null) continue;
+    parts.push(`${key}=${formatContextValue(value)}`);
+  }
+  for (const [key, value] of Object.entries(context)) {
+    if ((ORDER as readonly string[]).includes(key)) continue;
+    if (value === undefined || value === null) continue;
+    parts.push(`${key}=${formatContextValue(value)}`);
+  }
+  return parts.join(", ");
+}
+
+function formatContextValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
 }
 
 const EVENT_KEY_PATTERN = /^[0-9]{1,39}$/;

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -433,6 +433,15 @@ async function runInsideClaimedSlot(
         // semantics. Drops are fine — corpus B is a single bounded
         // run, so watermark forward-progress is not a concern.
         if (isExcluded(cols, { rules: active.rules })) continue;
+        // `eventListWithTriage` returns every event passing the
+        // standard filter; non-matching events have `triageScores`
+        // null/empty. Persisting them would make "With my policies"
+        // surface the full standard-filter corpus with empty score
+        // lists instead of the documented zero-row ready result for a
+        // no-match run. Drop here so `policy_triaged_event` only
+        // carries policy-matched rows.
+        const scores = event.triageScores ?? [];
+        if (scores.length === 0) continue;
         rows.push({
           eventKey: cursorToEventKey(edge.cursor),
           eventTimeIso: event.time,
@@ -448,7 +457,7 @@ async function runInsideClaimedSlot(
           uri: cols.uri,
           category: event.category ?? null,
           snapshot: {
-            scores: (event.triageScores ?? []).map((s) => ({
+            scores: scores.map((s) => ({
               policyId: Number(s.policyId),
               score: s.score,
             })),

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -40,14 +40,14 @@ import {
   normalizeEventColumns,
   STORAGE_EXCLUSION_SET_RESOLVER,
 } from "@/lib/triage/exclusion";
-import {
-  type EncodedEventTriagePolicyInput,
-  InlinePolicyEncodingError,
-  translatePolicyToInlineInput,
-} from "@/lib/triage/inline-policy";
+import { InlinePolicyEncodingError } from "@/lib/triage/inline-policy";
 import type { TriageEvent } from "@/lib/triage/types";
 
 import { getCustomerPool } from "../customer-db";
+import {
+  type EncodedEventTriagePolicyInput,
+  translatePolicyToInlineInput,
+} from "../inline-translator";
 import type { TriagePolicyRow } from "../types";
 
 import { computePoliciesFingerprint } from "./fingerprint";

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -516,13 +516,9 @@ async function defaultFetchPage(
     role: CORPUS_B_ROLE,
     customerIds: Number.isFinite(customerIdNum) ? [customerIdNum] : [],
   };
-  return graphqlRequest<ResolverPage, CorpusBFetchVariables>(
-    // scope-allowlist: corpus B system-actor runner; customer scope materialised via JWT customer_ids + filter.customers
-    CORPUS_B_EVENT_LIST_QUERY,
-    variables,
-    context,
-    signal,
-  );
+  // biome-ignore format: keep the call on one line so the scope-allowlist
+  // override sits on the same line as the graphqlRequest call.
+  return graphqlRequest<ResolverPage, CorpusBFetchVariables>(CORPUS_B_EVENT_LIST_QUERY, variables, context, signal); // scope-allowlist: corpus B system-actor runner; customer scope materialised via JWT customer_ids + filter.customers
 }
 
 export const _testing = {

--- a/src/lib/triage/policy/corpus-b/runner.ts
+++ b/src/lib/triage/policy/corpus-b/runner.ts
@@ -54,6 +54,7 @@ import { computePoliciesFingerprint } from "./fingerprint";
 import { CORPUS_B_EVENT_LIST_QUERY } from "./queries";
 import {
   findActiveRun,
+  getRunById,
   insertComputingRun,
   insertTriagedEventsBatch,
   markRunFailed,
@@ -346,6 +347,40 @@ class CorpusBPageCapExceededError extends Error {
   }
 }
 
+/**
+ * Raised when the resolver returns `hasNextPage = true` but
+ * `endCursor = null`. Without an `endCursor` the runner cannot
+ * continue paging, so this is the same user-visible failure mode as
+ * the page cap: the run is incomplete and must not silently
+ * materialise as `ready`.
+ */
+class CorpusBMalformedPaginationError extends Error {
+  constructor() {
+    super(
+      "Corpus B: resolver returned hasNextPage=true with endCursor=null; cannot continue paging, run marked failed",
+    );
+    this.name = "CorpusBMalformedPaginationError";
+  }
+}
+
+/**
+ * Raised when the `computing → ready` UPDATE finds zero rows — meaning
+ * the run was already transitioned to a terminal status (`failed` by
+ * 1B-7's reaper, `superseded` by a concurrent recompute) before this
+ * runner reached the ready flip. The transaction is rolled back so the
+ * already-inserted events do not get committed under a stale run id;
+ * the runner re-reads the current row and returns it as-is rather than
+ * reviving a terminal row.
+ */
+class CorpusBRunSlotLostError extends Error {
+  constructor() {
+    super(
+      "Corpus B: run row was no longer in 'computing' state at the ready flip; another transition has already terminalised it",
+    );
+    this.name = "CorpusBRunSlotLostError";
+  }
+}
+
 async function runInsideClaimedSlot(
   args: ClaimedSlotArgs,
 ): Promise<CorpusBRunResult> {
@@ -425,7 +460,13 @@ async function runInsideClaimedSlot(
       }
       lastHasNextPage = conn.pageInfo.hasNextPage;
       if (!conn.pageInfo.hasNextPage) break;
-      if (conn.pageInfo.endCursor === null) break;
+      // `hasNextPage = true` with `endCursor = null` is a malformed
+      // pagination response: the runner cannot continue paging, so
+      // treating it as a clean exit would materialise an incomplete
+      // run as `ready`. Surface as a structured failure instead.
+      if (conn.pageInfo.endCursor === null) {
+        throw new CorpusBMalformedPaginationError();
+      }
       after = conn.pageInfo.endCursor;
       if (page + 1 === MAX_PAGES_PER_RUN) {
         truncated = true;
@@ -441,13 +482,35 @@ async function runInsideClaimedSlot(
     // UPDATE would otherwise leave the slot occupied as `computing`
     // until 1B-7's reaper noticed.
     elapsed = Date.now() - startedAt;
-    await markRunReadyOnClient(client, run.id, elapsed);
+    const flipped = await markRunReadyOnClient(client, run.id, elapsed);
+    if (flipped === 0) {
+      // The row was transitioned to a terminal status (`failed` by the
+      // reaper, `superseded` by a concurrent recompute) before this
+      // runner reached the ready flip. Roll back so the events do not
+      // commit under a stale run id and surface the current state of
+      // the row instead of reviving the terminal one.
+      throw new CorpusBRunSlotLostError();
+    }
 
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK").catch(() => {
       // Already rolled back / connection broken.
     });
+    if (err instanceof CorpusBRunSlotLostError) {
+      // The row already has a terminal status — re-read it so the
+      // caller sees the actual outcome (failed / superseded) instead
+      // of a synthesised one. `markRunFailed` is intentionally NOT
+      // called here: its `WHERE status='computing'` guard would no-op
+      // anyway, and we must not write `last_error` over the existing
+      // terminal row.
+      const current = await getRunById(request.customerId, run.id);
+      return {
+        run: current ?? { ...run, status: "failed", lastError: err.message },
+        insertedEventCount: 0,
+        reusedCache: false,
+      };
+    }
     const message = formatRunError(err);
     await markRunFailed(request.customerId, run.id, message).catch(() => {
       // Best-effort: the original error is what matters.
@@ -510,5 +573,7 @@ export const _testing = {
   cursorToEventKey,
   exclusionsForResolver,
   CorpusBPageCapExceededError,
+  CorpusBMalformedPaginationError,
+  CorpusBRunSlotLostError,
   MAX_PAGES_PER_RUN,
 };

--- a/src/lib/triage/policy/corpus-b/types.ts
+++ b/src/lib/triage/policy/corpus-b/types.ts
@@ -15,9 +15,12 @@ export type PolicyTriageRunStatus =
 /**
  * Corpus B-specific triage outcome stored on each
  * `policy_triaged_event` row. Matches review-web's `TriageScore` shape
- * (one entry per matching policy with the raw score). Empty list when
- * no policy matched; the run still owns the row because the runner
- * persists everything that passed standard filter + exclusions.
+ * (one entry per matching policy with the raw score). Every persisted
+ * row carries at least one matching policy score — the runner drops
+ * events whose `triageScores` is null or empty after the app-side
+ * exclusion pass, so a no-match period materialises as a `ready` run
+ * with zero `policy_triaged_event` rows rather than rows with empty
+ * score lists.
  */
 export interface PolicyTriageScoreSnapshot {
   scores: { policyId: number; score: number }[];

--- a/src/lib/triage/policy/corpus-b/types.ts
+++ b/src/lib/triage/policy/corpus-b/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Corpus B run / event domain types.
+ *
+ * Mirrors the columns in `migrations/customer/0008_policy_corpus_b.sql`.
+ * Used by the runner, repository, and (eventually) the menu read-path
+ * for "With my policies" mode.
+ */
+
+export type PolicyTriageRunStatus =
+  | "computing"
+  | "ready"
+  | "failed"
+  | "superseded";
+
+/**
+ * Corpus B-specific triage outcome stored on each
+ * `policy_triaged_event` row. Matches review-web's `TriageScore` shape
+ * (one entry per matching policy with the raw score). Empty list when
+ * no policy matched; the run still owns the row because the runner
+ * persists everything that passed standard filter + exclusions.
+ */
+export interface PolicyTriageScoreSnapshot {
+  scores: { policyId: number; score: number }[];
+}
+
+export interface PolicyTriageRunRow {
+  id: string;
+  ownerAccountId: string;
+  periodStartIso: string;
+  periodEndIso: string;
+  policiesFingerprint: string;
+  exclusionsFingerprint: string;
+  baselineVersion: string;
+  status: PolicyTriageRunStatus;
+  replaces: string | null;
+  supersededBy: string | null;
+  refreshReason: string | null;
+  computationDurationMs: number | null;
+  lastError: string | null;
+  createdAtIso: string;
+  finalizedAtIso: string | null;
+}
+
+export interface PolicyTriagedEventRow {
+  runId: string;
+  eventKey: string;
+  eventTimeIso: string;
+  kind: string;
+  sensor: string;
+  origAddr: string | null;
+  origPort: number | null;
+  respAddr: string | null;
+  respPort: number | null;
+  proto: number | null;
+  host: string | null;
+  dnsQuery: string | null;
+  uri: string | null;
+  category: string | null;
+  snapshot: PolicyTriageScoreSnapshot;
+}

--- a/src/lib/triage/policy/inline-translator.ts
+++ b/src/lib/triage/policy/inline-translator.ts
@@ -1,22 +1,34 @@
 /**
  * Stored TriagePolicy row → inline `EventTriagePolicyInput`.
  *
- * Combines the enum-name translator (`src/lib/triage/policy/inline-input.ts`)
- * with the byte-array encoder from `./encode.ts` so the corpus B runner
- * can call `eventListWithTriage(triage: { policies: [...] })` with a
- * faithful wire representation of stored rows. Lives outside
- * `src/lib/triage/policy/` per §6: this is the inline-policy boundary
- * (shared with any future inline-policy caller), not a policy-mode
- * orchestrator.
+ * Composes the GraphQL enum-name translator
+ * (`src/lib/triage/inline-policy/graphql-names.ts`) with the byte-array
+ * encoder (`src/lib/triage/inline-policy/encode.ts`) so the corpus B
+ * runner can call `eventListWithTriage(triage: { policies: [...] })`
+ * with a faithful wire representation of stored `TriagePolicyRow`s.
+ *
+ * Lives inside `src/lib/triage/policy/` because it legitimately consumes
+ * the storage shape (`TriagePolicyRow` from `./types`). Per §6, the
+ * dependency direction is `triage/policy/ → triage/inline-policy/`
+ * (this module) and never the reverse — the inline-policy seam itself
+ * has no knowledge of stored-row shapes, so removing the policy mode
+ * leaves the encoder and GraphQL-name translator intact for any other
+ * inline-policy caller.
  */
 
+import {
+  type EncodedPacketAttrInput,
+  encodeRuleBytes,
+  InlinePolicyEncodingError,
+} from "@/lib/triage/inline-policy/encode";
 import {
   cmpKindToGraphql,
   rawEventKindToGraphql,
   responseKindToGraphql,
   threatCategoryToGraphql,
   valueKindToGraphql,
-} from "@/lib/triage/policy/inline-input";
+} from "@/lib/triage/inline-policy/graphql-names";
+
 import type {
   CmpKind,
   Confidence,
@@ -27,13 +39,7 @@ import type {
   ThreatCategory,
   TriagePolicyRow,
   ValueKind,
-} from "@/lib/triage/policy/types";
-
-import {
-  type EncodedPacketAttrInput,
-  encodeRuleBytes,
-  InlinePolicyEncodingError,
-} from "./encode";
+} from "./types";
 
 /**
  * Wire-shape ConfidenceInput. `threatCategory` is nullable to mirror
@@ -41,7 +47,7 @@ import {
  * matches against any category for its `(threatKind, confidence)`
  * pair. The runner-side panic-free contract requires us to round-trip
  * this null faithfully — see the smoke test in
- * `__tests__/lib/triage/inline-policy/translate.test.ts`.
+ * `__tests__/lib/triage/policy/inline-translator.test.ts`.
  */
 export interface EncodedConfidenceInput {
   threatCategory: string | null;
@@ -89,9 +95,6 @@ export function translatePolicyToInlineInput(
     };
   } catch (err) {
     if (err instanceof InlinePolicyEncodingError) {
-      // Re-throw with policy id context populated. Throw the same
-      // structured error type so the runner's catch sees a single
-      // class.
       throw new InlinePolicyEncodingError(err.kind, err.message, {
         ...err.context,
         policyId: policy.id,

--- a/src/lib/triage/policy/types.ts
+++ b/src/lib/triage/policy/types.ts
@@ -21,101 +21,43 @@
 
 import { z } from "zod";
 
-// ── Enum-like literal sets ────────────────────────────────────────
+// ── Wire enum literals (shared with the inline-policy seam) ──────
 //
-// Each set mirrors the matching GraphQL enum in `schemas/review.graphql`.
-// `inline-input.ts` proves the round-trip mapping; if you edit a list
-// here, update that translator and its test together.
+// The literal sets and their types live in `src/lib/triage/inline-policy/kinds.ts`
+// so the inline-policy boundary (encoder, GraphQL-name mapping) can
+// compile without importing from this storage namespace. The §6
+// deprecatability seam allows `triage/policy/ → triage/inline-policy/`
+// but never the reverse, so re-exports flow in this direction only.
+// `inline-policy/graphql-names.ts` proves the round-trip mapping; if
+// you edit a list there, update that translator and its test together.
 
-export const VALUE_KINDS = [
-  "string",
-  "integer",
-  "u_integer",
-  "vector",
-  "float",
-  "ipaddr",
-  "bool",
-] as const;
-export type ValueKind = (typeof VALUE_KINDS)[number];
+import {
+  CMP_KINDS,
+  type CmpKind,
+  RANGE_CMP_KINDS,
+  RAW_EVENT_KINDS,
+  type RawEventKind,
+  RESPONSE_KINDS,
+  type ResponseKind,
+  THREAT_CATEGORIES,
+  type ThreatCategory,
+  VALUE_KINDS,
+  type ValueKind,
+} from "@/lib/triage/inline-policy/kinds";
 
-export const CMP_KINDS = [
-  "less",
-  "equal",
-  "greater",
-  "less_or_equal",
-  "greater_or_equal",
-  "contain",
-  "open_range",
-  "close_range",
-  "left_open_range",
-  "right_open_range",
-  "not_equal",
-  "not_contain",
-  "not_open_range",
-  "not_close_range",
-  "not_left_open_range",
-  "not_right_open_range",
-] as const;
-export type CmpKind = (typeof CMP_KINDS)[number];
-
-// Range cmp kinds require a non-empty `second_value` so the engine has
-// both ends of the interval. Listed here so `validation.ts` and the
-// inline-input translator can share a single source of truth.
-export const RANGE_CMP_KINDS = new Set<CmpKind>([
-  "open_range",
-  "close_range",
-  "left_open_range",
-  "right_open_range",
-  "not_open_range",
-  "not_close_range",
-  "not_left_open_range",
-  "not_right_open_range",
-]);
-
-export const RESPONSE_KINDS = ["manual", "blacklist", "whitelist"] as const;
-export type ResponseKind = (typeof RESPONSE_KINDS)[number];
-
-export const RAW_EVENT_KINDS = [
-  "bootp",
-  "conn",
-  "dhcp",
-  "dns",
-  "ftp",
-  "http",
-  "kerberos",
-  "ldap",
-  "log",
-  "mqtt",
-  "network",
-  "nfs",
-  "ntlm",
-  "radius",
-  "rdp",
-  "smb",
-  "smtp",
-  "ssh",
-  "tls",
-  "window",
-] as const;
-export type RawEventKind = (typeof RAW_EVENT_KINDS)[number];
-
-export const THREAT_CATEGORIES = [
-  "reconnaissance",
-  "initial_access",
-  "execution",
-  "credential_access",
-  "discovery",
-  "lateral_movement",
-  "command_and_control",
-  "exfiltration",
-  "impact",
-  "collection",
-  "defense_evasion",
-  "persistence",
-  "privilege_escalation",
-  "resource_development",
-] as const;
-export type ThreatCategory = (typeof THREAT_CATEGORIES)[number];
+export {
+  CMP_KINDS,
+  type CmpKind,
+  RANGE_CMP_KINDS,
+  RAW_EVENT_KINDS,
+  type RawEventKind,
+  RESPONSE_KINDS,
+  type ResponseKind,
+  THREAT_CATEGORIES,
+  type ThreatCategory,
+  VALUE_KINDS,
+  type ValueKind,
+};
 
 // ── Rule schemas ─────────────────────────────────────────────────
 

--- a/src/lib/triage/policy/types.ts
+++ b/src/lib/triage/policy/types.ts
@@ -12,8 +12,10 @@
  * input without any kind-by-kind reinterpretation. The byte-array
  * encoding of `first_value` / `second_value` for the GraphQL
  * `[Int!]!` shape happens at that boundary; we keep human-readable
- * strings here for storage and UI editing. See `inline-input.ts` for
- * the enum-name translator and round-trip test.
+ * strings here for storage and UI editing. See `./inline-translator.ts`
+ * for the storage→wire translator and
+ * `@/lib/triage/inline-policy/graphql-names` for the enum-name
+ * translator and its round-trip test.
  *
  * No `server-only` import: this module is also consumed by the form
  * components for client-side input shape parity.

--- a/src/lib/triage/policy/validation.ts
+++ b/src/lib/triage/policy/validation.ts
@@ -9,7 +9,7 @@
  * under ticket 1B-2 (#447 §2.1, §3.4) and is not part of TriagePolicy
  * under the new model. Removing the legacy `match` / `not_match`
  * cmp kinds here keeps the stored shape aligned with review-web's
- * `AttrCmpKind` enum (see `inline-input.ts`).
+ * `AttrCmpKind` enum (see `@/lib/triage/inline-policy/kinds`).
  */
 
 import { isIP } from "node:net";


### PR DESCRIPTION
## Summary

- Adds the `policy_triage_run` and `policy_triaged_event` tables in tenant DBs with the partial unique index on `(status IN ('computing', 'ready'))` that enforces "one active run per fingerprint" while letting `failed` / `superseded` rows accumulate for diagnostics. Schema mirrors corpus A's normalized exclusion columns (`orig_addr`, `resp_addr`, `host`, `dns_query`, `uri`) so 1B-2's retroactive DELETE planner applies symmetrically to `policy_triaged_event`.
- Adds the corpus B runner that calls `eventListWithTriage` (1B-4a) with inline policies + the union of global and customer-scoped exclusions, then re-applies the same exclusion set app-side against the normalized columns before INSERT. The corpus B `eventListWithTriage` query mirrors corpus A's IP-bearing subtype set one-for-one (`FtpBruteForce`, `FtpPlainText`, `LdapBruteForce`, `LdapPlainText`, `MultiHostPortScan`, `NetworkThreat`, `PortScan`, `RdpBruteForce`, and every `Blocklist*` curated subtype) so the normalized exclusion columns persist with the same coverage. The app-side re-application is load-bearing for TLS Domain / Hostname matching while review-database#723 is unresolved; it remains correct once #723 lands, just no longer load-bearing for TLS specifically. Events whose `triageScores` is null or empty (i.e. no selected policy matched) are dropped after the exclusion re-application so "With my policies" surfaces a zero-row ready run for a no-match period rather than the full standard-filter corpus with empty score lists.
- Adds the recompute transaction model (pre-allocate id → supersede old → insert new) so the partial unique index never rejects a legitimate recompute, with a rowcount-0 check on the supersede UPDATE to handle concurrent recompute and 1B-7 reaper races. `policy_triage_run.superseded_by` is `DEFERRABLE INITIALLY DEFERRED` so the supersede UPDATE in step 2 can name the still-unallocated `new_id` without tripping the FK at statement boundary. Empty runs are persisted as `status='ready'` so a legitimately-empty result is not confused with in-progress or failed.
- Splits the inline-policy boundary along the §6 deprecatability seam:
  - `src/lib/triage/inline-policy/` owns the shared seam — wire enum literals (`kinds.ts`), the lower_snake_case → GraphQL SCREAMING_SNAKE_CASE name mapping (`graphql-names.ts`), and the byte encoder (`encode.ts`) for `PacketAttrInput.firstValue` / `secondValue`. The encoder takes a minimal local `PacketAttrRule` shape and has zero imports from `triage/policy/`, so the seam can be reused by any future inline-policy caller after the policy mode is removed.
  - `src/lib/triage/policy/inline-translator.ts` consumes `TriagePolicyRow` and composes the seam pieces into an `EncodedEventTriagePolicyInput`. Lives inside the policy deprecatability namespace because it legitimately depends on the storage shape; the dependency direction is `triage/policy/ → triage/inline-policy/`, never the reverse.
  - `src/lib/triage/policy/types.ts` re-exports the kinds from `inline-policy/kinds.ts` so existing storage callers and Zod schemas keep compiling against the same names.
- The byte encoder produces `PacketAttrInput.firstValue` / `secondValue` per the wire contract: fixed-width big-endian for integers / floats, packed octets for `ipaddr` literals, UTF-8 for strings, and explicit structured-error rejection for CIDR and `vector` value kinds. The encoder is the defensive boundary called out in the issue: every JSONB scalar shape mismatch (number for `string`, object for `integer`, JSON-number above `Number.MAX_SAFE_INTEGER` for i64/u64, empty / whitespace-only integer string, etc.) surfaces as `InlinePolicyEncodingError` rather than a `TypeError` from `.trim()` or a silent `BigInt("") === 0n` coercion. Booleans accept JSON `true` / `false` literals **and** the case-sensitive strings `"true"` / `"false"` per the issue body — `"True"` / `"TRUE"` / `"False"` / `"FALSE"`, numeric `0`/`1`, and `null` are rejected.
- Runner lifecycle hardening:
  - The `computing` row is claimed **before** policy encoding; an `InlinePolicyEncodingError` rolls back inside the transaction and flows through `markRunFailed`, persisting a real `status='failed'` row with `last_error` populated (visible to the menu / audit / 1B-7 retention).
  - The `MAX_PAGES_PER_RUN` cap surfaces as a structured `CorpusBPageCapExceededError` and fails the run when the cap is reached with `hasNextPage` still true, so a truncated run never silently lands as `ready`. A malformed pagination response (`hasNextPage = true` with `endCursor = null`) is treated the same way — the runner cannot continue paging, so the run is marked failed rather than materialised as a "complete" incomplete result.
  - The `computing → ready` flip happens via `markRunReadyOnClient` inside the same transaction as the event INSERTs. The UPDATE is guarded with `AND status = 'computing'` and the runner checks rowcount — if the row has already been terminalised (by 1B-7's reaper or a concurrent recompute) the transaction is rolled back, the events are not committed under a stale run id, and the runner re-reads the current row instead of reviving the terminal one.
- Adds the canonical `policies_fingerprint` hash used in the active-slot tuple, plus a round-trip test for the encoder against `eventListWithTriage`'s contract and a panic-free smoke test for null `threat_category` at the runner boundary.

## Not addressed

This PR delivers the schema, fingerprint, recompute, encoder, and runner pieces of 1B-6. The following remain for a follow-up:

- **Menu wiring of "With my policies" mode.** The mode-toggle and triage-shell entry points already include a future seam (`d0cdb9c` "Compose Triage menu via §4/§6 over corpus A") but do not yet dispatch on the runner. Wiring the menu to call `runCorpusBTriage` / `recomputeCorpusBRun` and render the run list belongs to a separate UI PR.
- **`[Recompute]` stale-confirm modal.** The recompute UI surface (modal copy, "selection conditions changed" line, estimated-time-from-`computation_duration_ms`) is not implemented here. The underlying transaction model and `computation_duration_ms` column are in place so the modal can be wired without backend changes.
- **`computing`-row timeout cleanup.** This PR defines the contract (predicate, target status, `last_error` value) but the cleanup job itself is owned by 1B-7 per the issue's coordination note.
- **Manual page.** Per CLAUDE.md "a feature is not done until its manual page is written" — manual coverage is deferred until the menu wiring above lands and the feature becomes user-visible.

Part of #460

## Test plan

- [x] `pnpm vitest run src/__tests__/lib/triage/inline-policy src/__tests__/lib/triage/policy/corpus-b src/__tests__/lib/triage/policy/inline-translator.test.ts` passes.
- [x] `pnpm vitest run` — full suite, 4283 tests pass.
- [x] `pnpm tsc --noEmit` is clean.
- [x] `pnpm biome check` is clean.
- [x] `pnpm check:scope` is clean.
- [x] `pnpm build` is clean.
- [x] No file under `src/lib/triage/inline-policy/` imports from `@/lib/triage/policy/*`; the §6 deprecatability seam is one-directional (`policy/ → inline-policy/`).
- [x] Apply `migrations/customer/0008_policy_corpus_b.sql` against a tenant DB and confirm:
  - [x] `policy_triage_run` and `policy_triaged_event` exist with the documented columns / constraints.
  - [x] `policy_triage_run_active_fingerprint` is present as a partial unique index with predicate `status IN ('computing', 'ready')`.
  - [x] GiST `inet_ops` indexes exist on `orig_addr` and `resp_addr`; btree indexes exist on `host`, `dns_query`, `uri`.
  - [x] `policy_triaged_event.run_id` cascades on delete.
- [x] Insert a `computing` row, then insert a second row with the same `(owner_account_id, period_start, period_end, policies_fingerprint, exclusions_fingerprint, baseline_version)` and confirm the unique index rejects it.
- [x] Transition the first row to `failed` (or `superseded`) and confirm the same insert now succeeds.
- [x] Round-trip a JSONB-stored TriagePolicy through `translatePolicyToInlineInput` and `encodeRuleBytes`; confirm the resulting `[Int!]!` decodes back to the same logical value.
- [x] Encode a `value_kind = ipaddr` policy whose value is `"1.2.3.0/24"`; confirm the encoder rejects it with `InlinePolicyEncodingError`.
- [x] Encode a `value_kind = vector` policy; confirm the encoder rejects it with `InlinePolicyEncodingError`.
- [x] Encode a `value_kind = bool` with `"True"` / `"TRUE"` / `"False"` / `"FALSE"`; confirm each is rejected with `InlinePolicyEncodingError`.
- [x] Encode a `value_kind = bool` with the native JSON literals `true` / `false`; confirm both encode to the documented single-byte payload.
- [x] Encode `value_kind = integer` with a JSON number above `Number.MAX_SAFE_INTEGER`, a non-integer `1.5`, and a `null`; confirm each is rejected with `InlinePolicyEncodingError`.
- [x] Encode `value_kind = integer` / `u_integer` with an empty string `""` or whitespace-only `"   "`; confirm each is rejected with `InlinePolicyEncodingError` (would otherwise silently encode as `0` via `BigInt("")`).
- [x] Run a corpus B run end-to-end against a fixture where every fetched event is dropped by the app-side exclusion fallback; confirm the run still transitions to `status='ready'` with zero `policy_triaged_event` rows.
- [x] Run a corpus B run end-to-end against a fixture where the resolver returns events with `triageScores: null` and `triageScores: []`; confirm the run transitions to `status='ready'` with zero `policy_triaged_event` rows (no-match events do not leak in).
- [x] Drive `recomputeCorpusBRun` on an existing `ready` fingerprint and confirm the old row's `status` becomes `superseded` with `superseded_by` set, and the new row is `computing` with `replaces` set to the old id.
- [x] Race two `recomputeCorpusBRun` calls on the same fingerprint; confirm one wins and the other sees the `PolicyTriageRunActiveSlotConflict` re-query path.
- [x] Synthesize a TriagePolicy with `confidence.threat_category = null` and drive it through the runner; confirm the translator surfaces a null `threatCategory` rather than panicking (per the issue body's "no panic plus a sensible scoring result" smoke).
- [x] Encoding-failure path: drive `runCorpusBTriage` with a `value_kind = vector` policy and confirm a real `policy_triage_run` row is claimed first, then transitioned to `status='failed'` with `last_error` containing the structured `InlinePolicyEncodingError.kind`.
- [x] Page-cap path: drive `runCorpusBTriage` against a `fetchPage` that always returns `hasNextPage = true`; confirm the run transitions to `status='failed'` with `last_error` referencing the page cap rather than silently landing as `ready`.
- [x] Malformed-pagination path: drive `runCorpusBTriage` against a `fetchPage` that returns `hasNextPage = true` with `endCursor = null`; confirm the run transitions to `status='failed'` with `last_error` referencing the malformed pagination response rather than silently landing as `ready`.
- [x] Lost-slot path: simulate `markRunReadyOnClient` returning rowcount 0 (row already transitioned to `failed` by the reaper) and confirm the runner re-reads the row via `getRunById` and surfaces the terminal status without calling `markRunFailed` or reviving the row.