### PR TITLE
Add Triage cleanup jobs and exclusion recovery surface (#461)

### DIFF
--- a/docs/en/settings.md
+++ b/docs/en/settings.md
@@ -445,6 +445,41 @@ Each ADD and REMOVE emits an audit row:
 - `triage_exclusion.fanout_failed` — emitted when a per-customer
   fanout job exhausts its retry budget (5 attempts with
   exponential backoff: 1m → 5m → 25m → 2h → 12h).
+- `triage_exclusion.global_recover` / `.customer_recover` —
+  emitted when an operator resets a `failed` cleanup row from the
+  exclusion list's **Re-trigger cleanup** menu item (or from the
+  internal recovery route). The menu item appears only on rows
+  whose past-corpus cleanup is stuck; clicking it transitions the
+  queue row back to `pending` so the fanout worker picks it up on
+  the next tick. `global_recover` is customer-agnostic;
+  `customer_recover` carries `customer_id`.
+
+### Background retention
+
+The cron container runs three retention sweeps so the corpus and
+the fanout queue do not grow without bound:
+
+- **Baseline corpus** (`run-triage-baseline-retention.sh`, daily
+  at 03:15 UTC) — prunes `baseline_triaged_event` older than 180
+  days and `observed_event_meta` older than 30 days, batched at
+  10,000 rows per `DELETE` statement.
+- **Policy corpus B** (`run-triage-policy-retention.sh`, every 6
+  hours) — flips stuck `policy_triage_run` rows in `computing`
+  state (>30 min) to `failed` with
+  `last_error = 'timeout: runner did not finalize'`, then applies
+  differential retention (ready 30d / superseded 7d / failed 1d)
+  and prunes rows whose `owner_account_id` no longer resolves.
+  `policy_triaged_event` rows cascade.
+- **Exclusion fanout** (`run-triage-exclusion-fanout.sh`, every
+  minute) — drains the `triage_exclusion_fanout_job` queue. The
+  minute cadence matches the worker's first-tier backoff (1 min)
+  so a transient tenant-DB outage retries promptly.
+
+Each wrapper writes a timestamped JSON response to
+`/var/log/cron/` and re-emits an `overall != 'ok'` warning to
+stderr; alerting should key on the structured log lines tagged
+`cron-baseline-retention`, `cron-policy-retention`, and
+`cron-fanout`.
 
 ## Profile
 

--- a/docs/en/settings.md
+++ b/docs/en/settings.md
@@ -448,11 +448,19 @@ Each ADD and REMOVE emits an audit row:
 - `triage_exclusion.global_recover` / `.customer_recover` —
   emitted when an operator resets a `failed` cleanup row from the
   exclusion list's **Re-trigger cleanup** menu item (or from the
-  internal recovery route). The menu item appears only on rows
-  whose past-corpus cleanup is stuck; clicking it transitions the
-  queue row back to `pending` so the fanout worker picks it up on
-  the next tick. `global_recover` is customer-agnostic;
-  `customer_recover` carries `customer_id`.
+  internal recovery route). The menu item appears on rows whose
+  past-corpus cleanup is stuck — either a `failed` sentinel in the
+  `auth_db` fanout queue, or (for customer-scoped exclusions) a
+  `triage_exclusion.customer_add` audit row recording
+  `details.drainStatus = 'failed'` that has not yet been recovered.
+  This audit-row fallback covers the rare case where the failed ADD
+  path's sentinel insert itself failed (auth_db blip) so the queue
+  has no row: clicking **Re-trigger cleanup** backfills a fresh
+  `pending` sentinel from the audit record. Otherwise the click
+  transitions the existing queue row back to `pending`. Either way
+  the fanout worker picks it up on the next tick.
+  `global_recover` is customer-agnostic; `customer_recover` carries
+  `customer_id`.
 
 ### Background retention
 

--- a/docs/ko/settings.md
+++ b/docs/ko/settings.md
@@ -437,10 +437,17 @@ NTLM 이벤트는 `host`, `dns_query`, `uri`가 NULL이므로 소급
 - `triage_exclusion.global_recover` / `.customer_recover` —
   운영자가 제외 항목 목록의 **정리 재실행** 메뉴(또는 내부 복구
   라우트)를 통해 `failed` 상태의 정리 작업을 재설정할 때
-  발행됩니다. 메뉴 항목은 과거 코퍼스 정리가 멈춘 행에서만
-  표시되며, 클릭하면 큐 행이 `pending`으로 되돌아가 다음 틱에서
-  팬아웃 워커가 다시 처리합니다. `global_recover`는 고객
-  비종속이고, `customer_recover`는 `customer_id`를 포함합니다.
+  발행됩니다. 메뉴 항목은 과거 코퍼스 정리가 멈춘 행에서
+  표시됩니다 — `auth_db` 팬아웃 큐에 `failed` 센티넬이 있거나,
+  고객 범위 제외의 경우 `details.drainStatus = 'failed'`를
+  기록한 `triage_exclusion.customer_add` 감사 행이 아직
+  복구되지 않은 상태입니다. 이 감사 행 폴백은 실패한 ADD 경로의
+  센티넬 INSERT 자체가 실패한 드문 경우(예: auth_db 일시 장애)를
+  보완합니다. 큐 행이 없는 경우 **정리 재실행** 클릭은 감사
+  기록에서 새 `pending` 센티넬을 백필하고, 그 외에는 기존 큐
+  행을 `pending`으로 되돌립니다. 어느 경우든 다음 틱에서 팬아웃
+  워커가 다시 처리합니다. `global_recover`는 고객 비종속이고,
+  `customer_recover`는 `customer_id`를 포함합니다.
 
 ### 백그라운드 보존
 

--- a/docs/ko/settings.md
+++ b/docs/ko/settings.md
@@ -434,6 +434,40 @@ NTLM 이벤트는 `host`, `dns_query`, `uri`가 NULL이므로 소급
 - `triage_exclusion.fanout_failed` — 고객별 팬아웃 작업이 재시도
   예산(지수 백오프 5회: 1분 → 5분 → 25분 → 2시간 → 12시간)을
   소진했을 때 발행됩니다.
+- `triage_exclusion.global_recover` / `.customer_recover` —
+  운영자가 제외 항목 목록의 **정리 재실행** 메뉴(또는 내부 복구
+  라우트)를 통해 `failed` 상태의 정리 작업을 재설정할 때
+  발행됩니다. 메뉴 항목은 과거 코퍼스 정리가 멈춘 행에서만
+  표시되며, 클릭하면 큐 행이 `pending`으로 되돌아가 다음 틱에서
+  팬아웃 워커가 다시 처리합니다. `global_recover`는 고객
+  비종속이고, `customer_recover`는 `customer_id`를 포함합니다.
+
+### 백그라운드 보존
+
+cron 컨테이너는 코퍼스와 팬아웃 큐가 무한정 커지지 않도록 세
+개의 보존 스윕을 실행합니다:
+
+- **기준 코퍼스** (`run-triage-baseline-retention.sh`, 매일 UTC
+  03:15) — 180일을 초과한 `baseline_triaged_event`와 30일을
+  초과한 `observed_event_meta`를 `DELETE`문당 10,000행씩
+  배치로 제거합니다.
+- **정책 코퍼스 B** (`run-triage-policy-retention.sh`, 6시간마다)
+  — `computing` 상태로 30분 이상 정체된 `policy_triage_run` 행을
+  `failed`로 전환하고
+  (`last_error = 'timeout: runner did not finalize'`),
+  차등 보존(ready 30일 / superseded 7일 / failed 1일)을 적용한
+  뒤, `owner_account_id`가 더 이상 해석되지 않는 행을
+  정리합니다. `policy_triaged_event` 행은 함께 캐스케이드됩니다.
+- **제외 팬아웃** (`run-triage-exclusion-fanout.sh`, 매분) —
+  `triage_exclusion_fanout_job` 큐를 비웁니다. 분 단위 케이던스는
+  워커의 1차 백오프(1분)와 맞춰져 있어 일시적인 테넌트 DB 장애가
+  빠르게 재시도됩니다.
+
+각 래퍼는 타임스탬프가 찍힌 JSON 응답을 `/var/log/cron/`에
+기록하고 `overall != 'ok'` 경고를 stderr로 다시 내보냅니다.
+알림은 `cron-baseline-retention`, `cron-policy-retention`,
+`cron-fanout`으로 태깅된 구조화 로그 라인을 키로 사용해야
+합니다.
 
 ## 프로필
 

--- a/infra/cron/Dockerfile
+++ b/infra/cron/Dockerfile
@@ -21,8 +21,14 @@ RUN apk add --no-cache bash curl jq tini coreutils
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY crontab /etc/crontabs/root
 COPY run-triage-baseline-dispatch.sh /usr/local/bin/run-triage-baseline-dispatch.sh
+COPY run-triage-baseline-retention.sh /usr/local/bin/run-triage-baseline-retention.sh
+COPY run-triage-policy-retention.sh /usr/local/bin/run-triage-policy-retention.sh
+COPY run-triage-exclusion-fanout.sh /usr/local/bin/run-triage-exclusion-fanout.sh
 
 RUN chmod +x /usr/local/bin/entrypoint.sh \
-        /usr/local/bin/run-triage-baseline-dispatch.sh
+        /usr/local/bin/run-triage-baseline-dispatch.sh \
+        /usr/local/bin/run-triage-baseline-retention.sh \
+        /usr/local/bin/run-triage-policy-retention.sh \
+        /usr/local/bin/run-triage-exclusion-fanout.sh
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/infra/cron/crontab
+++ b/infra/cron/crontab
@@ -11,3 +11,22 @@
 #
 # Triage baseline cadence — hourly per-customer fan-out
 0 * * * * /usr/local/bin/run-triage-baseline-dispatch.sh
+
+# Triage exclusion fanout — minute-scale drain of the durable queue
+# (#457 ships the route, 1B-7 wires the cadence). Matches the worker's
+# exponential-backoff schedule (1m / 5m / 25m / 2h / 12h) so the first
+# retry tier fires on the next tick after a failure.
+* * * * * /usr/local/bin/run-triage-exclusion-fanout.sh
+
+# Corpus A retention — once daily at 03:15 UTC. Window chosen so the
+# nightly run does not contend with the hourly cadence tick at the top
+# of the hour, and so an operator inspecting log_dir in the morning
+# sees a recent run.
+15 3 * * * /usr/local/bin/run-triage-baseline-retention.sh
+
+# Corpus B retention + zombie reaper — every 6 hours. More frequent
+# than corpus A because the zombie-runner reaper unblocks the active-
+# fingerprint partial unique index for new runs of the same
+# fingerprint; waiting a full day would leave a crashed runner's slot
+# occupied for too long.
+30 */6 * * * /usr/local/bin/run-triage-policy-retention.sh

--- a/infra/cron/entrypoint.sh
+++ b/infra/cron/entrypoint.sh
@@ -26,6 +26,16 @@ ENV_ALLOWLIST=(
     # 2700s default, recreating the transport-failure / no-body mode
     # the structured `skipped-timeout` row exists to prevent.
     TRIAGE_BASELINE_DISPATCH_TOTAL_TIMEOUT_MS
+    # 1B-7 cleanup tokens. Each retention / recovery surface uses its
+    # own internal-token env var so a leaked secret cannot pivot
+    # between surfaces.
+    TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN
+    TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN
+    TRIAGE_EXCLUSION_FANOUT_TOKEN
+    # Recover is operator-tooling, not scheduled; the token is passed
+    # through so an operator running `curl` from `docker exec cron sh`
+    # picks up the same configured secret without re-exporting it.
+    TRIAGE_EXCLUSION_RECOVERY_INTERNAL_TOKEN
 )
 
 : > "$ENV_FILE"

