### PR TITLE
Narrow ipaddr storage validator to IP literal (#542)

### DIFF
--- a/src/__tests__/app/api/triage/policies/[id]/route.test.ts
+++ b/src/__tests__/app/api/triage/policies/[id]/route.test.ts
@@ -232,7 +232,7 @@ describe("PATCH /api/triage/policies/[id]", () => {
     expect(response.status).toBe(400);
   });
 
-  it("rejects an invalid IP/CIDR in a packet_attr ipaddr rule", async () => {
+  it("rejects an invalid IP literal in a packet_attr ipaddr rule", async () => {
     const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
     const request = new NextRequest(
       "http://localhost:3000/api/triage/policies/7?customer_id=42",
@@ -245,7 +245,7 @@ describe("PATCH /api/triage/policies/[id]", () => {
               attr_name: "src_addr",
               value_kind: "ipaddr",
               cmp_kind: "equal",
-              first_value: "10.0.0.0/40",
+              first_value: "not-an-ip",
             },
           ],
         }),
@@ -253,6 +253,39 @@ describe("PATCH /api/triage/policies/[id]", () => {
     );
     const response = await PATCH(request, makeContext("7"));
     expect(response.status).toBe(400);
+    expect(mockUpdatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a CIDR-shaped ipaddr value at the API write path", async () => {
+    // Previously a syntactically valid CIDR was accepted at PATCH
+    // and only failed at corpus B run time. Pin the new
+    // storage-time rejection here.
+    const { PATCH } = await import("@/app/api/triage/policies/[id]/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies/7?customer_id=42",
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          packet_attr: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "src_addr",
+              value_kind: "ipaddr",
+              cmp_kind: "equal",
+              first_value: "10.0.0.0/24",
+            },
+          ],
+        }),
+      },
+    );
+    const response = await PATCH(request, makeContext("7"));
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "packet_attr.0.first_value" }),
+      ]),
+    );
     expect(mockUpdatePolicy).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/app/api/triage/policies/route.test.ts
+++ b/src/__tests__/app/api/triage/policies/route.test.ts
@@ -204,7 +204,7 @@ describe("POST /api/triage/policies", () => {
     );
   });
 
