### PR TITLE
Cap cadence pager at REVIEW_MAX_PAGE_SIZE

### DIFF
--- a/src/__tests__/lib/triage/baseline/pager.test.ts
+++ b/src/__tests__/lib/triage/baseline/pager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { REVIEW_MAX_PAGE_SIZE } from "@/lib/review/limits";
 import {
-  CADENCE_PAGE_SIZE,
   type CadencePagerOptions,
   createCadencePager,
   cursorToEventKey,
@@ -355,15 +355,34 @@ describe("createCadencePager — Phase 1.B four-selector pipeline", () => {
     }
 
     expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect((fetchPage.mock.calls[0] as unknown[])[0]).toMatchObject({
+    const firstCallArgs = (
+      fetchPage.mock.calls[0] as Array<{
+        customerId: number;
+        variables: {
+          filter: { customers: string[] };
+          triage: null;
+          first: number;
+          after: string | null;
+        };
+      }>
+    )[0];
+    expect(firstCallArgs).toMatchObject({
       customerId: 42,
       variables: {
         filter: { customers: ["42"] },
         triage: null,
-        first: CADENCE_PAGE_SIZE,
         after: null,
       },
     });
+    // #537: review-web's `Connection::pagination_input` rejects any
+    // `first` outside `[0, 100]`, so the cadence pager MUST stay at or
+    // below `REVIEW_MAX_PAGE_SIZE`. This bound (not an exact value)
+    // is the contract — drift back to a higher constant has bricked
+    // Phase 1.A/1.B corpus ingestion before.
+    expect(firstCallArgs.variables.first).toBeGreaterThan(0);
+    expect(firstCallArgs.variables.first).toBeLessThanOrEqual(
+      REVIEW_MAX_PAGE_SIZE,
+    );
   });
 
   it("drops events matching an active exclusion before BOTH corpus INSERTs", async () => {

--- a/src/lib/triage/baseline/pager.ts
+++ b/src/lib/triage/baseline/pager.ts
@@ -65,6 +65,7 @@ import type pg from "pg";
 
 import type { ThreatCategory } from "@/lib/detection";
 import { graphqlRequest } from "@/lib/graphql/client";
+import { REVIEW_MAX_PAGE_SIZE } from "@/lib/review/limits";
 import {
   type ActiveExclusionSetResolver,
   computeExclusionsFingerprint,
@@ -86,13 +87,6 @@ import {
   scoreEventFromBatch,
   scoreSelectorsForPage,
 } from "./selectors";
-
-/**
- * Page size for `eventListWithTriage`. Large enough to amortize the
- * resolver round-trip cost over many INSERTs but bounded so a single
- * page transaction does not hold the connection too long.
- */
-export const CADENCE_PAGE_SIZE = 500;
 
 /**
  * Role the cadence runner uses for outbound REview GraphQL. The
@@ -186,7 +180,13 @@ export function createCadencePager(
 ): CadencePager {
   const fetchPage = options.fetchPage ?? defaultFetchPage;
   const resolver = options.resolver ?? EMPTY_EXCLUSION_SET_RESOLVER;
-  const pageSize = options.pageSize ?? CADENCE_PAGE_SIZE;
+  // review-web's `Connection::pagination_input` validator rejects any
+  // `first` outside `[0, 100]` with a GraphQL-level error
+  // (`"The value of first and last must be within 0-100"`, #537), so
+  // the cadence pager pins its default to the shared BFF cap. Tests
+  // can still inject a smaller `pageSize` for deterministic per-page
+  // behaviour.
+  const pageSize = options.pageSize ?? REVIEW_MAX_PAGE_SIZE;
   const activeWindowsOverride = options.activeWindowsOverride;
 
   return {


### PR DESCRIPTION
## Summary

The Triage baseline cadence pager was sending `first: 500` to review-web's `eventListWithTriage`, but review-web's `Connection::pagination_input` validator caps `first` at `[0, 100]` and rejects anything larger with a GraphQL-level error (`"The value of first and last must be within 0-100"`). Every cadence tick failed before any row reached `observed_event_meta` or `baseline_triaged_event` — Phase 1.A/1.B menu read paths were empty for every customer, and the #524 measurement harness / #528 staging campaign were blocked.

The rest of the BFF (Detection menu, Tier 2 pivot, CSV export, node server-actions) already routes through `REVIEW_MAX_PAGE_SIZE` from `src/lib/review/limits.ts`; the cadence pager had drifted to its own local `500` constant.

### Changes

- `src/lib/triage/baseline/pager.ts`: drop the local `CADENCE_PAGE_SIZE` export entirely and read the page-size default from `REVIEW_MAX_PAGE_SIZE`, so the cadence path shares one source of truth with the rest of the BFF.
- `src/__tests__/lib/triage/baseline/pager.test.ts`: strengthen the per-page assertion to bound `variables.first` at `REVIEW_MAX_PAGE_SIZE` (not an exact value). Drift back to a value review will reject now trips a unit-level failure instead of a silent corpus outage.

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint src/lib/triage/baseline/pager.ts src/__tests__/lib/triage/baseline/pager.test.ts` — pass
- [x] `pnpm test src/__tests__/lib/triage/baseline/pager.test.ts` — 9/9 pass
- [x] `pnpm test` (full suite) — 4408/4408 pass (+3 skipped)
- [x] `pnpm check` (`biome ci --error-on-warnings .`) — pass (only an informational schema-version notice, unrelated to this change)
- [ ] Re-run the four-stack `test-clumit` smoke (manual): trigger `/api/internal/triage/baseline/cadence` and confirm `baseline_corpus_state.last_run_status = 'succeeded'` and rows land in `observed_event_meta` / `baseline_triaged_event`.

## Notes

- Operationally, per-cycle round-trip count rises by 5x (500 → 100) but per-page transaction discipline and `last_event_cursor` advancement are unchanged; cadence runner time budget should still fit since the alternative is zero throughput.
- If review-web later relaxes the cap, the fix is a single update to `REVIEW_MAX_PAGE_SIZE` and every consumer follows. A sibling upstream issue can be filed in `aicers/review-web` if 100 turns out to be a sustained operational pain point.

Closes #537