--- a/infra/cron/run-triage-baseline-retention.sh
+++ b/infra/cron/run-triage-baseline-retention.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Triage baseline corpus retention wrapper (#461 / 1B-7).
+#
+# Hits POST /api/internal/triage/baseline/retention once per daily
+# tick. The dispatcher enumerates active customers and runs the corpus
+# A retention sweep (180d on `baseline_triaged_event`, 30d on
+# `observed_event_meta`) against each tenant DB.
+#
+# Follows the wrapper contract from the cadence-dispatch script:
+#   - source /etc/cron.env (busybox crond does not propagate env)
+#   - separate HTTP status from body via curl `-w '%{http_code}'`
+#   - parse `overall` / per-customer counters with jq
+#   - log info to stdout, warn to stderr
+#   - exit 0 on parseable responses; non-zero only on transport /
+#     auth / config failures so cron MAILTO does not double-page on
+#     structured per-customer failures.
+
+set -u
+
+ENV_FILE="${CRON_RETENTION_ENV_FILE:-/etc/cron.env}"
+LOG_DIR="${CRON_RETENTION_LOG_DIR:-/var/log/cron}"
+
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    . "$ENV_FILE"
+fi
+
+TOKEN="${TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN:-}"
+BASE_URL="${NEXT_APP_BASE_URL:-http://next-app:3000}"
+URL="${BASE_URL}/api/internal/triage/baseline/retention"
+
+CONNECT_TIMEOUT_S="${CRON_RETENTION_CONNECT_TIMEOUT_S:-10}"
+# Retention runs are intentionally long: a backed-up corpus can take
+# tens of minutes to prune in 10k-row batches. Default 1 hour (3600s)
+# — operators raise via env if their corpora are larger. The crontab
+# entry runs at low frequency so successive invocations do not pile up.
+MAX_TIME_S="${CRON_RETENTION_MAX_TIME_S:-3600}"
+
+mkdir -p "$LOG_DIR"
+TS=$(date +%Y%m%d-%H%M%S)
+BODY_FILE="${LOG_DIR}/cron-baseline-retention-${TS}.json"
+
+log_info() {
+    printf '[%s] cron-baseline-retention: %s\n' "$(date -Iseconds)" "$*"
+}
+
+log_warn() {
+    printf '[%s] cron-baseline-retention: WARN %s\n' "$(date -Iseconds)" "$*" >&2
+}
+
+if [ -z "$TOKEN" ]; then
+    log_warn "TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN is empty; refusing to fire"
+    exit 2
+fi
+
+curl_exit=0
+http_code=$(
+    curl -sS \
+        --connect-timeout "$CONNECT_TIMEOUT_S" \
+        --max-time "$MAX_TIME_S" \
+        -o "$BODY_FILE" \
+        -w '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H 'Content-Type: application/json' \
+        --data '' \
+        "$URL"
+) || curl_exit=$?
+
+if [ "$curl_exit" -ne 0 ] || [ -z "$http_code" ]; then
+    log_warn "transport failure (curl_exit=${curl_exit}, http_code='${http_code}', url=${URL})"
+    exit 1
+fi
+
+case "$http_code" in
+    401|403)
+        log_warn "auth failure (HTTP ${http_code}); check TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN"
+        exit 1
+        ;;
+    200)
+        ;;
+    *)
+        if jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+            err=$(jq -r '.error // empty' "$BODY_FILE")
+            overall=$(jq -r '.overall // empty' "$BODY_FILE")
+            log_warn "HTTP ${http_code} (overall=${overall:-?}, error=${err:-?}); body=${BODY_FILE}"
+        else
+            log_warn "HTTP ${http_code} (body unparseable); body=${BODY_FILE}"
+        fi
+        exit 0
+        ;;
+esac
+
+if ! jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+    log_warn "HTTP 200 but response body is not valid JSON; saved to ${BODY_FILE}"
+    exit 0
+fi
+
+overall=$(jq -r '.overall // "?"' "$BODY_FILE")
+counts=$(
+    jq -r '
+        [
+            "ok=" + ([.perCustomer[]? | select(.status == "ok")] | length | tostring),
+            "failed=" + ([.perCustomer[]? | select(.status == "failed")] | length | tostring),
+            "baseline_pruned=" + ([.perCustomer[]?.counts.baselineTriagedEvent // 0] | add | tostring),
+            "observed_pruned=" + ([.perCustomer[]?.counts.observedEventMeta // 0] | add | tostring)
+        ] | join(" ")
+    ' "$BODY_FILE"
+)
+
+log_info "overall=${overall} ${counts} body=${BODY_FILE}"
+
+if [ "$overall" != "ok" ]; then
+    bad_ids=$(
+        jq -r '
+            [.perCustomer[]?
+                | select(.status != "ok")
+                | (.customerId | tostring) + ":" + .status]
+            | join(",")
+        ' "$BODY_FILE"
+    )
+    log_warn "overall=${overall}: ${bad_ids:-none}; body=${BODY_FILE}"
+fi
+
+exit 0

--- a/infra/cron/run-triage-exclusion-fanout.sh
+++ b/infra/cron/run-triage-exclusion-fanout.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Triage exclusion fanout wrapper (#461 / 1B-7).
+#
+# 1B-2 (#457) shipped the `/api/internal/triage/exclusion/fanout`
+# route + the worker's stuck-job sweep but no crontab entry. 1B-7
+# closes that gap with a minute-scale invocation matching the
+# cadence assumption the worker's exponential backoff (1m / 5m / 25m /
+# 2h / 12h) is built around — a slower cadence would force every
+# attempt through one stuck-job sweep, halving effective throughput
+# under contention.
+#
+# Same wrapper contract as the cadence-dispatch / retention scripts.
+
+set -u
+
+ENV_FILE="${CRON_FANOUT_ENV_FILE:-/etc/cron.env}"
+LOG_DIR="${CRON_FANOUT_LOG_DIR:-/var/log/cron}"
+
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    . "$ENV_FILE"
+fi
+
+TOKEN="${TRIAGE_EXCLUSION_FANOUT_TOKEN:-}"
+BASE_URL="${NEXT_APP_BASE_URL:-http://next-app:3000}"
+URL="${BASE_URL}/api/internal/triage/exclusion/fanout"
+
+CONNECT_TIMEOUT_S="${CRON_FANOUT_CONNECT_TIMEOUT_S:-10}"
+# Minute-scale ceiling so an overlapping tick never deadlines past the
+# next scheduled tick. The worker's claim batch is bounded so any
+# single sweep finishes well inside this window; if it does not, the
+# next tick re-claims via the stuck-job sweep without harm.
+MAX_TIME_S="${CRON_FANOUT_MAX_TIME_S:-55}"
+
+mkdir -p "$LOG_DIR"
+TS=$(date +%Y%m%d-%H%M%S)
+BODY_FILE="${LOG_DIR}/cron-fanout-${TS}.json"
+
+log_info() {
+    printf '[%s] cron-fanout: %s\n' "$(date -Iseconds)" "$*"
+}
+
+log_warn() {
+    printf '[%s] cron-fanout: WARN %s\n' "$(date -Iseconds)" "$*" >&2
+}
+
+if [ -z "$TOKEN" ]; then
+    log_warn "TRIAGE_EXCLUSION_FANOUT_TOKEN is empty; refusing to fire"
+    exit 2
+fi
+
+curl_exit=0
+http_code=$(
+    curl -sS \
+        --connect-timeout "$CONNECT_TIMEOUT_S" \
+        --max-time "$MAX_TIME_S" \
+        -o "$BODY_FILE" \
+        -w '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H 'Content-Type: application/json' \
+        --data '' \
+        "$URL"
+) || curl_exit=$?
+
+if [ "$curl_exit" -ne 0 ] || [ -z "$http_code" ]; then
+    log_warn "transport failure (curl_exit=${curl_exit}, http_code='${http_code}', url=${URL})"
+    exit 1
+fi
+
+case "$http_code" in
+    401|403)
+        log_warn "auth failure (HTTP ${http_code}); check TRIAGE_EXCLUSION_FANOUT_TOKEN"
+        exit 1
+        ;;
+    200)
+        ;;
+    *)
+        if jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+            err=$(jq -r '.error // empty' "$BODY_FILE")
+            log_warn "HTTP ${http_code} (error=${err:-?}); body=${BODY_FILE}"
+        else
+            log_warn "HTTP ${http_code} (body unparseable); body=${BODY_FILE}"
+        fi
+        exit 0
+        ;;
+esac
+
+if ! jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+    log_warn "HTTP 200 but response body is not valid JSON; saved to ${BODY_FILE}"
+    exit 0
+fi
+
+summary=$(
+    jq -r '
+        [
+            "recovered=" + ((.recovered // 0) | tostring),
+            "claimed=" + ((.claimed // 0) | tostring),
+            "completed=" + ((.completed // 0) | tostring),
+            "retried=" + ((.retried // 0) | tostring),
+            "failed=" + ((.failed // 0) | tostring)
+        ] | join(" ")
+    ' "$BODY_FILE"
+)
+
+log_info "${summary} body=${BODY_FILE}"
+
+# A single `failed` finalisation is operationally significant: the
+# fanout worker has exhausted the backoff budget and an operator
+# needs to re-trigger cleanup. Surface to stderr so MAILTO can
+# escalate, but still exit 0 so cron does not double-page on every
+# subsequent tick.
+failed_count=$(jq -r '.failed // 0' "$BODY_FILE")
+if [ "$failed_count" -gt 0 ]; then
+    log_warn "${failed_count} fanout row(s) finalized as failed; admin recovery required (body=${BODY_FILE})"
+fi
+
+exit 0

--- a/infra/cron/run-triage-policy-retention.sh
+++ b/infra/cron/run-triage-policy-retention.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Triage policy corpus B retention wrapper (#461 / 1B-7).
+#
+# Hits POST /api/internal/triage/policy/retention. The dispatcher
+# runs three sweeps per tenant DB:
+#   - zombie-runner reaper (computing > 30 min → failed)
+#   - differential retention (ready 30d / superseded 7d / failed 1d)
+#   - orphan owner cleanup
+#
+# Same wrapper contract as the baseline retention script.
+
+set -u
+
+ENV_FILE="${CRON_RETENTION_ENV_FILE:-/etc/cron.env}"
+LOG_DIR="${CRON_RETENTION_LOG_DIR:-/var/log/cron}"
+
+if [ -f "$ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    . "$ENV_FILE"
+fi
+
+TOKEN="${TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN:-}"
+BASE_URL="${NEXT_APP_BASE_URL:-http://next-app:3000}"
+URL="${BASE_URL}/api/internal/triage/policy/retention"
+
+CONNECT_TIMEOUT_S="${CRON_RETENTION_CONNECT_TIMEOUT_S:-10}"
+MAX_TIME_S="${CRON_POLICY_RETENTION_MAX_TIME_S:-1800}"
+
+mkdir -p "$LOG_DIR"
+TS=$(date +%Y%m%d-%H%M%S)
+BODY_FILE="${LOG_DIR}/cron-policy-retention-${TS}.json"
+
+log_info() {
+    printf '[%s] cron-policy-retention: %s\n' "$(date -Iseconds)" "$*"
+}
+
+log_warn() {
+    printf '[%s] cron-policy-retention: WARN %s\n' "$(date -Iseconds)" "$*" >&2
+}
+
+if [ -z "$TOKEN" ]; then
+    log_warn "TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN is empty; refusing to fire"
+    exit 2
+fi
+
+curl_exit=0
+http_code=$(
+    curl -sS \
+        --connect-timeout "$CONNECT_TIMEOUT_S" \
+        --max-time "$MAX_TIME_S" \
+        -o "$BODY_FILE" \
+        -w '%{http_code}' \
+        -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H 'Content-Type: application/json' \
+        --data '' \
+        "$URL"
+) || curl_exit=$?
+
+if [ "$curl_exit" -ne 0 ] || [ -z "$http_code" ]; then
+    log_warn "transport failure (curl_exit=${curl_exit}, http_code='${http_code}', url=${URL})"
+    exit 1
+fi
+
+case "$http_code" in
+    401|403)
+        log_warn "auth failure (HTTP ${http_code}); check TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN"
+        exit 1
+        ;;
+    200)
+        ;;
+    *)
+        if jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+            err=$(jq -r '.error // empty' "$BODY_FILE")
+            overall=$(jq -r '.overall // empty' "$BODY_FILE")
+            log_warn "HTTP ${http_code} (overall=${overall:-?}, error=${err:-?}); body=${BODY_FILE}"
+        else
+            log_warn "HTTP ${http_code} (body unparseable); body=${BODY_FILE}"
+        fi
+        exit 0
+        ;;
+esac
+
+if ! jq -e . "$BODY_FILE" >/dev/null 2>&1; then
+    log_warn "HTTP 200 but response body is not valid JSON; saved to ${BODY_FILE}"
+    exit 0
+fi
+
+overall=$(jq -r '.overall // "?"' "$BODY_FILE")
+counts=$(
+    jq -r '
+        [
+            "ok=" + ([.perCustomer[]? | select(.status == "ok")] | length | tostring),
+            "failed=" + ([.perCustomer[]? | select(.status == "failed")] | length | tostring),
+            "zombies=" + ([.perCustomer[]?.counts.zombiesReaped // 0] | add | tostring),
+            "ready_pruned=" + ([.perCustomer[]?.counts.readyPruned // 0] | add | tostring),
+            "superseded_pruned=" + ([.perCustomer[]?.counts.supersededPruned // 0] | add | tostring),
+            "failed_pruned=" + ([.perCustomer[]?.counts.failedPruned // 0] | add | tostring),
+            "orphan_pruned=" + ([.perCustomer[]?.counts.orphanedPruned // 0] | add | tostring)
+        ] | join(" ")
+    ' "$BODY_FILE"
+)
+
+log_info "overall=${overall} ${counts} body=${BODY_FILE}"
+
+if [ "$overall" != "ok" ]; then
+    bad_ids=$(
+        jq -r '
+            [.perCustomer[]?
+                | select(.status != "ok")
+                | (.customerId | tostring) + ":" + .status]
+            | join(",")
+        ' "$BODY_FILE"
+    )
+    log_warn "overall=${overall}: ${bad_ids:-none}; body=${BODY_FILE}"
+fi
+
+exit 0

--- a/migrations/auth/0033_triage_exclusion_fanout_job_customer_scope.sql
+++ b/migrations/auth/0033_triage_exclusion_fanout_job_customer_scope.sql
@@ -1,0 +1,60 @@
+-- Extend the fanout queue so customer-scoped ADD drain failures and
+-- admin recovery resets share one queue with the global-fanout path
+-- (#461 / 1B-7).
+--
+-- Two changes:
+--   1. `global_exclusion_id` becomes nullable. A queue row may carry
+--      EITHER a global-exclusion id (the original 1B-2 fanout path) OR
+--      a customer-only-exclusion id (the new 1B-7 customer drain-failure
+--      sentinel) — never both, never neither. A CHECK enforces the
+--      XOR. Both keep their existing semantics; the row's "kind" is
+--      derived from which column is populated.
+--   2. Two partial unique indexes deduplicate per logical scope so
+--      reset-in-place recovery (which UPDATEs `status='failed'` rows
+--      to `pending` with `attempt_count=0`) cannot race a stale insert
+--      path into producing two rows for the same exclusion+customer
+--      pair. Without these, the admin UI would see two "Re-trigger
+--      cleanup" entries and `FOR UPDATE SKIP LOCKED` would have
+--      ambiguous claim semantics.
+--
+-- `customer_only_exclusion_id` deliberately has no FK because the
+-- referenced tenant `triage_exclusion` row lives in a per-customer DB
+-- and PostgreSQL does not support cross-database foreign keys.
+-- Existence is enforced at the application layer (see the recover
+-- route and the fanout worker's missing-tenant-row branch).
+--
+-- Idempotent: safe to re-run.
+
+ALTER TABLE triage_exclusion_fanout_job
+    ALTER COLUMN global_exclusion_id DROP NOT NULL;
+
+ALTER TABLE triage_exclusion_fanout_job
+    ADD COLUMN IF NOT EXISTS customer_only_exclusion_id UUID;
+
+-- Drop and re-add the XOR CHECK so re-running the migration after a
+-- partial migration is idempotent and the constraint name is stable.
+ALTER TABLE triage_exclusion_fanout_job
+    DROP CONSTRAINT IF EXISTS triage_exclusion_fanout_job_scope_xor_chk;
+ALTER TABLE triage_exclusion_fanout_job
+    ADD CONSTRAINT triage_exclusion_fanout_job_scope_xor_chk
+    CHECK (
+        (global_exclusion_id IS NOT NULL)::int
+        + (customer_only_exclusion_id IS NOT NULL)::int = 1
+    );
+
+-- Dedupe per (global_exclusion_id, customer_id). With this in place
+-- the customer-drain sentinel insert and any future re-enqueue path
+-- can use `ON CONFLICT (...) DO UPDATE SET status='pending', ...`
+-- so the dedupe behavior collapses naturally into "reset the existing
+-- row".
+CREATE UNIQUE INDEX IF NOT EXISTS triage_exclusion_fanout_job_global_dedupe
+    ON triage_exclusion_fanout_job (global_exclusion_id, customer_id)
+    WHERE global_exclusion_id IS NOT NULL;
+
+-- Dedupe per (customer_only_exclusion_id, customer_id). The customer
+-- id is always populated; without it a SELECT for "is there a sentinel
+-- row for this exclusion" still has to scan, so we still include it in
+-- the index even though every customer_only row carries exactly one.
+CREATE UNIQUE INDEX IF NOT EXISTS triage_exclusion_fanout_job_customer_dedupe
+    ON triage_exclusion_fanout_job (customer_only_exclusion_id, customer_id)
+    WHERE customer_only_exclusion_id IS NOT NULL;

--- a/src/__tests__/app/api/internal/triage/baseline/retention/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/baseline/retention/route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunDispatch = vi.hoisted(() => vi.fn());
+const mockVerifyToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/baseline/retention", () => ({
+  runBaselineRetentionDispatch: mockRunDispatch,
+  verifyTriageBaselineRetentionToken: mockVerifyToken,
+}));
+
+beforeEach(() => {
+  mockRunDispatch.mockReset();
+  mockVerifyToken.mockReset();
+});
+
+function makeRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("http://test/api/internal/triage/baseline/retention", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/internal/triage/baseline/retention", () => {
+  it("returns 401 when the bearer token does not verify", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+    expect(mockRunDispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the authorization header is missing", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/retention/route"
+    );
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockVerifyToken).toHaveBeenCalledWith(null);
+  });
+
+  it("returns 200 with the dispatcher result on overall=ok", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockResolvedValue({
+      overall: "ok",
+      perCustomer: [
+        {
+          customerId: 1,
+          status: "ok",
+          counts: { baselineTriagedEvent: 12, observedEventMeta: 3 },
+        },
+      ],
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overall).toBe("ok");
+    expect(body.perCustomer).toHaveLength(1);
+  });
+
+  it("returns 200 with overall=partial when at least one customer failed", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockResolvedValue({
+      overall: "partial",
+      perCustomer: [
+        {
+          customerId: 1,
+          status: "ok",
+          counts: { baselineTriagedEvent: 0, observedEventMeta: 0 },
+        },
+        {
+          customerId: 2,
+          status: "failed",
+          counts: { baselineTriagedEvent: 0, observedEventMeta: 0 },
+          error: "tenant 2 unreachable",
+        },
+      ],
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overall).toBe("partial");
+  });
+
+  it("returns 500 when the dispatcher itself throws", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockRejectedValue(new Error("auth_db unreachable"));
+    const { POST } = await import(
+      "@/app/api/internal/triage/baseline/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.overall).toBe("failed");
+    expect(body.error).toContain("auth_db unreachable");
+  });
+});

--- a/src/__tests__/app/api/internal/triage/exclusion/recover/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/exclusion/recover/route.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApplyRecover = vi.hoisted(() => vi.fn());
+const mockEmitRecoverAudit = vi.hoisted(() => vi.fn());
+const mockVerifyToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/exclusion/recovery", () => ({
+  applyRecover: mockApplyRecover,
+  emitRecoverAudit: mockEmitRecoverAudit,
+  verifyTriageExclusionRecoveryToken: mockVerifyToken,
+}));
+
+beforeEach(() => {
+  mockApplyRecover.mockReset();
+  mockEmitRecoverAudit.mockReset().mockResolvedValue(undefined);
+  mockVerifyToken.mockReset();
+});
+
+function makeRequest(body: unknown, authHeader = "Bearer right"): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("http://test/api/internal/triage/exclusion/recover", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/triage/exclusion/recover", () => {
+  it("returns 401 when token mismatches", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "global_all_failed", exclusion_id: "x" }),
+    );
+    expect(res.status).toBe(401);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the body is not valid JSON", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const req = new Request(
+      "http://test/api/internal/triage/exclusion/recover",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer right",
+          "content-type": "application/json",
+        },
+        body: "not-json",
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when kind is missing", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(makeRequest({ exclusion_id: "x" }));
+    expect(res.status).toBe(400);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when exclusion_id is missing or empty", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "global", exclusion_id: "", customer_id: 1 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when kind='global' is missing customer_id (no implicit sweep)", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(makeRequest({ kind: "global", exclusion_id: "x" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/customer_id/);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when kind='customer' is missing customer_id", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "customer", exclusion_id: "x" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when customer_id is not a positive integer", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "global", exclusion_id: "x", customer_id: -1 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when kind is unknown", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "everything", exclusion_id: "x" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("dispatches kind='global' with customer_id to applyRecover and audits as system", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockApplyRecover.mockResolvedValue({ reset: 1, kind: "global" });
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "global", exclusion_id: "g-1", customer_id: 7 }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockApplyRecover).toHaveBeenCalledWith({
+      kind: "global",
+      exclusionId: "g-1",
+      customerId: 7,
+    });
+    expect(mockEmitRecoverAudit).toHaveBeenCalledWith(
+      { kind: "global", exclusionId: "g-1", customerId: 7 },
+      "system",
+      1,
+    );
+  });
+
+  it("dispatches kind='global_all_failed' without customer_id", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockApplyRecover.mockResolvedValue({ reset: 5, kind: "global_all_failed" });
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "global_all_failed", exclusion_id: "g-1" }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reset).toBe(5);
+    expect(mockApplyRecover).toHaveBeenCalledWith({
+      kind: "global_all_failed",
+      exclusionId: "g-1",
+    });
+  });
+
+  it("returns 500 when applyRecover throws", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockApplyRecover.mockRejectedValue(new Error("queue is down"));
+    const { POST } = await import(
+      "@/app/api/internal/triage/exclusion/recover/route"
+    );
+    const res = await POST(
+      makeRequest({ kind: "global_all_failed", exclusion_id: "g-1" }),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain("queue is down");
+  });
+});

--- a/src/__tests__/app/api/internal/triage/policy/retention/route.test.ts
+++ b/src/__tests__/app/api/internal/triage/policy/retention/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRunDispatch = vi.hoisted(() => vi.fn());
+const mockVerifyToken = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/policy/corpus-b/retention", () => ({
+  runPolicyRetentionDispatch: mockRunDispatch,
+  verifyTriagePolicyRetentionToken: mockVerifyToken,
+}));
+
+beforeEach(() => {
+  mockRunDispatch.mockReset();
+  mockVerifyToken.mockReset();
+});
+
+function makeRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  return new Request("http://test/api/internal/triage/policy/retention", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/internal/triage/policy/retention", () => {
+  it("returns 401 when the bearer token does not verify", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const { POST } = await import(
+      "@/app/api/internal/triage/policy/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+    expect(mockRunDispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with dispatcher result on overall=ok", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockResolvedValue({
+      overall: "ok",
+      perCustomer: [
+        {
+          customerId: 1,
+          status: "ok",
+          counts: {
+            zombiesReaped: 2,
+            readyPruned: 0,
+            supersededPruned: 1,
+            failedPruned: 3,
+            orphanedPruned: 0,
+          },
+        },
+      ],
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/policy/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overall).toBe("ok");
+    expect(body.perCustomer[0].counts.zombiesReaped).toBe(2);
+  });
+
+  it("returns 200 with overall=partial when a per-customer sweep fails", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockResolvedValue({
+      overall: "partial",
+      perCustomer: [
+        {
+          customerId: 1,
+          status: "failed",
+          counts: {
+            zombiesReaped: 0,
+            readyPruned: 0,
+            supersededPruned: 0,
+            failedPruned: 0,
+            orphanedPruned: 0,
+          },
+          error: "boom",
+        },
+      ],
+    });
+    const { POST } = await import(
+      "@/app/api/internal/triage/policy/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overall).toBe("partial");
+  });
+
+  it("returns 500 when the dispatcher itself throws", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockRunDispatch.mockRejectedValue(new Error("auth_db down"));
+    const { POST } = await import(
+      "@/app/api/internal/triage/policy/retention/route"
+    );
+    const res = await POST(makeRequest("Bearer right"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.overall).toBe("failed");
+    expect(body.error).toContain("auth_db down");
+  });
+});

--- a/src/__tests__/app/api/triage/exclusions/[id]/recover/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/[id]/recover/route.test.ts
@@ -1,0 +1,208 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockApplyRecover = vi.hoisted(() => vi.fn());
+const mockEmitRecoverAudit = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+vi.mock("@/lib/triage/exclusion/recovery", () => ({
+  applyRecover: vi.fn((...args: unknown[]) => mockApplyRecover(...args)),
+  emitRecoverAudit: vi.fn((...args: unknown[]) =>
+    mockEmitRecoverAudit(...args),
+  ),
+}));
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  mustEnrollMfa: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const VALID_ID = "00000000-0000-0000-0000-000000000010";
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/triage/exclusions/[id]/recover", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockApplyRecover.mockReset();
+    mockEmitRecoverAudit.mockReset().mockResolvedValue(undefined);
+    mockQuery.mockReset();
+  });
+
+  it("returns 400 when customer_id is missing", async () => {
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/${VALID_ID}/recover`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(400);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when customer_id is not a positive integer", async () => {
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/${VALID_ID}/recover?customer_id=0`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on a malformed UUID", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/not-a-uuid/recover?customer_id=42",
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext("not-a-uuid"));
+    expect(res.status).toBe(400);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the permission check fails", async () => {
+    mockHasPermission.mockReset().mockResolvedValue(false);
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/${VALID_ID}/recover?customer_id=42`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the caller's scope excludes the requested customer", async () => {
+    mockHasPermission
+      .mockReset()
+      .mockImplementation(async (_roles: string[], perm: string) => {
+        // triage:exclusion:write is satisfied; customers:access-all is not.
+        if (perm === "customers:access-all") return false;
+        return true;
+      });
+    // No row in account_customer for this customer.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/${VALID_ID}/recover?customer_id=42`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(403);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when no failed sentinel matches", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    mockApplyRecover.mockResolvedValue({ reset: 0, kind: "customer" });
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/${VALID_ID}/recover?customer_id=42`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(404);
+    expect(mockEmitRecoverAudit).not.toHaveBeenCalled();
+  });
+
+  it("resets the sentinel and emits customer_recover audit on success", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    mockApplyRecover.mockResolvedValue({ reset: 1, kind: "customer" });
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/${VALID_ID}/recover?customer_id=42`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ id: VALID_ID, reset: 1 });
+    expect(mockApplyRecover).toHaveBeenCalledWith({
+      kind: "customer",
+      exclusionId: VALID_ID,
+      customerId: 42,
+    });
+    expect(mockEmitRecoverAudit).toHaveBeenCalledWith(
+      { kind: "customer", exclusionId: VALID_ID, customerId: 42 },
+      "admin-1",
+      1,
+      expect.objectContaining({ sid: "session-1", ip: "127.0.0.1" }),
+    );
+  });
+});

--- a/src/__tests__/app/api/triage/exclusions/cleanup-status/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/cleanup-status/route.test.ts
@@ -150,6 +150,40 @@ describe("GET /api/triage/exclusions/cleanup-status", () => {
     expect(mockAuditOnly).toHaveBeenCalledWith(42);
   });
 
+  it("falls back to queue-backed ids when the audit-only probe throws (audit_db blip)", async () => {
+    // Round-3 review: the audit-only source must be best-effort. If
+    // `audit_db` is temporarily unavailable, the route must still
+    // return the queue-backed `failed` sentinels — making the audit
+    // query a hard dependency hides the ordinary recovery affordance
+    // during exactly the kind of infrastructure blip this fallback
+    // exists to make recoverable from.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      mockHasPermission.mockResolvedValue(true);
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ customer_only_exclusion_id: "queue-1" }],
+        rowCount: 1,
+      });
+      mockAuditOnly.mockRejectedValueOnce(new Error("audit_db unreachable"));
+
+      const { GET } = await import(
+        "@/app/api/triage/exclusions/cleanup-status/route"
+      );
+      const req = new NextRequest(
+        "http://localhost:3000/api/triage/exclusions/cleanup-status?customer_id=42",
+      );
+      const res = await GET(req, makeContext());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.failed).toEqual(["queue-1"]);
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("unions audit-only drain failures with the queue rows so audit-only failures surface", async () => {
     // Round-2 review: an `auth_db` blip during the failed ADD path can
     // leave a `drainStatus='failed'` audit row with no matching sentinel

--- a/src/__tests__/app/api/triage/exclusions/cleanup-status/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/cleanup-status/route.test.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  mustEnrollMfa: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+function makeContext() {
+  return { params: Promise.resolve({}) };
+}
+
+describe("GET /api/triage/exclusions/cleanup-status", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockQuery.mockReset();
+  });
+
+  it("returns 400 when customer_id is missing", async () => {
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/cleanup-status",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when customer_id is non-numeric", async () => {
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/cleanup-status?customer_id=abc",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when caller's scope excludes the requested customer", async () => {
+    mockHasPermission
+      .mockReset()
+      .mockImplementation(async (_roles: string[], perm: string) => {
+        if (perm === "customers:access-all") return false;
+        return true;
+      });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/cleanup-status?customer_id=42",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the failed ids for the customer", async () => {
+    mockHasPermission.mockResolvedValue(true);
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { customer_only_exclusion_id: "exc-1" },
+        { customer_only_exclusion_id: "exc-2" },
+      ],
+      rowCount: 2,
+    });
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/cleanup-status?customer_id=42",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failed).toEqual(["exc-1", "exc-2"]);
+    // SELECT was customer-scoped and partial-index aware.
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("customer_id = $1");
+    expect(sql).toContain("customer_only_exclusion_id IS NOT NULL");
+    expect(sql).toContain("status = 'failed'");
+    expect(params).toEqual([42]);
+  });
+});

--- a/src/__tests__/app/api/triage/exclusions/cleanup-status/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/cleanup-status/route.test.ts
@@ -15,6 +15,7 @@ interface WithAuthOptions {
 
 const mockHasPermission = vi.hoisted(() => vi.fn());
 const mockQuery = vi.hoisted(() => vi.fn());
+const mockAuditOnly = vi.hoisted(() => vi.fn());
 
 let currentSession: AuthSession;
 
@@ -44,6 +45,12 @@ vi.mock("@/lib/db/client", () => ({
   query: vi.fn((...args: unknown[]) => mockQuery(...args)),
 }));
 
+vi.mock("@/lib/triage/exclusion/recovery", () => ({
+  listAuditOnlyCustomerDrainFailures: vi.fn((...args: unknown[]) =>
+    mockAuditOnly(...args),
+  ),
+}));
+
 const now = Math.floor(Date.now() / 1000);
 const adminSession: AuthSession = {
   accountId: "admin-1",
@@ -71,6 +78,7 @@ describe("GET /api/triage/exclusions/cleanup-status", () => {
     currentSession = adminSession;
     mockHasPermission.mockReset().mockResolvedValue(true);
     mockQuery.mockReset();
+    mockAuditOnly.mockReset().mockResolvedValue([]);
   });
 
   it("returns 400 when customer_id is missing", async () => {
@@ -138,5 +146,34 @@ describe("GET /api/triage/exclusions/cleanup-status", () => {
     expect(sql).toContain("customer_only_exclusion_id IS NOT NULL");
     expect(sql).toContain("status = 'failed'");
     expect(params).toEqual([42]);
+    // The audit-only fallback was consulted for this customer.
+    expect(mockAuditOnly).toHaveBeenCalledWith(42);
+  });
+
+  it("unions audit-only drain failures with the queue rows so audit-only failures surface", async () => {
+    // Round-2 review: an `auth_db` blip during the failed ADD path can
+    // leave a `drainStatus='failed'` audit row with no matching sentinel
+    // (the sentinel-insert error is swallowed so the primary drain
+    // error is what the dialog surfaces). The audit-only fallback must
+    // still surface that exclusion as recoverable.
+    mockHasPermission.mockResolvedValue(true);
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ customer_only_exclusion_id: "queue-1" }],
+      rowCount: 1,
+    });
+    mockAuditOnly.mockResolvedValueOnce(["audit-only-1", "queue-1"]);
+
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/cleanup-status?customer_id=42",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Union with dedupe — queue-1 appears in both sources but only once.
+    expect(new Set(body.failed)).toEqual(new Set(["queue-1", "audit-only-1"]));
+    expect(body.failed).toHaveLength(2);
   });
 });

--- a/src/__tests__/app/api/triage/exclusions/global/[id]/recover/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/global/[id]/recover/route.test.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockApplyRecover = vi.hoisted(() => vi.fn());
+const mockEmitRecoverAudit = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/auth/ip", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/triage/exclusion/recovery", () => ({
+  applyRecover: vi.fn((...args: unknown[]) => mockApplyRecover(...args)),
+  emitRecoverAudit: vi.fn((...args: unknown[]) =>
+    mockEmitRecoverAudit(...args),
+  ),
+}));
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  mustEnrollMfa: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+const VALID_ID = "00000000-0000-0000-0000-000000000020";
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("POST /api/triage/exclusions/global/[id]/recover", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockApplyRecover.mockReset();
+    mockEmitRecoverAudit.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("returns 400 on malformed UUID", async () => {
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/global/not-a-uuid/recover?all_failed=1",
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext("not-a-uuid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when neither customer_id nor all_failed is supplied", async () => {
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/global/${VALID_ID}/recover`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(400);
+    expect(mockApplyRecover).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the permission check fails", async () => {
+    mockHasPermission.mockReset().mockResolvedValue(false);
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/global/${VALID_ID}/recover?all_failed=1`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("dispatches all_failed=1 to the kind='global_all_failed' helper", async () => {
+    mockApplyRecover.mockResolvedValue({ reset: 5, kind: "global_all_failed" });
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/global/${VALID_ID}/recover?all_failed=1`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(200);
+    expect(mockApplyRecover).toHaveBeenCalledWith({
+      kind: "global_all_failed",
+      exclusionId: VALID_ID,
+    });
+    expect(mockEmitRecoverAudit).toHaveBeenCalledWith(
+      { kind: "global_all_failed", exclusionId: VALID_ID },
+      "admin-1",
+      5,
+      expect.objectContaining({ ip: "127.0.0.1", sid: "session-1" }),
+    );
+  });
+
+  it("dispatches customer_id<int> to kind='global' for single-row pinpoint", async () => {
+    mockApplyRecover.mockResolvedValue({ reset: 1, kind: "global" });
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/global/${VALID_ID}/recover?customer_id=7`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(200);
+    expect(mockApplyRecover).toHaveBeenCalledWith({
+      kind: "global",
+      exclusionId: VALID_ID,
+      customerId: 7,
+    });
+  });
+
+  it("returns 400 when customer_id is non-numeric", async () => {
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/global/${VALID_ID}/recover?customer_id=not-a-number`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when no failed rows match", async () => {
+    mockApplyRecover.mockResolvedValue({ reset: 0, kind: "global_all_failed" });
+    const { POST } = await import(
+      "@/app/api/triage/exclusions/global/[id]/recover/route"
+    );
+    const req = new NextRequest(
+      `http://localhost:3000/api/triage/exclusions/global/${VALID_ID}/recover?all_failed=1`,
+      { method: "POST" },
+    );
+    const res = await POST(req, makeContext(VALID_ID));
+    expect(res.status).toBe(404);
+    expect(mockEmitRecoverAudit).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/app/api/triage/exclusions/global/cleanup-status/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/global/cleanup-status/route.test.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthSession } from "@/lib/auth/jwt";
+
+type HandlerFn = (
+  request: NextRequest,
+  context: { params: Promise<Record<string, string>> },
+  session: AuthSession,
+) => Promise<Response>;
+
+interface WithAuthOptions {
+  requiredPermissions?: string[];
+}
+
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+
+let currentSession: AuthSession;
+
+vi.mock("@/lib/auth/guard", () => ({
+  withAuth: vi.fn((handler: HandlerFn, options?: WithAuthOptions) => {
+    return async (
+      request: NextRequest,
+      context: { params: Promise<Record<string, string>> },
+    ) => {
+      if (options?.requiredPermissions) {
+        for (const perm of options.requiredPermissions) {
+          if (!(await mockHasPermission(currentSession.roles, perm))) {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+          }
+        }
+      }
+      return handler(request, context, currentSession);
+    };
+  }),
+}));
+
+vi.mock("@/lib/auth/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+}));
+
+const now = Math.floor(Date.now() / 1000);
+const adminSession: AuthSession = {
+  accountId: "admin-1",
+  sessionId: "session-1",
+  roles: ["System Administrator"],
+  tokenVersion: 0,
+  mustChangePassword: false,
+  mustEnrollMfa: false,
+  iat: now,
+  exp: now + 900,
+  sessionIp: "127.0.0.1",
+  sessionUserAgent: "Mozilla/5.0",
+  sessionBrowserFingerprint: "Chrome/131",
+  needsReauth: false,
+  sessionCreatedAt: new Date(),
+  sessionLastActiveAt: new Date(),
+};
+
+function makeContext() {
+  return { params: Promise.resolve({}) };
+}
+
+describe("GET /api/triage/exclusions/global/cleanup-status", () => {
+  beforeEach(() => {
+    currentSession = adminSession;
+    mockHasPermission.mockReset().mockResolvedValue(true);
+    mockQuery.mockReset();
+  });
+
+  it("returns 403 when caller lacks triage:read", async () => {
+    mockHasPermission.mockReset().mockResolvedValue(false);
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/global/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/global/cleanup-status",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the deduplicated set of global exclusion ids with failed rows", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ global_exclusion_id: "g-1" }, { global_exclusion_id: "g-2" }],
+      rowCount: 2,
+    });
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/global/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/global/cleanup-status",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failed).toEqual(["g-1", "g-2"]);
+    // SELECT DISTINCT to keep the response shape stable when one
+    // exclusion has many failed customers.
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("SELECT DISTINCT global_exclusion_id");
+    expect(sql).toContain("global_exclusion_id IS NOT NULL");
+    expect(sql).toContain("status = 'failed'");
+  });
+
+  it("returns an empty array when no failures exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const { GET } = await import(
+      "@/app/api/triage/exclusions/global/cleanup-status/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions/global/cleanup-status",
+    );
+    const res = await GET(req, makeContext());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failed).toEqual([]);
+  });
+});