-  it("rejects an invalid IP/CIDR in a packet_attr ipaddr rule", async () => {
+  it("rejects an invalid IP literal in a packet_attr ipaddr rule", async () => {
     const { POST } = await import("@/app/api/triage/policies/route");
     const request = new NextRequest(
       "http://localhost:3000/api/triage/policies?customer_id=42",
@@ -230,6 +230,43 @@ describe("POST /api/triage/policies", () => {
     const body = await response.json();
     expect(response.status).toBe(400);
     expect(body.details).toBeDefined();
+    expect(mockCreatePolicy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a CIDR-shaped ipaddr value at the API write path", async () => {
+    // Previously this value was accepted at storage and only failed
+    // at corpus B run time with a `status='failed'` row. The
+    // storage-time rejection here pins the new contract: CIDR is
+    // never persisted under `value_kind=ipaddr`.
+    const { POST } = await import("@/app/api/triage/policies/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/policies?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "p",
+          packet_attr: [
+            {
+              raw_event_kind: "conn",
+              attr_name: "src_addr",
+              value_kind: "ipaddr",
+              cmp_kind: "equal",
+              first_value: "10.0.0.0/24",
+            },
+          ],
+          confidence: [],
+          response: [],
+        }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "packet_attr.0.first_value" }),
+      ]),
+    );
     expect(mockCreatePolicy).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/lib/triage/policy/validation.test.ts
+++ b/src/__tests__/lib/triage/policy/validation.test.ts
@@ -1,56 +1,38 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  _validateIpOrCidr,
+  _validateIp,
   validatePolicySemantics,
 } from "@/lib/triage/policy/validation";
 
-describe("validateIpOrCidr", () => {
+describe("validateIp", () => {
   it("accepts plain IPv4", () => {
-    expect(_validateIpOrCidr("192.168.1.1")).toBeNull();
+    expect(_validateIp("192.168.1.1")).toBeNull();
   });
 
   it("accepts plain IPv6", () => {
-    expect(_validateIpOrCidr("::1")).toBeNull();
-    expect(_validateIpOrCidr("2001:db8::1")).toBeNull();
-  });
-
-  it("accepts IPv4 CIDR", () => {
-    expect(_validateIpOrCidr("10.0.0.0/8")).toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/32")).toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/0")).toBeNull();
-  });
-
-  it("accepts IPv6 CIDR", () => {
-    expect(_validateIpOrCidr("2001:db8::/32")).toBeNull();
-    expect(_validateIpOrCidr("::/0")).toBeNull();
+    expect(_validateIp("::1")).toBeNull();
+    expect(_validateIp("2001:db8::1")).toBeNull();
   });
 
   it("rejects invalid IPs", () => {
-    expect(_validateIpOrCidr("not-an-ip")).not.toBeNull();
-    expect(_validateIpOrCidr("999.999.999.999")).not.toBeNull();
+    expect(_validateIp("not-an-ip")).not.toBeNull();
+    expect(_validateIp("999.999.999.999")).not.toBeNull();
   });
 
-  it("rejects out-of-range CIDR prefix", () => {
-    expect(_validateIpOrCidr("10.0.0.0/33")).not.toBeNull();
-    expect(_validateIpOrCidr("2001:db8::/129")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/-1")).not.toBeNull();
-  });
-
-  it("rejects non-decimal CIDR prefixes that Number() would coerce", () => {
-    // Empty / whitespace prefixes.
-    expect(_validateIpOrCidr("10.0.0.0/")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/ ")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/ 8")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/8 ")).not.toBeNull();
-    // Signed prefixes.
-    expect(_validateIpOrCidr("10.0.0.0/+8")).not.toBeNull();
-    // Exponent / hex / float / underscore notation.
-    expect(_validateIpOrCidr("10.0.0.0/1e1")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/0x8")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/8.0")).not.toBeNull();
-    expect(_validateIpOrCidr("10.0.0.0/0_8")).not.toBeNull();
-    expect(_validateIpOrCidr("2001:db8::/0x10")).not.toBeNull();
+  it("rejects any value containing '/'", () => {
+    // CIDR notation has no wire shape inside a packet-attr equality /
+    // range comparison; the encoder rejects it and so does this
+    // storage-time validator. Any slash is enough — we do not parse
+    // the prefix.
+    expect(_validateIp("10.0.0.0/8")).not.toBeNull();
+    expect(_validateIp("10.0.0.0/32")).not.toBeNull();
+    expect(_validateIp("10.0.0.0/0")).not.toBeNull();
+    expect(_validateIp("2001:db8::/32")).not.toBeNull();
+    expect(_validateIp("::/0")).not.toBeNull();
+    expect(_validateIp("10.0.0.0/33")).not.toBeNull();
+    expect(_validateIp("10.0.0.0/")).not.toBeNull();
+    expect(_validateIp("not-an-ip/8")).not.toBeNull();
   });
 });
 
@@ -74,7 +56,7 @@ describe("validatePolicySemantics", () => {
     expect(result.issues[0].path).toBe("packet_attr.0.first_value");
   });
 
-  it("accepts a packet_attr ipaddr rule with a valid CIDR", () => {
+  it("rejects a packet_attr ipaddr rule whose first_value is CIDR", () => {
     const result = validatePolicySemantics({
       name: "p",
       packet_attr: [
@@ -89,7 +71,8 @@ describe("validatePolicySemantics", () => {
       confidence: [],
       response: [],
     });
-    expect(result.valid).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.issues[0].path).toBe("packet_attr.0.first_value");
   });
 
   it("flags a range cmp_kind without a second_value", () => {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2168,7 +2168,7 @@
     "ruleCountsValue": "{packetAttr} attr · {confidence} confidence · {response} response",
     "createdAt": "Created",
     "packetAttr": "Packet attribute rules",
-    "packetAttrHelp": "JSON array of packet_attr rules. IP/CIDR (value_kind=ipaddr) values and range cmp_kinds (open_range / close_range / left_open_range / right_open_range and their not_* variants) are validated server-side.",
+    "packetAttrHelp": "JSON array of packet_attr rules. IP literal only (value_kind=ipaddr); CIDR is not accepted. Range cmp_kinds (open_range / close_range / left_open_range / right_open_range and their not_* variants) are validated server-side.",
     "confidence": "Confidence rules",
     "response": "Response rules",
     "deleteConfirm": "Delete triage policy '{name}'? This cannot be undone.",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2168,7 +2168,7 @@
     "ruleCountsValue": "{packetAttr} attr · {confidence} confidence · {response} response",
     "createdAt": "생성일",
     "packetAttr": "패킷 속성 규칙",
-    "packetAttrHelp": "packet_attr 규칙 JSON 배열입니다. IP/CIDR(value_kind=ipaddr) 값과 범위 cmp_kind(open_range / close_range / left_open_range / right_open_range 및 not_* 변형)는 서버에서 검증됩니다.",
+    "packetAttrHelp": "packet_attr 규칙 JSON 배열입니다. IP 리터럴만 허용됩니다(value_kind=ipaddr); CIDR은 허용되지 않습니다. 범위 cmp_kind(open_range / close_range / left_open_range / right_open_range 및 not_* 변형)는 서버에서 검증됩니다.",
     "confidence": "신뢰도 규칙",
     "response": "응답 규칙",
     "deleteConfirm": "트리아지 정책 '{name}'을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",

--- a/src/lib/triage/policy/validation.ts
+++ b/src/lib/triage/policy/validation.ts
@@ -2,14 +2,18 @@
  * Semantic validation for TriagePolicy rules beyond Zod's structural
  * checks.
  *
- * Scope here is the IP/CIDR validity of `ipaddr`-typed `packet_attr`
+ * Scope here is the IP literal validity of `ipaddr`-typed `packet_attr`
  * values and the range-cmp invariant that range comparisons carry both
- * ends of the interval. Domain exclusion regex compilability — the
- * other half of the wording in #459 — lives on `ExclusionReason` rows
- * under ticket 1B-2 (#447 §2.1, §3.4) and is not part of TriagePolicy
- * under the new model. Removing the legacy `match` / `not_match`
- * cmp kinds here keeps the stored shape aligned with review-web's
- * `AttrCmpKind` enum (see `@/lib/triage/inline-policy/kinds`).
+ * ends of the interval. CIDR notation is rejected here so the failure
+ * surfaces at authoring time — the inline-policy encoder
+ * (`@/lib/triage/inline-policy/encode`) keeps its CIDR-reject branch
+ * as a belt-and-braces guard at the wire boundary. Domain exclusion
+ * regex compilability — the other half of the wording in #459 — lives
+ * on `ExclusionReason` rows under ticket 1B-2 (#447 §2.1, §3.4) and is
+ * not part of TriagePolicy under the new model. Removing the legacy
+ * `match` / `not_match` cmp kinds here keeps the stored shape aligned
+ * with review-web's `AttrCmpKind` enum (see
+ * `@/lib/triage/inline-policy/kinds`).
  */
 
 import { isIP } from "node:net";
@@ -34,29 +38,15 @@ export interface PolicyValidationResult {
   issues: PolicyValidationIssue[];
 }
 
-// Match the prefix as a non-empty digit-only string. `Number()` coerces
-// "", "+8", "1e1", and " 8" silently — none of which are valid CIDR
-// prefixes — so we parse the raw substring with a strict regex first
-// and only then range-check the integer.
-const CIDR_PREFIX_RE = /^\d+$/;
-
-function validateIpOrCidr(value: string): string | null {
-  const slash = value.indexOf("/");
-  if (slash === -1) {
-    if (isIP(value) === 0) return "Not a valid IP address";
-    return null;
-  }
-  const ip = value.slice(0, slash);
-  const prefixStr = value.slice(slash + 1);
-  const version = isIP(ip);
-  if (version === 0) return "Not a valid IP address in CIDR";
-  if (!CIDR_PREFIX_RE.test(prefixStr)) {
-    return "Invalid CIDR prefix length";
-  }
-  const prefix = Number(prefixStr);
-  if ((version === 4 && prefix > 32) || (version === 6 && prefix > 128)) {
-    return "Invalid CIDR prefix length";
-  }
+function validateIp(value: string): string | null {
+  // CIDR notation has no agreed wire shape inside a packet-attr
+  // equality / range comparison and the inline-policy encoder rejects
+  // it at the wire boundary. Reject here too so the failure surfaces
+  // at authoring time rather than at corpus B run time. If CIDR
+  // semantics are needed later, introduce a separate `value_kind`
+  // rather than overloading `ipaddr`.
+  if (value.includes("/")) return "CIDR notation is not accepted";
+  if (isIP(value) === 0) return "Not a valid IP address";
   return null;
 }
 
@@ -66,7 +56,7 @@ function validatePacketAttr(
   issues: PolicyValidationIssue[],
 ): void {
   if (rule.value_kind === "ipaddr") {
-    const firstErr = validateIpOrCidr(rule.first_value);
+    const firstErr = validateIp(rule.first_value);
     if (firstErr) {
       issues.push({
         path: `packet_attr.${index}.first_value`,
@@ -78,7 +68,7 @@ function validatePacketAttr(
       rule.second_value !== null &&
       rule.second_value.length > 0
     ) {
-      const secondErr = validateIpOrCidr(rule.second_value);
+      const secondErr = validateIp(rule.second_value);
       if (secondErr) {
         issues.push({
           path: `packet_attr.${index}.second_value`,
@@ -161,4 +151,4 @@ export function validatePolicySemantics(
 }
 
 // Re-exported for tests covering address parsing in isolation.
-export { validateIpOrCidr as _validateIpOrCidr };
+export { validateIp as _validateIp };


### PR DESCRIPTION
## Summary

Addresses Option A from #542: narrow `TriagePolicy`'s `value_kind = ipaddr` storage validator to IP literal only and reject any CIDR-shaped value at insert time. This closes the documented asymmetry where storage accepted CIDR but the inline-policy encoder (#460) rejects it at the wire boundary, causing CIDR-shaped policies to save successfully but fail later at corpus B run time as `status='failed'` rows.

- `src/lib/triage/policy/validation.ts`: rename `validateIpOrCidr` → `validateIp`, drop the CIDR prefix parsing branch and `CIDR_PREFIX_RE`, reject any string containing `/`. Update the file scope comment to drop the "IP/CIDR" wording and point at the encoder for the belt-and-braces guard.
- `src/i18n/messages/{en,ko}.json`: update `packetAttrHelp` so the help text no longer advertises CIDR. EN/KR stay in sync.
- `src/__tests__/lib/triage/policy/validation.test.ts`: flip CIDR-acceptance assertions to rejection; collapse the prefix-parsing cases into a single "any value containing `/` is rejected" assertion; flip the corresponding case in `validatePolicySemantics`.
- `src/__tests__/app/api/triage/policies/route.test.ts` and `[id]/route.test.ts`: rename the "invalid IP/CIDR" cases to "invalid IP literal", and add new POST/PATCH cases pinning that a syntactically valid CIDR (`10.0.0.0/24`) is rejected by the API with a `packet_attr.0.first_value` validation issue.

The encoder's CIDR-reject branch (`src/lib/triage/inline-policy/encode.ts:361–373`) is unchanged and stays covered by `src/__tests__/lib/triage/inline-policy/encode.test.ts`. The translator-unit fixture using `10.0.0.0/24` in `src/__tests__/lib/triage/policy/inline-translator.test.ts` is left alone — it directly exercises the encoder's defense via a synthetic `PolicyDoc` input that bypasses the storage validator.

Part of #542 — keeping the issue open so the operator-side audit and back-migration decision (see below) can be recorded against the same ticket.

## Not addressed in this PR

- **Per-tenant JSONB audit of existing CIDR-shaped `ipaddr` rows.** #542's Option A acceptance criteria require the audit query and per-tenant counts to be recorded, plus a back-migration decision justified against those counts. The audit must run against live tenant DBs which is operator territory, not something this PR's author can perform from the repo. The linkage is `Part of #542` (not `Closes`) so #542 stays open until the operator records the counts and decision there.

  Suggested audit query (per tenant, against the customer DB):

  ```sql
  SELECT id,
         elem ->> 'attr_name'   AS attr_name,
         elem ->> 'first_value' AS first_value,
         elem ->> 'second_value' AS second_value
  FROM   triage_policy,
         LATERAL jsonb_array_elements(packet_attr) AS elem
  WHERE  elem ->> 'value_kind' = 'ipaddr'
    AND  (
           (elem ->> 'first_value')  LIKE '%/%' OR
           (elem ->> 'second_value') LIKE '%/%'
         );
  ```

  Operator follow-up (recorded on #542, not blocking this PR):
  1. Run the query against each tenant DB and record per-tenant counts on #542.
  2. If all counts are 0 → no back-migration needed; the new validator rejects on next edit and the encoder already fails CIDR at corpus B time, so no row that "worked" stops working.
  3. If any count is non-zero → decide between (a) reject-at-read with admin notice or (b) rewrite to a placeholder with operator notification, and justify the choice against the counts.

## Test plan

- [x] `pnpm biome check` passes (verified locally).
- [x] `pnpm tsc --noEmit` passes (verified locally).
- [x] `pnpm vitest run` passes — full suite (verified locally; 4408 passed, 3 skipped).
- [x] `_validateIp` rejects every value containing `/` (CIDR forms, partial slashes, garbage-with-slash).
- [x] `_validateIp` still accepts plain IPv4 / IPv6 literals.
- [x] `validatePolicySemantics` now flags `packet_attr.0.first_value` for a CIDR-shaped `ipaddr` rule (previously accepted).
- [x] `POST /api/triage/policies` rejects a `value_kind=ipaddr` rule whose `first_value` is `10.0.0.0/24` with `details[].path === \"packet_attr.0.first_value\"`.
- [x] `PATCH /api/triage/policies/[id]` rejects the same shape with the same details path.
- [x] CRUD form (`triage-policy-form-dialog.tsx`) renders the new server `details[]` rejection message under the existing details panel — no new UI work required (manual smoke). Verified by code reading: the dialog reads `body.details` on non-ok responses (lines 127-131) and renders each issue as a list item with \`path: message\` (lines 206-218).
- [x] EN and KR `packetAttrHelp` strings render the new \"IP literal only\" wording in the policy CRUD UI (manual smoke). Verified by code reading: both `en.json:2171` and `ko.json:2171` carry the new wording, and the form renders it via `t(\"packetAttrHelp\")` at line 179.
- [x] Encoder CIDR-reject branch and its direct unit test (`src/__tests__/lib/triage/inline-policy/encode.test.ts`) still pass — encoder defense is preserved as belt-and-braces.
- [x] No callers of `validateIpOrCidr` / `_validateIpOrCidr` remain (grep across the repo returns no matches).
- [ ] Operator follow-up on #542: run the JSONB audit query above against each tenant DB, record counts on the issue, and make the back-migration call.