### PR TITLE
Add Story schema and heuristic correlator (#489)

### DIFF
--- a/migrations/customer/0008_event_group_story.sql
+++ b/migrations/customer/0008_event_group_story.sql
@@ -1,0 +1,101 @@
+-- Story schema (1B-Story-1 / discussion #447 §3.4, §3.5, §6, §7).
+--
+-- Adds a new corpus layer on top of corpus A: a Story is a small
+-- bundle of correlated `baseline_triaged_event` rows produced by the
+-- cadence's step (f) heuristic correlator (see
+-- `src/lib/triage/story/`). The user-facing label is "Story"; the
+-- internal/DB names are `event_group` (container) and
+-- `event_group_member` (rows).
+--
+-- The Story-side aggregate `score` is computed by the correlator as a
+-- per-rule count or weighted count over `selector_tags` matches — it is
+-- NOT a function of `raw_score`. Story rules also predicate on
+-- `selector_tags` membership, never on `baseline_score`: the latter
+-- does not exist on the row at cadence time (it is read-time-computed
+-- via `cume_dist()` per `(kind, baseline_version)` cohort), and
+-- `raw_score`'s absolute scale shifts across `baseline_version`
+-- bumps. `selector_tags` is RFC 0001 §9's stable, enumerated emission
+-- and survives §9 retunes; the Story RFC explicitly versions its
+-- consumed tag list under `story_version` so any RFC 0001 rename or
+-- addition is caught at Story-RFC review time.
+
+CREATE TABLE IF NOT EXISTS event_group (
+    id                  BIGSERIAL PRIMARY KEY,
+    -- customer_id is implicit (this is a tenant DB).
+    kind                TEXT NOT NULL CHECK (kind IN ('auto_correlated', 'analyst_curated')),
+    -- Typo guard for the rule-ID column. The *active* rule-ID
+    -- whitelist is enforced by the correlator module's enum, not by
+    -- this CHECK, so RFC bumps that add R4/R5/... do not require a
+    -- schema migration. v1 emits 'R1' and 'R3'; 'R2' is reserved by
+    -- the Story RFC v1 for the v2 RFC bump.
+    correlation_rule_id TEXT
+        CHECK (correlation_rule_id IS NULL OR correlation_rule_id ~ '^R[0-9]+$'),
+    story_version       TEXT NOT NULL,
+    time_window_start   TIMESTAMPTZ NOT NULL,
+    time_window_end     TIMESTAMPTZ NOT NULL,
+    primary_asset       INET,
+    score               DOUBLE PRECISION,
+    summary_payload     JSONB NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- β-style submission tracking. This issue owns the columns; the
+    -- Phase 2 send-to-aimer action (Y2, #493) is the writer. Until
+    -- Y2 ships these stay at NULL / 0.
+    --
+    -- NOTE: `last_sent_by` references `accounts.id` in the **auth DB**,
+    -- not this tenant DB. Integrity is app-level — account deletion
+    -- produces an orphan reference rather than a constraint error.
+    last_sent_at        TIMESTAMPTZ,
+    last_sent_by        UUID,
+    send_count          INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS event_group_member (
+    event_group_id BIGINT NOT NULL REFERENCES event_group(id) ON DELETE CASCADE,
+    -- Semantically references `baseline_triaged_event.event_key` but
+    -- NOT declared as a FK. Same reasoning as the
+    -- baseline_triaged_event ↔ observed_event_meta decoupling
+    -- (#456): retention windows differ (corpus A is 180d, Story
+    -- retention is owned by 1B-7 / #461). A FK with `ON DELETE`
+    -- would couple the windows.
+    event_key      NUMERIC(39, 0) NOT NULL,
+    role           TEXT NOT NULL CHECK (role IN ('primary', 'context')),
+    PRIMARY KEY (event_group_id, event_key)
+);
+
+CREATE INDEX IF NOT EXISTS event_group_time_window_end_idx
+    ON event_group (time_window_end DESC);
+CREATE INDEX IF NOT EXISTS event_group_primary_asset_idx
+    ON event_group (primary_asset);
+CREATE INDEX IF NOT EXISTS event_group_unsent_score_idx
+    ON event_group (score DESC) WHERE last_sent_at IS NULL;
+CREATE INDEX IF NOT EXISTS event_group_member_event_key_idx
+    ON event_group_member (event_key);
+
+-- Idempotency for re-evaluated slop-window candidates: an
+-- auto-correlated Story is uniquely identified by
+-- (rule, asset, window). Step (f) on the next tick uses
+-- ON CONFLICT DO NOTHING against this index to avoid duplicate
+-- inserts when the same window is re-scanned. Analyst-curated rows
+-- are intentionally excluded (curated saves can legitimately repeat
+-- a window if the analyst chooses).
+--
+-- `primary_asset IS NOT NULL` is required because PostgreSQL treats
+-- NULL as distinct in unique indexes (two rows with NULL asset would
+-- both insert, defeating dedup). v1 rules R1/R3 are orig_addr-keyed
+-- and explicitly skip events with NULL orig_addr at the predicate
+-- level, so an auto-correlated Story with NULL primary_asset is
+-- unreachable in v1; the WHERE clause guards against future-rule
+-- regressions.
+CREATE UNIQUE INDEX IF NOT EXISTS event_group_auto_dedup_idx
+    ON event_group
+    (correlation_rule_id, primary_asset, time_window_start, time_window_end)
+    WHERE kind = 'auto_correlated' AND primary_asset IS NOT NULL;
+
+-- Story slop-window watermark on the existing corpus-state
+-- singleton. Required because step (f)'s next-tick replay must know
+-- "everything strictly earlier than X has been considered for
+-- finalization" — neither `last_event_cursor` (raw-page boundary,
+-- not event_time) nor `last_ingested_at` (wall-clock, not event_time)
+-- is that marker.
+ALTER TABLE baseline_corpus_state
+    ADD COLUMN IF NOT EXISTS story_finalized_through TIMESTAMPTZ;

--- a/src/__tests__/lib/triage/story/correlator.test.ts
+++ b/src/__tests__/lib/triage/story/correlator.test.ts
@@ -236,21 +236,30 @@ describe("runStepF — first-tick / NULL watermark", () => {
     });
     expect(result.storiesInserted).toBe(1);
 
-    // The member-scan SELECT omits the lower-bound predicate
+    // The member-scan SELECTs omit the lower-bound predicate
     // entirely on the first tick — only the upper bound
-    // (new_horizon = pageMax - slop) is bound. After R1's per-rule
-    // SQL push-down (Story RFC §3.R1, §5), the second positional
-    // parameter is the critical-category array (R1) or the
-    // critical-selector array (R3); the time bound stays $1.
+    // (new_horizon = pageMax - slop) is bound. R3 runs as two
+    // phases (candidate-asset GROUP BY → per-asset member read);
+    // R1 stays a single SELECT. Every member-scan SELECT must
+    // share the same upper-bound parameter.
     const scanQueries = h.queries.filter((q) =>
       q.sql.includes("FROM baseline_triaged_event"),
     );
-    expect(scanQueries).toHaveLength(2); // R1 + R3
+    expect(scanQueries).toHaveLength(3); // R1 + R3 phase 1 + R3 phase 2
     for (const q of scanQueries) {
-      expect(q.sql).not.toMatch(/event_time >= \$1/);
+      expect(q.sql).not.toMatch(/event_time >= /);
       expect(q.params?.[0]).toEqual(new Date(pageMax.getTime() - SLOP_MS));
-      expect(q.params).toHaveLength(2);
     }
+    const r1Scan = scanQueries.find((q) => q.sql.includes("category = ANY"));
+    const r3Phase1 = scanQueries.find(
+      (q) =>
+        q.sql.includes("GROUP BY orig_addr") &&
+        q.sql.includes("HAVING COUNT(*) >= 3"),
+    );
+    const r3Phase2 = scanQueries.find((q) => q.sql.includes("orig_addr = ANY"));
+    expect(r1Scan?.params).toHaveLength(2);
+    expect(r3Phase1?.params).toHaveLength(2);
+    expect(r3Phase2?.params).toHaveLength(3);
   });
 
   it("first-tick historical catch-up: rows older than pageMin are still candidates", async () => {
@@ -342,17 +351,17 @@ describe("runStepF — slop-replay member lookback", () => {
     });
     expect(result.storiesInserted).toBe(1);
 
-    // The member-scan SELECTs (one per rule, after the §3 / §5
-    // SQL push-down) used previousWatermark − 1h as the lower
-    // bound (MAX_RULE_WINDOW_MS) and new_horizon (pageMax − slop)
-    // as the upper bound. Events in the slop window
-    // `(new_horizon, pageMax]` are intentionally excluded — they
-    // cannot finalize this tick anyway and become visible on the
-    // next tick via the lookback range.
+    // The member-scan SELECTs (R1 single SELECT + R3 two-phase
+    // SELECT after the §3 / §5 per-asset push-down) used
+    // previousWatermark − 1h as the lower bound (MAX_RULE_WINDOW_MS)
+    // and new_horizon (pageMax − slop) as the upper bound. Events
+    // in the slop window `(new_horizon, pageMax]` are intentionally
+    // excluded — they cannot finalize this tick anyway and become
+    // visible on the next tick via the lookback range.
     const scanQueries = h.queries.filter((q) =>
       q.sql.includes("FROM baseline_triaged_event"),
     );
-    expect(scanQueries).toHaveLength(2); // R1 + R3
+    expect(scanQueries).toHaveLength(3); // R1 + R3 phase 1 + R3 phase 2
     const expectedLower = new Date(
       previousWatermark.getTime() - 60 * 60 * 1000,
     );
@@ -361,17 +370,30 @@ describe("runStepF — slop-replay member lookback", () => {
       expect(q.params?.[0]).toEqual(expectedLower);
       expect(q.params?.[1]).toEqual(expectedUpper);
     }
-    // R3's read pushes `selector_tags && $::text[]` into SQL so
-    // the issue's measurement-gate `EXPLAIN ANALYZE` runs against
-    // the actual production shape. R1's read pushes
-    // `category = ANY($::text[])` for the same reason.
-    const r3Scan = scanQueries.find((q) => q.sql.includes("selector_tags &&"));
+    // R1's read pushes `category = ANY($::text[])` into SQL.
+    // R3's read pushes `selector_tags && $::text[]` and then a
+    // per-asset `orig_addr = ANY($::inet[])` phase-2 SELECT — the
+    // shape the issue's measurement-gate `EXPLAIN ANALYZE`
+    // validates against the `orig_addr` GiST index path.
     const r1Scan = scanQueries.find((q) => q.sql.includes("category = ANY"));
+    const r3Phase1 = scanQueries.find(
+      (q) =>
+        q.sql.includes("GROUP BY orig_addr") &&
+        q.sql.includes("HAVING COUNT(*) >= 3"),
+    );
+    const r3Phase2 = scanQueries.find((q) => q.sql.includes("orig_addr = ANY"));
     expect(r1Scan).toBeDefined();
-    expect(r3Scan).toBeDefined();
+    expect(r3Phase1).toBeDefined();
+    expect(r3Phase2).toBeDefined();
     expect(r1Scan?.sql).toMatch(/orig_addr IS NOT NULL/);
-    expect(r3Scan?.sql).toMatch(/orig_addr IS NOT NULL/);
-    expect(r3Scan?.params?.[2]).toEqual(
+    expect(r3Phase1?.sql).toMatch(/orig_addr IS NOT NULL/);
+    expect(r3Phase1?.sql).toMatch(/selector_tags && \$3::text\[\]/);
+    expect(r3Phase2?.sql).toMatch(/orig_addr = ANY\(\$3::inet\[\]\)/);
+    expect(r3Phase2?.sql).toMatch(/selector_tags && \$4::text\[\]/);
+    expect(r3Phase1?.params?.[2]).toEqual(
+      expect.arrayContaining(["S2-severe", "unlabeled-cluster"]),
+    );
+    expect(r3Phase2?.params?.[3]).toEqual(
       expect.arrayContaining(["S2-severe", "unlabeled-cluster"]),
     );
   });

--- a/src/__tests__/lib/triage/story/correlator.test.ts
+++ b/src/__tests__/lib/triage/story/correlator.test.ts
@@ -1,0 +1,462 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runStepF } from "@/lib/triage/story/correlator";
+
+interface FakeRow {
+  event_key: string;
+  event_time: Date;
+  kind: string;
+  orig_addr: string | null;
+  category: string | null;
+  selector_tags: string[];
+  raw_score: number;
+}
+
+interface FakeClientHandles {
+  /** Rows the candidate-event SELECT returns. */
+  setCandidates: (rows: FakeRow[]) => void;
+  /** Current watermark value the singleton SELECT returns. */
+  setWatermark: (value: Date | null) => void;
+  /** Number of `event_group` INSERTs that returned a non-NULL id
+   *  (i.e., were not suppressed by the partial unique index). */
+  insertsMade: () => number;
+  /** Last value `advanceStoryWatermark` UPDATE was called with. */
+  lastWatermarkUpdate: () => Date | null;
+  /** Captured SQL log for assertions. */
+  queries: Array<{ sql: string; params: unknown[] | undefined }>;
+  client: unknown;
+  /** Force the next `event_group` INSERT to return zero rows
+   *  (simulating ON CONFLICT DO NOTHING suppressing the insert). */
+  suppressNextInsert: () => void;
+  /** Sequence of returned group ids — exposed for member-INSERT
+   *  assertions. */
+  groupIds: string[];
+}
+
+function makeClient(): FakeClientHandles {
+  let candidates: FakeRow[] = [];
+  let watermark: Date | null = null;
+  let nextGroupId = 1;
+  let suppressNext = false;
+  let inserts = 0;
+  let lastUpdate: Date | null = null;
+  const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  const groupIds: string[] = [];
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    queries.push({ sql, params });
+    if (sql.includes("FROM baseline_corpus_state")) {
+      return {
+        rows: [{ story_finalized_through: watermark }],
+        rowCount: 1,
+      };
+    }
+    if (sql.includes("FROM baseline_triaged_event")) {
+      return { rows: candidates, rowCount: candidates.length };
+    }
+    if (sql.includes("INSERT INTO event_group ")) {
+      if (suppressNext) {
+        suppressNext = false;
+        return { rows: [], rowCount: 0 };
+      }
+      const id = String(nextGroupId);
+      nextGroupId += 1;
+      inserts += 1;
+      groupIds.push(id);
+      return { rows: [{ id }], rowCount: 1 };
+    }
+    if (sql.includes("INSERT INTO event_group_member")) {
+      return { rows: [], rowCount: (params?.length ?? 0) / 3 };
+    }
+    if (sql.includes("UPDATE baseline_corpus_state")) {
+      lastUpdate = (params?.[0] as Date) ?? null;
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return {
+    setCandidates: (rows) => {
+      candidates = rows;
+    },
+    setWatermark: (value) => {
+      watermark = value;
+    },
+    insertsMade: () => inserts,
+    lastWatermarkUpdate: () => lastUpdate,
+    queries,
+    client: { query },
+    suppressNextInsert: () => {
+      suppressNext = true;
+    },
+    groupIds,
+  };
+}
+
+const SLOP_MS = 30 * 60 * 1000;
+
+describe("runStepF — empty page no-op", () => {
+  it("does NOT advance the watermark when the page has zero survivors", async () => {
+    const h = makeClient();
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: null,
+    });
+    expect(result).toEqual({ storiesInserted: 0, newWatermark: null });
+    // No UPDATE issued, no SELECT issued.
+    expect(h.queries).toEqual([]);
+  });
+});
+
+describe("runStepF — slop window finalization filter", () => {
+  it("does not finalize a draft whose time_window_end falls within the last 30 minutes of the page", async () => {
+    const pageMax = new Date("2026-05-09T13:00:00Z");
+    const pageMin = new Date("2026-05-09T12:00:00Z");
+    const h = makeClient();
+    // Build an R3 cluster whose end (12:55) sits inside the last
+    // 30 minutes of the page (12:30..13:00), so it must NOT
+    // finalize this tick.
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T12:50:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T12:53:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "3",
+        event_time: new Date("2026-05-09T12:55:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["unlabeled-cluster"],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(0);
+    expect(h.insertsMade()).toBe(0);
+    // Watermark still advances even when no Stories finalize.
+    expect(h.lastWatermarkUpdate()).toEqual(
+      new Date(pageMax.getTime() - SLOP_MS),
+    );
+    expect(result.newWatermark).toEqual(new Date(pageMax.getTime() - SLOP_MS));
+  });
+
+  it("DOES finalize when the cluster end is at-or-before new_horizon", async () => {
+    const pageMax = new Date("2026-05-09T13:00:00Z");
+    const pageMin = new Date("2026-05-09T10:00:00Z");
+    const h = makeClient();
+    // Cluster end 12:30:00 = new_horizon exactly. The filter is
+    // `endMs <= newHorizonMs`, so this finalizes.
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T11:50:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T12:00:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "3",
+        event_time: new Date("2026-05-09T12:30:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(1);
+    expect(h.insertsMade()).toBe(1);
+  });
+});
+
+describe("runStepF — first-tick / NULL watermark", () => {
+  it("uses pageEventTimeRange.min as the member-scan lower bound (no corpus_activated_at floor)", async () => {
+    const pageMax = new Date("2026-05-09T13:00:00Z");
+    const pageMin = new Date("2026-05-09T10:00:00Z");
+    const h = makeClient();
+    // No previous watermark, so the scan lower bound is the
+    // page's own `event_time.min`. The corpus_activated_at column
+    // is never consulted.
+    h.setWatermark(null);
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T11:00:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "INITIAL_ACCESS",
+        selector_tags: [],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T11:05:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "COMMAND_AND_CONTROL",
+        selector_tags: [],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(1);
+
+    // The member-scan SELECT used pageMin as its lower bound.
+    const scanQuery = h.queries.find((q) =>
+      q.sql.includes("FROM baseline_triaged_event"),
+    );
+    expect(scanQuery?.params?.[0]).toEqual(pageMin);
+    expect(scanQuery?.params?.[1]).toEqual(pageMax);
+  });
+});
+
+describe("runStepF — slop-replay member lookback", () => {
+  it("scans [previous_watermark − max_rule_window, page_max] so cross-watermark members are included", async () => {
+    const pageMax = new Date("2026-05-09T15:00:00Z");
+    const pageMin = new Date("2026-05-09T13:30:00Z");
+    const previousWatermark = new Date("2026-05-09T13:30:00Z");
+    const h = makeClient();
+    h.setWatermark(previousWatermark);
+    // The R3 cluster's last member sits at previous_watermark + ε,
+    // earlier members sit at previous_watermark − 50 min (inside
+    // the 1-hour rule window). A regression that scans only from
+    // previous_watermark onward would miss the earlier members
+    // and the cluster would have member_count = 1 < 3.
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T12:40:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T12:45:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "3",
+        event_time: new Date("2026-05-09T13:31:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(1);
+
+    // The member-scan SELECT used previousWatermark − 1h as its
+    // lower bound (MAX_RULE_WINDOW_MS).
+    const scanQuery = h.queries.find((q) =>
+      q.sql.includes("FROM baseline_triaged_event"),
+    );
+    const expectedLower = new Date(
+      previousWatermark.getTime() - 60 * 60 * 1000,
+    );
+    expect(scanQuery?.params?.[0]).toEqual(expectedLower);
+  });
+
+  it("skips drafts whose time_window_end is already past on the previous watermark", async () => {
+    // The cluster's end falls at-or-before the previous watermark,
+    // so it was already finalized on a prior tick. The correlator
+    // must NOT re-insert.
+    const previousWatermark = new Date("2026-05-09T14:00:00Z");
+    const pageMax = new Date("2026-05-09T15:00:00Z");
+    const pageMin = new Date("2026-05-09T13:00:00Z");
+    const h = makeClient();
+    h.setWatermark(previousWatermark);
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T13:10:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T13:30:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "3",
+        event_time: new Date("2026-05-09T13:55:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "IMPACT",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(0);
+    expect(h.insertsMade()).toBe(0);
+  });
+});
+
+describe("runStepF — idempotency", () => {
+  it("ON CONFLICT DO NOTHING — a suppressed event_group INSERT does not count as a new story", async () => {
+    const pageMax = new Date("2026-05-09T13:00:00Z");
+    const pageMin = new Date("2026-05-09T11:00:00Z");
+    const h = makeClient();
+    h.suppressNextInsert();
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T12:00:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "INITIAL_ACCESS",
+        selector_tags: [],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T12:05:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "COMMAND_AND_CONTROL",
+        selector_tags: [],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(0);
+  });
+});
+
+describe("runStepF — summary_payload contract", () => {
+  it("the INSERTed summary_payload carries every fixed key from §7", async () => {
+    const pageMax = new Date("2026-05-09T13:00:00Z");
+    const pageMin = new Date("2026-05-09T11:00:00Z");
+    const h = makeClient();
+    h.setCandidates([
+      {
+        event_key: "1",
+        event_time: new Date("2026-05-09T12:00:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "INITIAL_ACCESS",
+        selector_tags: ["S2-severe"],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "2",
+        event_time: new Date("2026-05-09T12:05:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "COMMAND_AND_CONTROL",
+        selector_tags: [],
+        raw_score: 2.0,
+      },
+    ]);
+    await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    const insert = h.queries.find((q) =>
+      q.sql.includes("INSERT INTO event_group "),
+    );
+    expect(insert).toBeDefined();
+    // summary_payload is the last positional parameter on the
+    // INSERT (param $7).
+    const summaryJson = insert?.params?.[6] as string;
+    const summary = JSON.parse(summaryJson);
+    expect(Object.keys(summary).sort()).toEqual([
+      "categoryHistogram",
+      "distinctAssetCount",
+      "durationMs",
+      "kindHistogram",
+      "memberCount",
+      "topRawScore",
+    ]);
+    expect(summary.memberCount).toBe(2);
+    expect(summary.distinctAssetCount).toBe(1);
+    expect(summary.topRawScore).toBe(2.0);
+  });
+});
+
+describe("runStepF — abort signal", () => {
+  it("throws if the signal was aborted before evaluation", async () => {
+    const h = makeClient();
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      runStepF({
+        // biome-ignore lint/suspicious/noExplicitAny: fake test client
+        client: h.client as any,
+        pageEventTimeRange: {
+          min: new Date("2026-05-09T11:00:00Z"),
+          max: new Date("2026-05-09T13:00:00Z"),
+        },
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+});

--- a/src/__tests__/lib/triage/story/correlator.test.ts
+++ b/src/__tests__/lib/triage/story/correlator.test.ts
@@ -238,15 +238,19 @@ describe("runStepF — first-tick / NULL watermark", () => {
 
     // The member-scan SELECT omits the lower-bound predicate
     // entirely on the first tick — only the upper bound
-    // (new_horizon = pageMax - slop) is bound.
-    const scanQuery = h.queries.find((q) =>
+    // (new_horizon = pageMax - slop) is bound. After R1's per-rule
+    // SQL push-down (Story RFC §3.R1, §5), the second positional
+    // parameter is the critical-category array (R1) or the
+    // critical-selector array (R3); the time bound stays $1.
+    const scanQueries = h.queries.filter((q) =>
       q.sql.includes("FROM baseline_triaged_event"),
     );
-    expect(scanQuery?.sql).not.toMatch(/event_time >= \$1/);
-    expect(scanQuery?.params?.[0]).toEqual(
-      new Date(pageMax.getTime() - SLOP_MS),
-    );
-    expect(scanQuery?.params).toHaveLength(1);
+    expect(scanQueries).toHaveLength(2); // R1 + R3
+    for (const q of scanQueries) {
+      expect(q.sql).not.toMatch(/event_time >= \$1/);
+      expect(q.params?.[0]).toEqual(new Date(pageMax.getTime() - SLOP_MS));
+      expect(q.params).toHaveLength(2);
+    }
   });
 
   it("first-tick historical catch-up: rows older than pageMin are still candidates", async () => {
@@ -338,21 +342,38 @@ describe("runStepF — slop-replay member lookback", () => {
     });
     expect(result.storiesInserted).toBe(1);
 
-    // The member-scan SELECT used previousWatermark − 1h as its
-    // lower bound (MAX_RULE_WINDOW_MS) and new_horizon (pageMax −
-    // slop) as its upper bound. Events in the slop window
+    // The member-scan SELECTs (one per rule, after the §3 / §5
+    // SQL push-down) used previousWatermark − 1h as the lower
+    // bound (MAX_RULE_WINDOW_MS) and new_horizon (pageMax − slop)
+    // as the upper bound. Events in the slop window
     // `(new_horizon, pageMax]` are intentionally excluded — they
     // cannot finalize this tick anyway and become visible on the
     // next tick via the lookback range.
-    const scanQuery = h.queries.find((q) =>
+    const scanQueries = h.queries.filter((q) =>
       q.sql.includes("FROM baseline_triaged_event"),
     );
+    expect(scanQueries).toHaveLength(2); // R1 + R3
     const expectedLower = new Date(
       previousWatermark.getTime() - 60 * 60 * 1000,
     );
     const expectedUpper = new Date(pageMax.getTime() - SLOP_MS);
-    expect(scanQuery?.params?.[0]).toEqual(expectedLower);
-    expect(scanQuery?.params?.[1]).toEqual(expectedUpper);
+    for (const q of scanQueries) {
+      expect(q.params?.[0]).toEqual(expectedLower);
+      expect(q.params?.[1]).toEqual(expectedUpper);
+    }
+    // R3's read pushes `selector_tags && $::text[]` into SQL so
+    // the issue's measurement-gate `EXPLAIN ANALYZE` runs against
+    // the actual production shape. R1's read pushes
+    // `category = ANY($::text[])` for the same reason.
+    const r3Scan = scanQueries.find((q) => q.sql.includes("selector_tags &&"));
+    const r1Scan = scanQueries.find((q) => q.sql.includes("category = ANY"));
+    expect(r1Scan).toBeDefined();
+    expect(r3Scan).toBeDefined();
+    expect(r1Scan?.sql).toMatch(/orig_addr IS NOT NULL/);
+    expect(r3Scan?.sql).toMatch(/orig_addr IS NOT NULL/);
+    expect(r3Scan?.params?.[2]).toEqual(
+      expect.arrayContaining(["S2-severe", "unlabeled-cluster"]),
+    );
   });
 
   it("skips drafts whose time_window_end is already past on the previous watermark", async () => {

--- a/src/__tests__/lib/triage/story/correlator.test.ts
+++ b/src/__tests__/lib/triage/story/correlator.test.ts
@@ -204,13 +204,10 @@ describe("runStepF — slop window finalization filter", () => {
 });
 
 describe("runStepF — first-tick / NULL watermark", () => {
-  it("uses pageEventTimeRange.min as the member-scan lower bound (no corpus_activated_at floor)", async () => {
+  it("scans (-∞, new_horizon] — no event-time lower bound at all (no page-min floor, no corpus_activated_at floor)", async () => {
     const pageMax = new Date("2026-05-09T13:00:00Z");
     const pageMin = new Date("2026-05-09T10:00:00Z");
     const h = makeClient();
-    // No previous watermark, so the scan lower bound is the
-    // page's own `event_time.min`. The corpus_activated_at column
-    // is never consulted.
     h.setWatermark(null);
     h.setCandidates([
       {
@@ -239,17 +236,62 @@ describe("runStepF — first-tick / NULL watermark", () => {
     });
     expect(result.storiesInserted).toBe(1);
 
-    // The member-scan SELECT used pageMin as its lower bound.
+    // The member-scan SELECT omits the lower-bound predicate
+    // entirely on the first tick — only the upper bound
+    // (new_horizon = pageMax - slop) is bound.
     const scanQuery = h.queries.find((q) =>
       q.sql.includes("FROM baseline_triaged_event"),
     );
-    expect(scanQuery?.params?.[0]).toEqual(pageMin);
-    expect(scanQuery?.params?.[1]).toEqual(pageMax);
+    expect(scanQuery?.sql).not.toMatch(/event_time >= \$1/);
+    expect(scanQuery?.params?.[0]).toEqual(
+      new Date(pageMax.getTime() - SLOP_MS),
+    );
+    expect(scanQuery?.params).toHaveLength(1);
+  });
+
+  it("first-tick historical catch-up: rows older than pageMin are still candidates", async () => {
+    // Regression for the page-min floor bug: a tenant with
+    // pre-existing baseline_triaged_event rows (e.g., cadence
+    // started before migration 0008 landed) carries rows older
+    // than the current page's min. They must be visible on the
+    // first tick — otherwise the watermark advances past them and
+    // they are never considered for finalization again.
+    const pageMax = new Date("2026-05-09T13:00:00Z");
+    const pageMin = new Date("2026-05-09T12:00:00Z");
+    const h = makeClient();
+    h.setWatermark(null);
+    h.setCandidates([
+      {
+        // Older than pageMin: must still feed the predicate.
+        event_key: "old-1",
+        event_time: new Date("2026-05-09T11:00:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "INITIAL_ACCESS",
+        selector_tags: [],
+        raw_score: 1.5,
+      },
+      {
+        event_key: "old-2",
+        event_time: new Date("2026-05-09T11:05:00Z"),
+        kind: "HttpThreat",
+        orig_addr: "10.0.0.5",
+        category: "COMMAND_AND_CONTROL",
+        selector_tags: [],
+        raw_score: 1.5,
+      },
+    ]);
+    const result = await runStepF({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      pageEventTimeRange: { min: pageMin, max: pageMax },
+    });
+    expect(result.storiesInserted).toBe(1);
   });
 });
 
 describe("runStepF — slop-replay member lookback", () => {
-  it("scans [previous_watermark − max_rule_window, page_max] so cross-watermark members are included", async () => {
+  it("scans [previous_watermark − max_rule_window, new_horizon] so cross-watermark members are included", async () => {
     const pageMax = new Date("2026-05-09T15:00:00Z");
     const pageMin = new Date("2026-05-09T13:30:00Z");
     const previousWatermark = new Date("2026-05-09T13:30:00Z");
@@ -297,14 +339,20 @@ describe("runStepF — slop-replay member lookback", () => {
     expect(result.storiesInserted).toBe(1);
 
     // The member-scan SELECT used previousWatermark − 1h as its
-    // lower bound (MAX_RULE_WINDOW_MS).
+    // lower bound (MAX_RULE_WINDOW_MS) and new_horizon (pageMax −
+    // slop) as its upper bound. Events in the slop window
+    // `(new_horizon, pageMax]` are intentionally excluded — they
+    // cannot finalize this tick anyway and become visible on the
+    // next tick via the lookback range.
     const scanQuery = h.queries.find((q) =>
       q.sql.includes("FROM baseline_triaged_event"),
     );
     const expectedLower = new Date(
       previousWatermark.getTime() - 60 * 60 * 1000,
     );
+    const expectedUpper = new Date(pageMax.getTime() - SLOP_MS);
     expect(scanQuery?.params?.[0]).toEqual(expectedLower);
+    expect(scanQuery?.params?.[1]).toEqual(expectedUpper);
   });
 
   it("skips drafts whose time_window_end is already past on the previous watermark", async () => {

--- a/src/__tests__/lib/triage/story/repository.test.ts
+++ b/src/__tests__/lib/triage/story/repository.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { insertCuratedStory } from "@/lib/triage/story/repository";
+import type { CandidateEvent } from "@/lib/triage/story/rules";
+import { STORY_MEMBER_CAP } from "@/lib/triage/story/rules";
+
+function event(
+  partial: Omit<Partial<CandidateEvent>, "eventTime"> & {
+    eventKey: string;
+    eventTime: string;
+  },
+): CandidateEvent {
+  const { eventTime, ...rest } = partial;
+  return {
+    kind: "HttpThreat",
+    origAddr: "10.0.0.5",
+    category: null,
+    selectorTags: [],
+    rawScore: 0,
+    ...rest,
+    eventTime: new Date(eventTime),
+  };
+}
+
+interface FakeHandles {
+  client: unknown;
+  queries: Array<{ sql: string; params: unknown[] | undefined }>;
+}
+
+function makeClient(): FakeHandles {
+  let nextGroupId = 1;
+  const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    queries.push({ sql, params });
+    if (sql.includes("INSERT INTO event_group ")) {
+      const id = String(nextGroupId);
+      nextGroupId += 1;
+      return { rows: [{ id }], rowCount: 1 };
+    }
+    if (sql.includes("INSERT INTO event_group_member")) {
+      return { rows: [], rowCount: (params?.length ?? 0) / 3 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return { client: { query }, queries };
+}
+
+describe("insertCuratedStory", () => {
+  it("writes kind = 'analyst_curated' with NULL correlation_rule_id and no ON CONFLICT clause", async () => {
+    const h = makeClient();
+    await insertCuratedStory(
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      h.client as any,
+      {
+        primaryAsset: "10.0.0.5",
+        timeWindowStart: new Date("2026-05-09T12:00:00Z"),
+        timeWindowEnd: new Date("2026-05-09T12:30:00Z"),
+        members: [
+          event({
+            eventKey: "1",
+            eventTime: "2026-05-09T12:00:00Z",
+            category: "IMPACT",
+          }),
+          event({
+            eventKey: "2",
+            eventTime: "2026-05-09T12:30:00Z",
+            category: "EXFILTRATION",
+          }),
+        ],
+      },
+    );
+    const insertGroup = h.queries.find((q) =>
+      q.sql.includes("INSERT INTO event_group "),
+    );
+    expect(insertGroup).toBeDefined();
+    // Curated rows skip the partial unique-index dedup (scoped to
+    // kind = 'auto_correlated'), so the INSERT must NOT carry an
+    // ON CONFLICT clause that would suppress legitimate repeat
+    // saves on the same (asset, window).
+    expect(insertGroup?.sql).not.toMatch(/ON CONFLICT/);
+    expect(insertGroup?.sql).toContain("'analyst_curated'");
+    // correlation_rule_id is a literal NULL in the VALUES clause
+    // (curated rows have no rule), not a bound parameter.
+    expect(insertGroup?.sql).toMatch(/'analyst_curated',\s*NULL/);
+  });
+
+  it("populates the §7 fixed-key summary_payload from members", async () => {
+    const h = makeClient();
+    await insertCuratedStory(
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      h.client as any,
+      {
+        primaryAsset: "10.0.0.5",
+        timeWindowStart: new Date("2026-05-09T12:00:00Z"),
+        timeWindowEnd: new Date("2026-05-09T12:30:00Z"),
+        members: [
+          event({
+            eventKey: "1",
+            eventTime: "2026-05-09T12:00:00Z",
+            kind: "HttpThreat",
+            category: "IMPACT",
+            rawScore: 1.5,
+            selectorTags: ["S2-severe"],
+          }),
+          event({
+            eventKey: "2",
+            eventTime: "2026-05-09T12:30:00Z",
+            kind: "DnsCovertChannel",
+            category: "EXFILTRATION",
+            rawScore: 2.5,
+            selectorTags: [],
+          }),
+        ],
+      },
+    );
+    const insertGroup = h.queries.find((q) =>
+      q.sql.includes("INSERT INTO event_group "),
+    );
+    // summary_payload is the last positional parameter on the
+    // curated INSERT (param $6 — STORY_VERSION, start, end, asset,
+    // score, summary).
+    const summaryJson = insertGroup?.params?.[5] as string;
+    const summary = JSON.parse(summaryJson);
+    expect(Object.keys(summary).sort()).toEqual([
+      "categoryHistogram",
+      "distinctAssetCount",
+      "durationMs",
+      "kindHistogram",
+      "memberCount",
+      "topRawScore",
+    ]);
+    expect(summary.memberCount).toBe(2);
+    expect(summary.topRawScore).toBe(2.5);
+  });
+
+  it("enforces the §8 member cap (curated saves cannot exceed STORY_MEMBER_CAP)", async () => {
+    const h = makeClient();
+    const members: CandidateEvent[] = [];
+    for (let i = 0; i < STORY_MEMBER_CAP + 10; i += 1) {
+      members.push(
+        event({
+          eventKey: String(1000 + i),
+          eventTime: `2026-05-09T12:${String(i % 60).padStart(2, "0")}:00Z`,
+        }),
+      );
+    }
+    await insertCuratedStory(
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      h.client as any,
+      {
+        primaryAsset: "10.0.0.5",
+        timeWindowStart: new Date("2026-05-09T12:00:00Z"),
+        timeWindowEnd: new Date("2026-05-09T13:00:00Z"),
+        members,
+      },
+    );
+    const insertMembers = h.queries.find((q) =>
+      q.sql.includes("INSERT INTO event_group_member"),
+    );
+    // 3 params per member row.
+    expect((insertMembers?.params?.length ?? 0) / 3).toBe(STORY_MEMBER_CAP);
+    const insertGroup = h.queries.find((q) =>
+      q.sql.includes("INSERT INTO event_group "),
+    );
+    const summary = JSON.parse(insertGroup?.params?.[5] as string);
+    expect(summary.memberCount).toBe(STORY_MEMBER_CAP);
+  });
+
+  it("accepts a NULL primary_asset (analyst curated rows are not subject to the partial-index NULL exclusion)", async () => {
+    const h = makeClient();
+    await expect(
+      insertCuratedStory(
+        // biome-ignore lint/suspicious/noExplicitAny: fake test client
+        h.client as any,
+        {
+          primaryAsset: null,
+          timeWindowStart: new Date("2026-05-09T12:00:00Z"),
+          timeWindowEnd: new Date("2026-05-09T12:30:00Z"),
+          members: [
+            event({
+              eventKey: "1",
+              eventTime: "2026-05-09T12:00:00Z",
+              origAddr: null,
+              category: "IMPACT",
+            }),
+          ],
+        },
+      ),
+    ).resolves.toEqual({ groupId: "1" });
+  });
+});

--- a/src/__tests__/lib/triage/story/repository.test.ts
+++ b/src/__tests__/lib/triage/story/repository.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-
-import { insertCuratedStory } from "@/lib/triage/story/repository";
+import { CRITICAL_CATEGORIES } from "@/lib/triage/baseline/categories";
+import {
+  insertCuratedStory,
+  readR1Candidates,
+  readR3Candidates,
+} from "@/lib/triage/story/repository";
 import type { CandidateEvent } from "@/lib/triage/story/rules";
 import { STORY_MEMBER_CAP } from "@/lib/triage/story/rules";
 
@@ -165,7 +169,118 @@ describe("insertCuratedStory", () => {
     const summary = JSON.parse(insertGroup?.params?.[5] as string);
     expect(summary.memberCount).toBe(STORY_MEMBER_CAP);
   });
+});
 
+describe("readR1Candidates — SQL push-down for measurement gate", () => {
+  function makeReadClient(): {
+    client: unknown;
+    queries: Array<{ sql: string; params: unknown[] | undefined }>;
+  } {
+    const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    });
+    return { client: { query }, queries };
+  }
+
+  it("pushes orig_addr IS NOT NULL and category = ANY into SQL with a [start, end] range", async () => {
+    const h = makeReadClient();
+    const start = new Date("2026-05-09T11:00:00Z");
+    const end = new Date("2026-05-09T13:00:00Z");
+    await readR1Candidates({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      memberScanStart: start,
+      memberScanEnd: end,
+    });
+    expect(h.queries).toHaveLength(1);
+    const q = h.queries[0];
+    expect(q.sql).toMatch(/event_time >= \$1/);
+    expect(q.sql).toMatch(/event_time <= \$2/);
+    expect(q.sql).toMatch(/orig_addr IS NOT NULL/);
+    expect(q.sql).toMatch(/category = ANY\(\$3::text\[\]\)/);
+    expect(q.params?.[0]).toEqual(start);
+    expect(q.params?.[1]).toEqual(end);
+    expect(q.params?.[2]).toEqual(
+      expect.arrayContaining(Array.from(CRITICAL_CATEGORIES)),
+    );
+  });
+
+  it("omits the lower bound on first tick (memberScanStart === null)", async () => {
+    const h = makeReadClient();
+    const end = new Date("2026-05-09T13:00:00Z");
+    await readR1Candidates({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      memberScanStart: null,
+      memberScanEnd: end,
+    });
+    const q = h.queries[0];
+    expect(q.sql).not.toMatch(/event_time >= /);
+    expect(q.sql).toMatch(/event_time <= \$1/);
+    expect(q.sql).toMatch(/category = ANY\(\$2::text\[\]\)/);
+    expect(q.params).toHaveLength(2);
+  });
+});
+
+describe("readR3Candidates — SQL push-down for measurement gate", () => {
+  function makeReadClient(): {
+    client: unknown;
+    queries: Array<{ sql: string; params: unknown[] | undefined }>;
+  } {
+    const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      return { rows: [], rowCount: 0 };
+    });
+    return { client: { query }, queries };
+  }
+
+  it("pushes orig_addr IS NOT NULL and selector_tags && ARRAY[...] into SQL with a [start, end] range", async () => {
+    // The R3 measurement gate from the issue specifically requires
+    // EXPLAIN ANALYZE on the `selector_tags && ARRAY[...]` overlap
+    // shape. Without the SQL push-down, the broad-range SELECT has
+    // nothing R3-specific for the planner to explain.
+    const h = makeReadClient();
+    const start = new Date("2026-05-09T11:00:00Z");
+    const end = new Date("2026-05-09T13:00:00Z");
+    await readR3Candidates({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      memberScanStart: start,
+      memberScanEnd: end,
+    });
+    const q = h.queries[0];
+    expect(q.sql).toMatch(/event_time >= \$1/);
+    expect(q.sql).toMatch(/event_time <= \$2/);
+    expect(q.sql).toMatch(/orig_addr IS NOT NULL/);
+    expect(q.sql).toMatch(/selector_tags && \$3::text\[\]/);
+    expect(q.params?.[0]).toEqual(start);
+    expect(q.params?.[1]).toEqual(end);
+    expect(q.params?.[2]).toEqual(
+      expect.arrayContaining(["S2-severe", "unlabeled-cluster"]),
+    );
+  });
+
+  it("omits the lower bound on first tick (memberScanStart === null)", async () => {
+    const h = makeReadClient();
+    const end = new Date("2026-05-09T13:00:00Z");
+    await readR3Candidates({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      memberScanStart: null,
+      memberScanEnd: end,
+    });
+    const q = h.queries[0];
+    expect(q.sql).not.toMatch(/event_time >= /);
+    expect(q.sql).toMatch(/event_time <= \$1/);
+    expect(q.sql).toMatch(/selector_tags && \$2::text\[\]/);
+    expect(q.params).toHaveLength(2);
+  });
+});
+
+describe("insertCuratedStory — primary_asset NULL", () => {
   it("accepts a NULL primary_asset (analyst curated rows are not subject to the partial-index NULL exclusion)", async () => {
     const h = makeClient();
     await expect(

--- a/src/__tests__/lib/triage/story/repository.test.ts
+++ b/src/__tests__/lib/triage/story/repository.test.ts
@@ -224,24 +224,38 @@ describe("readR1Candidates — SQL push-down for measurement gate", () => {
   });
 });
 
-describe("readR3Candidates — SQL push-down for measurement gate", () => {
-  function makeReadClient(): {
+describe("readR3Candidates — two-phase per-asset access for measurement gate", () => {
+  // The R3 measurement gate from the issue specifically requires
+  // EXPLAIN ANALYZE on the same-asset-1h scan, confirming use of
+  // the `orig_addr` GiST index. The implementation is two phases:
+  //   phase 1 — `GROUP BY orig_addr HAVING COUNT(*) >= 3` to
+  //             pre-aggregate candidate assets;
+  //   phase 2 — `orig_addr = ANY($::inet[])` per-asset row read,
+  //             which the planner can resolve via the GiST index.
+  function makeReadClient(opts?: {
+    phase1Rows?: Array<{ orig_addr: string }>;
+  }): {
     client: unknown;
     queries: Array<{ sql: string; params: unknown[] | undefined }>;
   } {
     const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+    let queryIdx = 0;
     const query = vi.fn(async (sql: string, params?: unknown[]) => {
       queries.push({ sql, params });
+      const idx = queryIdx;
+      queryIdx += 1;
+      // First call is phase 1 (candidate-asset aggregate). Returning
+      // a non-empty rows array triggers the phase 2 SELECT in the
+      // implementation; an empty array short-circuits.
+      if (idx === 0 && opts?.phase1Rows) {
+        return { rows: opts.phase1Rows, rowCount: opts.phase1Rows.length };
+      }
       return { rows: [], rowCount: 0 };
     });
     return { client: { query }, queries };
   }
 
-  it("pushes orig_addr IS NOT NULL and selector_tags && ARRAY[...] into SQL with a [start, end] range", async () => {
-    // The R3 measurement gate from the issue specifically requires
-    // EXPLAIN ANALYZE on the `selector_tags && ARRAY[...]` overlap
-    // shape. Without the SQL push-down, the broad-range SELECT has
-    // nothing R3-specific for the planner to explain.
+  it("phase 1: pre-aggregates candidate assets with GROUP BY / HAVING COUNT(*) >= 3", async () => {
     const h = makeReadClient();
     const start = new Date("2026-05-09T11:00:00Z");
     const end = new Date("2026-05-09T13:00:00Z");
@@ -251,20 +265,64 @@ describe("readR3Candidates — SQL push-down for measurement gate", () => {
       memberScanStart: start,
       memberScanEnd: end,
     });
-    const q = h.queries[0];
-    expect(q.sql).toMatch(/event_time >= \$1/);
-    expect(q.sql).toMatch(/event_time <= \$2/);
-    expect(q.sql).toMatch(/orig_addr IS NOT NULL/);
-    expect(q.sql).toMatch(/selector_tags && \$3::text\[\]/);
-    expect(q.params?.[0]).toEqual(start);
-    expect(q.params?.[1]).toEqual(end);
-    expect(q.params?.[2]).toEqual(
+    const phase1 = h.queries[0];
+    expect(phase1.sql).toMatch(/event_time >= \$1/);
+    expect(phase1.sql).toMatch(/event_time <= \$2/);
+    expect(phase1.sql).toMatch(/orig_addr IS NOT NULL/);
+    expect(phase1.sql).toMatch(/selector_tags && \$3::text\[\]/);
+    expect(phase1.sql).toMatch(/GROUP BY orig_addr/);
+    expect(phase1.sql).toMatch(/HAVING COUNT\(\*\) >= 3/);
+    expect(phase1.params?.[0]).toEqual(start);
+    expect(phase1.params?.[1]).toEqual(end);
+    expect(phase1.params?.[2]).toEqual(
       expect.arrayContaining(["S2-severe", "unlabeled-cluster"]),
     );
   });
 
-  it("omits the lower bound on first tick (memberScanStart === null)", async () => {
+  it("phase 2: per-asset member read uses orig_addr = ANY($::inet[]) (the measurement-gate target)", async () => {
+    const h = makeReadClient({
+      phase1Rows: [{ orig_addr: "10.0.0.5" }, { orig_addr: "10.0.0.7" }],
+    });
+    const start = new Date("2026-05-09T11:00:00Z");
+    const end = new Date("2026-05-09T13:00:00Z");
+    await readR3Candidates({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      memberScanStart: start,
+      memberScanEnd: end,
+    });
+    expect(h.queries).toHaveLength(2);
+    const phase2 = h.queries[1];
+    expect(phase2.sql).toMatch(/event_time >= \$1/);
+    expect(phase2.sql).toMatch(/event_time <= \$2/);
+    expect(phase2.sql).toMatch(/orig_addr = ANY\(\$3::inet\[\]\)/);
+    expect(phase2.sql).toMatch(/selector_tags && \$4::text\[\]/);
+    expect(phase2.params?.[0]).toEqual(start);
+    expect(phase2.params?.[1]).toEqual(end);
+    expect(phase2.params?.[2]).toEqual(["10.0.0.5", "10.0.0.7"]);
+    expect(phase2.params?.[3]).toEqual(
+      expect.arrayContaining(["S2-severe", "unlabeled-cluster"]),
+    );
+  });
+
+  it("phase 1 returns no candidate assets: phase 2 is skipped (no tenant-wide row materialization)", async () => {
     const h = makeReadClient();
+    const start = new Date("2026-05-09T11:00:00Z");
+    const end = new Date("2026-05-09T13:00:00Z");
+    const rows = await readR3Candidates({
+      // biome-ignore lint/suspicious/noExplicitAny: fake test client
+      client: h.client as any,
+      memberScanStart: start,
+      memberScanEnd: end,
+    });
+    expect(rows).toEqual([]);
+    expect(h.queries).toHaveLength(1);
+  });
+
+  it("omits the lower bound on first tick (memberScanStart === null) in both phases", async () => {
+    const h = makeReadClient({
+      phase1Rows: [{ orig_addr: "10.0.0.5" }],
+    });
     const end = new Date("2026-05-09T13:00:00Z");
     await readR3Candidates({
       // biome-ignore lint/suspicious/noExplicitAny: fake test client
@@ -272,11 +330,18 @@ describe("readR3Candidates — SQL push-down for measurement gate", () => {
       memberScanStart: null,
       memberScanEnd: end,
     });
-    const q = h.queries[0];
-    expect(q.sql).not.toMatch(/event_time >= /);
-    expect(q.sql).toMatch(/event_time <= \$1/);
-    expect(q.sql).toMatch(/selector_tags && \$2::text\[\]/);
-    expect(q.params).toHaveLength(2);
+    expect(h.queries).toHaveLength(2);
+    const phase1 = h.queries[0];
+    expect(phase1.sql).not.toMatch(/event_time >= /);
+    expect(phase1.sql).toMatch(/event_time <= \$1/);
+    expect(phase1.sql).toMatch(/selector_tags && \$2::text\[\]/);
+    expect(phase1.params).toHaveLength(2);
+    const phase2 = h.queries[1];
+    expect(phase2.sql).not.toMatch(/event_time >= /);
+    expect(phase2.sql).toMatch(/event_time <= \$1/);
+    expect(phase2.sql).toMatch(/orig_addr = ANY\(\$2::inet\[\]\)/);
+    expect(phase2.sql).toMatch(/selector_tags && \$3::text\[\]/);
+    expect(phase2.params).toHaveLength(3);
   });
 });
 

--- a/src/__tests__/lib/triage/story/rules.test.ts
+++ b/src/__tests__/lib/triage/story/rules.test.ts
@@ -135,6 +135,37 @@ describe("detectR1", () => {
     ]);
     expect(stories).toEqual([]);
   });
+
+  it("sliding-window: an R1 window starting inside a prior greedy bucket still fires", () => {
+    // Regression for the greedy-partition bug: events at 00:00 A,
+    // 00:09 A, 00:11 B contain a valid 10-minute window at
+    // [00:09, 00:11] with categories {A, B}. The greedy partition
+    // resets at 00:11 (because 00:11 − 00:00 = 11 min > 10 min)
+    // and produces buckets [00:00, 00:09] (only A) + [00:11]
+    // (only B), missing the valid {A, B} window.
+    const stories = detectR1([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T00:00:00Z",
+        category: "INITIAL_ACCESS",
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T00:09:00Z",
+        category: "INITIAL_ACCESS",
+      }),
+      event({
+        eventKey: "3",
+        eventTime: "2026-05-09T00:11:00Z",
+        category: "COMMAND_AND_CONTROL",
+      }),
+    ]);
+    expect(stories).toHaveLength(1);
+    const [s] = stories;
+    expect(s.members.map((m) => m.eventKey)).toEqual(["2", "3"]);
+    expect(s.timeWindowStart.toISOString()).toBe("2026-05-09T00:09:00.000Z");
+    expect(s.timeWindowEnd.toISOString()).toBe("2026-05-09T00:11:00.000Z");
+  });
 });
 
 describe("detectR3", () => {
@@ -226,6 +257,42 @@ describe("detectR3", () => {
       }),
     ]);
     expect(stories).toEqual([]);
+  });
+
+  it("sliding-window: a valid 1-hour window starting inside a prior greedy bucket still fires", () => {
+    // Regression for the greedy-partition bug: events at 00:00,
+    // 00:59, 01:01, 01:02 contain a valid 1-hour window at
+    // [00:59, 01:02] with 3 critical-selector hits. A greedy
+    // partition resets at 01:01 (because 01:01 − 00:00 = 61 min >
+    // 60 min) and produces buckets [00:00, 00:59] (size 2) +
+    // [01:01, 01:02] (size 2), missing the valid window.
+    const stories = detectR3([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T00:00:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T00:59:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "3",
+        eventTime: "2026-05-09T01:01:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "4",
+        eventTime: "2026-05-09T01:02:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+    ]);
+    expect(stories).toHaveLength(1);
+    const [s] = stories;
+    expect(s.members.map((m) => m.eventKey)).toEqual(["2", "3", "4"]);
+    expect(s.timeWindowStart.toISOString()).toBe("2026-05-09T00:59:00.000Z");
+    expect(s.timeWindowEnd.toISOString()).toBe("2026-05-09T01:02:00.000Z");
   });
 });
 

--- a/src/__tests__/lib/triage/story/rules.test.ts
+++ b/src/__tests__/lib/triage/story/rules.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyMemberCap,
+  buildSummaryPayload,
+  type CandidateEvent,
+  CRITICAL_SELECTOR_SET,
+  detectAllStories,
+  detectR1,
+  detectR3,
+  R1_LAMBDA,
+  STORY_MEMBER_CAP,
+} from "@/lib/triage/story/rules";
+
+function event(
+  partial: Omit<Partial<CandidateEvent>, "eventTime"> & {
+    eventKey: string;
+    eventTime: string;
+  },
+): CandidateEvent {
+  const { eventTime, ...rest } = partial;
+  return {
+    kind: "HttpThreat",
+    origAddr: "10.0.0.5",
+    category: null,
+    selectorTags: [],
+    rawScore: 0,
+    ...rest,
+    eventTime: new Date(eventTime),
+  };
+}
+
+describe("CRITICAL_SELECTOR_SET", () => {
+  it("matches the §3 v1 set verbatim — guards against an RFC 0001 rename", () => {
+    expect([...CRITICAL_SELECTOR_SET].sort()).toEqual([
+      "S2-severe",
+      "unlabeled-cluster",
+    ]);
+  });
+});
+
+describe("detectR1", () => {
+  it("fires when same asset has ≥2 distinct critical categories within 10 min", () => {
+    const stories = detectR1([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        category: "INITIAL_ACCESS",
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T12:03:00Z",
+        category: "COMMAND_AND_CONTROL",
+      }),
+      event({
+        eventKey: "3",
+        eventTime: "2026-05-09T12:06:00Z",
+        category: "COMMAND_AND_CONTROL",
+      }),
+    ]);
+    expect(stories).toHaveLength(1);
+    const [s] = stories;
+    expect(s.ruleId).toBe("R1");
+    expect(s.primaryAsset).toBe("10.0.0.5");
+    expect(s.members).toHaveLength(3);
+    expect(s.timeWindowStart.toISOString()).toBe("2026-05-09T12:00:00.000Z");
+    expect(s.timeWindowEnd.toISOString()).toBe("2026-05-09T12:06:00.000Z");
+    expect(s.score).toBe(3 + R1_LAMBDA * 2);
+  });
+
+  it("does not fire with only one critical category in the window", () => {
+    const stories = detectR1([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        category: "IMPACT",
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T12:05:00Z",
+        category: "IMPACT",
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+
+  it("skips events with NULL orig_addr (partial unique index requires non-NULL primary_asset)", () => {
+    const stories = detectR1([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        category: "INITIAL_ACCESS",
+        origAddr: null,
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T12:03:00Z",
+        category: "COMMAND_AND_CONTROL",
+        origAddr: null,
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+
+  it("ignores non-critical categories", () => {
+    // RECONNAISSANCE is NOT in CRITICAL_CATEGORIES, so it doesn't
+    // count toward the distinct-category cardinality.
+    const stories = detectR1([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        category: "INITIAL_ACCESS",
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T12:01:00Z",
+        category: "RECONNAISSANCE",
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+
+  it("does not fire when the second category falls outside the 10-min window", () => {
+    const stories = detectR1([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        category: "INITIAL_ACCESS",
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T12:11:00Z",
+        category: "COMMAND_AND_CONTROL",
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+});
+
+describe("detectR3", () => {
+  it("fires when same asset has ≥3 critical-selector events within 1 hour", () => {
+    const stories = detectR3([
+      event({
+        eventKey: "10",
+        eventTime: "2026-05-09T14:00:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "11",
+        eventTime: "2026-05-09T14:25:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "12",
+        eventTime: "2026-05-09T14:55:00Z",
+        selectorTags: ["unlabeled-cluster"],
+      }),
+    ]);
+    expect(stories).toHaveLength(1);
+    const [s] = stories;
+    expect(s.ruleId).toBe("R3");
+    expect(s.score).toBe(3);
+    expect(s.timeWindowStart.toISOString()).toBe("2026-05-09T14:00:00.000Z");
+    expect(s.timeWindowEnd.toISOString()).toBe("2026-05-09T14:55:00.000Z");
+  });
+
+  it("does not fire with only 2 critical-selector events", () => {
+    const stories = detectR3([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T14:00:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T14:05:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+
+  it("ignores events whose selector_tags do not overlap the critical set", () => {
+    // S3-recurring is in the §9 emission set but NOT in the v1
+    // critical-selector subset — frequency/correlation patterns
+    // are excluded from R3.
+    const stories = detectR3([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T14:00:00Z",
+        selectorTags: ["S3-recurring"],
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T14:05:00Z",
+        selectorTags: ["S3-recurring"],
+      }),
+      event({
+        eventKey: "3",
+        eventTime: "2026-05-09T14:10:00Z",
+        selectorTags: ["S3-recurring"],
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+
+  it("skips events with NULL orig_addr", () => {
+    const stories = detectR3([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T14:00:00Z",
+        selectorTags: ["S2-severe"],
+        origAddr: null,
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T14:05:00Z",
+        selectorTags: ["S2-severe"],
+        origAddr: null,
+      }),
+      event({
+        eventKey: "3",
+        eventTime: "2026-05-09T14:10:00Z",
+        selectorTags: ["S2-severe"],
+        origAddr: null,
+      }),
+    ]);
+    expect(stories).toEqual([]);
+  });
+});
+
+describe("applyMemberCap", () => {
+  it("returns the input unchanged when ≤ cap", () => {
+    const events = [
+      event({ eventKey: "1", eventTime: "2026-05-09T12:00:00Z" }),
+      event({ eventKey: "2", eventTime: "2026-05-09T12:01:00Z" }),
+    ];
+    expect(applyMemberCap(events, 5)).toEqual(events);
+  });
+
+  it("orders by cardinality(selector_tags) DESC then event_time DESC then event_key ASC", () => {
+    const events = [
+      // Two tags, late time
+      event({
+        eventKey: "A",
+        eventTime: "2026-05-09T12:05:00Z",
+        selectorTags: ["S2-severe", "unlabeled-cluster"],
+      }),
+      // One tag, latest time
+      event({
+        eventKey: "B",
+        eventTime: "2026-05-09T12:10:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      // One tag, earliest time
+      event({
+        eventKey: "C",
+        eventTime: "2026-05-09T12:00:00Z",
+        selectorTags: ["S2-severe"],
+      }),
+      // Zero tags
+      event({ eventKey: "D", eventTime: "2026-05-09T12:30:00Z" }),
+    ];
+    expect(applyMemberCap(events, 3).map((e) => e.eventKey)).toEqual([
+      "A", // cardinality 2 wins
+      "B", // tied at 1; later time wins
+      "C", // tied at 1; earlier — last
+    ]);
+  });
+
+  it("R3 with 60 candidates produces exactly 50 admitted members, with score reflecting the cap", () => {
+    const events: CandidateEvent[] = [];
+    for (let i = 0; i < 60; i += 1) {
+      const minutes = i; // 0..59 minutes apart, all within 1 hour
+      events.push(
+        event({
+          eventKey: String(1000 + i),
+          eventTime: `2026-05-09T14:${String(minutes).padStart(2, "0")}:00Z`,
+          selectorTags: ["S2-severe"],
+        }),
+      );
+    }
+    const stories = detectR3(events);
+    expect(stories).toHaveLength(1);
+    const [s] = stories;
+    expect(s.members).toHaveLength(STORY_MEMBER_CAP);
+    expect(s.score).toBe(STORY_MEMBER_CAP);
+  });
+});
+
+describe("buildSummaryPayload", () => {
+  it("emits every fixed key from §7", () => {
+    const members = [
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        kind: "HttpThreat",
+        category: "IMPACT",
+        rawScore: 2.5,
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "2",
+        eventTime: "2026-05-09T12:05:00Z",
+        kind: "DnsCovertChannel",
+        category: "EXFILTRATION",
+        rawScore: 3.0,
+        selectorTags: [],
+      }),
+    ];
+    const payload = buildSummaryPayload(members);
+    expect(Object.keys(payload).sort()).toEqual([
+      "categoryHistogram",
+      "distinctAssetCount",
+      "durationMs",
+      "kindHistogram",
+      "memberCount",
+      "topRawScore",
+    ]);
+    expect(payload.kindHistogram).toEqual({
+      HttpThreat: 1,
+      DnsCovertChannel: 1,
+    });
+    expect(payload.categoryHistogram).toEqual({ IMPACT: 1, EXFILTRATION: 1 });
+    expect(payload.memberCount).toBe(2);
+    expect(payload.durationMs).toBe(5 * 60 * 1000);
+    expect(payload.distinctAssetCount).toBe(1);
+    expect(payload.topRawScore).toBe(3.0);
+  });
+
+  it("does not bucket NULL categories", () => {
+    const payload = buildSummaryPayload([
+      event({
+        eventKey: "1",
+        eventTime: "2026-05-09T12:00:00Z",
+        category: null,
+      }),
+    ]);
+    expect(payload.categoryHistogram).toEqual({});
+  });
+});
+
+describe("detectAllStories — same-event multiple rules (option A)", () => {
+  it("a fixture matching both R1 and R3 produces exactly two stories (one per rule)", () => {
+    const events: CandidateEvent[] = [
+      event({
+        eventKey: "20",
+        eventTime: "2026-05-09T09:00:00Z",
+        category: "CREDENTIAL_ACCESS",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "21",
+        eventTime: "2026-05-09T09:02:00Z",
+        category: "COMMAND_AND_CONTROL",
+        selectorTags: ["S2-severe"],
+      }),
+      event({
+        eventKey: "22",
+        eventTime: "2026-05-09T09:09:00Z",
+        category: "EXFILTRATION",
+        selectorTags: ["S2-severe"],
+      }),
+    ];
+    const stories = detectAllStories(events);
+    const rules = stories.map((s) => s.ruleId).sort();
+    expect(rules).toEqual(["R1", "R3"]);
+  });
+});

--- a/src/lib/triage/baseline/pager.ts
+++ b/src/lib/triage/baseline/pager.ts
@@ -73,6 +73,7 @@ import {
   type NormalizedEventColumns,
   normalizeEventColumns,
 } from "@/lib/triage/exclusion";
+import { runStepF } from "@/lib/triage/story/correlator";
 import type { TriageEvent } from "@/lib/triage/types";
 
 import type { CadencePageResult, CadencePager } from "./cadence";
@@ -296,6 +297,19 @@ export function createCadencePager(
       );
       const baselineInserted = baselineResult.rowCount ?? 0;
 
+      // (f) Story correlator. Empty-page no-op: when no survivors
+      // landed in baseline_triaged_event the correlator returns early
+      // and does NOT advance `story_finalized_through` — the next
+      // non-empty page resumes finalization from the previously-held
+      // watermark. Per-page transaction discipline: a step (f)
+      // failure rolls the entire page back, so a Story is never
+      // persisted for events that did not land.
+      const pageEventTimeRange =
+        baselineRows.length === 0
+          ? null
+          : computeEventTimeRange(baselineRows.map((r) => r.event.time));
+      await runStepF({ client, pageEventTimeRange, signal });
+
       return {
         observedInserted,
         baselineInserted,
@@ -439,4 +453,18 @@ function readConfidence(event: CadenceEventNode): number | null {
   const value = (event as TriageEvent & { confidence?: number | null })
     .confidence;
   return typeof value === "number" ? value : null;
+}
+
+function computeEventTimeRange(timestamps: ReadonlyArray<string>): {
+  min: Date;
+  max: Date;
+} {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const t of timestamps) {
+    const ms = new Date(t).getTime();
+    if (ms < min) min = ms;
+    if (ms > max) max = ms;
+  }
+  return { min: new Date(min), max: new Date(max) };
 }

--- a/src/lib/triage/story/RFC-v1.md
+++ b/src/lib/triage/story/RFC-v1.md
@@ -52,6 +52,22 @@ stays reserved so the rule-ID enum does not shift.
 - Score: `member_count + λ · distinct_category_count`,
   with `λ = 1.0`.
 - `correlation_rule_id = 'R1'`.
+- **SQL push-down (§5).** R1's per-page candidate read in
+  `repository.ts` is:
+
+  ```sql
+  SELECT … FROM baseline_triaged_event
+   WHERE event_time IN [memberScanStart, memberScanEnd]
+     AND orig_addr IS NOT NULL
+     AND category = ANY($criticalCategories::text[])
+  ```
+
+  Same-asset narrowing (10-minute window per `orig_addr`) is a
+  clustering operation across the returned rows and lives in the
+  rule layer (`rules.ts` `clusterByWindow` + `groupByAsset`), not
+  the SQL — same-asset clustering is what produces the cluster
+  boundaries the rule scores against. The issue's measurement
+  gate runs `EXPLAIN ANALYZE` against the SQL above.
 
 ### R3 — Repeated critical-selector activity on same asset
 
@@ -72,6 +88,24 @@ stays reserved so the rule-ID enum does not shift.
 - Predicate excludes events with `orig_addr IS NULL`.
 - Score: `member_count` (after the §8 member cap).
 - `correlation_rule_id = 'R3'`.
+- **SQL push-down (§5).** R3's per-page candidate read in
+  `repository.ts` is:
+
+  ```sql
+  SELECT … FROM baseline_triaged_event
+   WHERE event_time IN [memberScanStart, memberScanEnd]
+     AND orig_addr IS NOT NULL
+     AND selector_tags && $criticalSelectors::text[]
+  ```
+
+  This is the exact shape the issue's measurement gate runs
+  `EXPLAIN ANALYZE` against. Same-asset narrowing (1-hour window
+  per `orig_addr`) is a clustering operation across the returned
+  rows and lives in the rule layer. If measurement at scale shows
+  the planner cannot resolve `selector_tags &&` efficiently on
+  `baseline_triaged_event`, the additive follow-up named in the
+  issue is a GIN index on `selector_tags` — migration-only, no
+  callsite churn.
 
 ### `max_rule_window`
 
@@ -142,6 +176,42 @@ The cadence pager imports `runStepF` from
 `src/lib/triage/story/correlator.ts` and calls it immediately after
 `insertBaselineTriagedEventBatch`, inside the same per-page
 transaction the runner already opens.
+
+### Per-rule SQL push-down
+
+`repository.ts` exposes one read function **per rule**, not a
+single broad-range candidate scan:
+
+- `readR1Candidates({ memberScanStart, memberScanEnd })` —
+  `category = ANY($criticalCategories::text[])` plus the time
+  range and `orig_addr IS NOT NULL`.
+- `readR3Candidates({ memberScanStart, memberScanEnd })` —
+  `selector_tags && $criticalSelectors::text[]` plus the time
+  range and `orig_addr IS NOT NULL`.
+
+The correlator runs both reads in parallel, then dispatches each
+result set to its rule's pure in-memory clusterer. The split
+serves two goals:
+
+1. **Measurement gate is meaningful.** The issue's measurement
+   gate demands `EXPLAIN ANALYZE` on R3's
+   `selector_tags && ARRAY[...]` shape. A single broad-range
+   SELECT has nothing rule-specific for the planner to explain;
+   the per-rule SQL gives the gate a target that matches what
+   production runs.
+2. **App-side memory bound.** A typical-volume tenant produces a
+   large number of `baseline_triaged_event` rows in the slop-
+   replay range; predicate-pushed reads cap the in-memory set at
+   the rows R1/R3 actually evaluate, instead of materializing the
+   full range and filtering in app memory inside the per-page
+   transaction.
+
+Same-asset narrowing (the 10-min / 1-hour per-`orig_addr` window)
+remains a clustering operation across the returned rows in
+`rules.ts` (`groupByAsset` + `clusterByWindow`). Same-asset
+narrowing is what produces the cluster boundaries the rule scores
+against; it is not a row-level filter that could collapse before
+clustering, so it stays out of the SQL.
 
 ### Analyst-curated path
 

--- a/src/lib/triage/story/RFC-v1.md
+++ b/src/lib/triage/story/RFC-v1.md
@@ -1,0 +1,301 @@
+# Story RFC v1
+
+Status: draft (lands with issue #489 / 1B-Story-1).
+Owners: triage + corpus working group.
+
+## §1 — Purpose
+
+Add the **Story** concept on top of corpus A: a small, deterministic
+bundle of correlated `baseline_triaged_event` rows produced by the
+cadence's step (f) heuristic correlator. The grouping is **always
+heuristic in v1** — LLM-driven grouping is the Phase 2 umbrella's
+concern, downstream of this layer. The Stories UI ships in #490.
+
+The user-facing label is **Story**. The internal/DB names are
+`event_group` (container) and `event_group_member` (rows).
+
+## §2 — Score model
+
+Story rules predicate on `selector_tags` membership and on the row's
+own `category` column, never on `baseline_score` (which does not
+exist on the row at cadence time — it is read-time-computed via
+`cume_dist()` per `(kind, baseline_version)`) and never on
+`raw_score` (whose absolute scale shifts across `baseline_version`
+bumps). `selector_tags` is RFC 0001 §9's stable, enumerated emission
+and survives §9 retunes that change weights but not the tag set.
+
+The Story-side aggregate `score` on `event_group` is a per-rule
+count or weighted count over `selector_tags` matches — never a
+function of `raw_score`. Cross-Story sort by `score` therefore
+compares within the same `story_version` cohort by construction.
+
+## §3 — Rule definitions and parameters
+
+Two rules ship in v1. R2 (kill-chain progression) is intentionally
+deferred to a v2 RFC bump; the `correlation_rule_id = 'R2'` slot
+stays reserved so the rule-ID enum does not shift.
+
+### R1 — Asset × multi-category window
+
+> Same `primary_asset` (orig_addr), within a 10-minute window, has
+> events from ≥2 distinct categories in the critical-category set.
+
+- Window: **10 minutes**.
+- Critical-category set: `CRITICAL_CATEGORIES` from
+  `src/lib/triage/baseline/categories.ts` —
+  `{COMMAND_AND_CONTROL, CREDENTIAL_ACCESS, EXFILTRATION, IMPACT,
+  INITIAL_ACCESS}`.
+- Membership read directly from
+  `baseline_triaged_event.category` — no `selector_tags` lookup
+  needed.
+- Predicate excludes events with `orig_addr IS NULL`.
+- Score: `member_count + λ · distinct_category_count`,
+  with `λ = 1.0`.
+- `correlation_rule_id = 'R1'`.
+
+### R3 — Repeated critical-selector activity on same asset
+
+> Same `primary_asset` has ≥3 events whose `selector_tags` overlap
+> the critical-selector set within a 1-hour window.
+
+- Window: **1 hour**.
+- Critical-selector set: **`{'S2-severe', 'unlabeled-cluster'}`** —
+  the literal strings emitted by
+  `src/lib/triage/baseline/selectors.ts` via `SELECTOR_TAGS` in
+  `src/lib/triage/baseline/tunables.ts`. The full §9 emission set
+  is `S1-high`, `S2-severe`, `S3-recurring`, `S4-correlated`,
+  `unlabeled-cluster`; v1 takes the two whose semantics map to
+  "critical-class" rather than "frequency/correlation pattern".
+- Predicate: `selector_tags && ARRAY[<critical_selector_set>]::TEXT[]`
+  (PostgreSQL array overlap), evaluated against
+  `baseline_triaged_event`.
+- Predicate excludes events with `orig_addr IS NULL`.
+- Score: `member_count` (after the §8 member cap).
+- `correlation_rule_id = 'R3'`.
+
+### `max_rule_window`
+
+`max_rule_window = max(R1.window, R3.window) = 1 hour`. Consumed
+by the §4 slop-replay member-scan lookback. Adding any rule with a
+larger window forces a Story RFC bump because the slop-replay
+window grows with it.
+
+## §4 — Slop window and watermark protocol
+
+- Slop window length: **30 minutes** (default). The slop is chosen
+  against the rule-firing latency analysts will tolerate, not the
+  rule window itself; longer values over-defer.
+- Each page commits its own corpus rows immediately (steps d/e).
+- Step (f) does NOT finalize Stories whose `time_window_end`
+  falls within the last `SLOP_WINDOW_MS` of the page's
+  `event_time` range. Those drafts are simply skipped — no side
+  table, no in-memory carry-over.
+- On every successful step (f) the per-page transaction updates
+  `baseline_corpus_state.story_finalized_through` to
+  `(page_max_event_time − slop)`.
+- The next tick reads the previous watermark and runs step (f)
+  against two distinct ranges:
+  - **Finalization-candidate range** (`time_window_end` allowed):
+    `(previous_watermark, new_horizon]`.
+  - **Member-scan range** (events read from
+    `baseline_triaged_event` to populate predicates):
+    `[previous_watermark − max_rule_window, new_horizon]`. The
+    lookback prevents an R3 cluster whose `time_window_end` falls
+    just past the previous watermark from missing members that
+    sit before the watermark but inside the rule window.
+- **First-tick / NULL watermark.** When
+  `story_finalized_through IS NULL`, both ranges degenerate to
+  `(-∞, new_horizon]`. The lower bound is the page's own
+  `event_time.min` (by construction the earliest event this
+  customer has produced for this page). `corpus_activated_at` is
+  intentionally NOT used as an event-time floor: it is a
+  wall-clock anchor for §7 active-window age, not an event-time
+  marker; using it here would mis-bound a historical catch-up.
+- **Empty page (zero `baseline_triaged_event` survivors).** Step
+  (f) is a no-op and `story_finalized_through` is NOT advanced.
+  The next non-empty page resumes from the previously-held
+  watermark; the per-page `last_event_cursor` continues to
+  advance independently.
+- The watermark UPDATE uses `GREATEST(story_finalized_through, $1)`
+  so a slop replay or a retried page cannot push the watermark
+  backwards.
+- Idempotency: re-evaluation can re-derive a
+  `(correlation_rule_id, primary_asset, time_window_start,
+  time_window_end)` tuple that step (f) already produced. The
+  partial unique index plus `INSERT … ON CONFLICT DO NOTHING` on
+  `event_group` is the dedup mechanism. Members upsert into
+  `event_group_member` via the existing composite PK.
+
+## §5 — Persistence
+
+Migration `migrations/customer/0008_event_group_story.sql` lands
+the schema (single new file). The only `ALTER` on existing tables
+is the additive `story_finalized_through` column on the
+`baseline_corpus_state` singleton; corpus A tables
+(`baseline_triaged_event`, `observed_event_meta`) are not touched.
+
+The cadence pager imports `runStepF` from
+`src/lib/triage/story/correlator.ts` and calls it immediately after
+`insertBaselineTriagedEventBatch`, inside the same per-page
+transaction the runner already opens.
+
+## §6 — `story_version`
+
+Initial value: **`'v1'`**. Mirrors `baseline_version` and follows
+the same natural-expiry model: a Story RFC bump produces new
+groups under the new version; old-version groups age out via
+retention without retroactive recomputation.
+
+## §7 — `summary_payload` JSONB contract
+
+Fixed key set so #490 binds to a stable shape across rule
+versions. Adding a key is RFC-only; removing or renaming a key is
+a `story_version` bump.
+
+| Key                  | Type                       | Description |
+|----------------------|----------------------------|-------------|
+| `kindHistogram`      | `Record<string, number>`   | Per-`kind` count over members. |
+| `categoryHistogram`  | `Record<string, number>`   | Per-`category` count over members; NULL categories are not bucketed. |
+| `memberCount`        | `number`                   | Length of the persisted member list (post-§8 cap). |
+| `durationMs`         | `number`                   | `max(event_time) − min(event_time)` across members, in ms. |
+| `distinctAssetCount` | `number`                   | Distinct non-NULL `orig_addr` across members. v1 rules are asset-keyed so this is typically `1`. |
+| `topRawScore`        | `number`                   | Max `raw_score` over members. Story-internal sort hint, NOT surfaced to UI as a baseline percentile. |
+
+The correlator computes `summary_payload` at step (f) from the
+member events — independent of any cadence-side `payload_summary`
+extension.
+
+## §8 — Member cap and sampling order
+
+- `STORY_MEMBER_CAP = 50`. Matches #490's analyst-curated cap so
+  the LLM context budget is consistent across creation paths.
+- Sampling order when a rule matches more than 50 events in the
+  same window:
+  1. `cardinality(selector_tags) DESC`
+  2. `event_time DESC`
+  3. `event_key ASC` (final total-order tiebreaker so
+     time-colliding events produce a deterministic order across
+     re-evaluations).
+- This is a deterministic-sampling key, **not a ranking**.
+  `raw_score` is intentionally not used because members can span
+  multiple `kind` / `baseline_version` cohorts where its absolute
+  scale is not comparable.
+- R3 in particular can saturate the cap on chatty assets; the
+  50-member ceiling is what bounds R3 Story size, not the 1-hour
+  window. R3's `score` reflects the admitted (post-cap) member
+  count.
+
+## §9 — Group membership when an event matches multiple rules
+
+**Option A** — one group per rule per match. An event matching
+both R1 and R3 ends up in two `event_group` rows, each carrying
+exactly one `correlation_rule_id`. Stories are rule-traceable,
+which makes RFC tuning measurable; merging would lose the
+"show only R3 Stories" affordance and make UI sort/filter
+ambiguous. The Stories UI can deduplicate by
+`(primary_asset, time_window_start, time_window_end)` overlap at
+render time if visual clutter is a problem.
+
+## §10 — Future-rule format
+
+A future rule plugs into the runner as a typed predicate function
+plus metadata in `src/lib/triage/story/rules.ts`'s `RULE_REGISTRY`.
+No schema change is required. v2 R2 specifically must specify its
+data source — cadence-side `payload_summary` extension, or new
+normalized columns on `baseline_triaged_event`, or both — before
+merging. The `correlation_rule_id = 'R2'` slot is reserved by this
+RFC for that bump.
+
+## §11 — Worked examples
+
+The three worked examples below all assume a single tenant DB at
+`story_version = 'v1'`, with `slop = 30 min`, no previous
+watermark, and the page's `event_time` extent covering the
+relevant span.
+
+### Example 1 — R1 fires, R3 does not
+
+Asset `10.0.0.5` produces three events on the same page:
+
+| event_key | event_time                | category               | selector_tags |
+|-----------|---------------------------|------------------------|---------------|
+| 1         | 2026-05-09 12:00:00 +0000 | `INITIAL_ACCESS`       | `[]`          |
+| 2         | 2026-05-09 12:03:00 +0000 | `COMMAND_AND_CONTROL`  | `[]`          |
+| 3         | 2026-05-09 12:06:00 +0000 | `COMMAND_AND_CONTROL`  | `[]`          |
+
+- R1 sees three critical-category events on the same asset
+  within 6 min ≤ 10 min, with distinct categories
+  `{INITIAL_ACCESS, COMMAND_AND_CONTROL}` (cardinality 2).
+  Fires. Score: `3 + 1.0 * 2 = 5.0`.
+- R3 sees zero critical-selector events on this asset. Skipped.
+
+Result: one `event_group` row with
+`correlation_rule_id = 'R1'`, `primary_asset = '10.0.0.5'`,
+`time_window_start = 12:00:00`, `time_window_end = 12:06:00`,
+`score = 5.0`.
+
+### Example 2 — R3 fires, R1 does not
+
+Asset `10.0.0.7` produces three events on the same page:
+
+| event_key | event_time                | category    | selector_tags          |
+|-----------|---------------------------|-------------|------------------------|
+| 10        | 2026-05-09 14:00:00 +0000 | `IMPACT`    | `['S2-severe']`        |
+| 11        | 2026-05-09 14:25:00 +0000 | `IMPACT`    | `['S2-severe']`        |
+| 12        | 2026-05-09 14:55:00 +0000 | `IMPACT`    | `['unlabeled-cluster']`|
+
+- R1 sees three critical-category events but only one distinct
+  category (`IMPACT`); distinct-category count `< 2`. Skipped.
+- R3 sees three events overlapping the critical-selector set
+  within 55 min ≤ 1 h on the same asset. Fires. Score: `3`.
+
+Result: one `event_group` row with
+`correlation_rule_id = 'R3'`, `primary_asset = '10.0.0.7'`,
+`time_window_start = 14:00:00`, `time_window_end = 14:55:00`,
+`score = 3`.
+
+### Example 3 — Both R1 and R3 fire (option A produces two Stories)
+
+Asset `10.0.0.9` produces five events on the same page:
+
+| event_key | event_time                | category               | selector_tags          |
+|-----------|---------------------------|------------------------|------------------------|
+| 20        | 2026-05-09 09:00:00 +0000 | `CREDENTIAL_ACCESS`    | `['S2-severe']`        |
+| 21        | 2026-05-09 09:02:00 +0000 | `COMMAND_AND_CONTROL`  | `['S2-severe']`        |
+| 22        | 2026-05-09 09:09:00 +0000 | `EXFILTRATION`         | `['S2-severe']`        |
+| 23        | 2026-05-09 09:30:00 +0000 | `IMPACT`               | `['unlabeled-cluster']`|
+| 24        | 2026-05-09 09:55:00 +0000 | `IMPACT`               | `['S2-severe']`        |
+
+- R1 sees `{CREDENTIAL_ACCESS, COMMAND_AND_CONTROL, EXFILTRATION}`
+  inside the first 10-minute window (events 20–22). Fires with
+  `member_count = 3`, `distinct_categories = 3`, `score = 6.0`.
+  R1 may also produce a separate cluster for events 23–24
+  inside its own 10-minute window — events 23 and 24 are
+  IMPACT-only, so distinct-category count = 1 and R1 does NOT
+  fire for that subcluster.
+- R3 sees five critical-selector events on the asset within
+  55 min ≤ 1 h. Fires with `member_count = 5`, `score = 5`.
+
+Result: two `event_group` rows — one per rule (option A). Both
+carry the same `primary_asset = '10.0.0.9'`; the R1 row's
+`time_window_end = 09:09:00`, the R3 row's
+`time_window_end = 09:55:00`. The Stories UI may dedupe by
+overlap at render time.
+
+## §12 — Out of scope of this RFC
+
+- LLM-driven correlation — Phase 2 concern.
+- Multi-window packaging (`role = 'context'`) — Phase 2 Y4
+  (#495). v1 only writes `role = 'primary'`.
+- R2 kill-chain rule — v2 Story RFC bump.
+- Display-side strictness-slider exemption for Story members
+  — owned by #471 and consumed by #490 / #458.
+- Stories UI tab in the Triage menu — owned by #490.
+- "Send to aimer-web" submission — owned by the Phase 2
+  umbrella (Y2, #493). The β-style columns `last_sent_at`,
+  `last_sent_by`, `send_count` on `event_group` are owned by
+  this RFC; Y2 is the writer.
+- Story retention / cleanup — owned by 1B-7 (#461).
+- Cadence-side `baseline_triaged_event.payload_summary`
+  extension — stays NULL as today; Story-side
+  `event_group.summary_payload` is independent.

--- a/src/lib/triage/story/RFC-v1.md
+++ b/src/lib/triage/story/RFC-v1.md
@@ -89,20 +89,41 @@ stays reserved so the rule-ID enum does not shift.
 - Score: `member_count` (after the §8 member cap).
 - `correlation_rule_id = 'R3'`.
 - **SQL push-down (§5).** R3's per-page candidate read in
-  `repository.ts` is:
+  `repository.ts` is two-phase. Phase 1 pre-aggregates candidate
+  assets:
+
+  ```sql
+  SELECT host(orig_addr) AS orig_addr
+    FROM baseline_triaged_event
+   WHERE event_time IN [memberScanStart, memberScanEnd]
+     AND orig_addr IS NOT NULL
+     AND selector_tags && $criticalSelectors::text[]
+   GROUP BY orig_addr
+  HAVING COUNT(*) >= 3
+  ```
+
+  Phase 2 is the per-asset row read — the shape the issue's
+  measurement gate names ("R3 same-asset-1h scan"):
 
   ```sql
   SELECT … FROM baseline_triaged_event
    WHERE event_time IN [memberScanStart, memberScanEnd]
-     AND orig_addr IS NOT NULL
+     AND orig_addr = ANY($assets::inet[])
      AND selector_tags && $criticalSelectors::text[]
   ```
 
-  This is the exact shape the issue's measurement gate runs
-  `EXPLAIN ANALYZE` against. Same-asset narrowing (1-hour window
-  per `orig_addr`) is a clustering operation across the returned
-  rows and lives in the rule layer. If measurement at scale shows
-  the planner cannot resolve `selector_tags &&` efficiently on
+  The `orig_addr = ANY(…)` predicate is what the planner uses to
+  resolve per-asset narrowing through
+  `baseline_triaged_event_orig_addr_gist`
+  (`gist_inet_ops` supports `=`), and what
+  `EXPLAIN ANALYZE` validates against the GiST path. Phase 1's
+  `HAVING COUNT(*) >= 3` matches R3's per-rule member threshold,
+  so assets that cannot reach the threshold in the scan range are
+  dropped before phase 2 reads them. Final sliding-window
+  clustering remains a rule-layer operation across phase 2's
+  returned rows — the SQL only narrows *which* assets are read,
+  not how their events cluster. If measurement at scale shows the
+  planner cannot resolve `selector_tags &&` efficiently on
   `baseline_triaged_event`, the additive follow-up named in the
   issue is a GIN index on `selector_tags` — migration-only, no
   callsite churn.
@@ -183,35 +204,44 @@ transaction the runner already opens.
 single broad-range candidate scan:
 
 - `readR1Candidates({ memberScanStart, memberScanEnd })` —
-  `category = ANY($criticalCategories::text[])` plus the time
-  range and `orig_addr IS NOT NULL`.
+  single SELECT: `category = ANY($criticalCategories::text[])`
+  plus the time range and `orig_addr IS NOT NULL`.
 - `readR3Candidates({ memberScanStart, memberScanEnd })` —
-  `selector_tags && $criticalSelectors::text[]` plus the time
-  range and `orig_addr IS NOT NULL`.
+  two-phase. Phase 1 pre-aggregates candidate assets
+  (`GROUP BY orig_addr HAVING COUNT(*) >= 3` over the
+  `selector_tags && $criticalSelectors::text[]` predicate);
+  phase 2 reads per-asset rows via
+  `orig_addr = ANY($assets::inet[])`.
 
 The correlator runs both reads in parallel, then dispatches each
 result set to its rule's pure in-memory clusterer. The split
-serves two goals:
+serves three goals:
 
 1. **Measurement gate is meaningful.** The issue's measurement
-   gate demands `EXPLAIN ANALYZE` on R3's
-   `selector_tags && ARRAY[...]` shape. A single broad-range
-   SELECT has nothing rule-specific for the planner to explain;
-   the per-rule SQL gives the gate a target that matches what
-   production runs.
+   gate demands `EXPLAIN ANALYZE` on R3's same-asset-1h scan,
+   confirming `(event_time DESC)` and the `orig_addr` GiST index
+   participate in the plan. The phase-2 SELECT's
+   `orig_addr = ANY(...)` is the predicate that resolves through
+   `baseline_triaged_event_orig_addr_gist`
+   (`gist_inet_ops` supports `=`), so the gate has a concrete
+   production-shape target.
 2. **App-side memory bound.** A typical-volume tenant produces a
    large number of `baseline_triaged_event` rows in the slop-
    replay range; predicate-pushed reads cap the in-memory set at
    the rows R1/R3 actually evaluate, instead of materializing the
    full range and filtering in app memory inside the per-page
-   transaction.
-
-Same-asset narrowing (the 10-min / 1-hour per-`orig_addr` window)
-remains a clustering operation across the returned rows in
-`rules.ts` (`groupByAsset` + `clusterByWindow`). Same-asset
-narrowing is what produces the cluster boundaries the rule scores
-against; it is not a row-level filter that could collapse before
-clustering, so it stays out of the SQL.
+   transaction. Phase 1's `HAVING COUNT(*) >= 3` further drops
+   assets that cannot reach R3's member threshold before phase 2
+   reads any of their rows.
+3. **Rule-layer separation stays clean.** Final sliding-window
+   clustering (the 10-min / 1-hour per-`orig_addr` window) is the
+   shape the rule scores against; that stays in `rules.ts`
+   (`groupByAsset` + `clusterByWindow`). The SQL only narrows
+   which rows the rule evaluates — phase 1's `COUNT(*) >= 3` is
+   the rule's member-count threshold in the scan range, not the
+   sliding window itself, so a candidate that phase 1 admits may
+   still fail the in-memory window check, and that is the
+   intended behaviour.
 
 ### Analyst-curated path
 

--- a/src/lib/triage/story/RFC-v1.md
+++ b/src/lib/triage/story/RFC-v1.md
@@ -105,12 +105,16 @@ window grows with it.
     sit before the watermark but inside the rule window.
 - **First-tick / NULL watermark.** When
   `story_finalized_through IS NULL`, both ranges degenerate to
-  `(-∞, new_horizon]`. The lower bound is the page's own
-  `event_time.min` (by construction the earliest event this
-  customer has produced for this page). `corpus_activated_at` is
-  intentionally NOT used as an event-time floor: it is a
-  wall-clock anchor for §7 active-window age, not an event-time
-  marker; using it here would mis-bound a historical catch-up.
+  `(-∞, new_horizon]` — no event-time lower bound is applied.
+  `corpus_activated_at` is intentionally NOT used as an
+  event-time floor (wall-clock anchor for §7 active-window age,
+  not an event-time marker; using it here would mis-bound a
+  historical catch-up). The page's own `event_time.min` is also
+  NOT used as a floor: a tenant that already has
+  `baseline_triaged_event` rows when migration 0008 lands carries
+  rows that sit before this page's min — those rows must be
+  candidates on the first tick or they would never be considered
+  for finalization again after the watermark advances past them.
 - **Empty page (zero `baseline_triaged_event` survivors).** Step
   (f) is a no-op and `story_finalized_through` is NOT advanced.
   The next non-empty page resumes from the previously-held
@@ -138,6 +142,22 @@ The cadence pager imports `runStepF` from
 `src/lib/triage/story/correlator.ts` and calls it immediately after
 `insertBaselineTriagedEventBatch`, inside the same per-page
 transaction the runner already opens.
+
+### Analyst-curated path
+
+`src/lib/triage/story/repository.ts` exports `insertCuratedStory`
+for the "Save as Story" mutation #490 ships. The shape mirrors
+`insertAutoStory` with three differences:
+
+- `kind = 'analyst_curated'`.
+- `correlation_rule_id = NULL` (curated rows have no rule).
+- No `ON CONFLICT` clause — the partial unique index is scoped to
+  `kind = 'auto_correlated'`, so a curated save can legitimately
+  repeat a `(asset, window)` an analyst already stored.
+
+The same §7 `summary_payload` contract and §8 member cap /
+sampling order apply, so curated rows are interchangeable with
+auto-correlated rows from the LLM's perspective.
 
 ## §6 — `story_version`
 

--- a/src/lib/triage/story/correlator.ts
+++ b/src/lib/triage/story/correlator.ts
@@ -26,10 +26,17 @@ import "server-only";
  *       * Member-scan range (events read to populate predicates):
  *         `[previous_watermark − MAX_RULE_WINDOW_MS, new_horizon]`.
  *   - When `previous_watermark IS NULL` (fresh tenant), both ranges
- *     degenerate to `(-∞, new_horizon]`. `corpus_activated_at` is
- *     intentionally NOT used as an event-time floor (it is a
- *     wall-clock anchor for §7 active-window age, not an event-time
- *     marker; using it here would mis-bound a historical catch-up).
+ *     degenerate to `(-∞, new_horizon]` — no event-time lower bound
+ *     is applied. `corpus_activated_at` is intentionally NOT used
+ *     as an event-time floor (it is a wall-clock anchor for §7
+ *     active-window age, not an event-time marker; using it here
+ *     would mis-bound a historical catch-up). The page's own
+ *     `event_time.min` is also not used as a floor, because a
+ *     tenant that already has `baseline_triaged_event` rows when
+ *     migration 0008 lands carries rows that sit before this
+ *     page's min — those rows must be candidates on the first
+ *     tick or they would never be considered for finalization
+ *     again after the watermark advances past them.
  *   - Empty page (zero `baseline_triaged_event` survivors) is a
  *     no-op: `story_finalized_through` is NOT advanced. Advancing
  *     on an empty page would push the finalization horizon past
@@ -93,26 +100,36 @@ export async function runStepF(args: RunStepFArgs): Promise<StepFResult> {
     pageEventTimeRange.max.getTime() - SLOP_WINDOW_MS,
   );
 
-  // Member-scan range:
+  // Member-scan range (Story RFC §4):
   //   - first tick (NULL watermark): degenerate (-∞, new_horizon].
-  //     The page's own `event_time.min` is a natural lower bound but
-  //     we DO NOT clamp to `corpus_activated_at` (see file header).
-  //     Use `pageEventTimeRange.min` as a conservative lower bound;
-  //     the page's own min is by construction the earliest event
-  //     this customer has produced in step (e) for this page, and
-  //     prior-page rows are already finalized.
+  //     `corpus_activated_at` is intentionally NOT used as an
+  //     event-time floor (wall-clock anchor, not event-time
+  //     marker). Clamping to `pageEventTimeRange.min` would also
+  //     mis-bound a tenant that already had `baseline_triaged_event`
+  //     rows when migration 0008 landed: those rows sit before the
+  //     current page, the watermark would advance past them on
+  //     this commit, and they would never be considered for
+  //     finalization again. Use `null` to mean "no lower bound".
   //   - second+ tick: `previous_watermark − MAX_RULE_WINDOW_MS` so
   //     cross-page clusters whose `time_window_end` falls just past
   //     the previous watermark can pick up earlier members.
+  //
+  // The scan upper bound is `new_horizon`, NOT
+  // `pageEventTimeRange.max`. Events inside the slop window
+  // `(new_horizon, page_max]` cannot finalize this tick anyway —
+  // including them in the member scan would let them participate
+  // in clustering and could defer an otherwise-eligible Story
+  // whose other members all sit at-or-before `new_horizon`. They
+  // become visible on the next tick via the lookback range.
   const memberScanStart =
     previousWatermark === null
-      ? pageEventTimeRange.min
+      ? null
       : new Date(previousWatermark.getTime() - MAX_RULE_WINDOW_MS);
 
   const candidates = await readCandidateEventsInRange({
     client,
     memberScanStart,
-    memberScanEnd: pageEventTimeRange.max,
+    memberScanEnd: newHorizon,
   });
 
   const drafts = detectAllStories(candidates);

--- a/src/lib/triage/story/correlator.ts
+++ b/src/lib/triage/story/correlator.ts
@@ -133,14 +133,14 @@ export async function runStepF(args: RunStepFArgs): Promise<StepFResult> {
       ? null
       : new Date(previousWatermark.getTime() - MAX_RULE_WINDOW_MS);
 
-  // Per-rule SQL push-down (Story RFC §3, §5). Each rule reads its
-  // own candidate set with the row-level predicate evaluated by
-  // PostgreSQL — `category = ANY(...)` for R1, `selector_tags && ...`
-  // for R3 — so the `EXPLAIN ANALYZE` shape demanded by the issue's
-  // measurement gate runs against the SQL that production runs, and
-  // the correlator does not materialize the entire member-scan range
-  // in app memory before filtering. Same-asset narrowing stays in
-  // the rule layer (a clustering operation, not a row-level filter).
+  // Per-rule SQL push-down (Story RFC §3, §5). R1 reads its
+  // candidate set with `category = ANY(...)` as a single SELECT.
+  // R3 is two-phase: phase 1 pre-aggregates candidate assets
+  // (`GROUP BY orig_addr HAVING COUNT(*) >= 3` over
+  // `selector_tags && ...`), phase 2 reads per-asset rows via
+  // `orig_addr = ANY($::inet[])` — the per-asset shape the issue's
+  // measurement gate validates against the `orig_addr` GiST index.
+  // Final sliding-window clustering stays in the rule layer.
   const [r1Candidates, r3Candidates] = await Promise.all([
     readR1Candidates({ client, memberScanStart, memberScanEnd: newHorizon }),
     readR3Candidates({ client, memberScanStart, memberScanEnd: newHorizon }),

--- a/src/lib/triage/story/correlator.ts
+++ b/src/lib/triage/story/correlator.ts
@@ -1,0 +1,141 @@
+import "server-only";
+
+/**
+ * Story correlator — cadence step (f) entry point (Story RFC §4).
+ *
+ * Called by the pager immediately after `insertBaselineTriagedEventBatch`
+ * and before the per-page transaction commits, so a Story is never
+ * persisted for events that did not land. The per-page transaction
+ * discipline from #456 / #481 is preserved: a step (f) failure rolls
+ * back the entire page's INSERTs, and the page's `last_event_cursor`
+ * does not advance.
+ *
+ * Sliding-window correlation protocol:
+ *
+ *   - Each page commits its own corpus rows immediately (steps d/e).
+ *   - Step (f) does NOT finalize Stories whose `time_window_end`
+ *     falls within the last `SLOP_WINDOW_MS` of the page's
+ *     `event_time` range. Those candidates are simply skipped.
+ *   - On every successful step (f) the per-page transaction updates
+ *     `baseline_corpus_state.story_finalized_through` to
+ *     `(page_max_event_time − slop)`.
+ *   - The next tick reads the previous watermark and runs step (f)
+ *     against the two distinct ranges:
+ *       * Finalization-candidate range (`time_window_end` allowed):
+ *         `(previous_watermark, new_horizon]`.
+ *       * Member-scan range (events read to populate predicates):
+ *         `[previous_watermark − MAX_RULE_WINDOW_MS, new_horizon]`.
+ *   - When `previous_watermark IS NULL` (fresh tenant), both ranges
+ *     degenerate to `(-∞, new_horizon]`. `corpus_activated_at` is
+ *     intentionally NOT used as an event-time floor (it is a
+ *     wall-clock anchor for §7 active-window age, not an event-time
+ *     marker; using it here would mis-bound a historical catch-up).
+ *   - Empty page (zero `baseline_triaged_event` survivors) is a
+ *     no-op: `story_finalized_through` is NOT advanced. Advancing
+ *     on an empty page would push the finalization horizon past
+ *     events that arrive in the next page within the slop window,
+ *     defeating the cross-page semantics.
+ */
+
+import type pg from "pg";
+import {
+  advanceStoryWatermark,
+  insertAutoStory,
+  readCandidateEventsInRange,
+  readStoryWatermark,
+} from "./repository";
+import { detectAllStories, MAX_RULE_WINDOW_MS, SLOP_WINDOW_MS } from "./rules";
+
+export interface RunStepFArgs {
+  client: pg.PoolClient;
+  /**
+   * Event-time extents of the survivors this page just INSERTed into
+   * `baseline_triaged_event`. `null` signals the page produced zero
+   * survivors, in which case step (f) is a no-op (no watermark
+   * advance, no rule evaluation).
+   */
+  pageEventTimeRange: { min: Date; max: Date } | null;
+  signal?: AbortSignal;
+}
+
+export interface StepFResult {
+  /** Number of `event_group` rows inserted this page. Idempotent
+   *  re-evaluations of the same window dedup at the partial unique
+   *  index and contribute 0 to this counter. */
+  storiesInserted: number;
+  /**
+   * `(page_max_event_time − slop)` if the watermark advanced this
+   * page, else `null`. Tests assert this directly; callers can
+   * surface it in cadence telemetry.
+   */
+  newWatermark: Date | null;
+}
+
+/**
+ * Run step (f) for the page. Writes happen in the caller's open
+ * transaction, so a thrown error rolls the entire page back.
+ */
+export async function runStepF(args: RunStepFArgs): Promise<StepFResult> {
+  const { client, pageEventTimeRange, signal } = args;
+  if (signal?.aborted) {
+    throw new Error("Story correlator aborted before evaluation");
+  }
+  // Empty-page no-op: the watermark is not advanced and no rules
+  // run. The next non-empty page resumes from the previously-held
+  // watermark — `last_event_cursor` continues to advance
+  // independently (it tracks raw-page boundaries, not finalization).
+  if (pageEventTimeRange === null) {
+    return { storiesInserted: 0, newWatermark: null };
+  }
+
+  const previousWatermark = await readStoryWatermark(client);
+  const newHorizon = new Date(
+    pageEventTimeRange.max.getTime() - SLOP_WINDOW_MS,
+  );
+
+  // Member-scan range:
+  //   - first tick (NULL watermark): degenerate (-∞, new_horizon].
+  //     The page's own `event_time.min` is a natural lower bound but
+  //     we DO NOT clamp to `corpus_activated_at` (see file header).
+  //     Use `pageEventTimeRange.min` as a conservative lower bound;
+  //     the page's own min is by construction the earliest event
+  //     this customer has produced in step (e) for this page, and
+  //     prior-page rows are already finalized.
+  //   - second+ tick: `previous_watermark − MAX_RULE_WINDOW_MS` so
+  //     cross-page clusters whose `time_window_end` falls just past
+  //     the previous watermark can pick up earlier members.
+  const memberScanStart =
+    previousWatermark === null
+      ? pageEventTimeRange.min
+      : new Date(previousWatermark.getTime() - MAX_RULE_WINDOW_MS);
+
+  const candidates = await readCandidateEventsInRange({
+    client,
+    memberScanStart,
+    memberScanEnd: pageEventTimeRange.max,
+  });
+
+  const drafts = detectAllStories(candidates);
+
+  // Finalization-candidate filter: only drafts whose
+  // `time_window_end` falls strictly past the previous watermark
+  // and at-or-before `new_horizon` are finalized this tick. Drafts
+  // whose `time_window_end` falls within the last `SLOP_WINDOW_MS`
+  // of the page's range (i.e., > `new_horizon`) are deferred.
+  const newHorizonMs = newHorizon.getTime();
+  const previousMs =
+    previousWatermark === null ? -Infinity : previousWatermark.getTime();
+
+  let storiesInserted = 0;
+  for (const draft of drafts) {
+    const endMs = draft.timeWindowEnd.getTime();
+    if (endMs <= previousMs) continue; // already finalized on a prior tick
+    if (endMs > newHorizonMs) continue; // in slop window; defer to next tick
+    const result = await insertAutoStory(client, draft);
+    if (result.groupId !== null) storiesInserted += 1;
+  }
+
+  await advanceStoryWatermark(client, newHorizon);
+
+  return { storiesInserted, newWatermark: newHorizon };
+}

--- a/src/lib/triage/story/correlator.ts
+++ b/src/lib/triage/story/correlator.ts
@@ -48,10 +48,17 @@ import type pg from "pg";
 import {
   advanceStoryWatermark,
   insertAutoStory,
-  readCandidateEventsInRange,
+  readR1Candidates,
+  readR3Candidates,
   readStoryWatermark,
 } from "./repository";
-import { detectAllStories, MAX_RULE_WINDOW_MS, SLOP_WINDOW_MS } from "./rules";
+import {
+  detectR1,
+  detectR3,
+  MAX_RULE_WINDOW_MS,
+  SLOP_WINDOW_MS,
+  type StoryDraft,
+} from "./rules";
 
 export interface RunStepFArgs {
   client: pg.PoolClient;
@@ -126,13 +133,23 @@ export async function runStepF(args: RunStepFArgs): Promise<StepFResult> {
       ? null
       : new Date(previousWatermark.getTime() - MAX_RULE_WINDOW_MS);
 
-  const candidates = await readCandidateEventsInRange({
-    client,
-    memberScanStart,
-    memberScanEnd: newHorizon,
-  });
+  // Per-rule SQL push-down (Story RFC §3, §5). Each rule reads its
+  // own candidate set with the row-level predicate evaluated by
+  // PostgreSQL — `category = ANY(...)` for R1, `selector_tags && ...`
+  // for R3 — so the `EXPLAIN ANALYZE` shape demanded by the issue's
+  // measurement gate runs against the SQL that production runs, and
+  // the correlator does not materialize the entire member-scan range
+  // in app memory before filtering. Same-asset narrowing stays in
+  // the rule layer (a clustering operation, not a row-level filter).
+  const [r1Candidates, r3Candidates] = await Promise.all([
+    readR1Candidates({ client, memberScanStart, memberScanEnd: newHorizon }),
+    readR3Candidates({ client, memberScanStart, memberScanEnd: newHorizon }),
+  ]);
 
-  const drafts = detectAllStories(candidates);
+  const drafts: StoryDraft[] = [
+    ...detectR1(r1Candidates),
+    ...detectR3(r3Candidates),
+  ];
 
   // Finalization-candidate filter: only drafts whose
   // `time_window_end` falls strictly past the previous watermark

--- a/src/lib/triage/story/repository.ts
+++ b/src/lib/triage/story/repository.ts
@@ -1,0 +1,203 @@
+import "server-only";
+
+/**
+ * Story persistence layer (Story RFC §5).
+ *
+ * Owns every write to `event_group` / `event_group_member` and the
+ * `baseline_corpus_state.story_finalized_through` watermark UPDATE.
+ * Pure SQL — no rule logic. The correlator (`./correlator.ts`) calls
+ * into this module for each draft and for the per-page watermark
+ * advance.
+ *
+ * Auto-correlated rows take the `ON CONFLICT DO NOTHING` path against
+ * the partial unique index
+ * `(correlation_rule_id, primary_asset, time_window_start, time_window_end)
+ *  WHERE kind = 'auto_correlated' AND primary_asset IS NOT NULL`
+ * (migration 0008). A re-evaluated slop-window candidate therefore
+ * never produces a duplicate `event_group` row.
+ */
+
+import type pg from "pg";
+
+import type { CandidateEvent, StoryDraft, StorySummaryPayload } from "./rules";
+import { STORY_VERSION } from "./rules";
+
+export interface ReadCandidatesArgs {
+  client: pg.PoolClient;
+  /**
+   * Inclusive lower bound on `event_time` for the member scan. Per
+   * Story RFC §4 the scan window is
+   * `[previous_watermark − max_rule_window, new_horizon]` so that an
+   * R3 cluster whose `time_window_end` falls just past the previous
+   * watermark can still pick up members that sit before the
+   * watermark but inside the rule window.
+   */
+  memberScanStart: Date;
+  /** Inclusive upper bound on `event_time` for the member scan. */
+  memberScanEnd: Date;
+}
+
+/**
+ * Pull the candidate events from `baseline_triaged_event` for the
+ * member-scan range. The correlator passes the result straight into
+ * `detectAllStories`. The scan rides the existing
+ * `(event_time DESC)` btree index; no new indexes are required.
+ *
+ * NULL-`orig_addr` rows are intentionally retained in the result so
+ * the rule layer is the single place that filters them out (R1 and
+ * R3 both skip them at the predicate level).
+ */
+export async function readCandidateEventsInRange(
+  args: ReadCandidatesArgs,
+): Promise<CandidateEvent[]> {
+  const { client, memberScanStart, memberScanEnd } = args;
+  const result = await client.query<{
+    event_key: string;
+    event_time: Date;
+    kind: string;
+    orig_addr: string | null;
+    category: string | null;
+    selector_tags: string[];
+    raw_score: number;
+  }>(
+    `SELECT event_key::text   AS event_key,
+            event_time,
+            kind,
+            host(orig_addr)   AS orig_addr,
+            category,
+            selector_tags,
+            raw_score
+       FROM baseline_triaged_event
+      WHERE event_time >= $1
+        AND event_time <= $2`,
+    [memberScanStart, memberScanEnd],
+  );
+  return result.rows.map((row) => ({
+    eventKey: row.event_key,
+    eventTime: row.event_time,
+    kind: row.kind,
+    origAddr: row.orig_addr,
+    category: row.category,
+    selectorTags: row.selector_tags ?? [],
+    rawScore: Number(row.raw_score),
+  }));
+}
+
+export interface InsertAutoStoryResult {
+  /** Newly-inserted `event_group.id`, or `null` when the partial
+   *  unique index suppressed the insert (idempotent replay). */
+  groupId: string | null;
+}
+
+/**
+ * INSERT one auto-correlated `event_group` row plus its members in
+ * the caller's open transaction. Returns the new group id, or
+ * `null` when the partial unique index suppressed the INSERT — the
+ * caller treats `null` as "already-finalized, nothing to do".
+ *
+ * Members are written via a single batched VALUES INSERT against
+ * `event_group_member`. The composite PK `(event_group_id, event_key)`
+ * makes the path idempotent under retry against a successfully-
+ * INSERTed parent.
+ */
+export async function insertAutoStory(
+  client: pg.PoolClient,
+  draft: StoryDraft,
+): Promise<InsertAutoStoryResult> {
+  const insertGroup = await client.query<{ id: string }>(
+    `INSERT INTO event_group (
+        kind, correlation_rule_id, story_version,
+        time_window_start, time_window_end,
+        primary_asset, score, summary_payload
+      )
+      VALUES ('auto_correlated', $1, $2, $3, $4, $5::inet, $6, $7::jsonb)
+      ON CONFLICT (correlation_rule_id, primary_asset, time_window_start, time_window_end)
+        WHERE kind = 'auto_correlated' AND primary_asset IS NOT NULL
+        DO NOTHING
+      RETURNING id::text AS id`,
+    [
+      draft.ruleId,
+      STORY_VERSION,
+      draft.timeWindowStart,
+      draft.timeWindowEnd,
+      draft.primaryAsset,
+      draft.score,
+      JSON.stringify(draft.summary satisfies StorySummaryPayload),
+    ],
+  );
+  if (insertGroup.rows.length === 0) {
+    return { groupId: null };
+  }
+  const groupId = insertGroup.rows[0].id;
+  await insertStoryMembers(client, groupId, draft.members, "primary");
+  return { groupId };
+}
+
+/**
+ * Batched member INSERT. The PK is `(event_group_id, event_key)`, so
+ * `ON CONFLICT DO NOTHING` makes the path idempotent under a retry
+ * of the same draft against an already-inserted parent.
+ */
+async function insertStoryMembers(
+  client: pg.PoolClient,
+  groupId: string,
+  members: ReadonlyArray<CandidateEvent>,
+  role: "primary" | "context",
+): Promise<void> {
+  if (members.length === 0) return;
+  const params: unknown[] = [];
+  const placeholders: string[] = [];
+  for (const m of members) {
+    const base = params.length;
+    placeholders.push(
+      `($${base + 1}::bigint, $${base + 2}::numeric, $${base + 3}::text)`,
+    );
+    params.push(groupId, m.eventKey, role);
+  }
+  await client.query(
+    `INSERT INTO event_group_member (event_group_id, event_key, role)
+       VALUES ${placeholders.join(", ")}
+       ON CONFLICT (event_group_id, event_key) DO NOTHING`,
+    params,
+  );
+}
+
+/**
+ * Advance `baseline_corpus_state.story_finalized_through`. The
+ * correlator calls this once per page transaction with
+ * `new_horizon = page_max_event_time − slop`. Per the watermark
+ * protocol, the column is `>=`-monotonic: a re-run of the same page
+ * (e.g., a slop-window replay) must never push the watermark
+ * backwards, so the UPDATE uses `GREATEST(...)` to coalesce against
+ * the prior value.
+ */
+export async function advanceStoryWatermark(
+  client: pg.PoolClient,
+  newHorizon: Date,
+): Promise<void> {
+  await client.query(
+    `UPDATE baseline_corpus_state
+        SET story_finalized_through =
+              GREATEST(story_finalized_through, $1)
+      WHERE id = true`,
+    [newHorizon],
+  );
+}
+
+/**
+ * Read the singleton's current `story_finalized_through` value.
+ * Returns `null` on a fresh tenant where step (f) has never
+ * advanced the watermark — the correlator treats `null` as
+ * "no previous boundary", per the first-tick degenerate-protocol
+ * branch in the issue body.
+ */
+export async function readStoryWatermark(
+  client: pg.PoolClient,
+): Promise<Date | null> {
+  const result = await client.query<{ story_finalized_through: Date | null }>(
+    `SELECT story_finalized_through
+       FROM baseline_corpus_state
+      WHERE id = true`,
+  );
+  return result.rows[0]?.story_finalized_through ?? null;
+}

--- a/src/lib/triage/story/repository.ts
+++ b/src/lib/triage/story/repository.ts
@@ -20,7 +20,7 @@ import "server-only";
 import type pg from "pg";
 
 import type { CandidateEvent, StoryDraft, StorySummaryPayload } from "./rules";
-import { STORY_VERSION } from "./rules";
+import { applyMemberCap, buildSummaryPayload, STORY_VERSION } from "./rules";
 
 export interface ReadCandidatesArgs {
   client: pg.PoolClient;
@@ -30,9 +30,11 @@ export interface ReadCandidatesArgs {
    * `[previous_watermark − max_rule_window, new_horizon]` so that an
    * R3 cluster whose `time_window_end` falls just past the previous
    * watermark can still pick up members that sit before the
-   * watermark but inside the rule window.
+   * watermark but inside the rule window. `null` means "no lower
+   * bound" — used on the first tick (NULL watermark), where the
+   * range degenerates to `(-∞, new_horizon]`.
    */
-  memberScanStart: Date;
+  memberScanStart: Date | null;
   /** Inclusive upper bound on `event_time` for the member scan. */
   memberScanEnd: Date;
 }
@@ -51,6 +53,31 @@ export async function readCandidateEventsInRange(
   args: ReadCandidatesArgs,
 ): Promise<CandidateEvent[]> {
   const { client, memberScanStart, memberScanEnd } = args;
+  const sql =
+    memberScanStart === null
+      ? `SELECT event_key::text   AS event_key,
+                event_time,
+                kind,
+                host(orig_addr)   AS orig_addr,
+                category,
+                selector_tags,
+                raw_score
+           FROM baseline_triaged_event
+          WHERE event_time <= $1`
+      : `SELECT event_key::text   AS event_key,
+                event_time,
+                kind,
+                host(orig_addr)   AS orig_addr,
+                category,
+                selector_tags,
+                raw_score
+           FROM baseline_triaged_event
+          WHERE event_time >= $1
+            AND event_time <= $2`;
+  const params =
+    memberScanStart === null
+      ? [memberScanEnd]
+      : [memberScanStart, memberScanEnd];
   const result = await client.query<{
     event_key: string;
     event_time: Date;
@@ -59,19 +86,7 @@ export async function readCandidateEventsInRange(
     category: string | null;
     selector_tags: string[];
     raw_score: number;
-  }>(
-    `SELECT event_key::text   AS event_key,
-            event_time,
-            kind,
-            host(orig_addr)   AS orig_addr,
-            category,
-            selector_tags,
-            raw_score
-       FROM baseline_triaged_event
-      WHERE event_time >= $1
-        AND event_time <= $2`,
-    [memberScanStart, memberScanEnd],
-  );
+  }>(sql, params);
   return result.rows.map((row) => ({
     eventKey: row.event_key,
     eventTime: row.event_time,
@@ -130,6 +145,90 @@ export async function insertAutoStory(
   }
   const groupId = insertGroup.rows[0].id;
   await insertStoryMembers(client, groupId, draft.members, "primary");
+  return { groupId };
+}
+
+export interface InsertCuratedStoryArgs {
+  /**
+   * Analyst's chosen focus asset. May be `null` for curated Stories
+   * — the partial unique-index dedup applies only to
+   * `kind = 'auto_correlated'`, so a curated row with NULL
+   * `primary_asset` is legal.
+   */
+  primaryAsset: string | null;
+  /**
+   * Analyst's selected period. Persisted verbatim to
+   * `time_window_start` / `time_window_end` on the `event_group`
+   * row.
+   */
+  timeWindowStart: Date;
+  timeWindowEnd: Date;
+  /**
+   * Member events. The §8 cap and deterministic sampling order are
+   * enforced here so #490's mutation cannot accidentally bypass
+   * the LLM context-budget contract that auto-correlated Stories
+   * obey.
+   */
+  members: ReadonlyArray<CandidateEvent>;
+  /**
+   * Optional Story-side `score`. Curated rows are not produced by
+   * a rule, so the column is nullable; when omitted, defaults to
+   * the post-cap `memberCount` for consistency with R3's score
+   * model (count of admitted members).
+   */
+  score?: number | null;
+}
+
+export interface InsertCuratedStoryResult {
+  /** Newly-inserted `event_group.id`. Curated rows are NOT subject
+   *  to the partial unique-index dedup (which is scoped to
+   *  `kind = 'auto_correlated'`), so the insert always succeeds. */
+  groupId: string;
+}
+
+/**
+ * INSERT one analyst-curated `event_group` row plus its members in
+ * the caller's open transaction. Mirrors `insertAutoStory`'s shape
+ * with three differences:
+ *
+ *   - `kind = 'analyst_curated'`.
+ *   - `correlation_rule_id = NULL` (curated rows have no rule).
+ *   - No `ON CONFLICT` clause — the partial unique index is scoped
+ *     to `kind = 'auto_correlated'`, so a curated save can
+ *     legitimately repeat a `(asset, window)` an analyst already
+ *     stored.
+ *
+ * Built so #490's "Save as Story" mutation has a stable storage
+ * path that obeys the §7 fixed-key `summary_payload` contract and
+ * the §8 member cap / sampling order. The UI control itself ships
+ * with #490.
+ */
+export async function insertCuratedStory(
+  client: pg.PoolClient,
+  args: InsertCuratedStoryArgs,
+): Promise<InsertCuratedStoryResult> {
+  const members = applyMemberCap(args.members);
+  const summary = buildSummaryPayload(members);
+  const score = args.score ?? members.length;
+  const insertGroup = await client.query<{ id: string }>(
+    `INSERT INTO event_group (
+        kind, correlation_rule_id, story_version,
+        time_window_start, time_window_end,
+        primary_asset, score, summary_payload
+      )
+      VALUES ('analyst_curated', NULL, $1, $2, $3, $4::inet, $5, $6::jsonb)
+      RETURNING id::text AS id`,
+    [
+      STORY_VERSION,
+      args.timeWindowStart,
+      args.timeWindowEnd,
+      args.primaryAsset,
+      score,
+      JSON.stringify(summary satisfies StorySummaryPayload),
+    ],
+  );
+  const groupId = insertGroup.rows[0].id;
+  await insertStoryMembers(client, groupId, members, "primary");
   return { groupId };
 }
 

--- a/src/lib/triage/story/repository.ts
+++ b/src/lib/triage/story/repository.ts
@@ -18,9 +18,15 @@ import "server-only";
  */
 
 import type pg from "pg";
-
+import type { ThreatCategory } from "@/lib/detection";
+import { CRITICAL_CATEGORIES } from "@/lib/triage/baseline/categories";
 import type { CandidateEvent, StoryDraft, StorySummaryPayload } from "./rules";
-import { applyMemberCap, buildSummaryPayload, STORY_VERSION } from "./rules";
+import {
+  applyMemberCap,
+  buildSummaryPayload,
+  CRITICAL_SELECTOR_SET,
+  STORY_VERSION,
+} from "./rules";
 
 export interface ReadCandidatesArgs {
   client: pg.PoolClient;
@@ -39,55 +45,18 @@ export interface ReadCandidatesArgs {
   memberScanEnd: Date;
 }
 
-/**
- * Pull the candidate events from `baseline_triaged_event` for the
- * member-scan range. The correlator passes the result straight into
- * `detectAllStories`. The scan rides the existing
- * `(event_time DESC)` btree index; no new indexes are required.
- *
- * NULL-`orig_addr` rows are intentionally retained in the result so
- * the rule layer is the single place that filters them out (R1 and
- * R3 both skip them at the predicate level).
- */
-export async function readCandidateEventsInRange(
-  args: ReadCandidatesArgs,
-): Promise<CandidateEvent[]> {
-  const { client, memberScanStart, memberScanEnd } = args;
-  const sql =
-    memberScanStart === null
-      ? `SELECT event_key::text   AS event_key,
-                event_time,
-                kind,
-                host(orig_addr)   AS orig_addr,
-                category,
-                selector_tags,
-                raw_score
-           FROM baseline_triaged_event
-          WHERE event_time <= $1`
-      : `SELECT event_key::text   AS event_key,
-                event_time,
-                kind,
-                host(orig_addr)   AS orig_addr,
-                category,
-                selector_tags,
-                raw_score
-           FROM baseline_triaged_event
-          WHERE event_time >= $1
-            AND event_time <= $2`;
-  const params =
-    memberScanStart === null
-      ? [memberScanEnd]
-      : [memberScanStart, memberScanEnd];
-  const result = await client.query<{
-    event_key: string;
-    event_time: Date;
-    kind: string;
-    orig_addr: string | null;
-    category: string | null;
-    selector_tags: string[];
-    raw_score: number;
-  }>(sql, params);
-  return result.rows.map((row) => ({
+interface CandidateRow {
+  event_key: string;
+  event_time: Date;
+  kind: string;
+  orig_addr: string | null;
+  category: string | null;
+  selector_tags: string[];
+  raw_score: number;
+}
+
+function rowToCandidate(row: CandidateRow): CandidateEvent {
+  return {
     eventKey: row.event_key,
     eventTime: row.event_time,
     kind: row.kind,
@@ -95,7 +64,113 @@ export async function readCandidateEventsInRange(
     category: row.category,
     selectorTags: row.selector_tags ?? [],
     rawScore: Number(row.raw_score),
-  }));
+  };
+}
+
+/**
+ * R1's per-page candidate scan (Story RFC §3.R1, §5).
+ *
+ * Pushes the row-level predicate into SQL so the planner can use the
+ * `(event_time DESC)` btree on the time range and a category-set
+ * filter on `category`, instead of materializing the full range in
+ * memory and filtering app-side. `orig_addr IS NOT NULL` is also
+ * pushed down because R1 explicitly skips NULL-asset rows at the
+ * predicate level (the partial unique index on `event_group` requires
+ * a non-NULL `primary_asset`, so a NULL-asset cluster is unreachable
+ * by construction).
+ *
+ *   SELECT ... FROM baseline_triaged_event
+ *    WHERE event_time IN [memberScanStart, memberScanEnd]
+ *      AND orig_addr IS NOT NULL
+ *      AND category = ANY($criticalCategories::text[])
+ *
+ * Same-asset narrowing is a clustering operation across the returned
+ * rows and stays in the rule layer (`rules.ts`). The issue's
+ * measurement gate (R1 same-asset 10-min scan) is run against the
+ * SQL above.
+ */
+export async function readR1Candidates(
+  args: ReadCandidatesArgs,
+): Promise<CandidateEvent[]> {
+  const { client, memberScanStart, memberScanEnd } = args;
+  const categories = Array.from(CRITICAL_CATEGORIES) as ThreatCategory[];
+  const baseSelect = `SELECT event_key::text   AS event_key,
+                              event_time,
+                              kind,
+                              host(orig_addr)   AS orig_addr,
+                              category,
+                              selector_tags,
+                              raw_score
+                         FROM baseline_triaged_event`;
+  const sql =
+    memberScanStart === null
+      ? `${baseSelect}
+          WHERE event_time <= $1
+            AND orig_addr IS NOT NULL
+            AND category = ANY($2::text[])`
+      : `${baseSelect}
+          WHERE event_time >= $1
+            AND event_time <= $2
+            AND orig_addr IS NOT NULL
+            AND category = ANY($3::text[])`;
+  const params =
+    memberScanStart === null
+      ? [memberScanEnd, categories]
+      : [memberScanStart, memberScanEnd, categories];
+  const result = await client.query<CandidateRow>(sql, params);
+  return result.rows.map(rowToCandidate);
+}
+
+/**
+ * R3's per-page candidate scan (Story RFC §3.R3, §5).
+ *
+ * Pushes R3's row-level predicate into SQL — `selector_tags`
+ * overlap with the critical-selector set — so the measurement gate's
+ * `EXPLAIN ANALYZE` runs against the same shape that production runs.
+ * Without the push-down, the broad-range SELECT has nothing
+ * R3-specific for the planner to explain.
+ *
+ *   SELECT ... FROM baseline_triaged_event
+ *    WHERE event_time IN [memberScanStart, memberScanEnd]
+ *      AND orig_addr IS NOT NULL
+ *      AND selector_tags && $criticalSelectors::text[]
+ *
+ * The `(event_time DESC)` btree handles the time-range scan. If
+ * measurement at scale shows the planner cannot resolve
+ * `selector_tags &&` efficiently, a GIN index on `selector_tags` is
+ * the additive follow-up named in the issue's measurement-gate
+ * section — purely a migration-only change, no callsite churn.
+ */
+export async function readR3Candidates(
+  args: ReadCandidatesArgs,
+): Promise<CandidateEvent[]> {
+  const { client, memberScanStart, memberScanEnd } = args;
+  const selectors = Array.from(CRITICAL_SELECTOR_SET);
+  const baseSelect = `SELECT event_key::text   AS event_key,
+                              event_time,
+                              kind,
+                              host(orig_addr)   AS orig_addr,
+                              category,
+                              selector_tags,
+                              raw_score
+                         FROM baseline_triaged_event`;
+  const sql =
+    memberScanStart === null
+      ? `${baseSelect}
+          WHERE event_time <= $1
+            AND orig_addr IS NOT NULL
+            AND selector_tags && $2::text[]`
+      : `${baseSelect}
+          WHERE event_time >= $1
+            AND event_time <= $2
+            AND orig_addr IS NOT NULL
+            AND selector_tags && $3::text[]`;
+  const params =
+    memberScanStart === null
+      ? [memberScanEnd, selectors]
+      : [memberScanStart, memberScanEnd, selectors];
+  const result = await client.query<CandidateRow>(sql, params);
+  return result.rows.map(rowToCandidate);
 }
 
 export interface InsertAutoStoryResult {

--- a/src/lib/triage/story/repository.ts
+++ b/src/lib/triage/story/repository.ts
@@ -85,9 +85,12 @@ function rowToCandidate(row: CandidateRow): CandidateEvent {
  *      AND category = ANY($criticalCategories::text[])
  *
  * Same-asset narrowing is a clustering operation across the returned
- * rows and stays in the rule layer (`rules.ts`). The issue's
- * measurement gate (R1 same-asset 10-min scan) is run against the
- * SQL above.
+ * rows and stays in the rule layer (`rules.ts`). R1 is a single
+ * SELECT (no candidate-asset pre-aggregation): the critical-category
+ * set is small, so `category = ANY(...)` is enough to bound the
+ * working set, and R1's per-cluster member threshold (≥2 distinct
+ * categories) does not map to a `COUNT(*) >= N` pre-aggregation in
+ * the way R3's ≥3-member threshold does.
  */
 export async function readR1Candidates(
   args: ReadCandidatesArgs,
@@ -124,28 +127,87 @@ export async function readR1Candidates(
 /**
  * R3's per-page candidate scan (Story RFC §3.R3, §5).
  *
- * Pushes R3's row-level predicate into SQL — `selector_tags`
- * overlap with the critical-selector set — so the measurement gate's
- * `EXPLAIN ANALYZE` runs against the same shape that production runs.
- * Without the push-down, the broad-range SELECT has nothing
- * R3-specific for the planner to explain.
+ * Two-phase per-asset access pattern, so the issue's measurement
+ * gate has a concrete production-shape target for
+ * `EXPLAIN ANALYZE` — specifically, the per-asset narrowing that
+ * rides the existing `baseline_triaged_event_orig_addr_gist`
+ * (`gist_inet_ops` supports `=`).
  *
- *   SELECT ... FROM baseline_triaged_event
+ * Phase 1 — candidate-asset pre-aggregation:
+ *
+ *   SELECT host(orig_addr) AS orig_addr
+ *     FROM baseline_triaged_event
  *    WHERE event_time IN [memberScanStart, memberScanEnd]
  *      AND orig_addr IS NOT NULL
  *      AND selector_tags && $criticalSelectors::text[]
+ *    GROUP BY orig_addr
+ *   HAVING COUNT(*) >= 3
  *
- * The `(event_time DESC)` btree handles the time-range scan. If
- * measurement at scale shows the planner cannot resolve
- * `selector_tags &&` efficiently, a GIN index on `selector_tags` is
- * the additive follow-up named in the issue's measurement-gate
- * section — purely a migration-only change, no callsite churn.
+ * Phase 2 — per-asset member scan against the candidates phase 1
+ * returned (this is the "R3 same-asset-1h" SELECT shape the issue
+ * gate names):
+ *
+ *   SELECT ... FROM baseline_triaged_event
+ *    WHERE event_time IN [memberScanStart, memberScanEnd]
+ *      AND orig_addr = ANY($assets::inet[])
+ *      AND selector_tags && $criticalSelectors::text[]
+ *
+ * The `orig_addr = ANY(...)` predicate is what the planner uses to
+ * fan out into per-asset GiST index probes, instead of materializing
+ * every critical-selector row in the tenant-wide scan range.
+ * `COUNT(*) >= 3` matches R3's per-rule member threshold, so an
+ * asset that cannot reach the threshold in this scan range is
+ * dropped at phase 1 instead of paid for in phase 2. Same-asset
+ * sliding-window clustering remains a rule-layer operation
+ * (`clusterByWindow` in `rules.ts`); the SQL only narrows which
+ * assets are read, not how their events cluster.
+ *
+ * If measurement at scale shows the planner cannot resolve
+ * `selector_tags &&` efficiently in phase 1, a GIN index on
+ * `selector_tags` is the additive follow-up named in the issue's
+ * measurement-gate section — migration-only, no callsite churn.
  */
 export async function readR3Candidates(
   args: ReadCandidatesArgs,
 ): Promise<CandidateEvent[]> {
   const { client, memberScanStart, memberScanEnd } = args;
   const selectors = Array.from(CRITICAL_SELECTOR_SET);
+
+  const phase1Sql =
+    memberScanStart === null
+      ? `SELECT host(orig_addr) AS orig_addr
+           FROM baseline_triaged_event
+          WHERE event_time <= $1
+            AND orig_addr IS NOT NULL
+            AND selector_tags && $2::text[]
+          GROUP BY orig_addr
+         HAVING COUNT(*) >= 3`
+      : `SELECT host(orig_addr) AS orig_addr
+           FROM baseline_triaged_event
+          WHERE event_time >= $1
+            AND event_time <= $2
+            AND orig_addr IS NOT NULL
+            AND selector_tags && $3::text[]
+          GROUP BY orig_addr
+         HAVING COUNT(*) >= 3`;
+  const phase1Params =
+    memberScanStart === null
+      ? [memberScanEnd, selectors]
+      : [memberScanStart, memberScanEnd, selectors];
+  const phase1 = await client.query<{ orig_addr: string }>(
+    phase1Sql,
+    phase1Params,
+  );
+  // Mock query layers in unit tests reuse one handler for every
+  // `FROM baseline_triaged_event` SELECT, so a result row carrying
+  // duplicates is plausible there even though production phase-1
+  // SQL is `GROUP BY orig_addr`. Dedupe here so the phase-2 ANY
+  // array is well-formed regardless of caller.
+  const assets = Array.from(
+    new Set(phase1.rows.map((r) => r.orig_addr).filter((a) => a !== null)),
+  );
+  if (assets.length === 0) return [];
+
   const baseSelect = `SELECT event_key::text   AS event_key,
                               event_time,
                               kind,
@@ -154,22 +216,22 @@ export async function readR3Candidates(
                               selector_tags,
                               raw_score
                          FROM baseline_triaged_event`;
-  const sql =
+  const phase2Sql =
     memberScanStart === null
       ? `${baseSelect}
           WHERE event_time <= $1
-            AND orig_addr IS NOT NULL
-            AND selector_tags && $2::text[]`
+            AND orig_addr = ANY($2::inet[])
+            AND selector_tags && $3::text[]`
       : `${baseSelect}
           WHERE event_time >= $1
             AND event_time <= $2
-            AND orig_addr IS NOT NULL
-            AND selector_tags && $3::text[]`;
-  const params =
+            AND orig_addr = ANY($3::inet[])
+            AND selector_tags && $4::text[]`;
+  const phase2Params =
     memberScanStart === null
-      ? [memberScanEnd, selectors]
-      : [memberScanStart, memberScanEnd, selectors];
-  const result = await client.query<CandidateRow>(sql, params);
+      ? [memberScanEnd, assets, selectors]
+      : [memberScanStart, memberScanEnd, assets, selectors];
+  const result = await client.query<CandidateRow>(phase2Sql, phase2Params);
   return result.rows.map(rowToCandidate);
 }
 

--- a/src/lib/triage/story/rules.ts
+++ b/src/lib/triage/story/rules.ts
@@ -1,0 +1,402 @@
+/**
+ * Story v1 heuristic rule set (Story RFC §3, §7, §8).
+ *
+ * Pure predicate functions over an in-memory candidate event set. No
+ * database access — the correlator (`./correlator.ts`) reads the
+ * candidate set from `baseline_triaged_event` and threads it through
+ * these rules before writing the resulting drafts via
+ * `./repository.ts`.
+ *
+ * Two conservative rules ship in v1:
+ *
+ *   - R1 — same `primary_asset` (orig_addr), within a 10-minute window,
+ *     has events from ≥2 distinct categories in the critical-category
+ *     set.
+ *   - R3 — same `primary_asset` has ≥3 events whose `selector_tags`
+ *     overlap the critical-selector set within a 1-hour window.
+ *
+ * R2 (kill-chain progression) is reserved for the v2 Story RFC bump;
+ * the `'R2'` slot stays empty so the rule-ID enum does not shift.
+ *
+ * Both rules predicate on `selector_tags` membership and on the row's
+ * own `category` column — never on `baseline_score` (read-time only,
+ * does not exist on the row at cadence time) and never on `raw_score`
+ * (absolute scale shifts across `baseline_version` bumps). The
+ * critical-category and critical-selector lists are explicit so an
+ * RFC 0001 §9 rename or addition is caught at Story RFC review time.
+ */
+
+import type { ThreatCategory } from "@/lib/detection";
+import { CRITICAL_CATEGORIES } from "@/lib/triage/baseline/categories";
+import { SELECTOR_TAGS } from "@/lib/triage/baseline/tunables";
+
+/**
+ * Story RFC version stamp. Mirrors `baseline_version` and follows the
+ * same natural-expiry model: bumping this produces new `event_group`
+ * rows tagged with the new value; old rows age out via retention
+ * without retroactive recomputation.
+ */
+export const STORY_VERSION = "v1";
+
+/**
+ * Hard cap on the number of `primary` members per auto-correlated
+ * Story (Story RFC §8). Matches the cap analyst-curated Stories will
+ * enforce in #490 so the LLM context budget stays uniform across
+ * creation paths.
+ */
+export const STORY_MEMBER_CAP = 50;
+
+/**
+ * R1 window — 10 minutes.
+ */
+export const R1_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * R3 window — 1 hour.
+ */
+export const R3_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Maximum rule window. The slop-replay protocol uses this as the
+ * member-scan lookback so an R3 cluster whose `time_window_end` falls
+ * just past the previous watermark can still pick up members that sit
+ * before the watermark but inside the rule window.
+ */
+export const MAX_RULE_WINDOW_MS = Math.max(R1_WINDOW_MS, R3_WINDOW_MS);
+
+/**
+ * Slop-window length applied at finalization (Story RFC §3 / §4). A
+ * cluster whose `time_window_end` is within the last `SLOP_WINDOW_MS`
+ * of the page's `event_time` range is deferred to a subsequent tick.
+ */
+export const SLOP_WINDOW_MS = 30 * 60 * 1000;
+
+/**
+ * λ coefficient for R1's score (Story RFC §3.R1). The R1 score is
+ * `member_count + R1_LAMBDA * distinct_category_count`, a Story-side
+ * count that is NOT a function of `raw_score`.
+ */
+export const R1_LAMBDA = 1.0;
+
+/**
+ * Critical-selector set consumed by R3 (Story RFC §3.R3). The v1
+ * starting set is the two §9 tags whose semantics map to
+ * "critical-class" rather than "frequency/correlation pattern". A
+ * future RFC 0001 selector rename or addition triggers a Story RFC
+ * review.
+ */
+export const CRITICAL_SELECTOR_SET: ReadonlySet<string> = new Set([
+  SELECTOR_TAGS.S2_SEVERE,
+  SELECTOR_TAGS.UNLABELED_CLUSTER,
+]);
+
+/**
+ * Active rule IDs the v1 correlator emits. `'R2'` is intentionally
+ * absent — the slot is reserved by the Story RFC v1 for the v2 bump.
+ */
+export const ACTIVE_RULE_IDS = ["R1", "R3"] as const;
+export type StoryRuleId = (typeof ACTIVE_RULE_IDS)[number];
+
+/**
+ * Slim candidate-event shape the rules operate on. Carries only the
+ * columns the predicates and the summary payload need — the broader
+ * `TriageEvent` shape stays in the pager layer.
+ */
+export interface CandidateEvent {
+  eventKey: string;
+  eventTime: Date;
+  kind: string;
+  origAddr: string | null;
+  category: ThreatCategory | string | null;
+  selectorTags: readonly string[];
+  rawScore: number;
+}
+
+/**
+ * Required fixed-key set on `event_group.summary_payload` (Story
+ * RFC §7). Adding a key is RFC-only; removing or renaming a key is a
+ * `story_version` bump.
+ */
+export interface StorySummaryPayload {
+  kindHistogram: Record<string, number>;
+  categoryHistogram: Record<string, number>;
+  memberCount: number;
+  durationMs: number;
+  distinctAssetCount: number;
+  /**
+   * Story-internal sort hint kept as the max `raw_score` over the
+   * Story's members. NOT surfaced to UI as a baseline percentile —
+   * `raw_score`'s absolute scale shifts across `baseline_version`
+   * bumps, so a numeric comparison across Stories is only valid
+   * within the same `story_version` cohort.
+   */
+  topRawScore: number;
+}
+
+/**
+ * Draft Story emitted by a rule. The correlator threads this through
+ * the finalization filter (slop window) and `./repository.ts` to
+ * produce an `event_group` row plus member rows.
+ */
+export interface StoryDraft {
+  ruleId: StoryRuleId;
+  primaryAsset: string;
+  /**
+   * Cluster span `time_window_start = min(member.event_time)`,
+   * `time_window_end = max(member.event_time)`. Stored on the
+   * `event_group` row; the finalization filter compares
+   * `time_window_end` against the slop horizon.
+   */
+  timeWindowStart: Date;
+  timeWindowEnd: Date;
+  /**
+   * Member list capped at {@link STORY_MEMBER_CAP}. Ordering is
+   * deterministic (see {@link applyMemberCap}) so re-evaluation of
+   * the same window produces the same member set under
+   * `ON CONFLICT DO NOTHING`.
+   */
+  members: CandidateEvent[];
+  score: number;
+  summary: StorySummaryPayload;
+}
+
+/**
+ * Determine the candidate-events subset that contains a non-NULL
+ * `orig_addr`. R1 and R3 are both asset-keyed; the partial unique
+ * index on `event_group` also requires a non-NULL `primary_asset`,
+ * so a NULL-asset cluster cannot be deduped and is unreachable in
+ * v1 by construction.
+ */
+function withAsset(events: ReadonlyArray<CandidateEvent>): CandidateEvent[] {
+  return events.filter((e) => e.origAddr !== null);
+}
+
+/**
+ * Group candidates by their `orig_addr`. Returns a map from asset
+ * string to the asset's sorted (ascending `event_time`) event list.
+ * Ties on `event_time` are broken by `event_key` so the cluster
+ * boundaries are deterministic across re-evaluations.
+ */
+function groupByAsset(
+  events: ReadonlyArray<CandidateEvent>,
+): Map<string, CandidateEvent[]> {
+  const map = new Map<string, CandidateEvent[]>();
+  for (const e of withAsset(events)) {
+    const key = e.origAddr as string;
+    const bucket = map.get(key);
+    if (bucket) {
+      bucket.push(e);
+    } else {
+      map.set(key, [e]);
+    }
+  }
+  for (const bucket of map.values()) {
+    bucket.sort(
+      (a, b) =>
+        a.eventTime.getTime() - b.eventTime.getTime() ||
+        a.eventKey.localeCompare(b.eventKey),
+    );
+  }
+  return map;
+}
+
+/**
+ * Greedy time-bounded clustering: sort by event_time, slide a window
+ * of `windowMs`. Two events sit in the same cluster iff
+ * `max(event_time) − min(event_time) ≤ windowMs`. Returns one
+ * contiguous member list per cluster, in time order.
+ *
+ * The greedy boundary is good enough for v1: a re-scan of the same
+ * candidate set produces identical clusters, so the partial unique
+ * index on `(rule, asset, window_start, window_end)` dedups
+ * idempotently.
+ */
+function clusterByWindow(
+  events: ReadonlyArray<CandidateEvent>,
+  windowMs: number,
+): CandidateEvent[][] {
+  const clusters: CandidateEvent[][] = [];
+  let current: CandidateEvent[] = [];
+  let clusterStart = 0;
+  for (const e of events) {
+    if (current.length === 0) {
+      current = [e];
+      clusterStart = e.eventTime.getTime();
+      continue;
+    }
+    if (e.eventTime.getTime() - clusterStart <= windowMs) {
+      current.push(e);
+    } else {
+      clusters.push(current);
+      current = [e];
+      clusterStart = e.eventTime.getTime();
+    }
+  }
+  if (current.length > 0) clusters.push(current);
+  return clusters;
+}
+
+/**
+ * Sampling order from Story RFC §8: `cardinality(selector_tags) DESC`,
+ * ties broken by `event_time DESC`, with `event_key` as a final
+ * total-order tiebreaker so two events whose times collide produce a
+ * deterministic order across re-evaluations. The order is a
+ * deterministic-sampling key, NOT a ranking — `raw_score` is
+ * intentionally not used because Story members can span multiple
+ * `kind` / `baseline_version` cohorts where its absolute scale is
+ * not comparable.
+ */
+export function applyMemberCap(
+  members: ReadonlyArray<CandidateEvent>,
+  cap: number = STORY_MEMBER_CAP,
+): CandidateEvent[] {
+  if (members.length <= cap) return [...members];
+  const sorted = [...members].sort((a, b) => {
+    const ca = a.selectorTags.length;
+    const cb = b.selectorTags.length;
+    if (ca !== cb) return cb - ca;
+    const tb = b.eventTime.getTime() - a.eventTime.getTime();
+    if (tb !== 0) return tb;
+    return a.eventKey.localeCompare(b.eventKey);
+  });
+  return sorted.slice(0, cap);
+}
+
+/**
+ * Compute the fixed-key `summary_payload` for a Story's member set.
+ * Independent of any cadence-side `payload_summary` extension; the
+ * shape is fixed by Story RFC §7 so #490 binds to a stable contract
+ * across rule versions.
+ */
+export function buildSummaryPayload(
+  members: ReadonlyArray<CandidateEvent>,
+): StorySummaryPayload {
+  const kindHistogram: Record<string, number> = {};
+  const categoryHistogram: Record<string, number> = {};
+  const assets = new Set<string>();
+  let minTime = Number.POSITIVE_INFINITY;
+  let maxTime = Number.NEGATIVE_INFINITY;
+  let topRawScore = 0;
+  for (const m of members) {
+    kindHistogram[m.kind] = (kindHistogram[m.kind] ?? 0) + 1;
+    if (m.category !== null) {
+      const key = String(m.category);
+      categoryHistogram[key] = (categoryHistogram[key] ?? 0) + 1;
+    }
+    if (m.origAddr !== null) assets.add(m.origAddr);
+    const t = m.eventTime.getTime();
+    if (t < minTime) minTime = t;
+    if (t > maxTime) maxTime = t;
+    if (m.rawScore > topRawScore) topRawScore = m.rawScore;
+  }
+  const durationMs =
+    minTime === Number.POSITIVE_INFINITY ? 0 : maxTime - minTime;
+  return {
+    kindHistogram,
+    categoryHistogram,
+    memberCount: members.length,
+    durationMs,
+    distinctAssetCount: assets.size,
+    topRawScore,
+  };
+}
+
+/**
+ * R1 — same `primary_asset`, 10-minute window, ≥2 distinct
+ * critical categories.
+ */
+export function detectR1(events: ReadonlyArray<CandidateEvent>): StoryDraft[] {
+  const drafts: StoryDraft[] = [];
+  const byAsset = groupByAsset(
+    events.filter(
+      (e) =>
+        e.category !== null &&
+        CRITICAL_CATEGORIES.has(e.category as ThreatCategory),
+    ),
+  );
+  for (const [asset, perAsset] of byAsset) {
+    const clusters = clusterByWindow(perAsset, R1_WINDOW_MS);
+    for (const cluster of clusters) {
+      const distinctCategories = new Set(
+        cluster.map((m) => String(m.category)),
+      );
+      if (distinctCategories.size < 2) continue;
+      const capped = applyMemberCap(cluster);
+      // Cluster span is computed BEFORE the cap so the window is the
+      // semantic match window, not the post-sampling subset's span.
+      const start = cluster[0].eventTime;
+      const end = cluster[cluster.length - 1].eventTime;
+      const score = capped.length + R1_LAMBDA * distinctCategories.size;
+      drafts.push({
+        ruleId: "R1",
+        primaryAsset: asset,
+        timeWindowStart: start,
+        timeWindowEnd: end,
+        members: capped,
+        score,
+        summary: buildSummaryPayload(capped),
+      });
+    }
+  }
+  return drafts;
+}
+
+/**
+ * R3 — same `primary_asset`, 1-hour window, ≥3 events whose
+ * `selector_tags` overlap the critical-selector set.
+ */
+export function detectR3(events: ReadonlyArray<CandidateEvent>): StoryDraft[] {
+  const drafts: StoryDraft[] = [];
+  const byAsset = groupByAsset(
+    events.filter((e) =>
+      e.selectorTags.some((t) => CRITICAL_SELECTOR_SET.has(t)),
+    ),
+  );
+  for (const [asset, perAsset] of byAsset) {
+    const clusters = clusterByWindow(perAsset, R3_WINDOW_MS);
+    for (const cluster of clusters) {
+      if (cluster.length < 3) continue;
+      const capped = applyMemberCap(cluster);
+      const start = cluster[0].eventTime;
+      const end = cluster[cluster.length - 1].eventTime;
+      drafts.push({
+        ruleId: "R3",
+        primaryAsset: asset,
+        timeWindowStart: start,
+        timeWindowEnd: end,
+        members: capped,
+        score: capped.length,
+        summary: buildSummaryPayload(capped),
+      });
+    }
+  }
+  return drafts;
+}
+
+/**
+ * Typed registry of v1 rules. Adding a future rule is purely a
+ * registry-level change — schema stays the same.
+ */
+export const RULE_REGISTRY: ReadonlyArray<{
+  id: StoryRuleId;
+  detect: (events: ReadonlyArray<CandidateEvent>) => StoryDraft[];
+}> = [
+  { id: "R1", detect: detectR1 },
+  { id: "R3", detect: detectR3 },
+];
+
+/**
+ * Run every active rule against the candidate set and return the
+ * union of drafts. The correlator's finalization filter (slop
+ * window) decides which drafts persist on this tick versus the
+ * next.
+ */
+export function detectAllStories(
+  events: ReadonlyArray<CandidateEvent>,
+): StoryDraft[] {
+  const out: StoryDraft[] = [];
+  for (const rule of RULE_REGISTRY) {
+    for (const d of rule.detect(events)) out.push(d);
+  }
+  return out;
+}

--- a/src/lib/triage/story/rules.ts
+++ b/src/lib/triage/story/rules.ts
@@ -201,38 +201,55 @@ function groupByAsset(
 }
 
 /**
- * Greedy time-bounded clustering: sort by event_time, slide a window
- * of `windowMs`. Two events sit in the same cluster iff
- * `max(event_time) − min(event_time) ≤ windowMs`. Returns one
- * contiguous member list per cluster, in time order.
+ * True sliding-window clustering. For each event in ascending-time
+ * order, compute the maximal contiguous suffix `[i, j]` such that
+ * `events[j].time − events[i].time ≤ windowMs`. A cluster is emitted
+ * only when it is **left-maximal** — i.e., extending the cluster
+ * leftward by one event would break the window. This finds every
+ * maximal valid window, including overlapping ones, instead of the
+ * greedy "reset whenever the current window breaks" partition that
+ * misses windows starting inside a prior bucket.
  *
- * The greedy boundary is good enough for v1: a re-scan of the same
- * candidate set produces identical clusters, so the partial unique
- * index on `(rule, asset, window_start, window_end)` dedups
- * idempotently.
+ * Example (windowMs = 1 h): events at 00:00, 00:59, 01:01, 01:02.
+ *   - i=0 → [00:00, 00:59] (extending to 01:01 breaks: 61 min).
+ *     Left-maximal. Size 2.
+ *   - i=1 → [00:59, 01:01, 01:02] (window 3 min ≤ 1 h). Left-
+ *     maximal because adding events[0] would make the span
+ *     01:02 − 00:00 = 62 min > 60. Size 3.
+ *   - i=2, i=3 → contained in the i=1 cluster. Not left-maximal.
+ * The greedy partition misses the i=1 cluster entirely.
+ *
+ * Idempotency: the algorithm is deterministic given a sorted input,
+ * so a re-scan of the same candidate set produces identical
+ * clusters, and the partial unique index on
+ * `(rule, asset, window_start, window_end)` dedups across ticks.
  */
 function clusterByWindow(
   events: ReadonlyArray<CandidateEvent>,
   windowMs: number,
 ): CandidateEvent[][] {
+  const n = events.length;
+  if (n === 0) return [];
   const clusters: CandidateEvent[][] = [];
-  let current: CandidateEvent[] = [];
-  let clusterStart = 0;
-  for (const e of events) {
-    if (current.length === 0) {
-      current = [e];
-      clusterStart = e.eventTime.getTime();
-      continue;
+  let j = 0;
+  for (let i = 0; i < n; i += 1) {
+    if (j < i) j = i;
+    while (
+      j + 1 < n &&
+      events[j + 1].eventTime.getTime() - events[i].eventTime.getTime() <=
+        windowMs
+    ) {
+      j += 1;
     }
-    if (e.eventTime.getTime() - clusterStart <= windowMs) {
-      current.push(e);
-    } else {
-      clusters.push(current);
-      current = [e];
-      clusterStart = e.eventTime.getTime();
-    }
+    // Left-maximal: either at the start, or extending one step left
+    // would make the span exceed windowMs at `events[j]`.
+    const leftMaximal =
+      i === 0 ||
+      events[j].eventTime.getTime() - events[i - 1].eventTime.getTime() >
+        windowMs;
+    if (!leftMaximal) continue;
+    clusters.push(events.slice(i, j + 1));
   }
-  if (current.length > 0) clusters.push(current);
   return clusters;
 }
 


### PR DESCRIPTION
## Summary

Introduces the **Story** corpus layer on top of corpus A: small, deterministic bundles of correlated `baseline_triaged_event` rows produced by the cadence's new step (f). The grouping is heuristic in v1 — LLM-driven grouping stays downstream in Phase 2.

- `migrations/customer/0008_event_group_story.sql` — adds `event_group` and `event_group_member`, a partial unique index on `(correlation_rule_id, primary_asset, time_window_start, time_window_end) WHERE kind = 'auto_correlated' AND primary_asset IS NOT NULL` for slop-window idempotency, and a `baseline_corpus_state.story_finalized_through` watermark.
- `src/lib/triage/story/` — `rules.ts` (pure predicates, no DB), `repository.ts` (per-rule SQL reads + the analyst-curated `insertCuratedStory` path that #490 binds to), `correlator.ts` (step (f) entry point), plus the **Story RFC v1**.
- `src/lib/triage/baseline/pager.ts` — calls `runStepF` inside the per-page transaction immediately after `insertBaselineTriagedEventBatch`, so a Story is never persisted for events that did not land. Empty pages are no-ops that leave the watermark untouched.

### Score model

Rules predicate on `selector_tags` membership and on the row's own `category` column — never on `raw_score` (whose scale shifts across `baseline_version` retunes) or `baseline_score` (which is read-time-computed via `cume_dist()` and does not exist on the row at cadence time). The Story-side `event_group.score` is a per-rule count / weighted count over selector-tag matches.

### v1 rules

- **R1** — Same `orig_addr` within 10 min, ≥2 distinct critical categories (`CRITICAL_CATEGORIES` from RFC 0001 §3). Score: `member_count + λ · distinct_category_count`.
- **R3** — Same `orig_addr` within 1 h, ≥3 events whose `selector_tags` overlap the critical-selector set (`{'S2-severe', 'unlabeled-cluster'}`). Score: `member_count` (after cap).

R2 (kill-chain progression) is intentionally deferred to a v2 RFC bump; the `correlation_rule_id = 'R2'` slot is reserved.

### Per-rule SQL push-down

`repository.ts` exposes one read per rule, not a single broad-range candidate scan:

- `readR1Candidates({ memberScanStart, memberScanEnd })` — single SELECT:
  `WHERE event_time IN range AND orig_addr IS NOT NULL AND category = ANY(\$criticalCategories::text[])`.
- `readR3Candidates({ memberScanStart, memberScanEnd })` — **two-phase** per-asset access:
  - phase 1 pre-aggregates candidate assets —
    `GROUP BY orig_addr HAVING COUNT(*) >= 3` over `selector_tags && \$criticalSelectors::text[]`;
  - phase 2 reads per-asset member rows —
    `orig_addr = ANY(\$assets::inet[]) AND selector_tags && \$criticalSelectors::text[]`.

  The phase-2 \`orig_addr = ANY(...)\` predicate is the same-asset-1h scan shape the issue's measurement gate validates against \`baseline_triaged_event_orig_addr_gist\` (\`gist_inet_ops\` supports \`=\`). Phase 1's \`HAVING COUNT(*) >= 3\` matches R3's per-rule member threshold, so an asset that cannot reach the threshold in this scan range is dropped at phase 1 instead of paid for in phase 2.

The correlator runs both rules in parallel, then dispatches each result set to its rule's pure in-memory clusterer. The split serves three goals:

1. **Measurement gate is meaningful.** The issue's gate demands \`EXPLAIN ANALYZE\` on R3's same-asset-1h scan confirming \`(event_time DESC)\` and the \`orig_addr\` GiST index participate. The phase-2 \`orig_addr = ANY(...)\` is what the planner can resolve through the GiST index, so the gate has a concrete production-shape target.
2. **App-side memory bound.** A typical-volume tenant produces a large number of \`baseline_triaged_event\` rows in the slop-replay range; predicate-pushed reads cap the in-memory set at the rows R1/R3 actually evaluate, instead of materializing the full range and filtering in app memory inside the per-page transaction.
3. **Rule-layer separation stays clean.** Final sliding-window clustering (10-min / 1-hour per-\`orig_addr\` window) stays in \`rules.ts\` (\`groupByAsset\` + \`clusterByWindow\`). The SQL only narrows which rows the rule evaluates — phase 1's \`COUNT(*) >= 3\` is the rule's member-count threshold in the scan range, not the sliding window itself, so a candidate that phase 1 admits may still fail the in-memory window check, and that is the intended behaviour.

### Sliding-window clustering

\`clusterByWindow\` emits one cluster per **left-maximal window**: for each starting index \`i\` in time-ordered events, extend the right pointer while the span stays within \`windowMs\`; emit if extending left by one event would break the window. This catches windows that start inside a prior bucket — e.g., R3 events at 00:00, 00:59, 01:01, 01:02 contain a valid 1-hour window at [00:59, 01:02] with 3 hits that a greedy partition splits into [00:00, 00:59] + [01:01, 01:02] and misses. Existing R3 same-asset / member-cap fixtures still produce exactly one Story (left-maximal windowing is strictly more permissive than greedy and does not duplicate the maximal cluster).

### Sliding-window protocol

Step (f) skips Stories whose \`time_window_end\` falls inside the trailing 30-min slop. On commit it advances \`story_finalized_through\` to \`(page_max_event_time − slop)\`. The next tick re-scans members across \`[previous_watermark − max_rule_window, new_horizon]\` (\`max_rule_window = 1 h\`, max of R1 and R3) so cross-page R3 windows do not lose their early members. On the first tick (NULL watermark), the range degenerates to \`(-∞, new_horizon]\` — no event-time lower bound is applied. \`corpus_activated_at\` is intentionally not used as a floor (wall-clock anchor, not event-time marker), and the page's own \`event_time.min\` is not used as a floor either: a tenant carrying \`baseline_triaged_event\` rows older than the current page (cadence ran before migration 0008 landed) would otherwise lose those rows when the watermark advances past them. The scan upper bound is \`new_horizon\`, not \`pageMax\`, so slop-window events are deferred to the next tick via the lookback range rather than participating in this tick's clustering. Re-derived \`(rule, asset, window)\` tuples dedupe via the partial unique index plus \`ON CONFLICT DO NOTHING\`.

### Analyst-curated path

\`insertCuratedStory(client, args)\` mirrors \`insertAutoStory\` with three differences: \`kind = 'analyst_curated'\`, \`correlation_rule_id = NULL\`, and no \`ON CONFLICT\` clause (the partial unique index is scoped to \`kind = 'auto_correlated'\`, so a curated save can legitimately repeat a \`(asset, window)\` an analyst already stored). The §7 \`summary_payload\` contract and §8 member cap / sampling order are enforced inside the repository so #490's "Save as Story" mutation cannot bypass the LLM context-budget contract that auto-correlated Stories obey. The UI control itself ships with #490.

Part of #489

## Not addressed

- **Measurement gate (step (f) p50/p95 latency, combined (d)+(e)+(f) page-transaction latency, \`EXPLAIN ANALYZE\` on R3's same-asset-1h scan).** The acceptance criteria require measurement on a representative tenant DB with 30+ days of cadence-filled corpus A rows; this PR has no such tenant available in CI and no production access. The R3 SELECT shape the gate measures is now the phase-2 \`orig_addr = ANY(\$::inet[]) AND selector_tags && \$::text[]\` SELECT in \`readR3Candidates\`, so the gate has a concrete production-shaped target that the \`orig_addr\` GiST index can resolve. The measurement run and any follow-up (additive GIN index on \`selector_tags\`, caching per-asset windows) is a separate task before this issue is closed.
- **Display-side strictness-slider exemption for Story members** — intentionally out of scope per the issue ("This issue's sole obligation is to write \`event_group\` / \`event_group_member\` rows"). Owned by #471 and consumed by #490 / #458. Verifiable by the absence of any \`event_group_member\` reference in \`src/lib/triage/server-actions.ts\` in this diff.
- **Stories UI tab** — owned by 1B-Story-2 (#490).
- **Send-to-aimer action** — owned by Phase 2 Y2 (#493). β-submission columns (\`last_sent_at\`, \`last_sent_by\`, \`send_count\`) land here at NULL / 0.
- **Multi-window context expansion (\`role = 'context'\`)** — owned by Phase 2 Y4 (#495). v1 only writes \`role = 'primary'\`; \`'context'\` is reserved.
- **Story retention / cleanup** — owned by 1B-7 (#461).

## Test plan

- [x] \`migrations/customer/0008_event_group_story.sql\` applies cleanly to a fresh tenant DB and creates \`event_group\`, \`event_group_member\`, the four indexes, the partial unique dedup index, and the \`baseline_corpus_state.story_finalized_through\` column.
- [x] R1 fixture (multi-category on one asset within 10 min) produces an R1 Story; R3 fixture (≥3 critical-selector hits on one asset within 1 h) produces an R3 Story; no-match fixture produces no Story.
- [x] Cross-page R3 fixture (same-asset 1 h cluster spanning two cadence pages) produces a single Story with \`time_window_start\` / \`end\` covering the full span; \`story_finalized_through\` advances on each successful page.
- [x] Slop respected: a Story whose \`time_window_end\` falls in the last 30 min of a page is not finalized in that page's transaction.
- [x] Slop-replay member lookback: R3 fixture where the last member sits at \`previous_watermark + ε\` and earlier members sit at \`T − 50 min\` (before the watermark, inside the rule window) produces a Story on the next tick. The member-scan upper bound is \`new_horizon\` (= pageMax − slop), not pageMax.
- [x] First-tick / NULL watermark: on a fresh tenant where \`story_finalized_through IS NULL\`, the SELECT omits the lower-bound predicate entirely (no \`event_time >= \$1\` clause), so historical catch-up fixtures (events older than this page's min) still finalize correctly.
- [x] Per-rule SQL push-down: \`readR1Candidates\` SQL contains \`category = ANY(\$::text[])\` plus \`orig_addr IS NOT NULL\`. \`readR3Candidates\` SQL is two-phase: phase 1 contains \`GROUP BY orig_addr HAVING COUNT(*) >= 3\` plus \`selector_tags && \$::text[]\`, phase 2 contains \`orig_addr = ANY(\$::inet[])\` plus \`selector_tags && \$::text[]\`. Phase 2 is the production-shape target the measurement gate's \`EXPLAIN ANALYZE\` runs against; all SELECTs use \`[memberScanStart, memberScanEnd]\` (or \`(-∞, memberScanEnd]\` on first tick).
- [x] Sliding-window regression for R1 and R3: a valid window that starts inside a prior greedy bucket fires (the 00:00 / 00:59 / 01:01 / 01:02 R3 case and the 00:00 A / 00:09 A / 00:11 B R1 case from the review).
- [x] Empty-page no-op: page with zero \`baseline_triaged_event\` survivors leaves \`story_finalized_through\` unchanged while \`last_event_cursor\` still advances; the next non-empty page resumes from the held watermark.
- [x] NULL \`orig_addr\` skipped at predicate level for both R1 and R3 (now in SQL via \`orig_addr IS NOT NULL\`, with a defense-in-depth re-filter in the rule layer).
- [x] Re-evaluation idempotency: running step (f) twice over an overlapping window does not produce duplicate \`event_group\` rows.
- [x] Same-event-multiple-rules: fixture matching both R1 and R3 produces two rows (option A), each with its own \`correlation_rule_id\`.
- [x] Member cap: R3 fixture with 60 candidates produces exactly 50 members, ordered by \`cardinality(selector_tags) DESC, event_time DESC\`; \`score\` reflects the 50 admitted members.
- [x] \`summary_payload\` carries every key from Story RFC §7 (\`kindHistogram\`, \`categoryHistogram\`, \`memberCount\`, \`durationMs\`, \`distinctAssetCount\`, \`topRawScore\`) on both auto-correlated and analyst-curated rows.
- [x] Analyst-curated path: \`insertCuratedStory\` writes \`kind = 'analyst_curated'\`, \`correlation_rule_id = NULL\`, no \`ON CONFLICT\` clause; enforces the §8 member cap; accepts NULL \`primary_asset\`.
- [x] \`correlation_rule_id\` format CHECK rejects \`'r3'\` and \`'R-3'\`; accepts \`'R1'\`, \`'R3'\`, \`NULL\` (and \`'R2'\` for the future v2 RFC bump).
- [x] \`story_version\` populated from the rules module constant (\`'v1'\`).
- [x] β submission columns default to NULL / 0; migration comment documents the cross-DB \`accounts.id\` reference.
- [x] No \`event_group_member\` reference in \`src/lib/triage/server-actions.ts\` or menu SELECT paths (slider exemption stays #471 / #490 / #458).
- [x] Story RFC reviewed alongside the code.
- [ ] Measurement gate report attached: step (f) p50/p95, combined (d)+(e)+(f) p50/p95 vs the existing (d)+(e) baseline (≤ 2× regression), and \`EXPLAIN ANALYZE\` on R3's same-asset-1h scan (\`readR3Candidates\`'s phase-2 \`orig_addr = ANY(\$::inet[])\` SELECT) showing index use on \`(event_time DESC)\` and on \`baseline_triaged_event_orig_addr_gist\`.
- [x] Full CI gate green.