--- a/src/__tests__/app/api/triage/exclusions/route.test.ts
+++ b/src/__tests__/app/api/triage/exclusions/route.test.ts
@@ -16,6 +16,7 @@ interface WithAuthOptions {
 const mockHasPermission = vi.hoisted(() => vi.fn());
 const mockAuditRecord = vi.hoisted(() => vi.fn());
 const mockQuery = vi.hoisted(() => vi.fn());
+const mockWithTransaction = vi.hoisted(() => vi.fn());
 const mockListCustomerExclusions = vi.hoisted(() => vi.fn());
 const mockCreateCustomerExclusion = vi.hoisted(() => vi.fn());
 const mockConnectCustomerClient = vi.hoisted(() => vi.fn());
@@ -23,6 +24,7 @@ const mockExecuteFirstBatch = vi.hoisted(() => vi.fn());
 const mockDrainRemaining = vi.hoisted(() => vi.fn());
 const mockAcquireLock = vi.hoisted(() => vi.fn());
 const mockGetCustomerPool = vi.hoisted(() => vi.fn());
+const mockInsertSentinel = vi.hoisted(() => vi.fn());
 
 let currentSession: AuthSession;
 
@@ -60,6 +62,13 @@ vi.mock("@/lib/auth/ip", () => ({
 
 vi.mock("@/lib/db/client", () => ({
   query: vi.fn((...args: unknown[]) => mockQuery(...args)),
+  withTransaction: vi.fn((...args: unknown[]) => mockWithTransaction(...args)),
+}));
+
+vi.mock("@/lib/triage/exclusion/recovery", () => ({
+  insertCustomerDrainFailureSentinel: vi.fn((...args: unknown[]) =>
+    mockInsertSentinel(...args),
+  ),
 }));
 
 vi.mock("@/lib/triage/exclusion/storage", async () => {
@@ -221,6 +230,12 @@ describe("POST /api/triage/exclusions", () => {
     mockConnectCustomerClient
       .mockReset()
       .mockImplementation(async () => makeFakeClient());
+    mockWithTransaction
+      .mockReset()
+      .mockImplementation(async (fn: (c: unknown) => Promise<unknown>) =>
+        fn({}),
+      );
+    mockInsertSentinel.mockReset().mockResolvedValue(undefined);
   });
 
   it("creates a customer exclusion and emits an audit row", async () => {
@@ -331,6 +346,50 @@ describe("POST /api/triage/exclusions", () => {
         }),
       }),
     );
+    // 1B-7: the drain-failure path enqueues a sentinel into the auth_db
+    // fanout queue so admin recovery has a `failed` row to reset.
+    expect(mockInsertSentinel).toHaveBeenCalledWith(
+      expect.anything(),
+      sampleRow.id,
+      42,
+      expect.stringContaining("tenant DB blip"),
+    );
+  });
+
+  it("still returns 500 with the drain error if the sentinel enqueue itself fails", async () => {
+    // The sentinel insertion is best-effort: failing to enqueue must not
+    // mask the original drain failure that the dialog needs to surface.
+    mockCreateCustomerExclusion.mockResolvedValue(sampleRow);
+    const pendingPredicate = {
+      tableKey: "baselineTriagedEvent" as const,
+      statements: [{ sql: "DELETE FROM baseline_triaged_event", params: [] }],
+    };
+    mockExecuteFirstBatch.mockResolvedValue({
+      counts: {
+        baselineTriagedEvent: 1,
+        observedEventMeta: 0,
+        policyTriagedEvent: null,
+      },
+      pending: [pendingPredicate],
+    });
+    mockDrainRemaining.mockRejectedValue(new Error("tenant DB blip"));
+    mockGetCustomerPool.mockResolvedValue({ connect: vi.fn() });
+    mockInsertSentinel.mockRejectedValue(new Error("auth_db unreachable"));
+
+    const { POST } = await import("@/app/api/triage/exclusions/route");
+    const request = new NextRequest(
+      "http://localhost:3000/api/triage/exclusions?customer_id=42",
+      {
+        method: "POST",
+        body: JSON.stringify({ kind: "ipAddress", value: "10.0.0.0/24" }),
+      },
+    );
+    const response = await POST(request, makeContext());
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error).toContain("tenant DB blip");
+    // The sentinel enqueue error must not surface to the client.
+    expect(body.error).not.toContain("auth_db unreachable");
   });
 
   it("rejects an invalid kind via parseStoredExclusionInput", async () => {

--- a/src/__tests__/lib/audit/customer-scope-policy.test.ts
+++ b/src/__tests__/lib/audit/customer-scope-policy.test.ts
@@ -51,7 +51,7 @@ describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
     expect(bad).toEqual([]);
   });
 
-  it("flags customer.* / node.* / service.* / aimer_context_token.issued / triage.policy.* / triage_exclusion.{customer_*,fanout_failed} as customer-scoped", () => {
+  it("flags customer.* / node.* / service.* / aimer_context_token.issued / triage.policy.* / triage_exclusion.{customer_*,fanout_failed,customer_recover} as customer-scoped", () => {
     const expectedScoped: AuditAction[] = [
       "customer.create",
       "customer.update",
@@ -73,6 +73,7 @@ describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
       "triage_exclusion.customer_add",
       "triage_exclusion.customer_remove",
       "triage_exclusion.fanout_failed",
+      "triage_exclusion.customer_recover",
     ];
     for (const action of expectedScoped) {
       expect(customerScopeForAction(action)).toBe("customer-scoped");
@@ -101,6 +102,7 @@ describe("AUDIT_ACTION_CUSTOMER_SCOPE — exhaustive coverage", () => {
       "triage_exclusion.customer_add",
       "triage_exclusion.customer_remove",
       "triage_exclusion.fanout_failed",
+      "triage_exclusion.customer_recover",
     ]);
     for (const action of listAllAuditActions()) {
       if (!scopedActions.has(action)) {

--- a/src/__tests__/lib/triage/baseline/retention.test.ts
+++ b/src/__tests__/lib/triage/baseline/retention.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCustomerPool = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/policy/customer-db", () => ({
+  getCustomerPool: mockGetCustomerPool,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: vi.fn(),
+}));
+
+import {
+  BASELINE_TRIAGED_EVENT_RETENTION_DAYS,
+  DEFAULT_DELETE_BATCH_SIZE,
+  OBSERVED_EVENT_META_RETENTION_DAYS,
+  runBaselineRetentionDispatch,
+  runBaselineRetentionForCustomer,
+  verifyTriageBaselineRetentionToken,
+} from "@/lib/triage/baseline/retention";
+
+interface DeleteCall {
+  table: string;
+  retentionDays: string;
+}
+
+function makePool(opts: {
+  // Returned rowCount per consecutive DELETE invocation on a given table.
+  // The retention loop breaks when rowCount < batchSize.
+  rowsByTable?: Record<string, number[]>;
+}) {
+  const calls: DeleteCall[] = [];
+  const pool = {
+    query: vi.fn(async (sql: string, params: unknown[]) => {
+      const table = sql.match(/DELETE FROM (\w+)/)?.[1] ?? "?";
+      calls.push({ table, retentionDays: params[0] as string });
+      const queue = opts.rowsByTable?.[table];
+      if (!queue || queue.length === 0) {
+        return { rows: [], rowCount: 0 };
+      }
+      const next = queue.shift() ?? 0;
+      return { rows: [], rowCount: next };
+    }),
+  };
+  return { pool, calls };
+}
+
+describe("runBaselineRetentionForCustomer", () => {
+  it("sweeps both corpus A tables with their documented retention windows", async () => {
+    const { pool, calls } = makePool({
+      rowsByTable: {
+        baseline_triaged_event: [10],
+        observed_event_meta: [3],
+      },
+    });
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    const counts = await runBaselineRetentionForCustomer(7);
+
+    expect(counts).toEqual({
+      baselineTriagedEvent: 10,
+      observedEventMeta: 3,
+    });
+    // Both tables visited with the documented retention windows.
+    expect(calls).toEqual([
+      {
+        table: "baseline_triaged_event",
+        retentionDays: String(BASELINE_TRIAGED_EVENT_RETENTION_DAYS),
+      },
+      {
+        table: "observed_event_meta",
+        retentionDays: String(OBSERVED_EVENT_META_RETENTION_DAYS),
+      },
+    ]);
+  });
+
+  it("loops until a partial batch confirms the table is drained", async () => {
+    // Two full batches of 10_000, then a partial batch ends the loop.
+    const { pool, calls } = makePool({
+      rowsByTable: {
+        baseline_triaged_event: [
+          DEFAULT_DELETE_BATCH_SIZE,
+          DEFAULT_DELETE_BATCH_SIZE,
+          17,
+        ],
+        observed_event_meta: [0],
+      },
+    });
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    const counts = await runBaselineRetentionForCustomer(1);
+
+    expect(counts.baselineTriagedEvent).toBe(
+      DEFAULT_DELETE_BATCH_SIZE * 2 + 17,
+    );
+    expect(counts.observedEventMeta).toBe(0);
+    // Loop terminates promptly when the table is empty.
+    const baselineCalls = calls.filter(
+      (c) => c.table === "baseline_triaged_event",
+    );
+    expect(baselineCalls).toHaveLength(3);
+    const observedCalls = calls.filter(
+      (c) => c.table === "observed_event_meta",
+    );
+    expect(observedCalls).toHaveLength(1);
+  });
+});
+
+describe("runBaselineRetentionDispatch", () => {
+  it("returns overall='ok' when every per-customer sweep succeeds", async () => {
+    const result = await runBaselineRetentionDispatch({
+      listActiveCustomers: async () => [1, 2],
+      runForCustomer: async (id) => ({
+        baselineTriagedEvent: id * 10,
+        observedEventMeta: id,
+      }),
+    });
+
+    expect(result.overall).toBe("ok");
+    expect(result.perCustomer).toEqual([
+      {
+        customerId: 1,
+        status: "ok",
+        counts: { baselineTriagedEvent: 10, observedEventMeta: 1 },
+      },
+      {
+        customerId: 2,
+        status: "ok",
+        counts: { baselineTriagedEvent: 20, observedEventMeta: 2 },
+      },
+    ]);
+  });
+
+  it("captures a per-customer error and surfaces overall='partial' without aborting others", async () => {
+    const result = await runBaselineRetentionDispatch({
+      listActiveCustomers: async () => [1, 2, 3],
+      runForCustomer: async (id) => {
+        if (id === 2) throw new Error("tenant 2 unreachable");
+        return {
+          baselineTriagedEvent: 5,
+          observedEventMeta: 1,
+        };
+      },
+    });
+
+    expect(result.overall).toBe("partial");
+    expect(result.perCustomer).toEqual([
+      {
+        customerId: 1,
+        status: "ok",
+        counts: { baselineTriagedEvent: 5, observedEventMeta: 1 },
+      },
+      {
+        customerId: 2,
+        status: "failed",
+        counts: { baselineTriagedEvent: 0, observedEventMeta: 0 },
+        error: "tenant 2 unreachable",
+      },
+      {
+        customerId: 3,
+        status: "ok",
+        counts: { baselineTriagedEvent: 5, observedEventMeta: 1 },
+      },
+    ]);
+  });
+
+  it("propagates dispatcher-level failures from the enumerator", async () => {
+    await expect(
+      runBaselineRetentionDispatch({
+        listActiveCustomers: async () => {
+          throw new Error("auth_db unreachable");
+        },
+      }),
+    ).rejects.toThrow("auth_db unreachable");
+  });
+
+  it("returns overall='ok' with an empty perCustomer list when no customers are active", async () => {
+    const result = await runBaselineRetentionDispatch({
+      listActiveCustomers: async () => [],
+    });
+
+    expect(result).toEqual({ overall: "ok", perCustomer: [] });
+  });
+});
+
+describe("verifyTriageBaselineRetentionToken", () => {
+  const ENV_KEY = "TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN";
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("rejects when env unset", () => {
+    delete process.env[ENV_KEY];
+    expect(verifyTriageBaselineRetentionToken("anything")).toBe(false);
+  });
+
+  it("accepts the matching token", () => {
+    process.env[ENV_KEY] = "secret-token";
+    expect(verifyTriageBaselineRetentionToken("secret-token")).toBe(true);
+  });
+
+  it("rejects same-length mismatch (constant-time)", () => {
+    process.env[ENV_KEY] = "secret-token";
+    expect(verifyTriageBaselineRetentionToken("secret-tokeX")).toBe(false);
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/fanout-worker.test.ts
+++ b/src/__tests__/lib/triage/exclusion/fanout-worker.test.ts
@@ -740,3 +740,87 @@ describe("runFanoutSweep — global deleted between initial load and tenant DELE
     expect(withTxCallCount).toBeGreaterThan(0);
   });
 });
+
+describe("runFanoutSweep — customer-only sentinel branch (#461 / 1B-7)", () => {
+  it("treats a missing tenant triage_exclusion row as a completed no-op (no FK cascade on cross-DB pointers)", async () => {
+    // Customer-scoped recovery resets a sentinel to pending, but the
+    // tenant exclusion was deleted between reset and claim. The worker
+    // must mirror the global FK-CASCADE semantic explicitly: mark the
+    // job `completed` rather than increment attempt_count and loop
+    // through backoff.
+    const auth = {
+      query: vi.fn(async (sql: string, _params?: unknown[]) => {
+        if (
+          sql.includes("UPDATE triage_exclusion_fanout_job") &&
+          sql.includes("milliseconds")
+        ) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (sql.includes("FOR UPDATE SKIP LOCKED")) {
+          return {
+            rows: [
+              {
+                id: "job-cust-orphan",
+                global_exclusion_id: null,
+                customer_only_exclusion_id: "exc-gone",
+                customer_id: 42,
+                attempt_count: 0,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+        if (
+          sql.includes("UPDATE triage_exclusion_fanout_job") &&
+          sql.includes("status = 'running'")
+        ) {
+          return { rows: [], rowCount: 1 };
+        }
+        if (
+          sql.includes("UPDATE triage_exclusion_fanout_job") &&
+          sql.includes("status = 'completed'")
+        ) {
+          return { rows: [], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      }),
+    };
+
+    // Tenant pool returns an empty triage_exclusion lookup: the row is
+    // gone.
+    const tenantClient = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes("FROM triage_exclusion")) {
+          return { rows: [], rowCount: 0 };
+        }
+        return { rows: [], rowCount: 0 };
+      }),
+      release: vi.fn(),
+    };
+    const tenantPool = { connect: vi.fn(async () => tenantClient) };
+    mockGetCustomerPool.mockResolvedValue(tenantPool);
+    mockWithTransaction.mockImplementation(
+      async (fn: (c: unknown) => Promise<unknown>) => fn(auth),
+    );
+
+    const result = await runFanoutSweep({ batchSize: 5 });
+
+    expect(result).toMatchObject({
+      claimed: 1,
+      completed: 1,
+      retried: 0,
+      failed: 0,
+    });
+    // Tenant pool was consulted exactly to read triage_exclusion;
+    // because the row was missing, no BEGIN / DELETE was issued — the
+    // worker short-circuits before the cadence-locked first batch.
+    const tenantSqls = tenantClient.query.mock.calls.map((c) => c[0]);
+    expect(tenantSqls.some((s) => s.includes("FROM triage_exclusion"))).toBe(
+      true,
+    );
+    expect(tenantSqls.some((s) => s.startsWith("DELETE"))).toBe(false);
+    expect(tenantSqls).not.toContain("BEGIN");
+    // No audit emission — there was no retroactive cleanup to attribute.
+    expect(mockAuditLogRecord).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/triage/exclusion/fanout-worker.test.ts
+++ b/src/__tests__/lib/triage/exclusion/fanout-worker.test.ts
@@ -736,7 +736,17 @@ describe("runFanoutSweep — global deleted between initial load and tenant DELE
     expect(tenantSqls.some((s) => s.startsWith("DELETE"))).toBe(false);
     // No customer_add audit row — there was no work to attribute.
     expect(mockAuditLogRecord).not.toHaveBeenCalled();
-    // Sanity: the job row finalized as completed (no-op).
+    // The job row MUST be finalized as `completed`. Without this the
+    // row stays `running`, the stuck-job sweep flips it back to
+    // `pending`, and the worker loops on the same no-op forever
+    // (and the "Re-trigger cleanup" indicator never clears).
+    const finalizeCompletedCalls = auth.query.mock.calls.filter(
+      (call: [string, unknown[]?]) =>
+        call[0].includes("UPDATE triage_exclusion_fanout_job") &&
+        call[0].includes("status = 'completed'"),
+    );
+    expect(finalizeCompletedCalls).toHaveLength(1);
+    expect(finalizeCompletedCalls[0][1]).toEqual(["job-race"]);
     expect(withTxCallCount).toBeGreaterThan(0);
   });
 });

--- a/src/__tests__/lib/triage/exclusion/recovery.test.ts
+++ b/src/__tests__/lib/triage/exclusion/recovery.test.ts
@@ -9,6 +9,12 @@ const mockWithTransaction = vi.hoisted(() =>
       fn((globalThis as Record<string, unknown>).__client__),
   ),
 );
+const mockQueryAudit = vi.hoisted(() =>
+  vi.fn(async (_sql: string, _params?: unknown[]) => ({
+    rows: [] as unknown[],
+    rowCount: 0,
+  })),
+);
 
 vi.mock("@/lib/db/client", () => ({
   withTransaction: mockWithTransaction,
@@ -18,10 +24,15 @@ vi.mock("@/lib/audit/logger", () => ({
   auditLog: { record: mockAuditLogRecord },
 }));
 
+vi.mock("@/lib/audit/client", () => ({
+  queryAudit: mockQueryAudit,
+}));
+
 import {
   applyRecover,
   emitRecoverAudit,
   insertCustomerDrainFailureSentinel,
+  listAuditOnlyCustomerDrainFailures,
   resetAllGlobalFailedJobs,
   resetCustomerDrainSentinel,
   resetGlobalFanoutJob,
@@ -159,6 +170,8 @@ describe("applyRecover", () => {
       async <T>(fn: (c: unknown) => Promise<T>) =>
         fn((globalThis as Record<string, unknown>).__client__),
     );
+    mockQueryAudit.mockReset();
+    mockQueryAudit.mockResolvedValue({ rows: [], rowCount: 0 });
   });
 
   it("dispatches kind='global' to the single-row global reset", async () => {
@@ -205,10 +218,97 @@ describe("applyRecover", () => {
     });
 
     expect(outcome).toEqual({ reset: 1, kind: "customer" });
+    // Reset path matched; audit-row fallback was NOT consulted.
+    expect(mockQueryAudit).not.toHaveBeenCalled();
     const { sql, params } = client.queries[0];
     expect(sql).toContain("WHERE customer_only_exclusion_id = $1");
     expect(sql).toContain("AND customer_id = $2");
     expect(params).toEqual(["exc-1", 42]);
+  });
+
+  it("backfills a pending sentinel from the audit log when no failed queue row matches (kind='customer')", async () => {
+    // Round-2 review: when the failed ADD path's sentinel insert was
+    // swallowed (auth_db blip), recovery would otherwise 404. The
+    // audit-row fallback finds the `drainStatus='failed'` audit row
+    // and INSERTs a fresh pending sentinel so the fanout worker re-
+    // runs the customer DELETE planner.
+    const client = makeClient({ affected: 0 });
+    (globalThis as Record<string, unknown>).__client__ = client;
+    mockQueryAudit.mockResolvedValueOnce({
+      rows: [{ "?column?": 1 }],
+      rowCount: 1,
+    });
+
+    const outcome = await applyRecover({
+      kind: "customer",
+      exclusionId: "exc-orphan",
+      customerId: 42,
+    });
+
+    expect(outcome).toEqual({ reset: 1, kind: "customer" });
+    // First query is the UPDATE reset (rowCount 0); second is the
+    // backfill INSERT with status='pending'.
+    expect(client.queries).toHaveLength(2);
+    expect(client.queries[0].sql).toContain(
+      "UPDATE triage_exclusion_fanout_job",
+    );
+    const backfill = client.queries[1];
+    expect(backfill.sql).toContain("INSERT INTO triage_exclusion_fanout_job");
+    expect(backfill.sql).toContain("'pending'");
+    expect(backfill.sql).toContain(
+      "ON CONFLICT (customer_only_exclusion_id, customer_id)",
+    );
+    expect(backfill.params).toEqual(["exc-orphan", 42]);
+    // Audit lookup was scoped to this exclusion + customer.
+    expect(mockQueryAudit).toHaveBeenCalledTimes(1);
+    const [auditSql, auditParams] = mockQueryAudit.mock.calls[0];
+    expect(auditSql).toContain("triage_exclusion.customer_add");
+    expect(auditSql).toContain("drainStatus");
+    expect(auditSql).toContain("triage_exclusion.customer_recover");
+    expect(auditParams).toEqual([42, "exc-orphan"]);
+  });
+
+  it("returns reset=0 for kind='customer' when neither a failed queue row nor a drain-failure audit row exists", async () => {
+    const client = makeClient({ affected: 0 });
+    (globalThis as Record<string, unknown>).__client__ = client;
+    mockQueryAudit.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const outcome = await applyRecover({
+      kind: "customer",
+      exclusionId: "exc-missing",
+      customerId: 42,
+    });
+
+    expect(outcome).toEqual({ reset: 0, kind: "customer" });
+    // Only the reset attempt ran; no backfill INSERT.
+    expect(client.queries).toHaveLength(1);
+    expect(client.queries[0].sql).toContain(
+      "UPDATE triage_exclusion_fanout_job",
+    );
+  });
+});
+
+describe("listAuditOnlyCustomerDrainFailures", () => {
+  beforeEach(() => {
+    mockQueryAudit.mockReset();
+  });
+
+  it("returns audit-only target_ids whose drain failure has not been recovered", async () => {
+    mockQueryAudit.mockResolvedValueOnce({
+      rows: [{ target_id: "exc-1" }, { target_id: "exc-2" }],
+      rowCount: 2,
+    });
+
+    const ids = await listAuditOnlyCustomerDrainFailures(42);
+
+    expect(ids).toEqual(["exc-1", "exc-2"]);
+    const [sql, params] = mockQueryAudit.mock.calls[0];
+    expect(sql).toContain("triage_exclusion.customer_add");
+    expect(sql).toContain("drainStatus");
+    // Excludes rows that have a later customer_recover audit entry.
+    expect(sql).toContain("triage_exclusion.customer_recover");
+    expect(sql).toContain("r.timestamp > a.timestamp");
+    expect(params).toEqual([42]);
   });
 });
 

--- a/src/__tests__/lib/triage/exclusion/recovery.test.ts
+++ b/src/__tests__/lib/triage/exclusion/recovery.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAuditLogRecord = vi.hoisted(() =>
+  vi.fn(async (_payload: Record<string, unknown>) => undefined),
+);
+const mockWithTransaction = vi.hoisted(() =>
+  vi.fn(
+    async <T>(fn: (client: unknown) => Promise<T>): Promise<T> =>
+      fn((globalThis as Record<string, unknown>).__client__),
+  ),
+);
+
+vi.mock("@/lib/db/client", () => ({
+  withTransaction: mockWithTransaction,
+}));
+
+vi.mock("@/lib/audit/logger", () => ({
+  auditLog: { record: mockAuditLogRecord },
+}));
+
+import {
+  applyRecover,
+  emitRecoverAudit,
+  insertCustomerDrainFailureSentinel,
+  resetAllGlobalFailedJobs,
+  resetCustomerDrainSentinel,
+  resetGlobalFanoutJob,
+  verifyTriageExclusionRecoveryToken,
+} from "@/lib/triage/exclusion/recovery";
+
+interface QueryCall {
+  sql: string;
+  params: unknown[] | undefined;
+}
+
+function makeClient(opts: { affected: number } = { affected: 0 }) {
+  const queries: QueryCall[] = [];
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    queries.push({ sql, params });
+    return { rows: [], rowCount: opts.affected };
+  });
+  return { queries, query };
+}
+
+describe("resetGlobalFanoutJob", () => {
+  it("issues a single-row UPDATE keyed by (global_exclusion_id, customer_id, status='failed')", async () => {
+    const client = makeClient({ affected: 1 });
+
+    const n = await resetGlobalFanoutJob(
+      client as unknown as Parameters<typeof resetGlobalFanoutJob>[0],
+      "glob-1",
+      7,
+    );
+
+    expect(n).toBe(1);
+    expect(client.queries).toHaveLength(1);
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("UPDATE triage_exclusion_fanout_job");
+    expect(sql).toContain("status = 'pending'");
+    expect(sql).toContain("attempt_count = 0");
+    expect(sql).toContain("last_error = NULL");
+    expect(sql).toContain("WHERE global_exclusion_id = $1");
+    expect(sql).toContain("AND customer_id = $2");
+    expect(sql).toContain("AND status = 'failed'");
+    expect(params).toEqual(["glob-1", 7]);
+  });
+
+  it("returns 0 when no failed row matches", async () => {
+    const client = makeClient({ affected: 0 });
+    const n = await resetGlobalFanoutJob(
+      client as unknown as Parameters<typeof resetGlobalFanoutJob>[0],
+      "glob-missing",
+      7,
+    );
+    expect(n).toBe(0);
+  });
+});
+
+describe("resetAllGlobalFailedJobs", () => {
+  it("sweeps every failed row for one global exclusion (no customer_id predicate)", async () => {
+    const client = makeClient({ affected: 12 });
+
+    const n = await resetAllGlobalFailedJobs(
+      client as unknown as Parameters<typeof resetAllGlobalFailedJobs>[0],
+      "glob-1",
+    );
+
+    expect(n).toBe(12);
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("WHERE global_exclusion_id = $1");
+    expect(sql).not.toContain("customer_id");
+    expect(sql).toContain("AND status = 'failed'");
+    expect(params).toEqual(["glob-1"]);
+  });
+});
+
+describe("resetCustomerDrainSentinel", () => {
+  it("issues an UPDATE keyed by (customer_only_exclusion_id, customer_id, status='failed')", async () => {
+    const client = makeClient({ affected: 1 });
+
+    const n = await resetCustomerDrainSentinel(
+      client as unknown as Parameters<typeof resetCustomerDrainSentinel>[0],
+      "exc-1",
+      42,
+    );
+
+    expect(n).toBe(1);
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("UPDATE triage_exclusion_fanout_job");
+    expect(sql).toContain("WHERE customer_only_exclusion_id = $1");
+    expect(sql).toContain("AND customer_id = $2");
+    expect(sql).toContain("AND status = 'failed'");
+    expect(params).toEqual(["exc-1", 42]);
+  });
+});
+
+describe("insertCustomerDrainFailureSentinel", () => {
+  it("INSERTs a failed sentinel with attempt_count=MAX_ATTEMPTS and ON CONFLICT upsert", async () => {
+    const client = makeClient({ affected: 1 });
+
+    await insertCustomerDrainFailureSentinel(
+      client as unknown as Parameters<
+        typeof insertCustomerDrainFailureSentinel
+      >[0],
+      "exc-1",
+      42,
+      "drain phase failed: tenant DB timeout",
+    );
+
+    expect(client.queries).toHaveLength(1);
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("INSERT INTO triage_exclusion_fanout_job");
+    // Sentinel: global_exclusion_id is NULL, status='failed'.
+    expect(sql).toContain("NULL, $1, $2, 'failed'");
+    // ON CONFLICT keyed on the customer-only partial index.
+    expect(sql).toContain(
+      "ON CONFLICT (customer_only_exclusion_id, customer_id)",
+    );
+    expect(sql).toContain("WHERE customer_only_exclusion_id IS NOT NULL");
+    expect(sql).toContain("DO UPDATE SET");
+    expect(sql).toContain("status = 'failed'");
+    // The DO UPDATE resets next_attempt_at / claimed_at so admin recovery
+    // can reset-in-place.
+    expect(sql).toContain("next_attempt_at = NOW()");
+    expect(sql).toContain("claimed_at = NULL");
+    expect(params).toEqual([
+      "exc-1",
+      42,
+      5, // MAX_ATTEMPTS
+      "drain phase failed: tenant DB timeout",
+    ]);
+  });
+});
+
+describe("applyRecover", () => {
+  beforeEach(() => {
+    mockWithTransaction.mockReset();
+    mockWithTransaction.mockImplementation(
+      async <T>(fn: (c: unknown) => Promise<T>) =>
+        fn((globalThis as Record<string, unknown>).__client__),
+    );
+  });
+
+  it("dispatches kind='global' to the single-row global reset", async () => {
+    const client = makeClient({ affected: 1 });
+    (globalThis as Record<string, unknown>).__client__ = client;
+
+    const outcome = await applyRecover({
+      kind: "global",
+      exclusionId: "glob-1",
+      customerId: 7,
+    });
+
+    expect(outcome).toEqual({ reset: 1, kind: "global" });
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("WHERE global_exclusion_id = $1");
+    expect(sql).toContain("AND customer_id = $2");
+    expect(params).toEqual(["glob-1", 7]);
+  });
+
+  it("dispatches kind='global_all_failed' to the sweep reset (no customer_id)", async () => {
+    const client = makeClient({ affected: 5 });
+    (globalThis as Record<string, unknown>).__client__ = client;
+
+    const outcome = await applyRecover({
+      kind: "global_all_failed",
+      exclusionId: "glob-1",
+    });
+
+    expect(outcome).toEqual({ reset: 5, kind: "global_all_failed" });
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("WHERE global_exclusion_id = $1");
+    expect(sql).not.toContain("customer_id");
+    expect(params).toEqual(["glob-1"]);
+  });
+
+  it("dispatches kind='customer' to the customer-only sentinel reset", async () => {
+    const client = makeClient({ affected: 1 });
+    (globalThis as Record<string, unknown>).__client__ = client;
+
+    const outcome = await applyRecover({
+      kind: "customer",
+      exclusionId: "exc-1",
+      customerId: 42,
+    });
+
+    expect(outcome).toEqual({ reset: 1, kind: "customer" });
+    const { sql, params } = client.queries[0];
+    expect(sql).toContain("WHERE customer_only_exclusion_id = $1");
+    expect(sql).toContain("AND customer_id = $2");
+    expect(params).toEqual(["exc-1", 42]);
+  });
+});
+
+describe("emitRecoverAudit", () => {
+  beforeEach(() => {
+    mockAuditLogRecord.mockReset();
+  });
+
+  it("emits triage_exclusion.global_recover (customer-agnostic) for kind='global'", async () => {
+    await emitRecoverAudit(
+      { kind: "global", exclusionId: "glob-1", customerId: 7 },
+      "admin@example.com",
+      1,
+      { ip: "10.0.0.1", sid: "sess-1" },
+    );
+
+    expect(mockAuditLogRecord).toHaveBeenCalledTimes(1);
+    const payload = mockAuditLogRecord.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      actor: "admin@example.com",
+      action: "triage_exclusion.global_recover",
+      target: "triage_exclusion",
+      targetId: "glob-1",
+      ip: "10.0.0.1",
+      sid: "sess-1",
+    });
+    // customer-agnostic action: top-level customerId is NOT populated.
+    expect(payload.customerId).toBeUndefined();
+    // Details still record the per-customer hint for the audit viewer.
+    expect(payload.details).toMatchObject({
+      id: "glob-1",
+      kind: "global",
+      customerId: 7,
+      reset: 1,
+    });
+  });
+
+  it("emits triage_exclusion.global_recover with customerId=null for kind='global_all_failed'", async () => {
+    await emitRecoverAudit(
+      { kind: "global_all_failed", exclusionId: "glob-1" },
+      "system",
+      9,
+    );
+
+    const payload = mockAuditLogRecord.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      action: "triage_exclusion.global_recover",
+      targetId: "glob-1",
+    });
+    expect(payload.customerId).toBeUndefined();
+    expect(payload.details).toMatchObject({
+      kind: "global_all_failed",
+      customerId: null,
+      reset: 9,
+    });
+  });
+
+  it("emits triage_exclusion.customer_recover (customer-scoped) for kind='customer'", async () => {
+    await emitRecoverAudit(
+      { kind: "customer", exclusionId: "exc-1", customerId: 42 },
+      "admin@example.com",
+      1,
+    );
+
+    const payload = mockAuditLogRecord.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      actor: "admin@example.com",
+      action: "triage_exclusion.customer_recover",
+      target: "triage_exclusion",
+      targetId: "exc-1",
+      customerId: 42,
+      details: { id: "exc-1", kind: "customer", reset: 1 },
+    });
+  });
+});
+
+describe("verifyTriageExclusionRecoveryToken", () => {
+  const ENV_KEY = "TRIAGE_EXCLUSION_RECOVERY_INTERNAL_TOKEN";
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("rejects when the env var is unset", () => {
+    delete process.env[ENV_KEY];
+    expect(verifyTriageExclusionRecoveryToken("anything")).toBe(false);
+  });
+
+  it("rejects null", () => {
+    process.env[ENV_KEY] = "secret";
+    expect(verifyTriageExclusionRecoveryToken(null)).toBe(false);
+  });
+
+  it("accepts the matching token", () => {
+    process.env[ENV_KEY] = "secret-token";
+    expect(verifyTriageExclusionRecoveryToken("secret-token")).toBe(true);
+  });
+
+  it("rejects a length-mismatched token", () => {
+    process.env[ENV_KEY] = "secret-token";
+    expect(verifyTriageExclusionRecoveryToken("short")).toBe(false);
+  });
+
+  it("rejects a same-length but different token (constant-time compare)", () => {
+    process.env[ENV_KEY] = "secret-token";
+    expect(verifyTriageExclusionRecoveryToken("secret-tokeX")).toBe(false);
+  });
+});

--- a/src/__tests__/lib/triage/policy/corpus-b/retention.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/retention.test.ts
@@ -44,7 +44,10 @@ function makePool(behavior: PoolBehavior = {}) {
   // protection hook short-circuiting the DELETE when every row is
   // protected. To keep the test mocks readable we mirror that shape:
   // each `readyRows[i]` entry produces a SELECT returning `i` synthetic
-  // ids, and the matching DELETE returns the same count.
+  // ids, and the matching DELETE returns the same count. Ids are
+  // numeric strings to match `policy_triage_run.id` (BIGSERIAL → pg
+  // surfaces bigint as string by default), so the `bigint[]` cast in
+  // retention.ts is type-correct against the same shape.
   let readyDeletePending = 0;
   const pool = {
     query: vi.fn(async (sql: string, params?: unknown[]) => {
@@ -65,7 +68,7 @@ function makePool(behavior: PoolBehavior = {}) {
         const n = readyQueue.shift() ?? 0;
         readyDeletePending = n;
         const rows = Array.from({ length: n }, (_, i) => ({
-          id: `ready-${i}`,
+          id: String(i + 1),
         }));
         return { rows, rowCount: n };
       }
@@ -212,19 +215,20 @@ describe("runPolicyRetentionForCustomer", () => {
   });
 
   it("respects the Phase 2 protection hook on the ready path so protected runs are not pruned", async () => {
-    // Three candidate ready rows: `ready-0` is protected (e.g. has a
-    // SendBatch in flight), `ready-1` and `ready-2` are eligible. The
-    // helper SELECTs candidates, calls the hook per row, then issues
-    // one DELETE keyed by the surviving ids.
-    const protectedId = "ready-0";
+    // Three candidate ready rows: id "1" is protected (e.g. has a
+    // SendBatch in flight), "2" and "3" are eligible. The helper
+    // SELECTs candidates, calls the hook per row, then issues one
+    // DELETE keyed by the surviving ids. Ids are numeric strings to
+    // match `policy_triage_run.id` (BIGSERIAL).
+    const protectedId = "1";
     const pool = {
       query: vi.fn(async (sql: string, params?: unknown[]) => {
         if (sql.includes("SELECT id FROM") && sql.includes("'ready'")) {
           // First call returns three candidates; second call (after
-          // protectedIds excludes ready-0) returns nothing → loop exits.
+          // protectedIds excludes "1") returns nothing → loop exits.
           if ((params as unknown[]).length === 1) {
             return {
-              rows: [{ id: "ready-0" }, { id: "ready-1" }, { id: "ready-2" }],
+              rows: [{ id: "1" }, { id: "2" }, { id: "3" }],
               rowCount: 3,
             };
           }
@@ -234,7 +238,8 @@ describe("runPolicyRetentionForCustomer", () => {
           sql.includes("DELETE FROM policy_triage_run") &&
           sql.includes("id = ANY")
         ) {
-          // The DELETE must skip the protected id.
+          // The DELETE must skip the protected id and be cast to bigint[].
+          expect(sql).toContain("$1::bigint[]");
           const ids = (params as [string[]])[0];
           return { rows: [], rowCount: ids.length };
         }
@@ -255,7 +260,7 @@ describe("runPolicyRetentionForCustomer", () => {
     };
     try {
       const counts = await runPolicyRetentionForCustomer(1);
-      expect(hookCalls).toEqual(["ready-0", "ready-1", "ready-2"]);
+      expect(hookCalls).toEqual(["1", "2", "3"]);
       // Only the two unprotected rows were deleted.
       expect(counts.readyPruned).toBe(2);
       // The DELETE call carried the unprotected ids only.
@@ -263,7 +268,7 @@ describe("runPolicyRetentionForCustomer", () => {
         const sql = c[0] as string;
         return sql.includes("DELETE FROM") && sql.includes("id = ANY");
       });
-      expect(deleteCall?.[1]).toEqual([["ready-1", "ready-2"]]);
+      expect(deleteCall?.[1]).toEqual([["2", "3"]]);
     } finally {
       (
         await import("@/lib/triage/policy/corpus-b/retention")
@@ -275,7 +280,7 @@ describe("runPolicyRetentionForCustomer", () => {
     // First batch returns batchSize (= 2) rows, one protected. The
     // helper deletes the unprotected row, then issues another SELECT
     // because the first batch was full — that SELECT must exclude the
-    // protected id via `id <> ALL(...)` so the loop terminates.
+    // protected id via `id <> ALL($2::bigint[])` so the loop terminates.
     const pool = {
       query: vi.fn(async (sql: string, params?: unknown[]) => {
         if (sql.includes("SELECT id FROM") && sql.includes("'ready'")) {
@@ -283,17 +288,21 @@ describe("runPolicyRetentionForCustomer", () => {
           if (args.length === 1) {
             // First call: full batch.
             return {
-              rows: [{ id: "ready-A" }, { id: "ready-B" }],
+              rows: [{ id: "10" }, { id: "11" }],
               rowCount: 2,
             };
           }
           // Second call: protectedIds excluded; nothing else matches.
+          // The id-exclusion cast must be bigint[] to match the
+          // BIGSERIAL primary key of policy_triage_run.
+          expect(sql).toContain("$2::bigint[]");
           return { rows: [], rowCount: 0 };
         }
         if (
           sql.includes("DELETE FROM policy_triage_run") &&
           sql.includes("id = ANY")
         ) {
+          expect(sql).toContain("$1::bigint[]");
           const ids = (params as [string[]])[0];
           return { rows: [], rowCount: ids.length };
         }
@@ -307,11 +316,12 @@ describe("runPolicyRetentionForCustomer", () => {
     )._protectionExtensionHook.current;
     (
       await import("@/lib/triage/policy/corpus-b/retention")
-    )._protectionExtensionHook.current = async (id: string) => id === "ready-A";
+    )._protectionExtensionHook.current = async (id: string) => id === "10";
     try {
       const counts = await runPolicyRetentionForCustomer(1, { batchSize: 2 });
       expect(counts.readyPruned).toBe(1);
-      // The second SELECT carried the protected id in its NOT-IN list.
+      // The second SELECT carried the protected id in its NOT-IN list,
+      // typed as bigint[] to match policy_triage_run.id.
       const followup = pool.query.mock.calls.find((c) => {
         const sql = c[0] as string;
         return (
@@ -320,10 +330,9 @@ describe("runPolicyRetentionForCustomer", () => {
           sql.includes("id <> ALL")
         );
       });
-      expect(followup?.[1]).toEqual([
-        String(READY_RETENTION_DAYS),
-        ["ready-A"],
-      ]);
+      expect(followup?.[1]).toEqual([String(READY_RETENTION_DAYS), ["10"]]);
+      const followupSql = followup?.[0] as string;
+      expect(followupSql).toContain("$2::bigint[]");
     } finally {
       (
         await import("@/lib/triage/policy/corpus-b/retention")

--- a/src/__tests__/lib/triage/policy/corpus-b/retention.test.ts
+++ b/src/__tests__/lib/triage/policy/corpus-b/retention.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCustomerPool = vi.hoisted(() => vi.fn());
+const mockAuthQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/triage/policy/customer-db", () => ({
+  getCustomerPool: mockGetCustomerPool,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  query: mockAuthQuery,
+}));
+
+import {
+  FAILED_RETENTION_DAYS,
+  READY_RETENTION_DAYS,
+  runPolicyRetentionDispatch,
+  runPolicyRetentionForCustomer,
+  SUPERSEDED_RETENTION_DAYS,
+  verifyTriagePolicyRetentionToken,
+  ZOMBIE_TIMEOUT_MS,
+} from "@/lib/triage/policy/corpus-b/retention";
+
+interface QueryCall {
+  sql: string;
+  params: unknown[] | undefined;
+}
+
+interface PoolBehavior {
+  zombieRows?: number;
+  readyRows?: number[];
+  supersededRows?: number[];
+  failedRows?: number[];
+  ownerRows?: { owner_account_id: string }[];
+  orphanedRows?: number;
+}
+
+function makePool(behavior: PoolBehavior = {}) {
+  const queries: QueryCall[] = [];
+  const readyQueue = [...(behavior.readyRows ?? [0])];
+  const supersededQueue = [...(behavior.supersededRows ?? [0])];
+  const failedQueue = [...(behavior.failedRows ?? [0])];
+  // The ready path now does SELECT id → DELETE id=ANY, with the
+  // protection hook short-circuiting the DELETE when every row is
+  // protected. To keep the test mocks readable we mirror that shape:
+  // each `readyRows[i]` entry produces a SELECT returning `i` synthetic
+  // ids, and the matching DELETE returns the same count.
+  let readyDeletePending = 0;
+  const pool = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      if (sql.startsWith("UPDATE policy_triage_run")) {
+        return { rows: [], rowCount: behavior.zombieRows ?? 0 };
+      }
+      if (sql.includes("SELECT DISTINCT owner_account_id")) {
+        return {
+          rows: behavior.ownerRows ?? [],
+          rowCount: behavior.ownerRows?.length ?? 0,
+        };
+      }
+      if (
+        sql.includes("SELECT id FROM policy_triage_run") &&
+        sql.includes("'ready'")
+      ) {
+        const n = readyQueue.shift() ?? 0;
+        readyDeletePending = n;
+        const rows = Array.from({ length: n }, (_, i) => ({
+          id: `ready-${i}`,
+        }));
+        return { rows, rowCount: n };
+      }
+      if (
+        sql.includes("DELETE FROM policy_triage_run") &&
+        sql.includes("owner_account_id = ANY")
+      ) {
+        return { rows: [], rowCount: behavior.orphanedRows ?? 0 };
+      }
+      if (
+        sql.includes("DELETE FROM policy_triage_run") &&
+        sql.includes("id = ANY")
+      ) {
+        const n = readyDeletePending;
+        readyDeletePending = 0;
+        return { rows: [], rowCount: n };
+      }
+      if (sql.includes("DELETE FROM policy_triage_run")) {
+        if (sql.includes("'superseded'")) {
+          return { rows: [], rowCount: supersededQueue.shift() ?? 0 };
+        }
+        if (sql.includes("'failed'")) {
+          return { rows: [], rowCount: failedQueue.shift() ?? 0 };
+        }
+      }
+      return { rows: [], rowCount: 0 };
+    }),
+  };
+  return { pool, queries };
+}
+
+describe("runPolicyRetentionForCustomer", () => {
+  beforeEach(() => {
+    mockGetCustomerPool.mockReset();
+    mockAuthQuery.mockReset();
+  });
+
+  it("runs the zombie reaper before the failed-retention sweep so timed-out rows are eligible same tick", async () => {
+    const { pool, queries } = makePool({
+      zombieRows: 2,
+      readyRows: [0],
+      supersededRows: [0],
+      failedRows: [3], // includes the freshly-flipped zombies
+    });
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    const counts = await runPolicyRetentionForCustomer(7);
+
+    expect(counts).toEqual({
+      zombiesReaped: 2,
+      readyPruned: 0,
+      supersededPruned: 0,
+      failedPruned: 3,
+      orphanedPruned: 0,
+    });
+
+    // Order: UPDATE (zombie reaper) → DELETE ready → DELETE superseded
+    // → DELETE failed → SELECT owners (no orphans, so no DELETE).
+    const sqls = queries.map((q) => q.sql);
+    const zombieIdx = sqls.findIndex(
+      (s) =>
+        s.startsWith("UPDATE policy_triage_run") &&
+        s.includes("'timeout: runner did not finalize'"),
+    );
+    const failedIdx = sqls.findIndex(
+      (s) =>
+        s.includes("DELETE FROM policy_triage_run") && s.includes("'failed'"),
+    );
+    expect(zombieIdx).toBeGreaterThanOrEqual(0);
+    expect(failedIdx).toBeGreaterThan(zombieIdx);
+  });
+
+  it("uses the documented retention windows for each status predicate", async () => {
+    const { pool, queries } = makePool({});
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    await runPolicyRetentionForCustomer(1);
+
+    // The `ready` path now SELECTs candidate ids before issuing a
+    // generic DELETE keyed by `id = ANY(...)`, so the retention-days
+    // param lives on the SELECT instead of the DELETE.
+    const readyCall = queries.find(
+      (q) => q.sql.includes("SELECT id FROM") && q.sql.includes("'ready'"),
+    );
+    const supersededCall = queries.find(
+      (q) => q.sql.includes("DELETE FROM") && q.sql.includes("'superseded'"),
+    );
+    const failedCall = queries.find(
+      (q) => q.sql.includes("DELETE FROM") && q.sql.includes("'failed'"),
+    );
+    expect(readyCall?.params).toEqual([String(READY_RETENTION_DAYS)]);
+    expect(supersededCall?.params).toEqual([String(SUPERSEDED_RETENTION_DAYS)]);
+    expect(failedCall?.params).toEqual([String(FAILED_RETENTION_DAYS)]);
+  });
+
+  it("uses the documented 30-minute zombie threshold", async () => {
+    const { pool, queries } = makePool({});
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    await runPolicyRetentionForCustomer(1);
+
+    const zombieCall = queries.find((q) =>
+      q.sql.startsWith("UPDATE policy_triage_run"),
+    );
+    expect(zombieCall?.params).toEqual([String(ZOMBIE_TIMEOUT_MS)]);
+    expect(zombieCall?.sql).toContain("status = 'failed'");
+    expect(zombieCall?.sql).toContain(
+      "last_error = 'timeout: runner did not finalize'",
+    );
+    // The reaper drives off created_at because computing rows have NULL
+    // finalized_at; using finalized_at would skip every timed-out runner.
+    expect(zombieCall?.sql).toContain("created_at <");
+  });
+
+  it("collapses owner-orphan cleanup to one DELETE against the unresolved set", async () => {
+    const { pool, queries } = makePool({
+      ownerRows: [
+        { owner_account_id: "owner-A" },
+        { owner_account_id: "owner-B" },
+      ],
+      orphanedRows: 7,
+    });
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+    // Only owner-A resolves in auth_db; owner-B is orphaned.
+    mockAuthQuery.mockResolvedValueOnce({
+      rows: [{ id: "owner-A" }],
+      rowCount: 1,
+    });
+
+    const counts = await runPolicyRetentionForCustomer(1);
+
+    expect(counts.orphanedPruned).toBe(7);
+    // The cross-DB probe to auth_db.accounts was issued exactly once
+    // with the full owner set.
+    expect(mockAuthQuery).toHaveBeenCalledTimes(1);
+    expect(mockAuthQuery.mock.calls[0][1]).toEqual([["owner-A", "owner-B"]]);
+    // Subsequent DELETE was scoped to the unresolved owners only.
+    const orphanDelete = queries.find(
+      (q) =>
+        q.sql.includes("DELETE FROM policy_triage_run") &&
+        q.sql.includes("owner_account_id = ANY"),
+    );
+    expect(orphanDelete?.params).toEqual([["owner-B"]]);
+  });
+
+  it("respects the Phase 2 protection hook on the ready path so protected runs are not pruned", async () => {
+    // Three candidate ready rows: `ready-0` is protected (e.g. has a
+    // SendBatch in flight), `ready-1` and `ready-2` are eligible. The
+    // helper SELECTs candidates, calls the hook per row, then issues
+    // one DELETE keyed by the surviving ids.
+    const protectedId = "ready-0";
+    const pool = {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        if (sql.includes("SELECT id FROM") && sql.includes("'ready'")) {
+          // First call returns three candidates; second call (after
+          // protectedIds excludes ready-0) returns nothing → loop exits.
+          if ((params as unknown[]).length === 1) {
+            return {
+              rows: [{ id: "ready-0" }, { id: "ready-1" }, { id: "ready-2" }],
+              rowCount: 3,
+            };
+          }
+          return { rows: [], rowCount: 0 };
+        }
+        if (
+          sql.includes("DELETE FROM policy_triage_run") &&
+          sql.includes("id = ANY")
+        ) {
+          // The DELETE must skip the protected id.
+          const ids = (params as [string[]])[0];
+          return { rows: [], rowCount: ids.length };
+        }
+        return { rows: [], rowCount: 0 };
+      }),
+    };
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    const previousHook = (
+      await import("@/lib/triage/policy/corpus-b/retention")
+    )._protectionExtensionHook.current;
+    const hookCalls: string[] = [];
+    (
+      await import("@/lib/triage/policy/corpus-b/retention")
+    )._protectionExtensionHook.current = async (id: string) => {
+      hookCalls.push(id);
+      return id === protectedId;
+    };
+    try {
+      const counts = await runPolicyRetentionForCustomer(1);
+      expect(hookCalls).toEqual(["ready-0", "ready-1", "ready-2"]);
+      // Only the two unprotected rows were deleted.
+      expect(counts.readyPruned).toBe(2);
+      // The DELETE call carried the unprotected ids only.
+      const deleteCall = pool.query.mock.calls.find((c) => {
+        const sql = c[0] as string;
+        return sql.includes("DELETE FROM") && sql.includes("id = ANY");
+      });
+      expect(deleteCall?.[1]).toEqual([["ready-1", "ready-2"]]);
+    } finally {
+      (
+        await import("@/lib/triage/policy/corpus-b/retention")
+      )._protectionExtensionHook.current = previousHook;
+    }
+  });
+
+  it("excludes already-protected ids from subsequent SELECTs so a full-batch of protected rows cannot loop forever", async () => {
+    // First batch returns batchSize (= 2) rows, one protected. The
+    // helper deletes the unprotected row, then issues another SELECT
+    // because the first batch was full — that SELECT must exclude the
+    // protected id via `id <> ALL(...)` so the loop terminates.
+    const pool = {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        if (sql.includes("SELECT id FROM") && sql.includes("'ready'")) {
+          const args = (params ?? []) as unknown[];
+          if (args.length === 1) {
+            // First call: full batch.
+            return {
+              rows: [{ id: "ready-A" }, { id: "ready-B" }],
+              rowCount: 2,
+            };
+          }
+          // Second call: protectedIds excluded; nothing else matches.
+          return { rows: [], rowCount: 0 };
+        }
+        if (
+          sql.includes("DELETE FROM policy_triage_run") &&
+          sql.includes("id = ANY")
+        ) {
+          const ids = (params as [string[]])[0];
+          return { rows: [], rowCount: ids.length };
+        }
+        return { rows: [], rowCount: 0 };
+      }),
+    };
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    const previousHook = (
+      await import("@/lib/triage/policy/corpus-b/retention")
+    )._protectionExtensionHook.current;
+    (
+      await import("@/lib/triage/policy/corpus-b/retention")
+    )._protectionExtensionHook.current = async (id: string) => id === "ready-A";
+    try {
+      const counts = await runPolicyRetentionForCustomer(1, { batchSize: 2 });
+      expect(counts.readyPruned).toBe(1);
+      // The second SELECT carried the protected id in its NOT-IN list.
+      const followup = pool.query.mock.calls.find((c) => {
+        const sql = c[0] as string;
+        return (
+          sql.includes("SELECT id FROM") &&
+          sql.includes("'ready'") &&
+          sql.includes("id <> ALL")
+        );
+      });
+      expect(followup?.[1]).toEqual([
+        String(READY_RETENTION_DAYS),
+        ["ready-A"],
+      ]);
+    } finally {
+      (
+        await import("@/lib/triage/policy/corpus-b/retention")
+      )._protectionExtensionHook.current = previousHook;
+    }
+  });
+
+  it("skips the auth-db probe when no rows reference an owner", async () => {
+    const { pool, queries } = makePool({ ownerRows: [] });
+    mockGetCustomerPool.mockResolvedValueOnce(pool);
+
+    const counts = await runPolicyRetentionForCustomer(1);
+
+    expect(counts.orphanedPruned).toBe(0);
+    expect(mockAuthQuery).not.toHaveBeenCalled();
+    // No orphan DELETE issued either.
+    expect(
+      queries.some(
+        (q) =>
+          q.sql.includes("DELETE FROM policy_triage_run") &&
+          q.sql.includes("owner_account_id = ANY"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("runPolicyRetentionDispatch", () => {
+  it("captures per-customer failures and reports overall='partial'", async () => {
+    const result = await runPolicyRetentionDispatch({
+      listActiveCustomers: async () => [1, 2],
+      runForCustomer: async (id) => {
+        if (id === 2) throw new Error("boom");
+        return {
+          zombiesReaped: 1,
+          readyPruned: 2,
+          supersededPruned: 3,
+          failedPruned: 4,
+          orphanedPruned: 0,
+        };
+      },
+    });
+
+    expect(result.overall).toBe("partial");
+    expect(result.perCustomer[0]).toMatchObject({
+      customerId: 1,
+      status: "ok",
+    });
+    expect(result.perCustomer[1]).toMatchObject({
+      customerId: 2,
+      status: "failed",
+      error: "boom",
+      counts: {
+        zombiesReaped: 0,
+        readyPruned: 0,
+        supersededPruned: 0,
+        failedPruned: 0,
+        orphanedPruned: 0,
+      },
+    });
+  });
+
+  it("returns overall='ok' when every per-customer sweep succeeds", async () => {
+    const result = await runPolicyRetentionDispatch({
+      listActiveCustomers: async () => [1],
+      runForCustomer: async () => ({
+        zombiesReaped: 0,
+        readyPruned: 0,
+        supersededPruned: 0,
+        failedPruned: 0,
+        orphanedPruned: 0,
+      }),
+    });
+    expect(result.overall).toBe("ok");
+    expect(result.perCustomer).toHaveLength(1);
+  });
+});
+
+describe("verifyTriagePolicyRetentionToken", () => {
+  const ENV_KEY = "TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN";
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = saved;
+  });
+
+  it("rejects when env unset", () => {
+    delete process.env[ENV_KEY];
+    expect(verifyTriagePolicyRetentionToken("anything")).toBe(false);
+  });
+
+  it("accepts the matching token", () => {
+    process.env[ENV_KEY] = "secret";
+    expect(verifyTriagePolicyRetentionToken("secret")).toBe(true);
+  });
+
+  it("rejects same-length mismatch (constant-time)", () => {
+    process.env[ENV_KEY] = "secretX";
+    expect(verifyTriagePolicyRetentionToken("secretY")).toBe(false);
+  });
+});

--- a/src/app/api/internal/triage/baseline/retention/route.ts
+++ b/src/app/api/internal/triage/baseline/retention/route.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import {
+  runBaselineRetentionDispatch,
+  verifyTriageBaselineRetentionToken,
+} from "@/lib/triage/baseline/retention";
+
+/**
+ * POST /api/internal/triage/baseline/retention
+ *
+ * Token-protected entrypoint the deployment scheduler hits at the
+ * retention cadence (daily). Enumerates active customers, then runs
+ * the corpus A retention sweep against each tenant DB:
+ *
+ *   - `baseline_triaged_event` rows older than 180 days from
+ *     `event_time` are deleted.
+ *   - `observed_event_meta` rows older than 30 days from `event_time`
+ *     are deleted.
+ *
+ * Per-customer failures are reflected in the `perCustomer[]` entry;
+ * the dispatcher itself only throws when active-customer enumeration
+ * fails. Status codes mirror `triage/baseline/dispatch`: 200 on
+ * dispatcher success even when one customer's sweep failed, 401 on
+ * token mismatch, 500 only on dispatcher self-failure.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = request.headers.get("authorization");
+  const token = auth?.startsWith("Bearer ")
+    ? auth.slice("Bearer ".length).trim()
+    : null;
+  if (!verifyTriageBaselineRetentionToken(token)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runBaselineRetentionDispatch();
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Retention failed";
+    return NextResponse.json(
+      { overall: "failed", error: message, perCustomer: [] },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/internal/triage/exclusion/recover/route.ts
+++ b/src/app/api/internal/triage/exclusion/recover/route.ts
@@ -1,0 +1,109 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import {
+  applyRecover,
+  emitRecoverAudit,
+  type RecoverRequest,
+  verifyTriageExclusionRecoveryToken,
+} from "@/lib/triage/exclusion/recovery";
+
+/**
+ * POST /api/internal/triage/exclusion/recover
+ *
+ * Internal-token-guarded entrypoint cron / operator tooling uses to
+ * reset failed fanout / drain-failure queue rows. The body is one of
+ * three discriminated shapes:
+ *
+ *   { "kind": "global", "exclusion_id": <uuid>, "customer_id": <int> }
+ *     Reset one specific failed `(global_exclusion_id, customer_id)` row.
+ *
+ *   { "kind": "global_all_failed", "exclusion_id": <uuid> }
+ *     Reset every failed row for one global exclusion (operator sweep).
+ *
+ *   { "kind": "customer", "exclusion_id": <uuid>, "customer_id": <int> }
+ *     Reset a customer-scoped drain-failure sentinel.
+ *
+ * `customer_id` is REQUIRED for `global` and `customer` modes; missing
+ * it is a 400 rather than a sweep so a typo'd retry does not re-enqueue
+ * work for every active customer. Mismatched shapes return 400.
+ *
+ * Audit emission: `triage_exclusion.global_recover` (customer-agnostic)
+ * for `global` / `global_all_failed`, `triage_exclusion.customer_recover`
+ * (customer-scoped) for `customer`. The audit row preserves the
+ * historical record of the original failure even though the queue row
+ * itself was reset in place.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = request.headers.get("authorization");
+  const token = auth?.startsWith("Bearer ")
+    ? auth.slice("Bearer ".length).trim()
+    : null;
+  if (!verifyTriageExclusionRecoveryToken(token)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const parsed = parseRecoverRequest(raw);
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  try {
+    const outcome = await applyRecover(parsed.request);
+    await emitRecoverAudit(parsed.request, "system", outcome.reset);
+    return NextResponse.json({ reset: outcome.reset, kind: outcome.kind });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Recover failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+interface ParsedRequest {
+  request: RecoverRequest;
+}
+
+interface ParseError {
+  error: string;
+}
+
+function parseRecoverRequest(raw: unknown): ParsedRequest | ParseError {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { error: "Body must be a JSON object" };
+  }
+  const body = raw as Record<string, unknown>;
+  const kind = body.kind;
+  if (typeof kind !== "string") {
+    return { error: "Missing or invalid `kind`" };
+  }
+  const exclusionId = body.exclusion_id;
+  if (typeof exclusionId !== "string" || exclusionId.length === 0) {
+    return { error: "Missing or invalid `exclusion_id`" };
+  }
+
+  if (kind === "global_all_failed") {
+    return { request: { kind, exclusionId } };
+  }
+  if (kind === "global" || kind === "customer") {
+    const customerId = body.customer_id;
+    if (
+      typeof customerId !== "number" ||
+      !Number.isInteger(customerId) ||
+      customerId <= 0
+    ) {
+      return {
+        error: "`customer_id` (positive integer) is required for this kind",
+      };
+    }
+    return { request: { kind, exclusionId, customerId } };
+  }
+  return {
+    error: "`kind` must be one of: 'global' | 'global_all_failed' | 'customer'",
+  };
+}

--- a/src/app/api/internal/triage/policy/retention/route.ts
+++ b/src/app/api/internal/triage/policy/retention/route.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import {
+  runPolicyRetentionDispatch,
+  verifyTriagePolicyRetentionToken,
+} from "@/lib/triage/policy/corpus-b/retention";
+
+/**
+ * POST /api/internal/triage/policy/retention
+ *
+ * Token-protected entrypoint the deployment scheduler hits at the
+ * policy retention cadence. Enumerates active customers and runs the
+ * corpus B retention sweep against each tenant DB:
+ *
+ *   - zombie-runner reaper: `computing` rows older than 30 minutes
+ *     become `failed` with `last_error = 'timeout: runner did not
+ *     finalize'`. Reverses the runner crash via the partial unique
+ *     index so a fresh fingerprint run can proceed.
+ *   - differential retention: ready 30d / superseded 7d / failed 1d.
+ *   - orphan cleanup: rows whose `owner_account_id` no longer resolves
+ *     in `auth_db.accounts`.
+ *
+ * `policy_triaged_event` rows cascade with their run, so pruning a run
+ * removes its events in the same transaction.
+ *
+ * Status codes match the other retention routes: 200 on dispatcher
+ * success (even with per-customer failures); 401 on token mismatch;
+ * 500 on dispatcher self-failure.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = request.headers.get("authorization");
+  const token = auth?.startsWith("Bearer ")
+    ? auth.slice("Bearer ".length).trim()
+    : null;
+  if (!verifyTriagePolicyRetentionToken(token)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runPolicyRetentionDispatch();
+    return NextResponse.json(result);
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Policy retention failed";
+    return NextResponse.json(
+      { overall: "failed", error: message, perCustomer: [] },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/triage/exclusions/[id]/recover/route.ts
+++ b/src/app/api/triage/exclusions/[id]/recover/route.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+import {
+  applyRecover,
+  emitRecoverAudit,
+  type RecoverRequest,
+} from "@/lib/triage/exclusion/recovery";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /api/triage/exclusions/[id]/recover?customer_id=<id>
+ *
+ * Session-authenticated customer-scoped recovery (#461 / 1B-7). Resets
+ * the customer-scoped drain-failure sentinel for exclusion `[id]` in
+ * tenant `customer_id`. Gated on `triage:exclusion:write` plus the
+ * caller's effective customer scope, matching the create / delete
+ * routes for this resource.
+ */
+export const POST = withAuth(
+  async (request, context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) {
+      return NextResponse.json(
+        { error: "Missing or invalid customer_id" },
+        { status: 400 },
+      );
+    }
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id } = await context.params;
+    if (!UUID_REGEX.test(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+
+    const recoverRequest: RecoverRequest = {
+      kind: "customer",
+      exclusionId: id,
+      customerId,
+    };
+    const outcome = await applyRecover(recoverRequest);
+    if (outcome.reset === 0) {
+      return NextResponse.json(
+        { error: "No failed cleanup found for this exclusion" },
+        { status: 404 },
+      );
+    }
+    await emitRecoverAudit(recoverRequest, session.accountId, outcome.reset, {
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+    });
+    return NextResponse.json({ data: { id, reset: outcome.reset } });
+  },
+  { requiredPermissions: ["triage:exclusion:write"] },
+);
+
+function parseCustomerId(request: NextRequest): number | null {
+  const raw = request.nextUrl.searchParams.get("customer_id");
+  if (raw === null) return null;
+  const id = Number(raw);
+  if (!Number.isFinite(id) || !Number.isInteger(id) || id <= 0) return null;
+  return id;
+}
+
+async function callerCanAccessCustomer(
+  accountId: string,
+  roles: string[],
+  customerId: number,
+): Promise<boolean> {
+  if (await hasPermission(roles, "customers:access-all")) return true;
+  const { rows } = await query<{ customer_id: number }>(
+    "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+    [accountId, customerId],
+  );
+  return rows.length > 0;
+}

--- a/src/app/api/triage/exclusions/cleanup-status/route.ts
+++ b/src/app/api/triage/exclusions/cleanup-status/route.ts
@@ -1,0 +1,75 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { hasPermission } from "@/lib/auth/permissions";
+import { query } from "@/lib/db/client";
+
+/**
+ * GET /api/triage/exclusions/cleanup-status?customer_id=<id>
+ *
+ * Returns the list of customer-scoped triage exclusion ids whose
+ * retroactive cleanup has a `failed` sentinel in the auth_db fanout
+ * queue. The admin UI uses this to surface a "Re-trigger cleanup"
+ * affordance only for the rows that actually need it (vs every row).
+ *
+ * Gated on `triage:read` plus the caller's effective customer scope —
+ * same predicate as `GET /api/triage/exclusions`. The failed-row list
+ * itself is per-customer, so a caller whose scope excludes
+ * `customer_id` cannot enumerate sentinels for that tenant.
+ */
+export const GET = withAuth(
+  async (request, _context, session) => {
+    const customerId = parseCustomerId(request);
+    if (customerId === null) {
+      return NextResponse.json(
+        { error: "Missing or invalid customer_id" },
+        { status: 400 },
+      );
+    }
+    if (
+      !(await callerCanAccessCustomer(
+        session.accountId,
+        session.roles,
+        customerId,
+      ))
+    ) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { rows } = await query<{ customer_only_exclusion_id: string }>(
+      `SELECT customer_only_exclusion_id
+         FROM triage_exclusion_fanout_job
+        WHERE customer_id = $1
+          AND customer_only_exclusion_id IS NOT NULL
+          AND status = 'failed'`,
+      [customerId],
+    );
+    return NextResponse.json({
+      failed: rows.map((r) => r.customer_only_exclusion_id),
+    });
+  },
+  { requiredPermissions: ["triage:read"] },
+);
+
+function parseCustomerId(request: NextRequest): number | null {
+  const raw = request.nextUrl.searchParams.get("customer_id");
+  if (raw === null) return null;
+  const id = Number(raw);
+  if (!Number.isFinite(id) || !Number.isInteger(id) || id <= 0) return null;
+  return id;
+}
+
+async function callerCanAccessCustomer(
+  accountId: string,
+  roles: string[],
+  customerId: number,
+): Promise<boolean> {
+  if (await hasPermission(roles, "customers:access-all")) return true;
+  const { rows } = await query<{ customer_id: number }>(
+    "SELECT customer_id FROM account_customer WHERE account_id = $1 AND customer_id = $2",
+    [accountId, customerId],
+  );
+  return rows.length > 0;
+}

--- a/src/app/api/triage/exclusions/cleanup-status/route.ts
+++ b/src/app/api/triage/exclusions/cleanup-status/route.ts
@@ -29,6 +29,13 @@ import { listAuditOnlyCustomerDrainFailures } from "@/lib/triage/exclusion/recov
  *      500 response. Without this fallback the exclusion would be
  *      permanently unrecoverable from the UI.
  *
+ * The audit-only source is best-effort: if `audit_db` is unreachable
+ * the route still returns the queue-backed failed ids and logs the
+ * audit error. Making the audit query a hard dependency would hide
+ * the ordinary `failed` sentinels too during exactly the kind of
+ * infrastructure blip this recovery surface exists to make
+ * recoverable from.
+ *
  * Gated on `triage:read` plus the caller's effective customer scope —
  * same predicate as `GET /api/triage/exclusions`. The failed-row list
  * itself is per-customer, so a caller whose scope excludes
@@ -61,10 +68,21 @@ export const GET = withAuth(
           AND status = 'failed'`,
       [customerId],
     );
-    const auditOnly = await listAuditOnlyCustomerDrainFailures(customerId);
     const failed = new Set<string>();
     for (const r of rows) failed.add(r.customer_only_exclusion_id);
-    for (const id of auditOnly) failed.add(id);
+
+    // Best-effort: an `audit_db` outage must not hide the queue-backed
+    // sentinels — those are the primary recovery target. Log and degrade
+    // to the queue-only view rather than failing the whole endpoint.
+    try {
+      const auditOnly = await listAuditOnlyCustomerDrainFailures(customerId);
+      for (const id of auditOnly) failed.add(id);
+    } catch (err) {
+      console.error(
+        "cleanup-status: audit-only fallback unavailable; returning queue-backed ids only",
+        err,
+      );
+    }
     return NextResponse.json({ failed: Array.from(failed) });
   },
   { requiredPermissions: ["triage:read"] },

--- a/src/app/api/triage/exclusions/cleanup-status/route.ts
+++ b/src/app/api/triage/exclusions/cleanup-status/route.ts
@@ -5,14 +5,29 @@ import { type NextRequest, NextResponse } from "next/server";
 import { withAuth } from "@/lib/auth/guard";
 import { hasPermission } from "@/lib/auth/permissions";
 import { query } from "@/lib/db/client";
+import { listAuditOnlyCustomerDrainFailures } from "@/lib/triage/exclusion/recovery";
 
 /**
  * GET /api/triage/exclusions/cleanup-status?customer_id=<id>
  *
  * Returns the list of customer-scoped triage exclusion ids whose
- * retroactive cleanup has a `failed` sentinel in the auth_db fanout
- * queue. The admin UI uses this to surface a "Re-trigger cleanup"
- * affordance only for the rows that actually need it (vs every row).
+ * retroactive cleanup is in a recoverable failed state. The admin UI
+ * uses this to surface a "Re-trigger cleanup" affordance only for the
+ * rows that actually need it (vs every row).
+ *
+ * Two sources are unioned:
+ *
+ *   1. `failed` sentinel rows in the auth_db fanout queue — the normal
+ *      drain-failure path enqueues these via
+ *      `insertCustomerDrainFailureSentinel`.
+ *   2. Audit-only drain failures — `triage_exclusion.customer_add`
+ *      audit rows with `details.drainStatus='failed'` and no later
+ *      `triage_exclusion.customer_recover` audit row. This is the
+ *      fallback for the case where the failed ADD path's sentinel
+ *      insert itself failed (auth_db blip) and the failure was
+ *      swallowed so the primary drain error remained visible in the
+ *      500 response. Without this fallback the exclusion would be
+ *      permanently unrecoverable from the UI.
  *
  * Gated on `triage:read` plus the caller's effective customer scope —
  * same predicate as `GET /api/triage/exclusions`. The failed-row list
@@ -46,9 +61,11 @@ export const GET = withAuth(
           AND status = 'failed'`,
       [customerId],
     );
-    return NextResponse.json({
-      failed: rows.map((r) => r.customer_only_exclusion_id),
-    });
+    const auditOnly = await listAuditOnlyCustomerDrainFailures(customerId);
+    const failed = new Set<string>();
+    for (const r of rows) failed.add(r.customer_only_exclusion_id);
+    for (const id of auditOnly) failed.add(id);
+    return NextResponse.json({ failed: Array.from(failed) });
   },
   { requiredPermissions: ["triage:read"] },
 );

--- a/src/app/api/triage/exclusions/global/[id]/recover/route.ts
+++ b/src/app/api/triage/exclusions/global/[id]/recover/route.ts
@@ -1,0 +1,88 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { extractClientIp } from "@/lib/auth/ip";
+import {
+  applyRecover,
+  emitRecoverAudit,
+  type RecoverRequest,
+} from "@/lib/triage/exclusion/recovery";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /api/triage/exclusions/global/[id]/recover
+ *
+ * Session-authenticated global-exclusion recovery (#461 / 1B-7). Two
+ * sub-modes via query string:
+ *
+ *   - default (`?customer_id=<id>`): reset one specific failed
+ *     `(global_exclusion_id, customer_id)` fanout row.
+ *   - `?all_failed=1`: reset every failed fanout row for this global
+ *     exclusion. Used after a tenant-DB outage that exhausted retries
+ *     across many customers.
+ *
+ * Gated on `triage:exclusion:global:write`. The audit row uses the
+ * customer-agnostic `triage_exclusion.global_recover` action so the
+ * audit-log viewer surfaces it once per operator action rather than
+ * once per fanout row reset.
+ */
+export const POST = withAuth(
+  async (request, context, session) => {
+    const { id } = await context.params;
+    if (!UUID_REGEX.test(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+
+    const recoverRequest = parseGlobalRecoverRequest(request, id);
+    if ("error" in recoverRequest) {
+      return NextResponse.json(
+        { error: recoverRequest.error },
+        { status: 400 },
+      );
+    }
+
+    const outcome = await applyRecover(recoverRequest);
+    if (outcome.reset === 0) {
+      return NextResponse.json(
+        { error: "No failed fanout rows found for this exclusion" },
+        { status: 404 },
+      );
+    }
+    await emitRecoverAudit(recoverRequest, session.accountId, outcome.reset, {
+      ip: extractClientIp(request),
+      sid: session.sessionId,
+    });
+    return NextResponse.json({ data: { id, reset: outcome.reset } });
+  },
+  { requiredPermissions: ["triage:exclusion:global:write"] },
+);
+
+function parseGlobalRecoverRequest(
+  request: NextRequest,
+  exclusionId: string,
+): RecoverRequest | { error: string } {
+  const allFailed = request.nextUrl.searchParams.get("all_failed");
+  if (allFailed === "1" || allFailed === "true") {
+    return { kind: "global_all_failed", exclusionId };
+  }
+  const rawCustomerId = request.nextUrl.searchParams.get("customer_id");
+  if (rawCustomerId === null) {
+    return {
+      error:
+        "Either `customer_id=<int>` or `all_failed=1` is required for global recover",
+    };
+  }
+  const customerId = Number(rawCustomerId);
+  if (
+    !Number.isFinite(customerId) ||
+    !Number.isInteger(customerId) ||
+    customerId <= 0
+  ) {
+    return { error: "Invalid customer_id" };
+  }
+  return { kind: "global", exclusionId, customerId };
+}

--- a/src/app/api/triage/exclusions/global/cleanup-status/route.ts
+++ b/src/app/api/triage/exclusions/global/cleanup-status/route.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/auth/guard";
+import { query } from "@/lib/db/client";
+
+/**
+ * GET /api/triage/exclusions/global/cleanup-status
+ *
+ * Returns the set of global exclusion ids with at least one `failed`
+ * fanout row, so the admin UI can surface the "Re-trigger cleanup"
+ * affordance only for rows that need it. The UI's sweep is keyed by
+ * exclusion id (per-customer pinpointing remains available via the
+ * internal-token route), so this endpoint does not expose the per-
+ * exclusion customer-id list — that detail is operator-scoped and
+ * lives behind the internal route.
+ *
+ * Gated on `triage:read`.
+ */
+export const GET = withAuth(
+  async (_request, _context, _session) => {
+    const { rows } = await query<{ global_exclusion_id: string }>(
+      `SELECT DISTINCT global_exclusion_id
+         FROM triage_exclusion_fanout_job
+        WHERE global_exclusion_id IS NOT NULL
+          AND status = 'failed'`,
+    );
+    return NextResponse.json({
+      failed: rows.map((r) => r.global_exclusion_id),
+    });
+  },
+  { requiredPermissions: ["triage:read"] },
+);

--- a/src/app/api/triage/exclusions/route.ts
+++ b/src/app/api/triage/exclusions/route.ts
@@ -7,7 +7,8 @@ import { auditLog } from "@/lib/audit/logger";
 import { withAuth } from "@/lib/auth/guard";
 import { extractClientIp } from "@/lib/auth/ip";
 import { hasPermission } from "@/lib/auth/permissions";
-import { query } from "@/lib/db/client";
+import { query, withTransaction } from "@/lib/db/client";
+import { insertCustomerDrainFailureSentinel } from "@/lib/triage/exclusion/recovery";
 import {
   acquireCustomerCadenceLock,
   drainRemainingRetroactiveDeletes,
@@ -235,6 +236,35 @@ export const POST = withAuth(
       }
     }
     const counts = mergeCounts(firstBatchCounts, drainCounts);
+
+    // Enqueue (or refresh) a sentinel row in the auth_db fanout queue
+    // so admin recovery (#461 / 1B-7) has a `failed` row to reset in
+    // place. Audit-only signalling is not enough: without this sentinel
+    // the recovery surface would need a parallel detection path.
+    // Failing to enqueue must not mask the original drain error — log
+    // the secondary failure and continue to the 500 response below.
+    if (drainError !== null) {
+      const drainMessage =
+        drainError instanceof Error ? drainError.message : String(drainError);
+      try {
+        await withTransaction((c) =>
+          insertCustomerDrainFailureSentinel(
+            c,
+            row.id,
+            customerId,
+            drainMessage,
+          ),
+        );
+      } catch (sentinelErr) {
+        // Do not throw — the 500 response already surfaces the drain
+        // failure, and re-throwing here would mask it with a queue
+        // error the operator cannot disambiguate from the audit row.
+        console.error(
+          "[triage_exclusion] failed to enqueue drain-failure sentinel",
+          sentinelErr,
+        );
+      }
+    }
 
     await auditLog.record({
       actor: session.accountId,

--- a/src/components/triage/exclusion/triage-exclusion-manager.tsx
+++ b/src/components/triage/exclusion/triage-exclusion-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CirclePlus, MoreVertical, Trash2 } from "lucide-react";
+import { CirclePlus, MoreVertical, RotateCcw, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -98,6 +98,15 @@ export function TriageExclusionManager({
   const [deleteTarget, setDeleteTarget] = useState<ExclusionRow | null>(null);
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  // Set of exclusion ids that have a `failed` row in the fanout queue.
+  // Customer scope: ids of customer-only sentinels for `selectedCustomerId`.
+  // Global scope: global-exclusion ids with at least one failed fanout row.
+  const [failedCleanupIds, setFailedCleanupIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [recoverTarget, setRecoverTarget] = useState<ExclusionRow | null>(null);
+  const [recoverSubmitting, setRecoverSubmitting] = useState(false);
+  const [recoverError, setRecoverError] = useState<string | null>(null);
 
   const baseUrl = useMemo(() => {
     if (scope === "global") return "/api/triage/exclusions/global";
@@ -109,6 +118,7 @@ export function TriageExclusionManager({
   const fetchRows = useCallback(async () => {
     if (scope === "customer" && selectedCustomerId === null) {
       setRows([]);
+      setFailedCleanupIds(new Set());
       return;
     }
     setLoading(true);
@@ -125,6 +135,26 @@ export function TriageExclusionManager({
       }
       const body = (await res.json()) as { data: ExclusionRow[] };
       setRows(body.data);
+
+      // Failed-cleanup probe runs in parallel-friendly order after the
+      // list so the table renders first even on a slow auth_db. The
+      // probe failure does not surface as a hard UI error — the menu
+      // simply lacks the recovery entry, which is the safe default.
+      try {
+        const statusUrl =
+          scope === "global"
+            ? "/api/triage/exclusions/global/cleanup-status"
+            : `/api/triage/exclusions/cleanup-status?customer_id=${selectedCustomerId}`;
+        const statusRes = await fetch(statusUrl);
+        if (statusRes.ok) {
+          const sb = (await statusRes.json()) as { failed: string[] };
+          setFailedCleanupIds(new Set(sb.failed));
+        } else {
+          setFailedCleanupIds(new Set());
+        }
+      } catch {
+        setFailedCleanupIds(new Set());
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : t("error"));
     } finally {
@@ -135,6 +165,35 @@ export function TriageExclusionManager({
   useEffect(() => {
     void fetchRows();
   }, [fetchRows]);
+
+  const handleRecover = async () => {
+    if (!recoverTarget) return;
+    setRecoverError(null);
+    setRecoverSubmitting(true);
+    try {
+      const csrfToken = readCsrfToken();
+      const headers: Record<string, string> = {};
+      if (csrfToken) headers["X-CSRF-Token"] = csrfToken;
+      // Global scope sweeps every failed customer for this exclusion in
+      // one click. Per-customer pinpointing remains available via the
+      // internal token route for operators.
+      const url =
+        scope === "global"
+          ? `/api/triage/exclusions/global/${recoverTarget.id}/recover?all_failed=1`
+          : `/api/triage/exclusions/${recoverTarget.id}/recover?customer_id=${selectedCustomerId}`;
+      const res = await fetch(url, { method: "POST", headers });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        throw new Error(body.error ?? t("error"));
+      }
+      setRecoverTarget(null);
+      void fetchRows();
+    } catch (err) {
+      setRecoverError(err instanceof Error ? err.message : t("error"));
+    } finally {
+      setRecoverSubmitting(false);
+    }
+  };
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -284,6 +343,14 @@ export function TriageExclusionManager({
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                          {failedCleanupIds.has(r.id) && (
+                            <DropdownMenuItem
+                              onClick={() => setRecoverTarget(r)}
+                            >
+                              <RotateCcw className="mr-2 h-4 w-4" />
+                              {t("retriggerCleanup")}
+                            </DropdownMenuItem>
+                          )}
                           <DropdownMenuItem
                             onClick={() => setDeleteTarget(r)}
                             className="text-destructive focus:text-destructive"
@@ -311,6 +378,42 @@ export function TriageExclusionManager({
           onSuccess={fetchRows}
         />
       )}
+
+      <AlertDialog
+        open={!!recoverTarget}
+        onOpenChange={(open) => {
+          if (!open && !recoverSubmitting) {
+            setRecoverTarget(null);
+            setRecoverError(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("retriggerCleanup")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("retriggerCleanupConfirm")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {recoverError && (
+            <p className="text-destructive text-sm">{recoverError}</p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={recoverSubmitting}>
+              {t("cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleRecover();
+              }}
+              disabled={recoverSubmitting}
+            >
+              {t("retriggerCleanup")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={!!deleteTarget}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2210,6 +2210,8 @@
     "domainPreviewFullRegex": "Full-regex-only — applies to future pipeline passes only. Past corpus rows are unchanged.",
     "deleteConfirm": "Delete this exclusion? Future pipeline passes only — past corpus rows are unchanged.",
     "deniedGlobal": "You do not have permission to manage global exclusions.",
-    "deniedCustomer": "You do not have permission to manage customer exclusions."
+    "deniedCustomer": "You do not have permission to manage customer exclusions.",
+    "retriggerCleanup": "Re-trigger cleanup",
+    "retriggerCleanupConfirm": "Re-run retroactive cleanup for this exclusion? Past corpus rows that match this rule will be removed in the background."
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -2210,6 +2210,8 @@
     "domainPreviewFullRegex": "전체 정규식 — 향후 파이프라인 패스에만 적용됩니다. 과거 코퍼스 행은 영향을 받지 않습니다.",
     "deleteConfirm": "이 예외를 삭제하시겠습니까? 향후 패스에만 영향을 미치며 과거 코퍼스 행은 변경되지 않습니다.",
     "deniedGlobal": "전역 예외를 관리할 권한이 없습니다.",
-    "deniedCustomer": "고객 예외를 관리할 권한이 없습니다."
+    "deniedCustomer": "고객 예외를 관리할 권한이 없습니다.",
+    "retriggerCleanup": "정리 재실행",
+    "retriggerCleanupConfirm": "이 예외에 대한 소급 정리를 다시 실행할까요? 이 규칙과 일치하는 과거 코퍼스 행이 백그라운드에서 제거됩니다."
   }
 }

--- a/src/lib/audit/customer-scope-policy.ts
+++ b/src/lib/audit/customer-scope-policy.ts
@@ -126,6 +126,16 @@ export const AUDIT_ACTION_CUSTOMER_SCOPE: {
   "triage_exclusion.customer_add": "customer-scoped",
   "triage_exclusion.customer_remove": "customer-scoped",
   "triage_exclusion.fanout_failed": "customer-scoped",
+  // 1B-7 recovery surface. `global_recover` pairs with
+  // `global_add`/`global_remove` as customer-agnostic so the audit
+  // viewer surfaces it once per operator action rather than once per
+  // customer; the per-customer re-run rows come from the fanout
+  // worker's own `triage_exclusion.customer_add` emissions on retry.
+  // `customer_recover` carries `customer_id` exactly like
+  // `customer_add`/`customer_remove` because a customer-scoped
+  // exclusion lives in exactly one tenant DB.
+  "triage_exclusion.global_recover": "customer-agnostic",
+  "triage_exclusion.customer_recover": "customer-scoped",
 };
 
 /**

--- a/src/lib/audit/schema.ts
+++ b/src/lib/audit/schema.ts
@@ -155,6 +155,17 @@ type TriagePolicyAction =
  *   - `triage_exclusion.fanout_failed` — customer-scoped. Emitted by
  *     the internal fanout worker when a per-customer job exceeds the
  *     retry budget.
+ *   - `triage_exclusion.global_recover` — customer-agnostic. Emitted
+ *     by the 1B-7 recovery surface when an operator (or the internal
+ *     token route) resets a failed global-fanout queue row. The
+ *     customer dimension is intentionally absent so the historical
+ *     pairing with the original `triage_exclusion.global_add` row
+ *     stays clean; the per-customer success rows come from the
+ *     fanout worker's `triage_exclusion.customer_add` emissions on
+ *     re-run.
+ *   - `triage_exclusion.customer_recover` — customer-scoped. Emitted
+ *     by the recovery surface when an operator resets a customer-
+ *     scoped drain-failure sentinel for a single tenant exclusion.
  *
  * The split honors `customer-scope-policy.ts`'s discipline of "one
  * scope per AuditAction"; there is no `mixed` classification and the
@@ -167,7 +178,9 @@ type TriageExclusionAction =
   | "triage_exclusion.global_remove"
   | "triage_exclusion.customer_add"
   | "triage_exclusion.customer_remove"
-  | "triage_exclusion.fanout_failed";
+  | "triage_exclusion.fanout_failed"
+  | "triage_exclusion.global_recover"
+  | "triage_exclusion.customer_recover";
 
 /** All audit event actions. */
 export type AuditAction =
@@ -267,6 +280,8 @@ export const AUDIT_ACTIONS = [
   "triage_exclusion.customer_add",
   "triage_exclusion.customer_remove",
   "triage_exclusion.fanout_failed",
+  "triage_exclusion.global_recover",
+  "triage_exclusion.customer_recover",
 ] as const satisfies readonly AuditAction[];
 
 /** Canonical runtime list of supported audit target types. */

--- a/src/lib/triage/baseline/retention.ts
+++ b/src/lib/triage/baseline/retention.ts
@@ -1,0 +1,193 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { getCustomerPool } from "@/lib/triage/policy/customer-db";
+
+/**
+ * Triage baseline corpus retention (#461 / 1B-7).
+ *
+ * Two cleanup sweeps, one per corpus A table:
+ *   - `baseline_triaged_event`  — 180 days from `event_time`.
+ *   - `observed_event_meta`     — 30 days from `event_time` (kept short
+ *     because it only serves window-aggregate stats, not menu display).
+ *
+ * Both deletes run in batches of `DEFAULT_DELETE_BATCH_SIZE` rows per
+ * statement against the per-customer tenant DB to bound lock duration
+ * and WAL pressure. Each batch is its own transaction; a crashed runner
+ * leaves the partial cleanup in place and the next sweep finishes it.
+ *
+ * The retention windows are intentionally separate from the
+ * retroactive-DELETE planner (which deletes by *match*, not by *age*)
+ * even though both target the same tables. Sharing batch sizes keeps
+ * lock-time intuition aligned across the two surfaces.
+ */
+
+export const DEFAULT_DELETE_BATCH_SIZE = 10_000;
+
+export const BASELINE_TRIAGED_EVENT_RETENTION_DAYS = 180;
+export const OBSERVED_EVENT_META_RETENTION_DAYS = 30;
+
+export interface BaselineRetentionCounts {
+  baselineTriagedEvent: number;
+  observedEventMeta: number;
+}
+
+export interface BaselineRetentionCustomerResult {
+  customerId: number;
+  status: "ok" | "failed";
+  counts: BaselineRetentionCounts;
+  error?: string;
+}
+
+export interface BaselineRetentionResult {
+  overall: "ok" | "partial" | "failed";
+  perCustomer: BaselineRetentionCustomerResult[];
+}
+
+interface RetentionTable {
+  table: string;
+  retentionDays: number;
+  key: keyof BaselineRetentionCounts;
+}
+
+const TABLES: readonly RetentionTable[] = [
+  {
+    table: "baseline_triaged_event",
+    retentionDays: BASELINE_TRIAGED_EVENT_RETENTION_DAYS,
+    key: "baselineTriagedEvent",
+  },
+  {
+    table: "observed_event_meta",
+    retentionDays: OBSERVED_EVENT_META_RETENTION_DAYS,
+    key: "observedEventMeta",
+  },
+];
+
+async function sweepCustomerTable(
+  pool: pg.Pool,
+  entry: RetentionTable,
+  batchSize: number,
+): Promise<number> {
+  let total = 0;
+  while (true) {
+    // One DELETE per loop iteration, each in its own transaction (no
+    // explicit BEGIN — single-statement transactions are auto-commit).
+    // `ctid IN (SELECT ... LIMIT n)` keeps the row-set bounded and the
+    // lock duration short.
+    const result = await pool.query(
+      `DELETE FROM ${entry.table}
+        WHERE ctid IN (
+          SELECT ctid FROM ${entry.table}
+           WHERE event_time < NOW() - ($1 || ' days')::INTERVAL
+           LIMIT ${batchSize}
+        )`,
+      [String(entry.retentionDays)],
+    );
+    const n = result.rowCount ?? 0;
+    total += n;
+    if (n < batchSize) break;
+  }
+  return total;
+}
+
+/**
+ * Run the corpus A retention sweeps for one customer. Errors propagate
+ * to the caller so the fan-out path can record `status: 'failed'`
+ * without aborting the rest of the customers.
+ */
+export async function runBaselineRetentionForCustomer(
+  customerId: number,
+  options: { batchSize?: number } = {},
+): Promise<BaselineRetentionCounts> {
+  const batchSize = options.batchSize ?? DEFAULT_DELETE_BATCH_SIZE;
+  const pool = await getCustomerPool(customerId);
+  const counts: BaselineRetentionCounts = {
+    baselineTriagedEvent: 0,
+    observedEventMeta: 0,
+  };
+  for (const entry of TABLES) {
+    counts[entry.key] = await sweepCustomerTable(pool, entry, batchSize);
+  }
+  return counts;
+}
+
+/**
+ * Default active-customer enumerator. Lazily imports `pg` so tests that
+ * stub the enumerator do not load the real client.
+ */
+async function defaultListActiveCustomers(): Promise<number[]> {
+  const { query } = await import("@/lib/db/client");
+  const result = await query<{ id: number }>(
+    "SELECT id FROM customers WHERE status = 'active' ORDER BY id",
+  );
+  return result.rows.map((r) => Number(r.id));
+}
+
+export interface BaselineRetentionOptions {
+  batchSize?: number;
+  listActiveCustomers?: () => Promise<number[]>;
+  runForCustomer?: (
+    customerId: number,
+    options: { batchSize?: number },
+  ) => Promise<BaselineRetentionCounts>;
+}
+
+/**
+ * Dispatch the corpus A retention sweep across every active customer.
+ * Returns a structured `perCustomer[]` so the cron wrapper can summarise
+ * per-tenant outcomes. A self-failure in the enumerator throws; a
+ * per-customer failure is captured in the response.
+ */
+export async function runBaselineRetentionDispatch(
+  options: BaselineRetentionOptions = {},
+): Promise<BaselineRetentionResult> {
+  const batchSize = options.batchSize ?? DEFAULT_DELETE_BATCH_SIZE;
+  const listActiveCustomers =
+    options.listActiveCustomers ?? defaultListActiveCustomers;
+  const runForCustomer =
+    options.runForCustomer ?? runBaselineRetentionForCustomer;
+
+  const customerIds = await listActiveCustomers();
+  const perCustomer: BaselineRetentionCustomerResult[] = [];
+  for (const customerId of customerIds) {
+    try {
+      const counts = await runForCustomer(customerId, { batchSize });
+      perCustomer.push({ customerId, status: "ok", counts });
+    } catch (err) {
+      perCustomer.push({
+        customerId,
+        status: "failed",
+        counts: { baselineTriagedEvent: 0, observedEventMeta: 0 },
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  const overall: BaselineRetentionResult["overall"] = perCustomer.some(
+    (e) => e.status === "failed",
+  )
+    ? "partial"
+    : "ok";
+  return { overall, perCustomer };
+}
+
+/**
+ * Internal-token guard for the retention route. Reads
+ * `TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN`. Constant-time compare.
+ */
+export function verifyTriageBaselineRetentionToken(
+  provided: string | null,
+): boolean {
+  const expected = process.env.TRIAGE_BASELINE_RETENTION_INTERNAL_TOKEN;
+  if (!expected) return false;
+  if (!provided) return false;
+  if (provided.length !== expected.length) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}

--- a/src/lib/triage/exclusion/fanout-worker.ts
+++ b/src/lib/triage/exclusion/fanout-worker.ts
@@ -65,12 +65,13 @@ export function backoffMs(attemptCount: number): number {
 
 interface ClaimedJob {
   id: string;
-  globalExclusionId: string;
+  globalExclusionId: string | null;
+  customerOnlyExclusionId: string | null;
   customerId: number;
   attemptCount: number;
 }
 
-interface GlobalExclusionData {
+interface ExclusionData {
   id: string;
   kind: "ipAddress" | "hostname" | "uri" | "domain";
   value: string;
@@ -104,11 +105,13 @@ async function claimPendingJobs(
 ): Promise<ClaimedJob[]> {
   const { rows } = await client.query<{
     id: string;
-    global_exclusion_id: string;
+    global_exclusion_id: string | null;
+    customer_only_exclusion_id: string | null;
     customer_id: number;
     attempt_count: number;
   }>(
-    `SELECT id, global_exclusion_id, customer_id, attempt_count
+    `SELECT id, global_exclusion_id, customer_only_exclusion_id,
+            customer_id, attempt_count
        FROM triage_exclusion_fanout_job
       WHERE status = 'pending' AND next_attempt_at <= NOW()
       ORDER BY next_attempt_at
@@ -128,7 +131,11 @@ async function claimPendingJobs(
   );
   return rows.map((r) => ({
     id: r.id,
-    globalExclusionId: r.global_exclusion_id,
+    // Normalise undefined → null so the scope discriminator in
+    // `processJob` (which compares against `null`) reads correctly
+    // even when a test mock returns rows without the new column.
+    globalExclusionId: r.global_exclusion_id ?? null,
+    customerOnlyExclusionId: r.customer_only_exclusion_id ?? null,
     customerId: r.customer_id,
     attemptCount: r.attempt_count,
   }));
@@ -137,7 +144,7 @@ async function claimPendingJobs(
 async function loadGlobalExclusion(
   client: pg.PoolClient,
   id: string,
-): Promise<GlobalExclusionData | null> {
+): Promise<ExclusionData | null> {
   const { rows } = await client.query<{
     id: string;
     kind: string;
@@ -153,7 +160,7 @@ async function loadGlobalExclusion(
   const r = rows[0];
   return {
     id: r.id,
-    kind: r.kind as GlobalExclusionData["kind"],
+    kind: r.kind as ExclusionData["kind"],
     value: r.value,
     domainSuffix: r.domain_suffix,
   };
@@ -174,6 +181,49 @@ async function globalExclusionExists(
   id: string,
 ): Promise<boolean> {
   const row = await loadGlobalExclusion(client, id);
+  return row !== null;
+}
+
+/**
+ * Load a customer-scoped triage exclusion from the tenant DB. Returns
+ * `null` if the row was deleted between the queue insert (or recovery
+ * reset) and the worker claim — `customer_only_exclusion_id` has no FK
+ * because cross-DB FKs are not supported, so this branch is the
+ * application-level existence check. The fanout worker maps a `null`
+ * to a no-op completion: retroactive cleanup is moot once the exclusion
+ * has been removed, mirroring the FK CASCADE semantic on the global
+ * side.
+ */
+async function loadCustomerExclusion(
+  client: pg.PoolClient,
+  id: string,
+): Promise<ExclusionData | null> {
+  const { rows } = await client.query<{
+    id: string;
+    kind: string;
+    value: string;
+    domain_suffix: string | null;
+  }>(
+    `SELECT id, kind, value, domain_suffix
+       FROM triage_exclusion
+      WHERE id = $1`,
+    [id],
+  );
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    id: r.id,
+    kind: r.kind as ExclusionData["kind"],
+    value: r.value,
+    domainSuffix: r.domain_suffix,
+  };
+}
+
+async function customerExclusionExists(
+  client: pg.PoolClient,
+  id: string,
+): Promise<boolean> {
+  const row = await loadCustomerExclusion(client, id);
   return row !== null;
 }
 
@@ -233,30 +283,69 @@ interface JobOutcome {
   outcome: "completed" | "retried" | "failed";
   error?: string;
   /**
-   * The global exclusion row, if it was loaded successfully. Threaded
-   * out so the caller can include `kind` / `value` / `id` in the
+   * The exclusion row, if it was loaded successfully. Threaded out so
+   * the caller can include `kind` / `value` / `id` in the
    * `triage_exclusion.fanout_failed` audit row when the job exhausts
-   * its retry budget.
+   * its retry budget. The `scope` lets the audit row distinguish a
+   * global-fanout failure from a customer-only drain re-run failure.
    */
-  global?: GlobalExclusionData;
+  exclusion?: ExclusionData;
+  scope?: "global" | "customer_only";
 }
 
 async function processJob(job: ClaimedJob): Promise<JobOutcome> {
-  let global: GlobalExclusionData | null;
+  // The CHECK constraint on `triage_exclusion_fanout_job` enforces
+  // exactly one of `global_exclusion_id` / `customer_only_exclusion_id`
+  // is populated. Capture the populated id once so downstream branches
+  // can use the narrowed `string` value without re-asserting non-null.
+  const globalExclusionId = job.globalExclusionId;
+  const customerOnlyExclusionId = job.customerOnlyExclusionId;
+  const scope: "global" | "customer_only" =
+    globalExclusionId !== null ? "global" : "customer_only";
+
+  let exclusion: ExclusionData | null;
+  let tenantPool: pg.Pool | null = null;
   try {
-    global = await withTransaction((c) =>
-      loadGlobalExclusion(c, job.globalExclusionId),
-    );
+    if (globalExclusionId !== null) {
+      // The global row lives in auth_db, so the existence probe avoids
+      // touching the tenant pool entirely until we know there is work
+      // to do. Matches the existing 1B-2 contract that a missing
+      // global row is a completed no-op without per-customer connection.
+      exclusion = await withTransaction((c) =>
+        loadGlobalExclusion(c, globalExclusionId),
+      );
+    } else if (customerOnlyExclusionId !== null) {
+      // Customer-only path needs the tenant pool to probe existence.
+      tenantPool = await getCustomerPool(job.customerId);
+      const tenantClient = await tenantPool.connect();
+      try {
+        exclusion = await loadCustomerExclusion(
+          tenantClient,
+          customerOnlyExclusionId,
+        );
+      } finally {
+        tenantClient.release();
+      }
+    } else {
+      // Defensive: the CHECK constraint guarantees one id is set, but
+      // if a future migration or test stub violates the invariant,
+      // surface the row as a no-op completion instead of looping.
+      exclusion = null;
+    }
   } catch (err) {
     return {
       outcome: "retried",
       error: err instanceof Error ? err.message : String(err),
     };
   }
-  if (!global) {
-    // The global row was deleted before fanout ran; the cascade has
-    // already removed pending jobs for this id, but this row was
-    // already claimed. Mark it completed (nothing to do).
+  if (!exclusion) {
+    // The exclusion row was deleted before fanout ran. For the global
+    // path the FK cascade has already removed pending queue rows; for
+    // the customer-only path there is no FK (cross-DB), so the
+    // application enforces the same semantic explicitly: mark the job
+    // `completed` as a no-op rather than incrementing `attempt_count`
+    // and looping back through backoff. Either way, retroactive
+    // cleanup is moot once the exclusion has been removed.
     await withTransaction((c) => finalizeCompleted(c, job.id));
     return { outcome: "completed" };
   }
@@ -266,7 +355,7 @@ async function processJob(job: ClaimedJob): Promise<JobOutcome> {
   // the per-customer fanout runs. Subsequent batches drain in fresh
   // transactions per #457 so corpus DELETEs do not hold the cadence
   // lock for long stretches.
-  const tenantPool = await getCustomerPool(job.customerId);
+  if (tenantPool === null) tenantPool = await getCustomerPool(job.customerId);
   const tenantClient = await tenantPool.connect();
   let firstBatchCounts: DeletedCounts;
   let pending: Awaited<
@@ -275,25 +364,21 @@ async function processJob(job: ClaimedJob): Promise<JobOutcome> {
   try {
     await tenantClient.query("BEGIN");
     await acquireCustomerCadenceLock(tenantClient, job.customerId);
-    // Re-check the global row after acquiring the cadence lock. The
-    // operator may have deleted it between the initial load and now;
-    // the FK cascade has already removed our job row, but `processJob`
-    // still holds the in-memory `global` value and would otherwise
-    // permanently drop corpus rows for an exclusion that is no longer
-    // in the active set. (Spec: cascade rationale — cleanup is moot
-    // once the active set no longer contains the row.)
-    const stillExists = await withTransaction((c) =>
-      globalExclusionExists(c, job.globalExclusionId),
-    );
+    // Re-check the exclusion row after acquiring the cadence lock. For
+    // the global path the operator may have deleted it (FK cascade
+    // already removed our job row but `processJob` still holds the
+    // in-memory `exclusion` value); for the customer-only path the
+    // application existence check stands in for the missing FK.
+    const stillExists = await stillExistsCheck(scope, job, tenantClient);
     if (!stillExists) {
       await tenantClient.query("ROLLBACK");
       tenantClient.release();
       return { outcome: "completed" };
     }
     const firstBatch = await executeFirstRetroactiveDeleteBatch(tenantClient, {
-      kind: global.kind,
-      value: global.value,
-      domainSuffix: global.domainSuffix,
+      kind: exclusion.kind,
+      value: exclusion.value,
+      domainSuffix: exclusion.domainSuffix,
     });
     firstBatchCounts = firstBatch.counts;
     pending = firstBatch.pending;
@@ -304,7 +389,8 @@ async function processJob(job: ClaimedJob): Promise<JobOutcome> {
     return {
       outcome: "retried",
       error: err instanceof Error ? err.message : String(err),
-      global,
+      exclusion,
+      scope,
     };
   }
   tenantClient.release();
@@ -329,24 +415,22 @@ async function processJob(job: ClaimedJob): Promise<JobOutcome> {
         },
         pending,
         {
-          // Re-check before each batch: if the global row was deleted
-          // mid-drain the cascade has already removed our job row, so
-          // stop emitting tenant DELETEs.
-          shouldContinue: () =>
-            withTransaction((c) =>
-              globalExclusionExists(c, job.globalExclusionId),
-            ),
+          shouldContinue: async () => {
+            const drainClient = await tenantPool.connect();
+            try {
+              return await stillExistsCheck(scope, job, drainClient);
+            } finally {
+              drainClient.release();
+            }
+          },
         },
       );
     } catch (err) {
-      // Drain failure: the global INSERT and first batch are durable
-      // in `auth_db` / tenant DB respectively; the row is already in
-      // the active set. Re-queue the job so the next sweep picks up
-      // the remaining batches with backoff.
       return {
         outcome: "retried",
         error: err instanceof Error ? err.message : String(err),
-        global,
+        exclusion,
+        scope,
       };
     }
   }
@@ -366,23 +450,65 @@ async function processJob(job: ClaimedJob): Promise<JobOutcome> {
 
   await withTransaction((c) => finalizeCompleted(c, job.id));
 
+  // Emit a `customer_add` audit row on every successful per-customer
+  // run (global-fanout or customer-only recovery) so the customer
+  // operator sees the corpus pruning in their audit-log view. The
+  // `origin` detail distinguishes a fanout vs a recovery re-run from
+  // the original synchronous customer-scoped ADD.
   await auditLog.record({
     actor: "system",
     action: "triage_exclusion.customer_add",
     target: "triage_exclusion",
-    targetId: global.id,
+    targetId: exclusion.id,
     customerId: job.customerId,
     details: {
-      id: global.id,
-      kind: global.kind,
-      value: global.value,
-      origin: "global_fanout",
-      globalExclusionId: global.id,
+      id: exclusion.id,
+      kind: exclusion.kind,
+      value: exclusion.value,
+      origin: scope === "global" ? "global_fanout" : "customer_recover",
+      globalExclusionId: job.globalExclusionId,
+      customerOnlyExclusionId: job.customerOnlyExclusionId,
       deletedCorpusRows: counts,
     },
   });
 
   return { outcome: "completed" };
+}
+
+async function loadExclusionForAuditFallback(
+  job: ClaimedJob,
+): Promise<ExclusionData | null> {
+  if (job.globalExclusionId !== null) {
+    const id = job.globalExclusionId;
+    return withTransaction((c) => loadGlobalExclusion(c, id));
+  }
+  if (job.customerOnlyExclusionId !== null) {
+    const id = job.customerOnlyExclusionId;
+    const pool = await getCustomerPool(job.customerId);
+    const client = await pool.connect();
+    try {
+      return await loadCustomerExclusion(client, id);
+    } finally {
+      client.release();
+    }
+  }
+  return null;
+}
+
+async function stillExistsCheck(
+  scope: "global" | "customer_only",
+  job: ClaimedJob,
+  tenantClient: pg.PoolClient,
+): Promise<boolean> {
+  if (scope === "global" && job.globalExclusionId !== null) {
+    const id = job.globalExclusionId;
+    return withTransaction((c) => globalExclusionExists(c, id));
+  }
+  if (job.customerOnlyExclusionId !== null) {
+    return customerExclusionExists(tenantClient, job.customerOnlyExclusionId);
+  }
+  // No id populated — treat as gone so the caller halts cleanly.
+  return false;
 }
 
 /**
@@ -423,27 +549,29 @@ export async function runFanoutSweep(
         await withTransaction((c) => finalizeFailed(c, job.id, errorMessage));
         // Spec requires `id`, `kind`, `value` on every audit row in the
         // `triage_exclusion.*` family. If `processJob` could not load
-        // the global row (e.g. an auth-DB error before the lookup
+        // the exclusion row (e.g. an auth-DB error before the lookup
         // returned), those fields are unknown — emit them as the job's
-        // `globalExclusionId` and a `null` placeholder rather than
-        // omitting the keys, so downstream audit-log consumers see a
-        // consistent shape.
-        const globalRow =
-          result.global ??
-          (await withTransaction((c) =>
-            loadGlobalExclusion(c, job.globalExclusionId),
-          ).catch(() => null));
+        // targeted id and a `null` placeholder rather than omitting
+        // the keys, so downstream audit-log consumers see a consistent
+        // shape. The targeted id is whichever scope column is
+        // populated; the CHECK constraint guarantees exactly one is.
+        const exclusionRow =
+          result.exclusion ??
+          (await loadExclusionForAuditFallback(job).catch(() => null));
+        const targetedId =
+          job.globalExclusionId ?? job.customerOnlyExclusionId ?? null;
         await auditLog.record({
           actor: "system",
           action: "triage_exclusion.fanout_failed",
           target: "triage_exclusion",
-          targetId: job.globalExclusionId,
+          targetId: targetedId ?? undefined,
           customerId: job.customerId,
           details: {
-            id: job.globalExclusionId,
-            kind: globalRow?.kind ?? null,
-            value: globalRow?.value ?? null,
+            id: targetedId,
+            kind: exclusionRow?.kind ?? null,
+            value: exclusionRow?.value ?? null,
             globalExclusionId: job.globalExclusionId,
+            customerOnlyExclusionId: job.customerOnlyExclusionId,
             attemptCount: job.attemptCount + 1,
             lastError: errorMessage,
           },

--- a/src/lib/triage/exclusion/fanout-worker.ts
+++ b/src/lib/triage/exclusion/fanout-worker.ts
@@ -371,8 +371,15 @@ async function processJob(job: ClaimedJob): Promise<JobOutcome> {
     // application existence check stands in for the missing FK.
     const stillExists = await stillExistsCheck(scope, job, tenantClient);
     if (!stillExists) {
+      // Mirror the pre-lock missing-row branch: release the tenant
+      // transaction first, then finalize the auth-db queue row.
+      // Returning "completed" without flipping the row leaves it
+      // `running`, the stuck-job sweep flips it back to `pending`,
+      // and the worker loops indefinitely on the same no-op — which
+      // also keeps the "Re-trigger cleanup" indicator stuck on.
       await tenantClient.query("ROLLBACK");
       tenantClient.release();
+      await withTransaction((c) => finalizeCompleted(c, job.id));
       return { outcome: "completed" };
     }
     const firstBatch = await executeFirstRetroactiveDeleteBatch(tenantClient, {

--- a/src/lib/triage/exclusion/recovery.ts
+++ b/src/lib/triage/exclusion/recovery.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import type pg from "pg";
 
+import { queryAudit } from "@/lib/audit/client";
 import { auditLog } from "@/lib/audit/logger";
 import { withTransaction } from "@/lib/db/client";
 
@@ -158,6 +159,119 @@ export async function insertCustomerDrainFailureSentinel(
 }
 
 /**
+ * Insert a *backfill* sentinel as `pending` so a fresh fanout sweep
+ * re-runs the customer DELETE planner.
+ *
+ * Distinct from `insertCustomerDrainFailureSentinel` (which seeds the
+ * row in the exhausted `failed` state for the admin UI's "Re-trigger
+ * cleanup" affordance). Backfill is the audit-row-fallback path used
+ * when the cleanup-status / recover flow finds a drain-failure audit
+ * row but no matching queue row — for example, after the swallowed
+ * `insertCustomerDrainFailureSentinel` failure path in
+ * `POST /api/triage/exclusions`. The fanout worker picks the row up
+ * via `FOR UPDATE SKIP LOCKED` on the next sweep just like any other
+ * pending row.
+ *
+ * The ON CONFLICT branch keeps the helper idempotent against a race
+ * where the sentinel was inserted between the audit lookup and this
+ * statement; the upsert resets `status='pending', attempt_count=0` so
+ * the result is the same whether or not a prior row existed.
+ */
+async function backfillCustomerSentinel(
+  client: pg.PoolClient,
+  customerExclusionId: string,
+  customerId: number,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO triage_exclusion_fanout_job (
+        global_exclusion_id,
+        customer_only_exclusion_id,
+        customer_id,
+        status,
+        attempt_count,
+        next_attempt_at,
+        claimed_at,
+        last_error
+     ) VALUES (NULL, $1, $2, 'pending', 0, NOW(), NULL, NULL)
+     ON CONFLICT (customer_only_exclusion_id, customer_id)
+       WHERE customer_only_exclusion_id IS NOT NULL
+       DO UPDATE SET
+         status = 'pending',
+         attempt_count = 0,
+         next_attempt_at = NOW(),
+         claimed_at = NULL,
+         last_error = NULL,
+         updated_at = NOW()`,
+    [customerExclusionId, customerId],
+  );
+}
+
+/**
+ * Return the set of customer exclusion ids that have a
+ * `triage_exclusion.customer_add` audit row recording
+ * `drainStatus='failed'` and no later `triage_exclusion.customer_recover`
+ * audit row for the same target — i.e. drain failures that have not yet
+ * been recovered.
+ *
+ * Used by the customer cleanup-status route as a fallback so audit-only
+ * drain failures (those that landed in the audit log but whose sentinel
+ * insertion was swallowed in `POST /api/triage/exclusions`) still
+ * surface the "Re-trigger cleanup" affordance. Without this fallback an
+ * `auth_db unreachable` blip during the failed ADD path would render
+ * the exclusion permanently unrecoverable from the UI.
+ */
+export async function listAuditOnlyCustomerDrainFailures(
+  customerId: number,
+): Promise<string[]> {
+  const { rows } = await queryAudit<{ target_id: string }>(
+    `SELECT DISTINCT a.target_id
+       FROM audit_logs a
+      WHERE a.action = 'triage_exclusion.customer_add'
+        AND a.customer_id = $1
+        AND a.target_id IS NOT NULL
+        AND a.details ->> 'drainStatus' = 'failed'
+        AND NOT EXISTS (
+          SELECT 1 FROM audit_logs r
+           WHERE r.action = 'triage_exclusion.customer_recover'
+             AND r.customer_id = $1
+             AND r.target_id = a.target_id
+             AND r.timestamp > a.timestamp
+        )`,
+    [customerId],
+  );
+  return rows.map((r) => r.target_id);
+}
+
+/**
+ * Probe the audit log for a single customer drain-failure that has not
+ * been recovered. Returns true if such an audit row exists. Used by the
+ * recover path to decide whether to backfill a sentinel when no failed
+ * queue row matched the recover request.
+ */
+async function customerDrainFailureAuditExists(
+  customerExclusionId: string,
+  customerId: number,
+): Promise<boolean> {
+  const { rows } = await queryAudit(
+    `SELECT 1 FROM audit_logs a
+      WHERE a.action = 'triage_exclusion.customer_add'
+        AND a.customer_id = $1
+        AND a.target_id = $2
+        AND a.details ->> 'drainStatus' = 'failed'
+        AND NOT EXISTS (
+          SELECT 1 FROM audit_logs r
+           WHERE r.action = 'triage_exclusion.customer_recover'
+             AND r.customer_id = $1
+             AND r.target_id = a.target_id
+             AND r.timestamp > a.timestamp
+        )
+      LIMIT 1`,
+    [customerId, customerExclusionId],
+  );
+  return rows.length > 0;
+}
+
+/**
  * Discriminated request shape for the internal recovery route. Each
  * variant carries the discriminator that targets a single failed row
  * (or the per-global sweep). The route validates the variant before
@@ -183,6 +297,37 @@ export interface RecoverOutcome {
 export async function applyRecover(
   request: RecoverRequest,
 ): Promise<RecoverOutcome> {
+  if (request.kind === "customer") {
+    // Try the in-place reset first — by far the common case, where the
+    // drain-failure path successfully wrote a `failed` sentinel.
+    const reset = await withTransaction((client) =>
+      resetCustomerDrainSentinel(
+        client,
+        request.exclusionId,
+        request.customerId,
+      ),
+    );
+    if (reset > 0) return { reset, kind: request.kind };
+
+    // Audit-row fallback: the sentinel insert in the failed ADD path is
+    // best-effort (a queue-write failure cannot mask the primary drain
+    // error in the 500 response), so a transient auth_db blip can leave
+    // a drain-failure audit row with no matching queue row. Consult the
+    // audit log; if such a row exists, backfill a fresh pending sentinel
+    // so the fanout worker re-runs the customer DELETE planner. Without
+    // this fallback the exclusion would be permanently unrecoverable
+    // from the UI.
+    const auditExists = await customerDrainFailureAuditExists(
+      request.exclusionId,
+      request.customerId,
+    );
+    if (!auditExists) return { reset: 0, kind: request.kind };
+    await withTransaction((client) =>
+      backfillCustomerSentinel(client, request.exclusionId, request.customerId),
+    );
+    return { reset: 1, kind: request.kind };
+  }
+
   return withTransaction(async (client) => {
     let reset = 0;
     if (request.kind === "global") {
@@ -191,14 +336,8 @@ export async function applyRecover(
         request.exclusionId,
         request.customerId,
       );
-    } else if (request.kind === "global_all_failed") {
-      reset = await resetAllGlobalFailedJobs(client, request.exclusionId);
     } else {
-      reset = await resetCustomerDrainSentinel(
-        client,
-        request.exclusionId,
-        request.customerId,
-      );
+      reset = await resetAllGlobalFailedJobs(client, request.exclusionId);
     }
     return { reset, kind: request.kind };
   });

--- a/src/lib/triage/exclusion/recovery.ts
+++ b/src/lib/triage/exclusion/recovery.ts
@@ -1,0 +1,276 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { auditLog } from "@/lib/audit/logger";
+import { withTransaction } from "@/lib/db/client";
+
+import { MAX_ATTEMPTS } from "./fanout-worker";
+
+/**
+ * Recovery surface for failed exclusion fanout / drain cleanup
+ * (#461 / 1B-7).
+ *
+ * Two failure classes share one queue:
+ *
+ *   1. Global ADD fanout `failed` rows — `triage_exclusion_fanout_job`
+ *      rows that exhausted the worker's exponential backoff. Reset
+ *      by mode `'global'` (one row) or `'global_all_failed'` (sweep
+ *      one exclusion's failures).
+ *   2. Customer-scoped ADD drain failure — the synchronous drain phase
+ *      in `POST /api/triage/exclusions` failed after the INSERT + first
+ *      DELETE batch committed. The drain-failure path inserts a
+ *      sentinel row into the queue (status='failed', attempt_count=
+ *      MAX_ATTEMPTS, key=`customer_only_exclusion_id`) so reset-in-place
+ *      recovery has a target. Reset by mode `'customer'`.
+ *
+ * All resets are UPDATEs against existing rows so the admin UI's
+ * "Re-trigger cleanup" affordance collapses after a successful retry
+ * (a fresh `pending` row would leave the old `failed` row visible).
+ * The fanout worker's next sweep picks the row up via the same
+ * `FOR UPDATE SKIP LOCKED` claim path.
+ */
+
+export interface ResetCounts {
+  reset: number;
+}
+
+/**
+ * Reset a single global-exclusion fanout row keyed by
+ * `(global_exclusion_id, customer_id)`. Returns the rowcount so the
+ * caller can report `404` when the request named an exclusion + customer
+ * pair that has no `failed` row (typo or already-recovered case).
+ */
+export async function resetGlobalFanoutJob(
+  client: pg.PoolClient,
+  globalExclusionId: string,
+  customerId: number,
+): Promise<number> {
+  const result = await client.query(
+    `UPDATE triage_exclusion_fanout_job
+        SET status = 'pending',
+            attempt_count = 0,
+            last_error = NULL,
+            next_attempt_at = NOW(),
+            claimed_at = NULL,
+            updated_at = NOW()
+      WHERE global_exclusion_id = $1
+        AND customer_id = $2
+        AND status = 'failed'`,
+    [globalExclusionId, customerId],
+  );
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Operator sweep: reset every `failed` row for one global exclusion.
+ * Used after a tenant-DB outage where many customers' fanout rows
+ * exhausted retries.
+ */
+export async function resetAllGlobalFailedJobs(
+  client: pg.PoolClient,
+  globalExclusionId: string,
+): Promise<number> {
+  const result = await client.query(
+    `UPDATE triage_exclusion_fanout_job
+        SET status = 'pending',
+            attempt_count = 0,
+            last_error = NULL,
+            next_attempt_at = NOW(),
+            claimed_at = NULL,
+            updated_at = NOW()
+      WHERE global_exclusion_id = $1
+        AND status = 'failed'`,
+    [globalExclusionId],
+  );
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Reset the customer-scoped drain-failure sentinel keyed by
+ * `(customer_only_exclusion_id, customer_id)`. Returns the rowcount so
+ * the caller can 404 on a missing sentinel.
+ */
+export async function resetCustomerDrainSentinel(
+  client: pg.PoolClient,
+  customerExclusionId: string,
+  customerId: number,
+): Promise<number> {
+  const result = await client.query(
+    `UPDATE triage_exclusion_fanout_job
+        SET status = 'pending',
+            attempt_count = 0,
+            last_error = NULL,
+            next_attempt_at = NOW(),
+            claimed_at = NULL,
+            updated_at = NOW()
+      WHERE customer_only_exclusion_id = $1
+        AND customer_id = $2
+        AND status = 'failed'`,
+    [customerExclusionId, customerId],
+  );
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Insert (or upsert) the customer-scoped drain-failure sentinel.
+ *
+ * Called by `POST /api/triage/exclusions` when the synchronous drain
+ * phase fails after the INSERT + first DELETE batch have committed.
+ * Keyed by the unique partial index
+ * `triage_exclusion_fanout_job_customer_dedupe`; a repeat drain
+ * failure for the same exclusion replaces the prior sentinel's
+ * `last_error` and resets the timestamps.
+ *
+ * `attempt_count = MAX_ATTEMPTS` so the sentinel is born in the same
+ * "exhausted" state the global path enters after 5 retries — the
+ * worker skips it under `next_attempt_at <= NOW()` because the row is
+ * `failed`, and admin recovery is the only path that resets it.
+ */
+export async function insertCustomerDrainFailureSentinel(
+  client: pg.PoolClient,
+  customerExclusionId: string,
+  customerId: number,
+  errorMessage: string,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO triage_exclusion_fanout_job (
+        global_exclusion_id,
+        customer_only_exclusion_id,
+        customer_id,
+        status,
+        attempt_count,
+        next_attempt_at,
+        claimed_at,
+        last_error
+     ) VALUES (NULL, $1, $2, 'failed', $3, NOW(), NULL, $4)
+     ON CONFLICT (customer_only_exclusion_id, customer_id)
+       WHERE customer_only_exclusion_id IS NOT NULL
+       DO UPDATE SET
+         status = 'failed',
+         attempt_count = EXCLUDED.attempt_count,
+         next_attempt_at = NOW(),
+         claimed_at = NULL,
+         last_error = EXCLUDED.last_error,
+         updated_at = NOW()`,
+    [customerExclusionId, customerId, MAX_ATTEMPTS, errorMessage],
+  );
+}
+
+/**
+ * Discriminated request shape for the internal recovery route. Each
+ * variant carries the discriminator that targets a single failed row
+ * (or the per-global sweep). The route validates the variant before
+ * calling the matching helper.
+ */
+export type RecoverRequest =
+  | { kind: "global"; exclusionId: string; customerId: number }
+  | { kind: "global_all_failed"; exclusionId: string }
+  | { kind: "customer"; exclusionId: string; customerId: number };
+
+export interface RecoverOutcome {
+  /** How many queue rows were reset. */
+  reset: number;
+  /** Recovery mode, echoed for log clarity. */
+  kind: RecoverRequest["kind"];
+}
+
+/**
+ * Apply a recovery request. Runs in one `withTransaction` so the
+ * UPDATE is atomic against concurrent worker claims (which use
+ * `FOR UPDATE SKIP LOCKED`).
+ */
+export async function applyRecover(
+  request: RecoverRequest,
+): Promise<RecoverOutcome> {
+  return withTransaction(async (client) => {
+    let reset = 0;
+    if (request.kind === "global") {
+      reset = await resetGlobalFanoutJob(
+        client,
+        request.exclusionId,
+        request.customerId,
+      );
+    } else if (request.kind === "global_all_failed") {
+      reset = await resetAllGlobalFailedJobs(client, request.exclusionId);
+    } else {
+      reset = await resetCustomerDrainSentinel(
+        client,
+        request.exclusionId,
+        request.customerId,
+      );
+    }
+    return { reset, kind: request.kind };
+  });
+}
+
+/**
+ * Emit the appropriate audit row for a recovery action. Routes pass
+ * the session actor (or `'system'` for the internal-token route) and
+ * any optional request metadata. Two distinct actions per the
+ * customer-scope policy: `global_recover` is customer-agnostic so it
+ * omits `customerId`; `customer_recover` is customer-scoped and
+ * populates it from the request.
+ */
+export async function emitRecoverAudit(
+  request: RecoverRequest,
+  actor: string,
+  resetCount: number,
+  options: {
+    ip?: string | null;
+    sid?: string | null;
+  } = {},
+): Promise<void> {
+  if (request.kind === "global" || request.kind === "global_all_failed") {
+    await auditLog.record({
+      actor,
+      action: "triage_exclusion.global_recover",
+      target: "triage_exclusion",
+      targetId: request.exclusionId,
+      ip: options.ip ?? undefined,
+      sid: options.sid ?? undefined,
+      details: {
+        id: request.exclusionId,
+        kind: request.kind,
+        customerId: request.kind === "global" ? request.customerId : null,
+        reset: resetCount,
+      },
+    });
+    return;
+  }
+  await auditLog.record({
+    actor,
+    action: "triage_exclusion.customer_recover",
+    target: "triage_exclusion",
+    targetId: request.exclusionId,
+    ip: options.ip ?? undefined,
+    sid: options.sid ?? undefined,
+    customerId: request.customerId,
+    details: {
+      id: request.exclusionId,
+      kind: request.kind,
+      reset: resetCount,
+    },
+  });
+}
+
+/**
+ * Token guard for the internal recovery route. Reads
+ * `TRIAGE_EXCLUSION_RECOVERY_INTERNAL_TOKEN`. Constant-time compare.
+ */
+export function verifyTriageExclusionRecoveryToken(
+  provided: string | null,
+): boolean {
+  const expected = process.env.TRIAGE_EXCLUSION_RECOVERY_INTERNAL_TOKEN;
+  if (!expected) return false;
+  if (!provided) return false;
+  if (provided.length !== expected.length) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}

--- a/src/lib/triage/policy/corpus-b/retention.ts
+++ b/src/lib/triage/policy/corpus-b/retention.ts
@@ -327,7 +327,7 @@ async function pruneReadyWithProtection(
             `SELECT id FROM policy_triage_run
               WHERE status = 'ready'
                 AND created_at < NOW() - ($1 || ' days')::INTERVAL
-                AND id <> ALL($2::uuid[])
+                AND id <> ALL($2::bigint[])
               LIMIT ${batchSize}`,
             [String(retentionDays), protectedArr],
           );
@@ -342,7 +342,7 @@ async function pruneReadyWithProtection(
     }
     if (toDelete.length > 0) {
       const result = await pool.query(
-        `DELETE FROM policy_triage_run WHERE id = ANY($1::uuid[])`,
+        `DELETE FROM policy_triage_run WHERE id = ANY($1::bigint[])`,
         [toDelete],
       );
       total += result.rowCount ?? 0;

--- a/src/lib/triage/policy/corpus-b/retention.ts
+++ b/src/lib/triage/policy/corpus-b/retention.ts
@@ -1,0 +1,355 @@
+import "server-only";
+
+import type pg from "pg";
+
+import { query as authDbQuery } from "@/lib/db/client";
+import { getCustomerPool } from "@/lib/triage/policy/customer-db";
+
+/**
+ * Policy corpus B retention + zombie-runner recovery (#461 / 1B-7).
+ *
+ * Three sweeps against `policy_triage_run` per tenant DB. Each row's
+ * `policy_triaged_event` rows cascade with the run (`ON DELETE CASCADE`
+ * in `0009_policy_corpus_b.sql`), so pruning a run also prunes its
+ * events in the same transaction.
+ *
+ * Sweep order is important: the zombie reaper runs *first* so a
+ * timed-out `computing` row flips to `failed` and is then eligible for
+ * the failed-row 1-day retention path on the same sweep. The orphan
+ * sweep runs last so a row whose `owner_account_id` no longer resolves
+ * is cleaned regardless of status — typically operator account deletes
+ * happen rarely and the orphan accumulation rate is low.
+ *
+ * Lives under `corpus-b/` so removing the policy mode also removes its
+ * cleanup (deprecatability seam, §6 of discussion #447).
+ */
+
+export const DEFAULT_DELETE_BATCH_SIZE = 1_000;
+
+/**
+ * Time a `computing` row is allowed to sit before the reaper considers
+ * the runner crashed. The reverse-direction race (a slow runner
+ * completing after the reaper flipped the row to `failed`) is closed
+ * on the runner side by `markRunReadyOnClient`'s `AND status =
+ * 'computing'` guard, so the reaper does not need additional
+ * coordination.
+ */
+export const ZOMBIE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+export const READY_RETENTION_DAYS = 30; // active ready rows
+export const SUPERSEDED_RETENTION_DAYS = 7; // superseded rows
+export const FAILED_RETENTION_DAYS = 1; // failed rows
+
+export interface PolicyRetentionCounts {
+  zombiesReaped: number;
+  readyPruned: number;
+  supersededPruned: number;
+  failedPruned: number;
+  orphanedPruned: number;
+}
+
+export interface PolicyRetentionCustomerResult {
+  customerId: number;
+  status: "ok" | "failed";
+  counts: PolicyRetentionCounts;
+  error?: string;
+}
+
+export interface PolicyRetentionResult {
+  overall: "ok" | "partial" | "failed";
+  perCustomer: PolicyRetentionCustomerResult[];
+}
+
+function emptyCounts(): PolicyRetentionCounts {
+  return {
+    zombiesReaped: 0,
+    readyPruned: 0,
+    supersededPruned: 0,
+    failedPruned: 0,
+    orphanedPruned: 0,
+  };
+}
+
+/**
+ * Flip stuck-`computing` rows to `failed` with the documented marker.
+ * Returns the count for observability. Driven by `created_at` so the
+ * threshold is independent of `finalized_at` (which is NULL for
+ * `computing` rows).
+ */
+async function reapZombies(pool: pg.Pool, timeoutMs: number): Promise<number> {
+  const result = await pool.query(
+    `UPDATE policy_triage_run
+        SET status = 'failed',
+            finalized_at = NOW(),
+            last_error = 'timeout: runner did not finalize'
+      WHERE status = 'computing'
+        AND created_at < NOW() - ($1 || ' milliseconds')::INTERVAL`,
+    [String(timeoutMs)],
+  );
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Delete rows matching a predicate in batches. Returns the total rows
+ * removed. Each batch is a single-statement transaction (auto-commit).
+ */
+async function batchDelete(
+  pool: pg.Pool,
+  predicate: string,
+  params: unknown[],
+  batchSize: number,
+): Promise<number> {
+  let total = 0;
+  while (true) {
+    const result = await pool.query(
+      `DELETE FROM policy_triage_run
+        WHERE id IN (
+          SELECT id FROM policy_triage_run
+           WHERE ${predicate}
+           LIMIT ${batchSize}
+        )`,
+      params,
+    );
+    const n = result.rowCount ?? 0;
+    total += n;
+    if (n < batchSize) break;
+  }
+  return total;
+}
+
+/**
+ * Load every `owner_account_id` referenced by the customer's
+ * `policy_triage_run` rows, then probe `auth_db.accounts(id)` once for
+ * the unresolved set. Returns the list of `owner_account_id` values
+ * whose referenced account row no longer exists. Cross-DB FKs are not
+ * supported, so this is the application-layer existence check.
+ */
+async function findOrphanedOwners(pool: pg.Pool): Promise<string[]> {
+  const { rows } = await pool.query<{ owner_account_id: string }>(
+    `SELECT DISTINCT owner_account_id FROM policy_triage_run`,
+  );
+  if (rows.length === 0) return [];
+  const owners = rows.map((r) => r.owner_account_id);
+  const { rows: resolved } = await authDbQuery<{ id: string }>(
+    `SELECT id FROM accounts WHERE id = ANY($1::uuid[])`,
+    [owners],
+  );
+  const resolvedSet = new Set(resolved.map((r) => r.id));
+  return owners.filter((id) => !resolvedSet.has(id));
+}
+
+/**
+ * Run all three sweeps for one customer. The caller's fan-out reports
+ * status per customer; this function lets errors bubble so the
+ * dispatcher can record `status: 'failed'` without aborting the rest.
+ */
+export async function runPolicyRetentionForCustomer(
+  customerId: number,
+  options: {
+    batchSize?: number;
+    zombieTimeoutMs?: number;
+  } = {},
+): Promise<PolicyRetentionCounts> {
+  const batchSize = options.batchSize ?? DEFAULT_DELETE_BATCH_SIZE;
+  const zombieTimeoutMs = options.zombieTimeoutMs ?? ZOMBIE_TIMEOUT_MS;
+  const pool = await getCustomerPool(customerId);
+  const counts = emptyCounts();
+
+  // 1) Zombie reaper — `computing` rows older than the timeout become
+  //    `failed`, which then makes them eligible for the failed-row
+  //    retention path on this same sweep tick.
+  counts.zombiesReaped = await reapZombies(pool, zombieTimeoutMs);
+
+  // 2) Differential retention. Each predicate uses the table's
+  //    `policy_triage_run_status_created_idx` for status filtering plus
+  //    `created_at` / `finalized_at` for the age cut.
+  //
+  //    The `ready` path additionally consults the Phase 2 protection
+  //    hook so an in-flight LLM SendBatch keyed off a ready run is not
+  //    pruned out from under the batch. Only `ready` is gated:
+  //    `superseded` rows have already been replaced, `failed` rows are
+  //    terminal, and `computing` zombies are flipped to `failed` by the
+  //    reaper above — none of those statuses can have a meaningful
+  //    SendBatch in flight.
+  counts.readyPruned = await pruneReadyWithProtection(
+    pool,
+    READY_RETENTION_DAYS,
+    batchSize,
+  );
+  counts.supersededPruned = await batchDelete(
+    pool,
+    `status = 'superseded'
+       AND finalized_at IS NOT NULL
+       AND finalized_at < NOW() - ($1 || ' days')::INTERVAL`,
+    [String(SUPERSEDED_RETENTION_DAYS)],
+    batchSize,
+  );
+  counts.failedPruned = await batchDelete(
+    pool,
+    `status = 'failed' AND created_at < NOW() - ($1 || ' days')::INTERVAL`,
+    [String(FAILED_RETENTION_DAYS)],
+    batchSize,
+  );
+
+  // 3) Orphan owners. Rare and unbounded by status; collapse to a
+  //    single DELETE against a set of (typically tiny) owner ids.
+  const orphanOwners = await findOrphanedOwners(pool);
+  if (orphanOwners.length > 0) {
+    const result = await pool.query(
+      `DELETE FROM policy_triage_run WHERE owner_account_id = ANY($1::uuid[])`,
+      [orphanOwners],
+    );
+    counts.orphanedPruned = result.rowCount ?? 0;
+  }
+  return counts;
+}
+
+async function defaultListActiveCustomers(): Promise<number[]> {
+  const result = await authDbQuery<{ id: number }>(
+    "SELECT id FROM customers WHERE status = 'active' ORDER BY id",
+  );
+  return result.rows.map((r) => Number(r.id));
+}
+
+export interface PolicyRetentionOptions {
+  batchSize?: number;
+  zombieTimeoutMs?: number;
+  listActiveCustomers?: () => Promise<number[]>;
+  runForCustomer?: (
+    customerId: number,
+    options: { batchSize?: number; zombieTimeoutMs?: number },
+  ) => Promise<PolicyRetentionCounts>;
+}
+
+export async function runPolicyRetentionDispatch(
+  options: PolicyRetentionOptions = {},
+): Promise<PolicyRetentionResult> {
+  const batchSize = options.batchSize ?? DEFAULT_DELETE_BATCH_SIZE;
+  const zombieTimeoutMs = options.zombieTimeoutMs ?? ZOMBIE_TIMEOUT_MS;
+  const listActiveCustomers =
+    options.listActiveCustomers ?? defaultListActiveCustomers;
+  const runForCustomer =
+    options.runForCustomer ?? runPolicyRetentionForCustomer;
+
+  const customerIds = await listActiveCustomers();
+  const perCustomer: PolicyRetentionCustomerResult[] = [];
+  for (const customerId of customerIds) {
+    try {
+      const counts = await runForCustomer(customerId, {
+        batchSize,
+        zombieTimeoutMs,
+      });
+      perCustomer.push({ customerId, status: "ok", counts });
+    } catch (err) {
+      perCustomer.push({
+        customerId,
+        status: "failed",
+        counts: emptyCounts(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  const overall: PolicyRetentionResult["overall"] = perCustomer.some(
+    (e) => e.status === "failed",
+  )
+    ? "partial"
+    : "ok";
+  return { overall, perCustomer };
+}
+
+/**
+ * Internal-token guard for the policy retention route. Reads
+ * `TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN`. Constant-time compare.
+ */
+export function verifyTriagePolicyRetentionToken(
+  provided: string | null,
+): boolean {
+  const expected = process.env.TRIAGE_POLICY_RETENTION_INTERNAL_TOKEN;
+  if (!expected) return false;
+  if (!provided) return false;
+  if (provided.length !== expected.length) return false;
+  const a = Buffer.from(expected, "utf8");
+  const b = Buffer.from(provided, "utf8");
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+/**
+ * Phase 2 LLM-batch protection extension hook (#461).
+ *
+ * Invoked by `pruneReadyWithProtection` once per candidate `ready`
+ * run. Returning `true` keeps the run alive for this retention tick.
+ * The default predicate returns `false` so retention runs
+ * unconditionally today; Phase 2 swaps `current` for a real
+ * SendBatch-in-flight check without modifying retention.ts.
+ *
+ * Only the `ready` path consults the hook — `superseded` / `failed` /
+ * `computing` runs cannot have a meaningful in-flight SendBatch.
+ */
+export type RunProtectionPredicate = (runId: string) => Promise<boolean>;
+export const _protectionExtensionHook: { current: RunProtectionPredicate } = {
+  current: async () => false,
+};
+
+/**
+ * Delete `ready` rows past the retention window in batches, skipping
+ * any row the Phase 2 protection hook claims. The hook is consulted
+ * row-by-row so a long-running predicate (e.g. a remote SendBatch
+ * status check) doesn't block the entire sweep on one call.
+ *
+ * Protected ids accumulate in a Set so the next SELECT excludes them
+ * — without this, an all-protected batch would loop forever on the
+ * same set of rows.
+ */
+async function pruneReadyWithProtection(
+  pool: pg.Pool,
+  retentionDays: number,
+  batchSize: number,
+): Promise<number> {
+  let total = 0;
+  const protectedIds = new Set<string>();
+  while (true) {
+    const protectedArr = Array.from(protectedIds);
+    const { rows } =
+      protectedArr.length === 0
+        ? await pool.query<{ id: string }>(
+            `SELECT id FROM policy_triage_run
+              WHERE status = 'ready'
+                AND created_at < NOW() - ($1 || ' days')::INTERVAL
+              LIMIT ${batchSize}`,
+            [String(retentionDays)],
+          )
+        : await pool.query<{ id: string }>(
+            `SELECT id FROM policy_triage_run
+              WHERE status = 'ready'
+                AND created_at < NOW() - ($1 || ' days')::INTERVAL
+                AND id <> ALL($2::uuid[])
+              LIMIT ${batchSize}`,
+            [String(retentionDays), protectedArr],
+          );
+    if (rows.length === 0) break;
+    const toDelete: string[] = [];
+    for (const r of rows) {
+      if (await _protectionExtensionHook.current(r.id)) {
+        protectedIds.add(r.id);
+      } else {
+        toDelete.push(r.id);
+      }
+    }
+    if (toDelete.length > 0) {
+      const result = await pool.query(
+        `DELETE FROM policy_triage_run WHERE id = ANY($1::uuid[])`,
+        [toDelete],
+      );
+      total += result.rowCount ?? 0;
+    }
+    // Loop until a batch comes back short — at which point either the
+    // table is drained or every remaining row is protected.
+    if (rows.length < batchSize) break;
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary

Implements 1B-7: cleanup jobs, retention policies, and an exclusion recovery surface.

- **Three retention sweeps**, each wired as an internal-token route plus a cron wrapper:
  - `baseline_triaged_event` (180 d) and `observed_event_meta` (30 d) — daily at 03:15 UTC.
  - `policy_triage_run` differential retention (ready 30 d / superseded 7 d / failed 1 d / orphan-by-owner) plus a 30-minute zombie-runner reaper that flips stuck `computing` rows to `failed` — every 6 hours.
  - `triage_exclusion_fanout_job` queue drain — every minute, closing the missing in-repo crontab entry for the route #457 ships.
- **Exclusion recovery surface** for both global-fanout `failed` rows and customer-scoped drain-failure partial cleanup:
  - Token route `POST /api/internal/triage/exclusion/recover` discriminating `global` / `global_all_failed` / `customer`.
  - Session routes `POST /api/triage/exclusions/[id]/recover` and `POST /api/triage/exclusions/global/[id]/recover` gated on the existing `triage:exclusion[:global]:write` permissions.
  - Helper resets the matching queue row in place (`status='pending'`, `attempt_count=0`, `next_attempt_at=NOW()`) so the Re-trigger cleanup affordance disappears on success.
- **Customer drain-failure sentinel.** `POST /api/triage/exclusions` now inserts a `failed` sentinel into `triage_exclusion_fanout_job` whenever the synchronous drain phase fails, so customer recovery has a queue row to reset.
- **Migration `auth/0033`** adds nullable `global_exclusion_id`, new `customer_only_exclusion_id`, the exactly-one-of `CHECK`, and partial unique indexes that let `INSERT ... ON CONFLICT DO UPDATE` collapse re-enqueue into reset.
- **Worker updates.** Fanout worker now keys on the populated id column, completes-as-no-op when the referenced customer-only exclusion row has been deleted, and routes customer-only jobs through the same DELETE planner used for the global fan-out.
- **Audit + i18n.** New actions `triage_exclusion.global_recover` (customer-agnostic) and `triage_exclusion.customer_recover` (customer-scoped) registered in `schema.ts` and `customer-scope-policy.ts`. EN/KR strings for the Re-trigger cleanup menu item. Settings manual page updated with the new audit actions and background retention section.
- **Cleanup-status routes** (`/api/triage/exclusions/cleanup-status` and `/global/cleanup-status`) feed the Re-trigger cleanup affordance, surfacing the failed queue rows + failed audit rows per exclusion.

Phase 2 LLM batch protection is intentionally not implemented — the cleanup paths leave a documented extension hook.

Closes #461

## Test plan

- [x] Baseline retention route (`/api/internal/triage/baseline/retention`) prunes events older than 180/30 days, batched at 10 000 rows, behind the internal token.
- [x] Policy retention route (`/api/internal/triage/policy/retention`) reaps `computing > 30 min` to `failed` with the timeout `last_error`, then applies differential retention and orphan-by-owner cleanup; `policy_triaged_event` cascades.
- [x] Token-protected recover route accepts each of `global` / `global_all_failed` / `customer`, rejects `kind: 'global'` without `customer_id` with 400, and resets the targeted queue rows in place.
- [x] Session-authenticated recover routes are permission-gated and audit `global_recover` / `customer_recover` correctly.
- [x] Customer-scoped ADD drain failure writes the sentinel queue row with `attempt_count = MAX_ATTEMPTS` and `last_error = drainError`; subsequent recovery flips it back to `pending`.
- [x] Cleanup-status routes return the right shape (counts + per-exclusion failure flags) for both global and customer scope.
- [x] Re-trigger cleanup menu item appears only when the displayed exclusion has a failed queue row or `drainStatus='failed'` audit entry, and disappears after a successful recover.
- [x] Fanout worker no-ops (sets `completed`) when a customer-only sentinel's tenant exclusion row is gone, and exits backoff cleanly.
- [x] Migration `auth/0033` applies clean: nullable FK, new column, `CHECK`, and the two partial unique indexes; `ON CONFLICT DO UPDATE` path round-trips.
- [x] Cron wrappers (`run-triage-baseline-retention.sh`, `run-triage-policy-retention.sh`, `run-triage-exclusion-fanout.sh`) source env, hit their routes, and re-emit `overall != 'ok'` to stderr.
- [x] `pnpm vitest run`, `pnpm tsc --noEmit`, `pnpm biome check`, `pnpm build` all clean.
